### PR TITLE
crosstool-ng

### DIFF
--- a/crosstool-ng/PKGBUILD
+++ b/crosstool-ng/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Martell Malone <martell malone at g mail dot com>
+
+_realname=crosstool-ng
+pkgname="${_realname}-git"
+_ver_base=1.19
+pkgver=1.19.291.5cc6769
+pkgrel=1
+pkgdesc="A cross-platform open-source toolchain system "
+arch=('i686' 'x86_64')
+url="http://www.crosstool-ng.org/"
+license=("MIT")
+makedepends=("gcc" "autoconf" "gperf" "bison" "flex" "wget" "tar" "patch" "make" "libtool" "automake" "xz")
+provides=("${_realname}")
+conflicts=("${_realname}")
+depends=( "ncurses-devel" )
+options=('staticlibs' 'strip')
+source=("${_realname}"::"git+https://github.com/diorcety/crosstool-ng")
+md5sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/$_realname"
+  printf "%s.%s.%s" "$_ver_base" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+	cd "$srcdir/$_realname"
+	./bootstrap
+	./configure --build=${CHOST} \
+    --prefix=/usr
+	make
+}
+
+package() {
+	cd "$srcdir/$_realname"
+	make DESTDIR=${pkgdir} install
+}


### PR DESCRIPTION
This package of crosstool-ng is able to build cross chains for PS3.

It should be a good starting point for a ct-ng package.

I will maintain it when required.
