### PR TITLE
openssh is an optdepends of git

### DIFF
--- a/git/PKGBUILD
+++ b/git/PKGBUILD
@@ -27,6 +27,7 @@ optdepends=(#'tk: gitk and git gui'
             #'perl-MIME-tools: git send-email'
             #'perl-Net-SMTP-SSL: git send-email TLS support'
             #'perl-Authen-SASL: git send-email TLS support'
+            'openssh: SSH support'
             'python2: various helper scripts'
             'subversion: git svn')
             #'cvsps: git cvsimport'


### PR DESCRIPTION
It is required for cloning and other operations over SSH protocol (as opposed to GIT and HTTPS)
