### PR TITLE
Added build-time dependencies to gcc/PKGBUILD.

### DIFF
--- a/gcc/PKGBUILD
+++ b/gcc/PKGBUILD
@@ -12,7 +12,8 @@ arch=('i686' 'x86_64')
 groups=('msys2-devel')
 license=('GPL' 'LGPL' 'FDL' 'custom')
 url="http://gcc.gnu.org"
-makedepends=('binutils>=2.23' 'mpc-devel' 'cloog-devel')
+makedepends=('binutils>=2.23' 'mpc-devel' 'cloog-devel' 'gmp-devel'
+             'mpfr-devel' 'mpc-devel' 'isl-devel' 'zlib-devel')
 
 options=('!emptydirs')
 source=(ftp://gcc.gnu.org/pub/gcc/releases/gcc-${pkgver}/gcc-${pkgver}.tar.bz2


### PR DESCRIPTION
Some of these dependencies caused the build to bail out relatively late
when missing. Declaring them upfront avoids that annoyance.
