### PR TITLE
zsh: Patch configure (s/cygwin/msys), fixes dynamic modules

### DIFF
--- a/zsh/PKGBUILD
+++ b/zsh/PKGBUILD
@@ -14,20 +14,24 @@ source=("http://www.zsh.org/pub/zsh-${pkgver}.tar.bz2"
         'config.sub::http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
         'zprofile'
         Makefile.in.patch
-        add-pwd-W-option.patch)
+        add-pwd-W-option.patch
+        patch-cygwin-msys.patch)
 md5sums=('1cd396ce17952de50b8a89980d617f0a'
          'ec04d46211a20281778ddbbde9aa680f'
          '0fb81517303511f05a01b14f41cec2cf'
          '1528b859cadb0b39f79df96c9f0e8599'
          '24a9335edf77252a7b5f52e079f7aef7'
          'ca9d481e1aa03e864734734d2267afb0'
-         'df6860fd5b5b46d59ad03220e9125c9d')
+         'df6860fd5b5b46d59ad03220e9125c9d'
+         'c4011e447ef000704b8eadd390dfe07f')
 
 prepare() {
     cd ${srcdir}/${pkgname}-${pkgver}
 
     patch -p0 -i "${srcdir}/Makefile.in.patch"
     patch -p1 -i "${srcdir}/add-pwd-W-option.patch"
+    patch -p1 -i "${srcdir}/patch-cygwin-msys.patch"
+
     mv -f ${srcdir}/config.guess ${srcdir}/config.sub ${srcdir}/${pkgname}-${pkgver}/
 
     # Set correct keymap path

--- a/zsh/patch-cygwin-msys.patch
+++ b/zsh/patch-cygwin-msys.patch
@@ -1,0 +1,49 @@
+diff --git a/configure b/configure-patched
+index 99430fb..c041bf5 100755
+--- a/configure
++++ b/configure-patched
+@@ -10588,7 +10588,7 @@ $as_echo_n "checking for /dev/fd filesystem... " >&6; }
+ if ${zsh_cv_sys_path_dev_fd+:} false; then :
+   $as_echo_n "(cached) " >&6
+ else
+-  if test "$host_os" = cygwin; then
++  if test "$host_os" = cygwin || test "$host_os" = msys; then
+ zsh_cv_sys_path_dev_fd=no
+ else
+ for zsh_cv_sys_path_dev_fd in /proc/self/fd /dev/fd no; do
+@@ -11138,7 +11138,7 @@ $as_echo_n "checking if named FIFOs work... " >&6; }
+ if ${zsh_cv_sys_fifo+:} false; then :
+   $as_echo_n "(cached) " >&6
+ else
+-  if test "$host_os" = cygwin; then
++  if test "$host_os" = cygwin || test "$host_os" = msys; then
+ zsh_cv_sys_fifo=yes
+ else
+ if test "$cross_compiling" = yes; then :
+@@ -11752,7 +11752,7 @@ if test "x$aixdynamic" = xyes; then
+   zsh_cv_sys_dynamic_strip_exe="${zsh_cv_sys_dynamic_strip_exe=yes}"
+   zsh_cv_sys_dynamic_strip_lib="${zsh_cv_sys_dynamic_strip_lib=yes}"
+   zsh_cv_shared_environ="${zsh_cv_shared_environ=yes}"
+-elif test "$host_os" = cygwin; then
++elif test "$host_os" = cygwin || test "$host_os" = msys; then
+   DL_EXT="${DL_EXT=dll}"
+ ##DLLD="${DLLD=dllwrap}"
+   DLLD="${DLLD=$CC}"
+@@ -12934,7 +12934,7 @@ $as_echo "$zsh_cv_sys_dynamic_strip_lib" >&6; }
+   if $strip_libldflags && test "$zsh_cv_sys_dynamic_strip_lib" = yes; then
+     LIBLDFLAGS="$LIBLDFLAGS -s"
+   fi
+-  if test "$host_os" = cygwin; then
++  if test "$host_os" = cygwin || test "$host_os" = msys; then
+     INSTLIB="install.cygwin-lib"
+     UNINSTLIB="uninstall.cygwin-lib"
+   fi
+@@ -12968,7 +12968,7 @@ fi
+ 
+ 
+ 
+-if test "$host_os" = cygwin; then
++if test "$host_os" = cygwin || test "$host_os" = msys; then
+   EXTRAZSHOBJS="$EXTRAZSHOBJS zsh.res.o"
+ fi
+ 


### PR DESCRIPTION
Without this none of the dynamically loaded modules worked (e.g. regex).
A simple if [[ "test" ~= "test" ]] .. will repro the problem.
