### PR TITLE
Escape special characters in *_shell.bat.

### DIFF
--- a/filesystem/mingw32_shell.bat
+++ b/filesystem/mingw32_shell.bat
@@ -25,7 +25,7 @@ set MSYSTEM=MINGW32
 rem To activate windows native symlinks uncomment next line
 rem set MSYS=winsymlinks:nativestrict
 rem Set debugging program for errors
-rem set MSYS=error_start:%WD%../../mingw32/bin/qtcreator.exe|-debug|<process-id>
+rem set MSYS=error_start:%WD%../../mingw32/bin/qtcreator.exe^|-debug^|^<process-id^>
 set MSYSCON=mintty.exe
 if "x%1" == "x-consolez" set MSYSCON=console.exe
 if "x%1" == "x-mintty" set MSYSCON=mintty.exe

--- a/filesystem/mingw64_shell.bat
+++ b/filesystem/mingw64_shell.bat
@@ -25,7 +25,7 @@ set MSYSTEM=MINGW64
 rem To activate windows native symlinks uncomment next line
 rem set MSYS=winsymlinks:nativestrict
 rem Set debugging program for errors
-rem set MSYS=error_start:%WD%../../mingw64/bin/qtcreator.exe|-debug|<process-id>
+rem set MSYS=error_start:%WD%../../mingw64/bin/qtcreator.exe^|-debug^|^<process-id^>
 set MSYSCON=mintty.exe
 if "x%1" == "x-consolez" set MSYSCON=console.exe
 if "x%1" == "x-mintty" set MSYSCON=mintty.exe

--- a/filesystem/msys2_shell.bat
+++ b/filesystem/msys2_shell.bat
@@ -25,7 +25,7 @@ set MSYSTEM=MSYS
 rem To activate windows native symlinks uncomment next line
 rem set MSYS=winsymlinks:nativestrict
 rem Set debugging program for errors
-rem set MSYS=error_start:%WD%../../mingw32/bin/qtcreator.exe|-debug|<process-id>
+rem set MSYS=error_start:%WD%../../mingw32/bin/qtcreator.exe^|-debug^|^<process-id^>
 set MSYSCON=mintty.exe
 if "x%1" == "x-consolez" set MSYSCON=console.exe
 if "x%1" == "x-mintty" set MSYSCON=mintty.exe


### PR DESCRIPTION
Windows uses ^ for escaping since \ is taken as the path separator.

The characters are in the commented-out value of the MSYS variable. If
the command were uncommented, cmd.exe would complain about syntax
errors.
