### PR TITLE
get_terminal_width checks both STDIN and STDOUT

### DIFF
--- a/util-linux/2.25.1-get_terminal_width.patch
+++ b/util-linux/2.25.1-get_terminal_width.patch
@@ -1,0 +1,18 @@
+diff -Naur origsrc/util-linux-2.25.1/lib/ttyutils.c src/util-linux-2.25.1/lib/ttyutils.c
+--- origsrc/util-linux-2.25.1/lib/ttyutils.c	2013-09-18 08:50:12.671263500 -0500
++++ src/util-linux-2.25.1/lib/ttyutils.c	2014-11-16 17:25:14.277411500 -0600
+@@ -22,10 +22,14 @@
+ #ifdef TIOCGSIZE
+ 	if (ioctl (STDIN_FILENO, TIOCGSIZE, &t_win) == 0)
+ 		return t_win.ts_cols;
++	if (ioctl (STDOUT_FILENO, TIOCGSIZE, &t_win) == 0)
++		return t_win.ts_cols;
+ #endif
+ #ifdef TIOCGWINSZ
+ 	if (ioctl (STDIN_FILENO, TIOCGWINSZ, &w_win) == 0)
+ 		return w_win.ws_col;
++	if (ioctl (STDOUT_FILENO, TIOCGWINSZ, &w_win) == 0)
++		return w_win.ws_col;
+ #endif
+         cp = getenv("COLUMNS");
+ 	if (cp) {

--- a/util-linux/PKGBUILD
+++ b/util-linux/PKGBUILD
@@ -2,12 +2,12 @@
 
 pkgname=("util-linux" "libutil-linux" "libutil-linux-devel")
 pkgver=2.25.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Miscellaneous system utilities for Linux"
 arch=('i686' 'x86_64')
 license=('GPL3')
 url="http://www.kernel.org/pub/linux/utils/util-linux/"
-makedepends=('gettext-devel' 'libiconv-devel')
+makedepends=('gettext-devel' 'libiconv-devel' 'ncurses-devel' 'libcrypt-devel' 'libtool' 'patch')
 source=(ftp://ftp.kernel.org/pub/linux/utils/$pkgname/v${pkgver%.*}/$pkgname-$pkgver.tar.xz
         2.24.2-agetty.patch
         2.24.2-libblkid-topology.patch
@@ -17,7 +17,8 @@ source=(ftp://ftp.kernel.org/pub/linux/utils/$pkgname/v${pkgver%.*}/$pkgname-$pk
         2.25.1-ipc-utils.patch
         2.25.1-lslogins.patch
         2.25.1-ncurses-reentrant.patch
-        2.25.1-scanf-ms.patch)
+        2.25.1-scanf-ms.patch
+        2.25.1-get_terminal_width.patch)
 md5sums=('2ff36a8f8ede70f66c5ad0fb09e40e79'
          '7bfa7a252cf44b70d489580dead33b4a'
          '4a6a486f374d90985ca4d636c6305b51'
@@ -27,7 +28,8 @@ md5sums=('2ff36a8f8ede70f66c5ad0fb09e40e79'
          'a8fd1f4a8821e9f2aebf4679d2d9d355'
          'b3c5b5275ceb07c2b3637700e21c8322'
          'feaa429e437a28d73c0a07d4c0359757'
-         '9a66b65aee60df39ff6e7c7e06bc6a8c')
+         '9a66b65aee60df39ff6e7c7e06bc6a8c'
+         '6e3a5043d221352f8a6cbb28d216a247')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
@@ -41,7 +43,7 @@ prepare() {
   patch -p2 -i $srcdir/2.25.1-ncurses-reentrant.patch
   patch -p2 -i $srcdir/2.25.1-scanf-ms.patch
   patch -p1 -i ${srcdir}/2.24.2-msysize.patch
-
+  patch -p2 -i $srcdir/2.25.1-get_terminal_width.patch
   autoreconf -fi
 }
 


### PR DESCRIPTION
changed get_terminal_width() of ttyutils.c to check both STDIN and STDOUT (instead of just STDIN) before resorting to $COLUMNS.
Not sure why it was checking the size of STDIN to begin with. Maybe it should be checking STDOUT/STDERR instead?
'ls /bin | column' now uses STDOUT's width.
'ls /bin | column | cat' still uses the default width (because get_env("COLUMNS") returns NULL)
