### PR TITLE
Include zlib to keep old-compression algo support in rsync

### DIFF
--- a/rsync/PKGBUILD
+++ b/rsync/PKGBUILD
@@ -29,8 +29,7 @@ build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   ./configure \
       --build=${CHOST} \
-      --prefix=/usr \
-      --without-included-zlib
+      --prefix=/usr
   
   make reconfigure
   make man all


### PR DESCRIPTION
Should fix #398 as per the comment on https://bugs.archlinux.org/task/41024
