### PR TITLE
DO NOT MERGE: Fix msys2-runtime upgrade issue by split core-update and compile into…

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,11 +1,19 @@
 build:
-  image: teaci/msys$$arch
-  pull: true
-  shell: msys$$arch
-  commands:
-    # TODO: remove this option when not anymore needed
-    - if [ $$arch = 32 ]; then export DISABLE_QUALITY_CHECK=true; fi
-    - ./ci-build.sh
+  core-update:
+    image: teaci/msys$$arch
+    pull: true
+    shell: msys$$arch
+    commands:
+      - pacman --noconfirm --sync --needed --refresh --refresh --sysupgrade --sysupgrade --noprogressbar
+
+  compile:
+    image: teaci/msys$$arch
+    pull: true
+    shell: msys$$arch
+    commands:
+      # TODO: remove this option when not anymore needed
+      - if [ $$arch = 32 ]; then export DISABLE_QUALITY_CHECK=true; fi
+      - ./ci-build.sh
 
 notify:
   irc:


### PR DESCRIPTION
… two shells.

Hi @renatosilva 

This patch could solve a "race-condition" when Tea CI mirror is upgraded by the teaci/msys32 and teaci/msys64 docker image have not upgraded to latest msys2-runtime.

See https://tea-ci.org/fracting/MSYS2-packages/114 for an example.

Could you comment on it?

I would be glad to here any suggestion for better naming than "core-update" and "compile" :)
