### PR TITLE
Issue #147 - check failure in flex

### DIFF
--- a/flex/PKGBUILD
+++ b/flex/PKGBUILD
@@ -42,9 +42,9 @@ check() {
   cd ${srcdir}/${pkgname}-${pkgver}
 
   # these tests used features removed in bison-2.6
-  sed -i -e '/test-bison-yylloc/d' -e '/test-bison-yylval/d' tests/Makefile.in
+#  sed -i -e '/test-bison-yylloc/d' -e '/test-bison-yylval/d' tests/Makefile.in
 
-  make check
+  make check -j 1
 }
 
 package() {


### PR DESCRIPTION
added -j 1 to make check
commented out sed line

Following instructions on MSYS2 wiki [Creating Packages - Re-building a package](https://github.com/msys2/msys2/wiki/Creating-packages#re-building-a-package) section failed at check(). Adding `-j 1` fixed the issue and also allowed me to remove the `sed` line.