### PR TITLE
dosfstools: new package

### DIFF
--- a/dosfstools/PKGBUILD
+++ b/dosfstools/PKGBUILD
@@ -1,0 +1,27 @@
+# Maintainer: Yong-hyu, Ban <yhban@quendi.moe>
+# Maintainer: Eon Jeong <administrator@korea.ac.kr>
+pkgname=dosfstools
+pkgver=4.1
+pkgrel=1
+pkgdesc="DOS filesystem utilities"
+arch=('i686' 'x86_64')
+depends=('libiconv' 'libiconv-devel')
+source=(https://github.com/$pkgname/$pkgname/releases/download/v$pkgver/$pkgname-$pkgver.tar.xz)
+url="https://github.com/dosfstools/dosfstools"
+license=('GPL2')
+sha256sums=('e6b2aca70ccc3fe3687365009dd94a2e18e82b688ed4e260e04b7412471cc173')
+
+prepare() {
+  cd $srcdir/$pkgname-$pkgver
+  ./configure --prefix=/usr --libexecdir=/usr/lib --sbindir=/usr/bin --mandir=/usr/share/man --docdir=/usr/share/doc/dosfstools --without-udev --enable-compat-symlinks
+}
+
+build() {
+   cd $srcdir/$pkgname-$pkgver
+   make LDADD="-liconv"
+}
+
+package () {
+   cd $srcdir/$pkgname-$pkgver
+   make DESTDIR=$pkgdir install
+}


### PR DESCRIPTION
This change delivers *dosfstools* commands to MSYS2, including `mkfs.fat`, `fsck.fat`, `fatlabel` and compatible aliases (such as `mkfs.vfat`, via `--enable-compat-symlinks`).

````
$ mkfs.fat --help
mkfs.fat 4.1 (2017-01-24)
Usage: mkfs.fat [-a][-A][-c][-C][-v][-I][-l bad-block-file][-b backup-boot-sector]
       [-m boot-msg-file][-n volume-name][-i volume-id]
       [-s sectors-per-cluster][-S logical-sector-size][-f number-of-FATs]
       [-h hidden-sectors][-F fat-size][-r root-dir-entries][-R reserved-sectors]
       [-M FAT-media-byte][-D drive_number]
       [--invariant]
       [--help]
       /dev/name [blocks]

$ pacman -Ql dosfstools
dosfstools /usr/
dosfstools /usr/bin/
dosfstools /usr/bin/dosfsck.exe
dosfstools /usr/bin/dosfslabel.exe
dosfstools /usr/bin/fatlabel.exe
dosfstools /usr/bin/fsck.fat.exe
dosfstools /usr/bin/fsck.msdos.exe
dosfstools /usr/bin/fsck.vfat.exe
dosfstools /usr/bin/mkdosfs.exe
dosfstools /usr/bin/mkfs.fat.exe
dosfstools /usr/bin/mkfs.msdos.exe
dosfstools /usr/bin/mkfs.vfat.exe
dosfstools /usr/share/
dosfstools /usr/share/doc/
dosfstools /usr/share/doc/dosfstools/
dosfstools /usr/share/doc/dosfstools/ANNOUNCE.mkdosfs
dosfstools /usr/share/doc/dosfstools/ChangeLog.dosfsck
dosfstools /usr/share/doc/dosfstools/ChangeLog.dosfstools-2.x
dosfstools /usr/share/doc/dosfstools/ChangeLog.mkdosfs
dosfstools /usr/share/doc/dosfstools/README.dosfsck
dosfstools /usr/share/doc/dosfstools/README.dosfstools-2.x
dosfstools /usr/share/doc/dosfstools/README.mkdosfs
dosfstools /usr/share/doc/dosfstools/TODO.dosfstools-2.x
dosfstools /usr/share/man/
dosfstools /usr/share/man/man8/
dosfstools /usr/share/man/man8/dosfsck.8.gz
dosfstools /usr/share/man/man8/dosfslabel.8.gz
dosfstools /usr/share/man/man8/fatlabel.8.gz
dosfstools /usr/share/man/man8/fsck.fat.8.gz
dosfstools /usr/share/man/man8/fsck.msdos.8.gz
dosfstools /usr/share/man/man8/fsck.vfat.8.gz
dosfstools /usr/share/man/man8/mkdosfs.8.gz
dosfstools /usr/share/man/man8/mkfs.fat.8.gz
dosfstools /usr/share/man/man8/mkfs.msdos.8.gz
dosfstools /usr/share/man/man8/mkfs.vfat.8.gz
````