### PR TITLE
tar: support Windows paths

### DIFF
--- a/tar/PKGBUILD
+++ b/tar/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=tar
 pkgver=1.30
-pkgrel=1
+pkgrel=2
 pkgdesc="Utility used to store, backup, and transport files"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/tar/tar.html"
@@ -14,11 +14,13 @@ options=('!emptydirs')
 install=tar.install
 source=(https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz{,.sig}
         1.29-mode-binary.patch
-        tar-1.29-msys2.patch)
+        tar-1.29-msys2.patch
+        allow-drives.patch)
 sha256sums=('f1bf92dbb1e1ab27911a861ea8dde8208ee774866c46c0bb6ead41f4d1f4d2d3'
             'SKIP'
             '50770e281d8b23c8d4ca301ea6f49962f01c55c89139157eb350f1d541052319'
-            '5ad664084e67d737924ff889ab05bfd771454cbe526d9e28330f06c430ebf4f3')
+            '5ad664084e67d737924ff889ab05bfd771454cbe526d9e28330f06c430ebf4f3'
+            '28edea3d1855d9828019ba8980333ab1d5758e373f567d0a5320c31eb0c4beb2')
 validpgpkeys=('325F650C4C2B6AD58807327A3602B07F55D0C732') # Sergey Poznyakoff
 
 prepare() {
@@ -26,6 +28,7 @@ prepare() {
 
   patch -p1 -i ${srcdir}/1.29-mode-binary.patch
   patch -p1 -i ${srcdir}/tar-1.29-msys2.patch
+  patch -p1 -i ${srcdir}/allow-drives.patch
 
   autoreconf -fi
 }

--- a/tar/allow-drives.patch
+++ b/tar/allow-drives.patch
@@ -1,0 +1,17 @@
+--- tar-1.28/lib/rmt.h.orig	2018-04-04 14:13:27.434833600 +0200
++++ tar-1.28/lib/rmt.h	2018-04-04 14:19:17.243518800 +0200
+@@ -35,10 +35,14 @@
+    Distributed File System (DFS).  However, when --force-local, a
+    filename is never remote.  */
+ 
++/*
+ #define _remdev(dev_name) \
+   (!force_local_option && (rmt_dev_name__ = strchr (dev_name, ':')) \
+    && rmt_dev_name__ > (dev_name) \
+    && ! memchr (dev_name, '/', rmt_dev_name__ - (dev_name)))
++*/
++
++#define _remdev(dev_name) 0
+ 
+ #define _isrmt(fd) \
+   ((fd) >= __REM_BIAS)


### PR DESCRIPTION
Here is a patch we have been using locally for years, which would be nice in msys2. By default tar does not support windows paths:

```sh
tar xzvf C:/Users/Jeroen/Documents/base/R-devel.tar.gz
# tar (child): Cannot connect to C: resolve failed
# gzip: stdin: unexpected end of file
# tar: Child returned status 128
# tar: Error is not recoverable: exiting now
```

This simple patch fixes that. It works great.