### PR TITLE
Add git-crypt package, version 0.6.0

### DIFF
--- a/git-crypt/PKGBUILD
+++ b/git-crypt/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Ladislav Laska <krakonos@krakonos.org>
+
+pkgname="git-crypt"
+pkgver="0.6.0"
+pkgrel="1"
+pkgdesc="Transparent file encryption in git"
+arch=("i686" "x86_64")
+url="https://www.agwa.name/projects/git-crypt/"
+license=("GPL")
+source=( "https://www.agwa.name/projects/git-crypt/downloads/${pkgname}-${pkgver}.tar.gz")
+sha256sums=('6d30fcd99442d50f4b3c8d554067ff1d980cdf9f3120ee774131172dba98fd6f')
+makedepends=("openssl-devel")
+depends=("gnupg" "git")
+
+build () {
+  cd "$pkgname-$pkgver"
+  make
+}
+package () {
+  cd "$pkgname-$pkgver"
+  make PREFIX="/usr" DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
A git plugin for transparent file encryption; works well in msys environment.