### PR TITLE
git-extras - Update to 4.7.0 - Updated git-extras-git

### DIFF
--- a/git-extras/PKGBUILD
+++ b/git-extras/PKGBUILD
@@ -1,0 +1,28 @@
+_pkgname=git-extras
+pkgname=${_pkgname}
+replaces=("${_pkgname}-git")
+conflicts=("${_pkgname}-git")
+pkgver=4.7.0
+pkgrel=1
+pkgdesc="GIT utilities -- repo summary, commit counting, repl, changelog population and more"
+arch=('any')
+license=('MIT')
+url='https://github.com/tj/git-extras'
+depends=('git')
+source=("$_pkgname-$pkgver.tar.gz"::"https://github.com/tj/git-extras/archive/$pkgver.tar.gz")
+noextract=("$_pkgname-$pkgver.tar.gz")
+sha256sums=('58ed54248a1efcb8e9981940040361343e175cb36f72adc61896d53a8b234b5d')
+
+build(){
+    cd "$srcdir"
+    bsdtar -zxf "$_pkgname-$pkgver.tar.gz"
+
+    cd "$srcdir/$_pkgname"
+    cp bin/git-scp bin/git-rscp
+}
+
+package() {
+    cd "$srcdir/$_pkgname"
+    make DESTDIR="$pkgdir" PREFIX=/usr SYSCONFDIR=/etc install
+    install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${_pkgname}/LICENSE"
+}


### PR DESCRIPTION
Indicate that this succedes git-extras-git.  - Use release version