### PR TITLE
DO NOT MERGE - This does NOT yet work.

### DIFF
--- a/msys2-runtime/0001-Add-MSYS-triplets.patch
+++ b/msys2-runtime/0001-Add-MSYS-triplets.patch
@@ -69,12 +69,12 @@ diff --git a/config.guess b/config.guess
 index 445c40683..a2ba842bf 100755
 --- a/config.guess
 +++ b/config.guess
-@@ -883,6 +883,9 @@ EOF
+@@ -909,6 +909,9 @@ EOF
      amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
- 	echo x86_64-unknown-cygwin
+ 	echo x86_64-pc-cygwin
  	exit ;;
 +    amd64:MSYS*:*:* | x86_64:MSYS*:*:*)
-+	echo x86_64-unknown-msys
++	echo x86_64-pc-msys
 +	exit ;;
      prep*:SunOS:5.*:*)
  	echo powerpcle-unknown-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
@@ -942,25 +942,25 @@ diff --git a/newlib/configure.host b/newlib/configure.host
 index bfa51669d..09a738d0b 100644
 --- a/newlib/configure.host
 +++ b/newlib/configure.host
-@@ -164,7 +164,7 @@ case "${host_cpu}" in
+@@ -188,7 +188,7 @@ case "${host_cpu}" in
    i[34567]86)
  	# Don't use for these since they provide their own setjmp.
  	case ${host} in
 -	*-*-sco* | *-*-cygwin*) 
-+	*-*-sco* | *-*-cygwin* | *-*-msys*) 
++	*-*-sco* | *-*-cygwin* | *-*-msys*)
  		libm_machine_dir=i386
  		machine_dir=i386
  		;;
-@@ -357,7 +357,7 @@ fi
+@@ -382,7 +382,7 @@ fi
  
  if [ "x${newlib_mb}" = "x" ]; then
  	case "${host}" in
 -  	  i[34567]86-pc-linux-*|*-*-cygwin*)
-+  	  i[34567]86-pc-linux-*|*-*-cygwin*|*-*-msys*)
++         i[34567]86-pc-linux-*|*-*-cygwin*|*-*-msys*)
  		newlib_mb=yes
  	  	;;
  	esac
-@@ -391,7 +391,7 @@ esac
+@@ -416,7 +416,7 @@ esac
  # THIS TABLE IS ALPHA SORTED.  KEEP IT THAT WAY.
  
  case "${host}" in
@@ -969,7 +969,7 @@ index bfa51669d..09a738d0b 100644
  	posix_dir=posix
  	stdio64_dir=stdio64
  	xdr_dir=xdr
-@@ -588,7 +588,7 @@ esac
+@@ -620,7 +620,7 @@ esac
  # THIS TABLE IS ALPHA SORTED.  KEEP IT THAT WAY.
  
  case "${host}" in
@@ -2738,7 +2738,7 @@ index 23b3a7b78..6231adeaf 100755
  CPP'
 -ac_subdirs_all='cygwin cygserver doc
 +ac_subdirs_all='cygwin cygserver
- utils lsaauth'
+ utils'
  
  # Initialize some variables set by options.
 @@ -3449,7 +3449,7 @@ export CXX
@@ -2749,7 +2749,8 @@ index 23b3a7b78..6231adeaf 100755
 +subdirs="$subdirs cygwin cygserver"
  
  if test "x$with_cross_bootstrap" != "xyes"; then
-     subdirs="$subdirs utils lsaauth"
+     subdirs="$subdirs utils"
+
 diff --git a/winsup/configure.ac b/winsup/configure.ac
 index b975dfc1a..8fad6601e 100644
 --- a/winsup/configure.ac
@@ -2761,10 +2762,8 @@ index b975dfc1a..8fad6601e 100644
 -AC_CONFIG_SUBDIRS(cygwin cygserver doc)
 +AC_CONFIG_SUBDIRS(cygwin cygserver)
  if test "x$with_cross_bootstrap" != "xyes"; then
-     AC_CONFIG_SUBDIRS([utils lsaauth])
+     AC_CONFIG_SUBDIRS([utils])
  fi
-diff --git a/winsup/cygserver/configure b/winsup/cygserver/configure
-index 71d1592f4..3f44b1234 100755
 --- a/winsup/cygserver/configure
 +++ b/winsup/cygserver/configure
 @@ -3449,7 +3449,7 @@ export CXX

--- a/msys2-runtime/0002-Rename-DLL-from-cygwin-to-msys.patch
+++ b/msys2-runtime/0002-Rename-DLL-from-cygwin-to-msys.patch
@@ -338,15 +338,25 @@ diff --git a/winsup/cygwin/cygthread.cc b/winsup/cygwin/cygthread.cc
 index 4404e4a19..db5858646 100644
 --- a/winsup/cygwin/cygthread.cc
 +++ b/winsup/cygwin/cygthread.cc
-@@ -168,7 +168,7 @@ new (size_t)
+@@ -170,10 +170,17 @@ new (size_t)
        }
  
  #ifdef DEBUGGING
--  if (!getenv ("CYGWIN_FREERANGE_NOCHECK"))
++  #ifdef __MSYS__
 +  if (!getenv ("MSYS_FREERANGE_NOCHECK"))
++    api_fatal ("overflowed MSYS thread pool");
++  else
++    thread_printf ("overflowed MSYS thread pool");
++  #else
+   if (!getenv ("CYGWIN_FREERANGE_NOCHECK"))
      api_fatal ("overflowed cygwin thread pool");
    else
      thread_printf ("overflowed cygwin thread pool");
++  #endif
+ #endif
+ 
+   info = freerange ();	/* exhausted thread pool */
+
 diff --git a/winsup/cygwin/cygwin.sc.in b/winsup/cygwin/cygwin.sc.in
 index 134ae3f76..d390a51ec 100644
 --- a/winsup/cygwin/cygwin.sc.in
@@ -395,48 +405,58 @@ diff --git a/winsup/cygwin/dcrt0.cc b/winsup/cygwin/dcrt0.cc
 index af5eaaca7..7a23e0320 100644
 --- a/winsup/cygwin/dcrt0.cc
 +++ b/winsup/cygwin/dcrt0.cc
-@@ -377,21 +377,21 @@ check_sanity_and_sync (per_process *p)
+@@ -377,17 +377,29 @@ check_sanity_and_sync (per_process *p)
  
    /* Complain if older than last incompatible change */
    if (p->dll_major < CYGWIN_VERSION_DLL_EPOCH)
--    api_fatal ("cygwin DLL and APP are out of sync -- DLL version mismatch %u < %u",
++#ifdef __MSYS__
 +    api_fatal ("msys DLL and APP are out of sync -- DLL version mismatch %u < %u",
++#else
+     api_fatal ("cygwin DLL and APP are out of sync -- DLL version mismatch %u < %u",
++#endif
  	       p->dll_major, CYGWIN_VERSION_DLL_EPOCH);
  
    /* magic_biscuit != 0 if using the old style version numbering scheme.  */
    if (p->magic_biscuit != SIZEOF_PER_PROCESS)
--    api_fatal ("Incompatible cygwin .dll -- incompatible per_process info %u != %u",
++#ifdef __MSYS__
 +    api_fatal ("Incompatible msys .dll -- incompatible per_process info %u != %u",
++#else
+     api_fatal ("Incompatible cygwin .dll -- incompatible per_process info %u != %u",
++#endif
  	       p->magic_biscuit, SIZEOF_PER_PROCESS);
  
    /* Complain if incompatible API changes made */
    if (p->api_major > cygwin_version.api_major)
--    api_fatal ("cygwin DLL and APP are out of sync -- API version mismatch %u > %u",
++#ifdef __MSYS__
 +    api_fatal ("msys DLL and APP are out of sync -- API version mismatch %u > %u",
++#else
+     api_fatal ("cygwin DLL and APP are out of sync -- API version mismatch %u > %u",
++#endif
  	       p->api_major, cygwin_version.api_major);
  
  #ifdef __i386__
--  /* This is a kludge to work around a version of _cygwin_common_crt0
-+  /* This is a kludge to work around a version of _msys_common_crt0
-      which overwrote the cxx_malloc field with the local DLL copy.
-      Hilarity ensues if the DLL is not loaded while the process
-      is forking. */
-@@ -490,12 +490,12 @@ break_here ()
+@@ -490,12 +502,20 @@ break_here ()
  static void
  initial_env ()
  {
--  if (GetEnvironmentVariableA ("CYGWIN_TESTING", NULL, 0))
++#ifdef __MSYS__
 +  if (GetEnvironmentVariableA ("MSYS_TESTING", NULL, 0))
++#else
+   if (GetEnvironmentVariableA ("CYGWIN_TESTING", NULL, 0))
++#endif
      _cygwin_testing = 1;
  
  #ifdef DEBUGGING
    char buf[PATH_MAX];
--  if (GetEnvironmentVariableA ("CYGWIN_DEBUG", buf, sizeof (buf) - 1))
++#ifdef __MSYS__
 +  if (GetEnvironmentVariableA ("MSYS_DEBUG", buf, sizeof (buf) - 1))
++#else
+   if (GetEnvironmentVariableA ("CYGWIN_DEBUG", buf, sizeof (buf) - 1))
++#endif
      {
        char buf1[PATH_MAX];
        GetModuleFileName (NULL, buf1, PATH_MAX);
-@@ -1101,7 +1101,11 @@ dll_crt0 (per_process *uptr)
+@@ -1105,7 +1125,11 @@ dll_crt0 (per_process *uptr)
     See winsup/testsuite/cygload for an example of how to use cygwin1.dll
     from MSVC and non-cygwin MinGW applications.  */
  extern "C" void
@@ -448,21 +468,27 @@ index af5eaaca7..7a23e0320 100644
  {
  #ifdef __i386__
    static char **envp;
-@@ -1314,7 +1318,7 @@ multiple_cygwin_problem (const char *what, uintptr_t magic_version, uintptr_t ve
+@@ -1318,7 +1342,11 @@ multiple_cygwin_problem (const char *what, uintptr_t magic_version, uintptr_t ve
        return;
      }
  
--  if (GetEnvironmentVariableA ("CYGWIN_MISMATCH_OK", NULL, 0))
++#ifdef __MSYS__
 +  if (GetEnvironmentVariableA ("MSYS_MISMATCH_OK", NULL, 0))
++#else
+   if (GetEnvironmentVariableA ("CYGWIN_MISMATCH_OK", NULL, 0))
++#endif
      return;
  
    if (CYGWIN_VERSION_MAGIC_VERSION (magic_version) == version)
-@@ -1334,7 +1338,7 @@ are unable to find another cygwin DLL.",
+@@ -1338,7 +1366,11 @@ are unable to find another cygwin DLL.",
  void __reg1
  cygbench (const char *s)
  {
--  if (GetEnvironmentVariableA ("CYGWIN_BENCH", NULL, 0))
++#ifdef __MSYS__
 +  if (GetEnvironmentVariableA ("MSYS_BENCH", NULL, 0))
++#else
+   if (GetEnvironmentVariableA ("CYGWIN_BENCH", NULL, 0))
++#endif
      small_printf ("%05u ***** %s : %10d\n", GetCurrentProcessId (), s, strace.microseconds ());
  }
  #endif
@@ -535,20 +561,26 @@ diff --git a/winsup/cygwin/exceptions.cc b/winsup/cygwin/exceptions.cc
 index 419b0976f..2cdfed770 100644
 --- a/winsup/cygwin/exceptions.cc
 +++ b/winsup/cygwin/exceptions.cc
-@@ -500,14 +500,14 @@ try_to_debug (bool waitloop)
+@@ -501,14 +501,22 @@ try_to_debug (bool waitloop)
    PWCHAR rawenv = GetEnvironmentStringsW () ;
    for (PWCHAR p = rawenv; *p != L'\0'; p = wcschr (p, L'\0') + 1)
      {
--      if (wcsncmp (p, L"CYGWIN=", wcslen (L"CYGWIN=")) == 0)
++#ifdef __MSYS__
 +      if (wcsncmp (p, L"MSYS=", wcslen (L"MSYS=")) == 0)
++#else
+       if (wcsncmp (p, L"CYGWIN=", wcslen (L"CYGWIN=")) == 0)
++#endif
  	{
  	  PWCHAR q = wcsstr (p, L"error_start") ;
  	  /* replace 'error_start=...' with '_rror_start=...' */
  	  if (q)
  	    {
  	      *q = L'_' ;
--	      SetEnvironmentVariableW (L"CYGWIN", p + wcslen (L"CYGWIN=")) ;
-+	      SetEnvironmentVariableW (L"MSYS", p + wcslen (L"MSYS=")) ;
++#ifdef __MSYS__
++              SetEnvironmentVariableW (L"MSYS", p + wcslen (L"MSYS=")) ;
++#else
+ 	      SetEnvironmentVariableW (L"CYGWIN", p + wcslen (L"CYGWIN=")) ;
++#endif
  	    }
  	  break;
  	}
@@ -596,12 +628,15 @@ diff --git a/winsup/cygwin/fork.cc b/winsup/cygwin/fork.cc
 index c6fef6755..fbac1f904 100644
 --- a/winsup/cygwin/fork.cc
 +++ b/winsup/cygwin/fork.cc
-@@ -160,7 +160,7 @@ frok::child (volatile char * volatile here)
+@@ -164,7 +164,11 @@ frok::child (volatile char * volatile here)
    char buf[80];
    /* This is useful for debugging fork problems.  Use gdb to attach to
       the pid reported here. */
--  if (GetEnvironmentVariableA ("CYGWIN_FORK_SLEEP", buf, sizeof (buf)))
++#ifdef __MSYS__
 +  if (GetEnvironmentVariableA ("MSYS_FORK_SLEEP", buf, sizeof (buf)))
++#else
+   if (GetEnvironmentVariableA ("CYGWIN_FORK_SLEEP", buf, sizeof (buf)))
++#endif
      {
        small_printf ("Sleeping %d after fork, pid %u\n", atoi (buf), GetCurrentProcessId ());
        Sleep (atoi (buf));
@@ -653,55 +688,97 @@ diff --git a/winsup/cygwin/include/cygwin/cygwin_dll.h b/winsup/cygwin/include/c
 index 56b4363ce..6bc948a08 100644
 --- a/winsup/cygwin/include/cygwin/cygwin_dll.h
 +++ b/winsup/cygwin/include/cygwin/cygwin_dll.h
-@@ -24,8 +24,8 @@ details. */
- CDECL_BEGIN								      \
-   int WINAPI Entry (HINSTANCE h, DWORD reason, void *ptr);	              \
-   typedef int (*mainfunc) (int, char **, char **);			      \
--  extern PVOID cygwin_attach_dll (HMODULE, mainfunc);			      \
--  extern void cygwin_detach_dll (PVOID);				      \
+@@ -19,6 +19,84 @@ details. */
+ #define CDECL_END
+ #endif
+ 
++#ifdef __MSYS__
++
++#define DECLARE_CYGWIN_DLL(Entry)					      \
++									      \
++CDECL_BEGIN								      \
++  int WINAPI Entry (HINSTANCE h, DWORD reason, void *ptr);	              \
++  typedef int (*mainfunc) (int, char **, char **);			      \
 +  extern PVOID msys_attach_dll (HMODULE, mainfunc);			      \
 +  extern void msys_detach_dll (PVOID);				      \
- CDECL_END								      \
- 									      \
- static HINSTANCE storedHandle;						      \
-@@ -42,7 +42,7 @@ static int __dllMain (int a __attribute__ ((__unused__)),		      \
- 									      \
- static PVOID dll_index;							      \
- 									      \
--int WINAPI _cygwin_dll_entry (HINSTANCE h, DWORD reason, void *ptr)	      \
++CDECL_END								      \
++									      \
++static HINSTANCE storedHandle;						      \
++static DWORD storedReason;						      \
++static void* storedPtr;							      \
++int __dynamically_loaded;						      \
++									      \
++static int __dllMain (int a __attribute__ ((__unused__)),		      \
++		      char **b __attribute__ ((__unused__)),		      \
++		      char **c __attribute__ ((__unused__)))		      \
++{									      \
++  return Entry (storedHandle, storedReason, storedPtr);		              \
++}									      \
++									      \
++static PVOID dll_index;							      \
++									      \
 +int WINAPI _msys_dll_entry (HINSTANCE h, DWORD reason, void *ptr)	      \
- {									      \
-   int ret;								      \
-   ret = 1;								      \
-@@ -55,7 +55,7 @@ int WINAPI _cygwin_dll_entry (HINSTANCE h, DWORD reason, void *ptr)	      \
-       storedReason = reason;						      \
-       storedPtr = ptr;							      \
-       __dynamically_loaded = (ptr == NULL);				      \
--      dll_index = cygwin_attach_dll (h, &__dllMain);			      \
++{									      \
++  int ret;								      \
++  ret = 1;								      \
++									      \
++  switch (reason)							      \
++  {									      \
++    case DLL_PROCESS_ATTACH:						      \
++    {									      \
++      storedHandle = h;							      \
++      storedReason = reason;						      \
++      storedPtr = ptr;							      \
++      __dynamically_loaded = (ptr == NULL);				      \
 +      dll_index = msys_attach_dll (h, &__dllMain);			      \
-       if (dll_index == (PVOID) -1)					      \
- 	ret = 0;							      \
-     }									      \
-@@ -66,7 +66,7 @@ int WINAPI _cygwin_dll_entry (HINSTANCE h, DWORD reason, void *ptr)	      \
-       ret = Entry (h, reason, ptr);					      \
-       if (ret)								      \
-       {									      \
--	cygwin_detach_dll (dll_index);					      \
++      if (dll_index == (PVOID) -1)					      \
++	ret = 0;							      \
++    }									      \
++    break;								      \
++									      \
++    case DLL_PROCESS_DETACH:						      \
++    {									      \
++      ret = Entry (h, reason, ptr);					      \
++      if (ret)								      \
++      {									      \
 +	msys_detach_dll (dll_index);					      \
- 	dll_index = (PVOID) -1;						      \
-       }									      \
-     }									      \
-@@ -88,9 +88,9 @@ int WINAPI _cygwin_dll_entry (HINSTANCE h, DWORD reason, void *ptr)	      \
- }									      \
- 									      \
- /* OBSOLETE: This is only provided for source level compatibility. */         \
--int WINAPI _cygwin_noncygwin_dll_entry (HINSTANCE h, DWORD reason, void *ptr) \
-+int WINAPI _msys_nonmsys_dll_entry (HINSTANCE h, DWORD reason, void *ptr) \
- {									      \
--  return _cygwin_dll_entry (h, reason, ptr);				      \
++	dll_index = (PVOID) -1;						      \
++      }									      \
++    }									      \
++    break;								      \
++									      \
++    case DLL_THREAD_ATTACH:						      \
++    {									      \
++      ret = Entry (h, reason, ptr);					      \
++    }									      \
++    break;								      \
++									      \
++    case DLL_THREAD_DETACH:						      \
++    {									      \
++      ret = Entry (h, reason, ptr);					      \
++    }									      \
++    break;								      \
++  }									      \
++  return ret;								      \
++}									      \
++									      \
++/* OBSOLETE: This is only provided for source level compatibility. */         \
++int WINAPI _cygwin_noncygwin_dll_entry (HINSTANCE h, DWORD reason, void *ptr) \
++{									      \
 +  return _msys_dll_entry (h, reason, ptr);				      \
++}									      \
++
++#else /* __MSYS__ */
++
+ #define DECLARE_CYGWIN_DLL(Entry)					      \
+ 									      \
+ CDECL_BEGIN								      \
+@@ -93,4 +171,6 @@ int WINAPI _cygwin_noncygwin_dll_entry (HINSTANCE h, DWORD reason, void *ptr) \
+   return _cygwin_dll_entry (h, reason, ptr);				      \
  }									      \
  
++#endif /* __MSYS__ */
++
  #endif /* __CYGWIN_CYGWIN_DLL_H__ */
 diff --git a/winsup/cygwin/include/cygwin/version.h b/winsup/cygwin/include/cygwin/version.h
 index 5a53a1d86..82a80fc12 100644
@@ -836,29 +913,23 @@ diff --git a/winsup/cygwin/pinfo.cc b/winsup/cygwin/pinfo.cc
 index 6b6986c9e..f4ca03299 100644
 --- a/winsup/cygwin/pinfo.cc
 +++ b/winsup/cygwin/pinfo.cc
-@@ -188,7 +188,7 @@ pinfo::maybe_set_exit_code_from_windows ()
+@@ -188,7 +188,11 @@ pinfo::maybe_set_exit_code_from_windows ()
        GetExitCodeProcess (hProcess, &x);
        set_exit_code (x);
      }
--  sigproc_printf ("pid %d, exit value - old %y, windows %y, cygwin %y",
++#ifdef __MSYS__
 +  sigproc_printf ("pid %d, exit value - old %y, windows %y, MSYS %y",
++#else
+   sigproc_printf ("pid %d, exit value - old %y, windows %y, cygwin %y",
++#endif
  		  self->pid, oexitcode, x, self->exitcode);
  }
  
-@@ -357,7 +357,7 @@ pinfo::init (pid_t n, DWORD flag, HANDLE h0)
-       if (procinfo->process_state & PID_EXECED)
- 	{
- 	  pid_t realpid = procinfo->pid;
--	  debug_printf ("execed process windows pid %u, cygwin pid %d", n, realpid);
-+	  debug_printf ("execed process windows pid %u, MSYS pid %d", n, realpid);
- 	  if (realpid == n)
- 	    api_fatal ("retrieval of execed process info for pid %d failed due to recursion.", n);
- 
-diff --git a/winsup/cygwin/pipe.cc b/winsup/cygwin/pipe.cc
+diff --git a/winsup/cygwin/fhandler_pipe.cc b/winsup/cygwin/fhandler_pipe.cc
 index f1eace6a6..071e09221 100644
---- a/winsup/cygwin/pipe.cc
-+++ b/winsup/cygwin/pipe.cc
-@@ -197,7 +197,11 @@ fhandler_pipe::dup (fhandler_base *child, int flags)
+--- a/winsup/cygwin/fhandler_pipe.cc
++++ b/winsup/cygwin/fhandler_pipe.cc
+@@ -201,7 +201,11 @@ fhandler_pipe::dup (fhandler_base *child, int flags)
    return res;
  }
  
@@ -874,12 +945,15 @@ diff --git a/winsup/cygwin/pseudo-reloc.cc b/winsup/cygwin/pseudo-reloc.cc
 index c250fdc01..a230b35e6 100644
 --- a/winsup/cygwin/pseudo-reloc.cc
 +++ b/winsup/cygwin/pseudo-reloc.cc
-@@ -87,7 +87,7 @@ __report_error (const char *msg, ...)
+@@ -87,7 +87,11 @@ __report_error (const char *msg, ...)
    char buf[128];
    char *posix_module = NULL;
    static const char UNKNOWN_MODULE[] = "<unknown module>: ";
--  static const char CYGWIN_FAILURE_MSG[] = "Cygwin runtime failure: ";
++#ifdef __MSYS__
 +  static const char CYGWIN_FAILURE_MSG[] = "MSYS runtime failure: ";
++#else
+   static const char CYGWIN_FAILURE_MSG[] = "Cygwin runtime failure: ";
++#endif
    HANDLE errh = GetStdHandle (STD_ERROR_HANDLE);
    va_list args;
  
@@ -887,68 +961,137 @@ diff --git a/winsup/cygwin/sec_auth.cc b/winsup/cygwin/sec_auth.cc
 index d4c2701da..600129928 100644
 --- a/winsup/cygwin/sec_auth.cc
 +++ b/winsup/cygwin/sec_auth.cc
-@@ -764,7 +764,7 @@ verify_token (HANDLE token, cygsid &usersid, user_groups &groups, bool *pintern)
+@@ -848,7 +848,11 @@ verify_token (HANDLE token, cygsid &usersid, user_groups &groups, bool *pintern)
        if (!NT_SUCCESS (status))
  	debug_printf ("NtQueryInformationToken(), %y", status);
        else
--	*pintern = intern = !memcmp (ts.SourceName, "Cygwin.1", 8);
++#ifdef __MSYS__
 +	*pintern = intern = !memcmp (ts.SourceName, "MSYS.2", 6);
++#else
+ 	*pintern = intern = !memcmp (ts.SourceName, "Cygwin.1", 8);
++#endif
      }
    /* Verify usersid */
    cygsid tok_usersid (NO_SID);
-@@ -882,7 +882,7 @@ create_token (cygsid &usersid, user_groups &new_groups)
+@@ -992,7 +996,11 @@ create_token (cygsid &usersid, user_groups &new_groups)
    TOKEN_DEFAULT_DACL dacl = {};
    TOKEN_SOURCE source;
    TOKEN_STATISTICS stats;
--  memcpy (source.SourceName, "Cygwin.1", 8);
++#ifdef __MSYS__
 +  memcpy (source.SourceName, "MSYS.2", 6);
++#else
+   memcpy (source.SourceName, "Cygwin.1", 8);
++#endif
    source.SourceIdentifier.HighPart = 0;
    source.SourceIdentifier.LowPart = 0x0101;
  
-@@ -1036,7 +1036,7 @@ lsaauth (cygsid &usersid, user_groups &new_groups)
+@@ -1151,7 +1159,11 @@ lsaauth (cygsid &usersid, user_groups &new_groups)
    push_self_privilege (SE_TCB_PRIVILEGE, true);
  
    /* Register as logon process. */
--  RtlInitAnsiString (&name, "Cygwin");
++#ifdef __MSYS__
 +  RtlInitAnsiString (&name, "MSYS");
-   SetLastError (0);
++#else
+   RtlInitAnsiString (&name, "Cygwin");
++#endif
    status = LsaRegisterLogonProcess (&name, &lsa_hdl, &sec_mode);
    if (status != STATUS_SUCCESS)
-@@ -1065,10 +1065,10 @@ lsaauth (cygsid &usersid, user_groups &new_groups)
+     {
+@@ -1174,10 +1186,18 @@ lsaauth (cygsid &usersid, user_groups &new_groups)
      goto out;
  
    /* Create origin. */
--  stpcpy (origin.buf, "Cygwin");
++#ifdef __MSYS__
 +  stpcpy (origin.buf, "MSYS");
++#else
+   stpcpy (origin.buf, "Cygwin");
++#endif
    RtlInitAnsiString (&origin.str, origin.buf);
    /* Create token source. */
--  memcpy (ts.SourceName, "Cygwin.1", 8);
++#ifdef __MSYS__
 +  memcpy (ts.SourceName, "MSYS.2", 6);
++#else
+   memcpy (ts.SourceName, "Cygwin.1", 8);
++#endif
    ts.SourceIdentifier.HighPart = 0;
    ts.SourceIdentifier.LowPart = 0x0103;
+ 
+@@ -1320,10 +1340,18 @@ lsaauth (cygsid &usersid, user_groups &new_groups)
+   if (status != STATUS_SUCCESS)
+     {
+       if (status == STATUS_ACCOUNT_RESTRICTION)
++#ifdef __MSYS__
++	debug_printf ("MSYS LSA Auth LsaLogonUser failed: %y (%s)",
++#else
+ 	debug_printf ("Cygwin LSA Auth LsaLogonUser failed: %y (%s)",
++#endif
+ 		      status, account_restriction (sub_status));
+       else
++#ifdef __MSYS__
++	debug_printf ("MSYS LSA Auth LsaLogonUser failed: %y", status);
++#else
+ 	debug_printf ("Cygwin LSA Auth LsaLogonUser failed: %y", status);
++#endif
+       __seterrno_from_nt_status (status);
+       goto out;
+     }
+@@ -1526,7 +1554,11 @@ s4uauth (bool logon, PCWSTR domain, PCWSTR user, NTSTATUS &ret_status)
+     {
+       /* Register as logon process. */
+       debug_printf ("Impersonation requested");
++#ifdef __MSYS__
++      RtlInitAnsiString (&name, "MSYS");
++#else
+       RtlInitAnsiString (&name, "Cygwin");
++#endif
+       status = LsaRegisterLogonProcess (&name, &lsa_hdl, &sec_mode);
+     }
+   else
+@@ -1562,11 +1594,19 @@ s4uauth (bool logon, PCWSTR domain, PCWSTR user, NTSTATUS &ret_status)
+     }
+ 
+   /* Create origin. */
++#ifdef __MSYS__
++  stpcpy (origin.buf, "MSYS");
++#else
+   stpcpy (origin.buf, "Cygwin");
++#endif
+   RtlInitAnsiString (&origin.str, origin.buf);
+ 
+   /* Create token source. */
++#ifdef __MSYS__
++  memcpy (ts.SourceName, "MSYS.2", 6);
++#else
+   memcpy (ts.SourceName, "Cygwin.1", 8);
++#endif
+   ts.SourceIdentifier.HighPart = 0;
+   ts.SourceIdentifier.LowPart = kerberos_auth ? 0x0105 : 0x0106;
  
 diff --git a/winsup/cygwin/syscalls.cc b/winsup/cygwin/syscalls.cc
 index 6d1085539..a81ce6ebd 100644
 --- a/winsup/cygwin/syscalls.cc
 +++ b/winsup/cygwin/syscalls.cc
-@@ -331,7 +331,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, ACCESS_MASK access, ULONG flags)
-   /* Create hopefully unique filename.
-      Since we have to stick to the current directory on remote shares, make
-      the new filename at least very unlikely to match by accident.  It starts
--     with ".cyg", with "cyg" transposed into the Unicode low surrogate area
-+     with ".msys", with "msys" transposed into the Unicode low surrogate area
-      starting at U+dc00.  Use plain ASCII chars on filesystems not supporting
-      Unicode.  The rest of the filename is the inode number in hex encoding
-      and a hash of the full NT path in hex.  The combination allows to remove
-@@ -340,7 +340,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, ACCESS_MASK access, ULONG flags)
-   RtlAppendUnicodeToString (&recycler,
- 			    (pc.fs_flags () & FILE_UNICODE_ON_DISK
- 			     && !pc.fs_is_samba ())
--			    ? L".\xdc63\xdc79\xdc67" : L".cyg");
-+			    ? L".\xdc73\xdc6d\xdc79\xdc6d" : L".msys");
-   pfii = (PFILE_INTERNAL_INFORMATION) infobuf;
-   /* Note: Modern Samba versions apparently don't like buffer sizes of more
-      than 65535 in some NtQueryInformationFile/NtSetInformationFile calls.
+@@ -327,7 +327,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, ACCESS_MASK access, ULONG flags)
+     }
+   else
+     {
+-      /* Create unique filename.  Start with a dot, followed by "cyg"
++      /* Create unique filename.  Start with a dot, followed by "cyg" or "msys"
+ 	 transposed into the Unicode low surrogate area (U+dc00) on file
+ 	 systems supporting Unicode (except Samba), followed by the inode
+ 	 number in hex, followed by a path hash in hex.  The combination
+@@ -335,7 +335,11 @@ try_to_bin (path_conv &pc, HANDLE &fh, ACCESS_MASK access, ULONG flags)
+       RtlAppendUnicodeToString (&recycler,
+ 				(pc.fs_flags () & FILE_UNICODE_ON_DISK
+ 				 && !pc.fs_is_samba ())
++#ifdef __MSYS__
++                                ? L".\xdc73\xdc6d\xdc79\xdc6d" : L".msys");
++#else
+ 				? L".\xdc63\xdc79\xdc67" : L".cyg");
++#endif
+       pfii = (PFILE_INTERNAL_INFORMATION) infobuf;
+       status = NtQueryInformationFile (fh, &io, pfii, sizeof *pfii,
+ 				       FileInternalInformation);
 diff --git a/winsup/cygwin/syslog.cc b/winsup/cygwin/syslog.cc
 index 6a295501f..431f9d239 100644
 --- a/winsup/cygwin/syslog.cc
@@ -1008,12 +1151,15 @@ diff --git a/winsup/lsaauth/cyglsa.c b/winsup/lsaauth/cyglsa.c
 index 9d9c9ff03..ffdb8f71e 100644
 --- a/winsup/lsaauth/cyglsa.c
 +++ b/winsup/lsaauth/cyglsa.c
-@@ -410,7 +410,7 @@ LsaApLogonUserEx (PLSA_CLIENT_REQUEST request, SECURITY_LOGON_TYPE logon_type,
+@@ -410,7 +410,11 @@ LsaApLogonUserEx (PLSA_CLIENT_REQUEST request, SECURITY_LOGON_TYPE logon_type,
  	  return stat;
  	}
  
--      memcpy (ts.SourceName, "Cygwin.1", 8);
++#ifdef __MSYS__
 +      memcpy (ts.SourceName, "MSYS.2", 6);
++#else
+       memcpy (ts.SourceName, "Cygwin.1", 8);
++#endif
        ts.SourceIdentifier.HighPart = 0;
        ts.SourceIdentifier.LowPart = 0x0104;
        RtlInitEmptyUnicodeString (&flatnm, flatname,
@@ -1054,23 +1200,29 @@ diff --git a/winsup/testsuite/cygrun.c b/winsup/testsuite/cygrun.c
 index d1f53aad3..e8220d0d2 100644
 --- a/winsup/testsuite/cygrun.c
 +++ b/winsup/testsuite/cygrun.c
-@@ -29,8 +29,8 @@ main (int argc, char **argv)
+@@ -29,8 +29,13 @@ main (int argc, char **argv)
        exit (0);
      }
  
--  SetEnvironmentVariable ("CYGWIN_TESTING", "1");
--  if ((p = getenv ("CYGWIN")) == NULL || (strstr (p, "ntsec") == NULL))
++#ifdef __MSYS__
 +  SetEnvironmentVariable ("MSYS_TESTING", "1");
 +  if ((p = getenv ("MSYS")) == NULL || (strstr (p, "ntsec") == NULL))
++#else
+   SetEnvironmentVariable ("CYGWIN_TESTING", "1");
+   if ((p = getenv ("CYGWIN")) == NULL || (strstr (p, "ntsec") == NULL))
++#endif
      {
        char buf[4096];
        if (!p)
-@@ -44,7 +44,7 @@ main (int argc, char **argv)
+@@ -44,7 +49,11 @@ main (int argc, char **argv)
  	  strcat (buf, " ");
  	}
        strcat(buf, "ntsec");
--      SetEnvironmentVariable ("CYGWIN", buf);
++#ifdef __MSYS__
 +      SetEnvironmentVariable ("MSYS", buf);
++#else
+       SetEnvironmentVariable ("CYGWIN", buf);
++#endif
      }
  
    memset (&sa, 0, sizeof (sa));
@@ -1078,49 +1230,79 @@ diff --git a/winsup/testsuite/winsup.api/cygload.cc b/winsup/testsuite/winsup.ap
 index ad4599666..7a398dc62 100644
 --- a/winsup/testsuite/winsup.api/cygload.cc
 +++ b/winsup/testsuite/winsup.api/cygload.cc
+@@ -9,13 +9,13 @@
+    under the GPL unless you purchase a Cygwin Contract with Red Hat, Inc.
+    See http://www.redhat.com/software/cygwin/ for more information.
+ 
+-   cygload demonstrates how to dynamically load cygwin1.dll.  The default
++   cygload demonstrates how to dynamically load cygwin1.dll or "msys-2.0.dll".  The default
+    build uses MinGW to compile it; the Makefile also shows how to build
+    it using the Microsoft compiler.
+ 
+    By default, the program will silently test basic functionality:
+      * Making space on the stack for cygtls
+-     * Loading and initializing cygwin1.dll
++     * Loading and initializing cygwin1.dll or "msys-2.0.dll"
+      * Path translation
+      * Error handling
+      * Signal handling
 @@ -25,7 +25,7 @@
  		     save for errors.
       -testinterrupts Pauses the program for 30 seconds so you can demonstrate
  		     that it handles ^C properly.
 -     -cygwin         Name of DLL to load.  Defaults to "cygwin1.dll". */
-+     -cygwin         Name of DLL to load.  Defaults to "msys-2.0.dll". */
++     -cygwin         Name of DLL to load.  Defaults to "cygwin1.dll" or "msys-2.0.dll". */
  
  #include "cygload.h"
  #include <iostream>
-@@ -136,15 +136,15 @@ cygwin::connector::connector (const char *dll)
+@@ -136,15 +136,23 @@ cygwin::connector::connector (const char *dll)
    if ((_library = LoadLibrary (dll)) == NULL)
      throw windows_error ("LoadLibrary", dll);
  
--  *out << "Initializing cygwin..." << endl;
++#ifdef __MSYS__
 +  *out << "Initializing msys..." << endl;
++#else
+   *out << "Initializing cygwin..." << endl;
++#endif
  
 -  // This calls dcrt0.cc:cygwin_dll_init(), which calls dll_crt0_1(),
-+  // This calls dcrt0.cc:msys_dll_init(), which calls dll_crt0_1(),
-   // which will, among other things:
+-  // which will, among other things:
++  // This calls dcrt0.cc:cygwin_dll_init() or dcrt0.cc:msys_dll_init(),
++  // which calls dll_crt0_1(), which will, among other things:
    // * spawn the cygwin signal handling thread from sigproc_init()
    // * initialize the thread-local storage for this thread and overwrite
    //   the first 4K of the stack
    void (*cyginit) ();
 -  get_symbol ("cygwin_dll_init", cyginit);
++#ifdef __MSYS__
 +  get_symbol ("msys_dll_init", cyginit);
++#else
++   get_symbol ("cygwin_dll_init", cyginit);
++#endif
    (*cyginit) ();
  
    *out << "Loading symbols..." << endl;
-@@ -210,7 +210,7 @@ cygwin::connector::~connector ()
+@@ -210,7 +218,11 @@ cygwin::connector::~connector ()
  
      // This should call init.cc:dll_entry() with DLL_PROCESS_DETACH.
      if (!FreeLibrary (_library))
--      throw windows_error ("FreeLibrary", "cygwin1.dll");
++#ifdef __MSYS__
 +      throw windows_error ("FreeLibrary", "msys-2.0.dll");
++#else
+       throw windows_error ("FreeLibrary", "cygwin1.dll");
++#endif
    }
    catch (std::exception &x)
    {
-@@ -476,7 +476,7 @@ main (int argc, char *argv[])
+@@ -476,7 +488,11 @@ main (int argc, char *argv[])
  
    std::ostringstream output;
    bool verbose = false, testinterrupts = false;
--  const char *dll = "cygwin1.dll";
++#ifdef __MSYS__
 +  const char *dll = "msys-2.0.dll";
++#else
+   const char *dll = "cygwin1.dll";
++#endif
  
    out = &output;
  
@@ -1141,15 +1323,19 @@ diff --git a/winsup/testsuite/winsup.api/cygload.h b/winsup/testsuite/winsup.api
 index 8007fd593..ab4003bd5 100644
 --- a/winsup/testsuite/winsup.api/cygload.h
 +++ b/winsup/testsuite/winsup.api/cygload.h
-@@ -76,7 +76,7 @@ namespace cygwin
+@@ -76,7 +76,11 @@ namespace cygwin
    // spawns a thread to let you receive signals from cygwin.
    class connector {
    public:
--    connector (const char *dll = "cygwin1.dll");
++#ifdef __MSYS__
 +    connector (const char *dll = "msys-2.0.dll");
++#else
+     connector (const char *dll = "cygwin1.dll");
++#endif
      ~connector ();
  
      // A wrapper around GetProcAddress() for fetching symbols from the
+
 diff --git a/winsup/testsuite/winsup.api/winsup.exp b/winsup/testsuite/winsup.api/winsup.exp
 index 639096267..769b7c0c6 100644
 --- a/winsup/testsuite/winsup.api/winsup.exp
@@ -1200,167 +1386,253 @@ diff --git a/winsup/utils/cygcheck.cc b/winsup/utils/cygcheck.cc
 index d5972c0cf..6d6189182 100644
 --- a/winsup/utils/cygcheck.cc
 +++ b/winsup/utils/cygcheck.cc
-@@ -69,8 +69,7 @@ static const char *known_env_vars[] = {
+@@ -69,8 +69,12 @@ static const char *known_env_vars[] = {
    "c_include_path",
    "compiler_path",
    "cxx_include_path",
--  "cygwin",
--  "cygwin32",
++#ifdef __MSYS__
 +  "msys",
++#else
+   "cygwin",
+   "cygwin32",
++#endif
    "dejagnu",
    "expect",
    "gcc_default_options",
-@@ -505,12 +504,12 @@ struct ImpDirectory
+@@ -505,12 +509,20 @@ struct ImpDirectory
  
  static bool track_down (const char *file, const char *suffix, int lvl);
  
--#define CYGPREFIX (sizeof ("%%% Cygwin ") - 1)
++#ifdef __MSYS__
 +#define CYGPREFIX (sizeof ("%%% Msys ") - 1)
++#else
+ #define CYGPREFIX (sizeof ("%%% Cygwin ") - 1)
++#endif
  static void
  cygwin_info (HANDLE h)
  {
    char *buf, *bufend, *buf_start = NULL;
--  const char *hello = "    Cygwin DLL version info:\n";
++#ifdef __MSYS__
 +  const char *hello = "    Msys DLL version info:\n";
++#else
+   const char *hello = "    Cygwin DLL version info:\n";
++#endif
    DWORD size = GetFileSize (h, NULL);
    DWORD n;
  
-@@ -537,7 +536,7 @@ cygwin_info (HANDLE h)
+@@ -537,7 +549,11 @@ cygwin_info (HANDLE h)
    while (buf < bufend)
      if ((buf = (char *) memchr (buf, '%', bufend - buf)) == NULL)
        break;
--    else if (strncmp ("%%% Cygwin ", buf, CYGPREFIX) != 0)
++#ifdef __MSYS__
 +    else if (strncmp ("%%% Msys ", buf, CYGPREFIX) != 0)
++#else
+     else if (strncmp ("%%% Cygwin ", buf, CYGPREFIX) != 0)
++#endif
        buf++;
      else
        {
-@@ -736,7 +735,7 @@ dll_info (const char *path, HANDLE fh, int lvl, int recurse)
+@@ -736,7 +752,11 @@ dll_info (const char *path, HANDLE fh, int lvl, int recurse)
  	    }
  	}
      }
--  if (strstr (path, "\\cygwin1.dll"))
++#ifdef __MSYS__
 +  if (strstr (path, "\\msys-2.0.dll"))
++#else
+   if (strstr (path, "\\cygwin1.dll"))
++#endif
      cygwin_info (fh);
  }
  
-@@ -983,7 +982,7 @@ scan_registry (RegInfo * prev, HKEY hKey, char *name, int cygwin, bool wow64)
+@@ -983,7 +1003,11 @@ scan_registry (RegInfo * prev, HKEY hKey, char *name, int cygwin, bool wow64)
  
    char *cp;
    for (cp = name; *cp; cp++)
--    if (strncasecmp (cp, "Cygwin", 6) == 0)
++#ifdef __MSYS__
 +    if (strncasecmp (cp, "Msys", 4) == 0)
++#else
+     if (strncasecmp (cp, "Cygwin", 6) == 0)
++#endif
        cygwin = 1;
  
    DWORD num_subkeys, max_subkey_len, num_values;
-@@ -1247,7 +1246,7 @@ dump_sysinfo_services ()
+@@ -1159,7 +1183,11 @@ dump_sysinfo_services ()
+   bool no_services = false;
+ 
+   if (givehelp)
++#ifdef __MSYS__
++    printf ("\nChecking for any Msys services... %s\n\n",
++#else
+     printf ("\nChecking for any Cygwin services... %s\n\n",
++#endif
+ 		  verbose ? "" : "(use -v for more detail)");
+   else
+     fputc ('\n', stdout);
+@@ -1247,7 +1275,11 @@ dump_sysinfo_services ()
  
    /* inform the user if nothing found */
    if (no_services)
--    puts ("No Cygwin services found.\n");
++#ifdef __MSYS__
 +    puts ("No Msys services found.\n");
++#else
+     puts ("No Cygwin services found.\n");
++#endif
  }
  
  enum handle_reg_t
-@@ -1262,10 +1261,10 @@ handle_reg_installation (handle_reg_t what)
+@@ -1262,10 +1294,18 @@ handle_reg_installation (handle_reg_t what)
    HKEY key;
  
    if (what == PRINT_KEY)
--    printf ("Cygwin installations found in the registry:\n");
++#ifdef __MSYS__
 +    printf ("Msys installations found in the registry:\n");
++#else
+     printf ("Cygwin installations found in the registry:\n");
++#endif
    for (int i = 0; i < 2; ++i)
      if (RegOpenKeyEx (i ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE,
--		      "SOFTWARE\\Cygwin\\Installations", 0,
++#ifdef __MSYS__
 +		      "SOFTWARE\\Msys\\Installations", 0,
++#else
+ 		      "SOFTWARE\\Cygwin\\Installations", 0,
++#endif
  		      what == DELETE_KEY ? KEY_READ | KEY_WRITE : KEY_READ,
  		      &key)
  	== ERROR_SUCCESS)
-@@ -1287,7 +1286,7 @@ handle_reg_installation (handle_reg_t what)
+@@ -1287,7 +1327,11 @@ handle_reg_installation (handle_reg_t what)
  	      if (what == PRINT_KEY)
  		printf ("  %s Key: %s Path: %s", i ? "User:  " : "System:",
  			name, path);
--	      strcat (path, "\\bin\\cygwin1.dll");
++#ifdef __MSYS__
 +	      strcat (path, "\\bin\\msys-2.0.dll");
++#else
+ 	      strcat (path, "\\bin\\cygwin1.dll");
++#endif
  	      if (what == PRINT_KEY)
  		printf ("%s\n", access (path, F_OK) ? " (ORPHANED)" : "");
  	      else if (access (path, F_OK))
-@@ -1361,7 +1360,7 @@ dump_sysinfo ()
+@@ -1361,7 +1405,11 @@ dump_sysinfo ()
        _wputenv (comspec);
      }
  
--  printf ("\nCygwin Configuration Diagnostics\n");
-+  printf ("\nMsys Configuration Diagnostics\n");
++#ifdef __MSYS__
++    printf ("\nMsys Configuration Diagnostics\n");
++#else
+   printf ("\nCygwin Configuration Diagnostics\n");
++#endif
    time (&now);
    printf ("Current System Time: %s\n", ctime (&now));
  
-@@ -1640,7 +1639,7 @@ dump_sysinfo ()
+@@ -1640,7 +1688,11 @@ dump_sysinfo ()
  
  
    if (givehelp)
--    printf ("Here's some environment variables that may affect cygwin:\n");
++#ifdef __MSYS__
 +    printf ("Here's some environment variables that may affect msys:\n");
++#else
+     printf ("Here's some environment variables that may affect cygwin:\n");
++#endif
    for (i = 0; environ[i]; i++)
      {
        char *eq = strchr (environ[i], '=');
-@@ -1690,7 +1689,7 @@ dump_sysinfo ()
+@@ -1662,7 +1714,11 @@ dump_sysinfo ()
+   if (verbose)
+     {
+       if (givehelp)
++#ifdef __MSYS__
++        printf ("Scanning registry for keys with 'Msys' in them...\n");
++#else
+ 	printf ("Here's the rest of your environment variables:\n");
++#endif
+       for (i = 0; environ[i]; i++)
+ 	{
+ 	  int found = 0;
+@@ -1690,7 +1746,11 @@ dump_sysinfo ()
    if (registry)
      {
        if (givehelp)
--	printf ("Scanning registry for keys with 'Cygwin' in them...\n");
-+	printf ("Scanning registry for keys with 'Msys' in them...\n");
++#ifdef __MSYS__
++        printf ("Looking for various Msys DLLs...  (-v gives version info)\n");
++#else
+ 	printf ("Scanning registry for keys with 'Cygwin' in them...\n");
++#endif
        scan_registry (0, HKEY_CURRENT_USER,
  		     (char *) "HKEY_CURRENT_USER", 0, false);
        scan_registry (0, HKEY_LOCAL_MACHINE,
-@@ -1868,7 +1867,7 @@ dump_sysinfo ()
+@@ -1868,7 +1928,11 @@ dump_sysinfo ()
    printf ("\n");
  
    if (givehelp)
--    printf ("Looking for various Cygwin DLLs...  (-v gives version info)\n");
++#ifdef __MSYS__
 +    printf ("Looking for various Msys DLLs...  (-v gives version info)\n");
++#else
+     printf ("Looking for various Cygwin DLLs...  (-v gives version info)\n");
++#endif
    int cygwin_dll_count = 0;
    char cygdll_path[32768];
    for (pathlike *pth = paths; pth->dir; pth++)
-@@ -1885,10 +1884,10 @@ dump_sysinfo ()
+@@ -1883,12 +1947,22 @@ dump_sysinfo ()
+ 	{
+ 	  char f[FILENAME_MAX + 1];
  	  wcstombs (f, ffinfo.cFileName, sizeof f);
++#ifdef __MSYS__
++	  if (strcasecmp (f + strlen (f) - 6, ".dll") == 0)
++	    {
++              if (strncasecmp (f, "msys-", 5) == 0)
++#else
  	  if (strcasecmp (f + strlen (f) - 4, ".dll") == 0)
  	    {
--	      if (strncasecmp (f, "cyg", 3) == 0)
-+	      if (strncasecmp (f, "msys-", 5) == 0)
+ 	      if (strncasecmp (f, "cyg", 3) == 0)
++#endif
  		{
  		  sprintf (tmp, "%s%s", pth->dir, f);
--		  if (strcasecmp (f, "cygwin1.dll") == 0)
-+		  if (strcasecmp (f, "msys-2.0.dll") == 0)
++#ifdef __MSYS__
++                  if (strcasecmp (f, "msys-2.0.dll") == 0)
++#else
+ 		  if (strcasecmp (f, "cygwin1.dll") == 0)
++#endif
  		    {
  		      if (!cygwin_dll_count)
  			strcpy (cygdll_path, pth->dir);
-@@ -1912,9 +1911,9 @@ dump_sysinfo ()
+@@ -1912,9 +1986,15 @@ dump_sysinfo ()
        FindClose (ff);
      }
    if (cygwin_dll_count > 1)
--    puts ("Warning: There are multiple cygwin1.dlls on your path");
++#ifdef __MSYS__
 +    puts ("Warning: There are multiple msys-2.0.dlls on your path");
-   if (!cygwin_dll_count)
--    puts ("Warning: cygwin1.dll not found on your path");
++  if (!cygwin_dll_count)
 +    puts ("Warning: msys-2.0.dll not found on your path");
++#else
+     puts ("Warning: There are multiple cygwin1.dlls on your path");
+   if (!cygwin_dll_count)
+     puts ("Warning: cygwin1.dll not found on your path");
++#endif
  
    dump_dodgy_apps (verbose);
  
-@@ -2161,8 +2160,8 @@ static char opts[] = "cdsrvkflphV";
+@@ -2161,8 +2241,13 @@ static char opts[] = "cdsrvkflphV";
  static void
  print_version ()
  {
--  printf ("cygcheck (cygwin) %d.%d.%d\n"
--	  "System Checker for Cygwin\n"
++#ifdef __MSYS__
 +  printf ("cygcheck (msys) %d.%d.%d\n"
 +	  "System Checker for Msys\n"
++#else
+   printf ("cygcheck (cygwin) %d.%d.%d\n"
+ 	  "System Checker for Cygwin\n"
++#endif
  	  "Copyright (C) 1998 - %s Cygwin Authors\n"
  	  "This is free software; see the source for copying conditions.  "
  	  "There is NO\n"
-@@ -2194,7 +2193,7 @@ load_cygwin (int& argc, char **&argv)
+@@ -2194,7 +2279,11 @@ load_cygwin (int& argc, char **&argv)
  {
    HMODULE h;
  
--  if (!(h = LoadLibrary ("cygwin1.dll")))
++#ifdef __MSYS__
 +  if (!(h = LoadLibrary ("msys-2.0.dll")))
++#else
+   if (!(h = LoadLibrary ("cygwin1.dll")))
++#endif
      return;
    GetModuleFileNameW (h, cygwin_dll_path, 32768);
    if ((cygwin_internal = (uintptr_t (*) (int, ...))
@@ -1368,12 +1640,15 @@ diff --git a/winsup/utils/ldd.cc b/winsup/utils/ldd.cc
 index bbc62f12f..82b9c0238 100644
 --- a/winsup/utils/ldd.cc
 +++ b/winsup/utils/ldd.cc
-@@ -246,7 +246,7 @@ tocyg (wchar_t *win_fn)
+@@ -246,7 +246,11 @@ tocyg (wchar_t *win_fn)
    return fn;
  }
  
--#define CYGWIN_DLL_LEN (wcslen (L"\\cygwin1.dll"))
++#ifdef __MSYS__
 +#define CYGWIN_DLL_LEN (wcslen (L"\\msys-2.0.dll"))
++#else
+ #define CYGWIN_DLL_LEN (wcslen (L"\\cygwin1.dll"))
++#endif
  static int
  print_dlls (dlls *dll, const wchar_t *dllfn, const wchar_t *process_fn)
  {
@@ -1386,18 +1661,21 @@ index c83b76478..42ffbfdc0 100644
  
  /* Load all system libs from the windows system directory by prepending the
 -   full path.  This doesn't work for loadling cygwin1.dll.  For this case,
-+   full path.  This doesn't work for loadling msys-2.0.dll.  For this case,
++   full path.  This doesn't work for loadling cygwin1.dll and msys-2.0.dll.  For this case,
     instead of prepending the path, make sure that the CWD is removed from
     the DLL search path, if possible (XP SP1++, Vista++). */
  static HMODULE _load_sys_library (const wchar_t *dll) __attribute__ ((used));
-@@ -45,8 +45,8 @@ _load_sys_library (const wchar_t *dll)
+@@ -45,8 +45,13 @@ _load_sys_library (const wchar_t *dll)
        	set_dll_directory (L"");
      }
  
--  if (wcscmp (dll, L"cygwin1.dll") == 0)
--    return LoadLibraryExW (L"cygwin1.dll", NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
++#ifdef __MSYS__
 +  if (wcscmp (dll, L"msys-2.0.dll") == 0)
 +    return LoadLibraryExW (L"msys-2.0.dll", NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
++#else
+   if (wcscmp (dll, L"cygwin1.dll") == 0)
+     return LoadLibraryExW (L"cygwin1.dll", NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
++#endif
  
    wcscpy (dllpath, sysdir);
    wcscpy (dllpath + sysdir_len, dll);
@@ -1410,105 +1688,185 @@ index 17ea3524d..d0d4cab83 100644
    max_mount_entry = 0;
  
 -  /* First fetch the cygwin1.dll path from the LoadLibrary call in load_cygwin.
--     This utilizes the DLL search order to find a matching cygwin1.dll and to
-+  /* First fetch the msys-2.0.dll path from the LoadLibrary call in load_cygwin.
-+     This utilizes the DLL search order to find a matching msys-2.0.dll and to
++  /* First fetch the cygwin1.dll or msys-2.0.dllpath from the LoadLibrary call in load_cygwin.
+      This utilizes the DLL search order to find a matching cygwin1.dll and to
       compute the installation path from that DLL's path. */
    if (cygwin_dll_path[0])
      wcscpy (path, cygwin_dll_path);
 -  /* If we can't load cygwin1.dll, check where cygcheck is living itself and
 -     try to fetch installation path from here.  Does cygwin1.dll exist in the
 -     same path?  This should only kick in if the cygwin1.dll in the same path
-+  /* If we can't load msys-2.0.dll, check where cygcheck is living itself and
-+     try to fetch installation path from here.  Does msys-2.0.dll exist in the
-+     same path?  This should only kick in if the msys-2.0.dll in the same path
++  /* If we can't load cygwin1.dll or msys-2.0.dll, check where cygcheck is living itself and
++     try to fetch installation path from here.  Does cygwin1.dll or msys-2.0.dll exist in the
++     same path?  This should only kick in if the cygwin1.dll or msys-2.0.dllin the same path
       has been made non-executable for the current user accidentally. */
    else if (!GetModuleFileNameW (NULL, path, 32768))
      return;
-@@ -614,7 +614,7 @@ read_mounts ()
+@@ -614,7 +614,11 @@ read_mounts ()
      {
        if (!cygwin_dll_path[0])
  	{
--	  wcscpy (path_end, L"\\cygwin1.dll");
++#ifdef __MSYS__
 +	  wcscpy (path_end, L"\\msys-2.0.dll");
++#else
+ 	  wcscpy (path_end, L"\\cygwin1.dll");
++#endif
  	  DWORD attr = GetFileAttributesW (path);
  	  if (attr == (DWORD) -1
  	      || (attr & (FILE_ATTRIBUTE_DIRECTORY
+@@ -633,7 +637,11 @@ read_mounts ()
+     {
+       for (int i = 0; i < 2; ++i)
+ 	if ((ret = RegOpenKeyExW (i ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER,
++#ifdef __MSYS__
++				  L"Software\\Msys\\setup", 0,
++#else
+ 				  L"Software\\Cygwin\\setup", 0,
++#endif
+ 				  KEY_READ, &setup_key)) == ERROR_SUCCESS)
+ 	  {
+ 	    len = 32768 * sizeof (WCHAR);
 diff --git a/winsup/utils/ssp.c b/winsup/utils/ssp.c
 index 548b89ac8..09ee26d01 100644
 --- a/winsup/utils/ssp.c
 +++ b/winsup/utils/ssp.c
-@@ -718,15 +718,15 @@ usage (FILE * stream)
+@@ -713,20 +713,40 @@ usage (FILE * stream)
+     "the profiling program \"gprof\", although gprof will claim the values\n"
+     "are seconds, they really are instruction counts.  More on that later.\n"
+     "\n"
+-    "Because the SSP was originally designed to profile the cygwin DLL, it\n"
++    "Because the SSP was originally designed to profile the "
++#ifdef __MSYS__
++"Msys"
++#else
++"cygwin"
++#endif
++" DLL, it\n"
+     "does not automatically select a block of code to report statistics on.\n"
      "You must specify the range of memory addresses to keep track of\n"
      "manually, but it's not hard to figure out what to specify.  Use the\n"
      "\"objdump\" program to determine the bounds of the target's \".text\"\n"
 -    "section.  Let's say we're profiling cygwin1.dll.  Make sure you've\n"
-+    "section.  Let's say we're profiling msys-2.0.dll.  Make sure you've\n"
++    "section.  Let's say we're profiling "
++#ifdef __MSYS__
++"msys-2.0.dll"
++#else
++"cygwin1.dll"
++#endif
++".  Make sure you've\n"
      "built it with debug symbols (else gprof won't run) and run objdump\n"
      "like this:\n"
      "\n"
--    "	objdump -h cygwin1.dll\n"
++#ifdef __MSYS__
 +    "	objdump -h msys-2.0.dll\n"
++#else
+     "	objdump -h cygwin1.dll\n"
++#endif
      "\n"
      "It will print a report like this:\n"
      "\n"
--    "cygwin1.dll:     file format pei-i386\n"
-+    "msys-2.0.dll:     file format pei-i386\n"
++#ifdef __MSYS__
++    "msys-2.0.dll:    file format pei-i386\n"
++#else
+     "cygwin1.dll:     file format pei-i386\n"
++#endif
      "\n"
      "Sections:\n"
      "Idx Name          Size      VMA       LMA       File off  Algn\n"
-@@ -757,7 +757,7 @@ usage (FILE * stream)
+@@ -757,7 +777,11 @@ usage (FILE * stream)
      "\"gmon.out\".  You can turn this data file into a readable report with\n"
      "gprof:\n"
      "\n"
--    "	gprof -b cygwin1.dll\n"
++#ifdef __MSYS__
 +    "	gprof -b msys-2.0.dll\n"
++#else
+     "	gprof -b cygwin1.dll\n"
++#endif
      "\n"
      "The \"-b\" means 'skip the help pages'.  You can omit this until you're\n"
      "familiar with the report layout.  The gprof documentation explains\n"
+@@ -840,7 +864,11 @@ usage (FILE * stream)
+ static void
+ print_version ()
+ {
++#ifdef __MSYS__
++  printf ("ssp (msys) %d.%d.%d\n"
++#else
+   printf ("ssp (cygwin) %d.%d.%d\n"
++#endif
+ 	  "Single-Step Profiler\n"
+ 	  "Copyright (C) 2000 - %s Cygwin Authors\n"
+ 	  "This is free software; see the source for copying conditions.  There is NO\n"
 diff --git a/winsup/utils/strace.cc b/winsup/utils/strace.cc
 index 21c0835d4..bf507981a 100644
 --- a/winsup/utils/strace.cc
 +++ b/winsup/utils/strace.cc
-@@ -283,7 +283,7 @@ load_cygwin ()
+@@ -283,7 +283,11 @@ load_cygwin ()
    if (h)
      return 0;
  
--  if (!(h = LoadLibrary ("cygwin1.dll")))
++#ifdef __MSYS__
 +  if (!(h = LoadLibrary ("msys-2.0.dll")))
++#else
+   if (!(h = LoadLibrary ("cygwin1.dll")))
++#endif
      {
        errno = ENOENT;
        return 0;
-@@ -353,17 +353,16 @@ create_child (char **argv)
-   make_command_line (one_line, argv);
+@@ -354,16 +358,26 @@ create_child (char **argv)
  
    SetConsoleCtrlHandler (NULL, 0);
--
--  const char *cygwin_env = getenv ("CYGWIN");
+ 
++#ifdef __MSYS__
 +  const char *cygwin_env = getenv ("MSYS");
++#else
+   const char *cygwin_env = getenv ("CYGWIN");
++#endif
    const char *space;
  
    if (cygwin_env && strlen (cygwin_env) <= 256) /* sanity check */
      space = " ";
    else
      space = cygwin_env = "";
--  char *newenv = (char *) malloc (sizeof ("CYGWIN=noglob")
++#ifdef __MSYS__
 +  char *newenv = (char *) malloc (sizeof ("MSYS=noglob")
- 				  + strlen (space) + strlen (cygwin_env));
--  sprintf (newenv, "CYGWIN=noglob%s%s", space, cygwin_env);
++				  + strlen (space) + strlen (cygwin_env));
 +  sprintf (newenv, "MSYS=noglob%s%s", space, cygwin_env);
++#else
+   char *newenv = (char *) malloc (sizeof ("CYGWIN=noglob")
+ 				  + strlen (space) + strlen (cygwin_env));
+   sprintf (newenv, "CYGWIN=noglob%s%s", space, cygwin_env);
++#endif
    _putenv (newenv);
    ret = CreateProcess (0, one_line.buf,	/* command line */
  		       NULL,	/* Security */
-@@ -794,7 +793,7 @@ dotoggle (pid_t pid)
+@@ -794,7 +808,11 @@ dotoggle (pid_t pid)
    child_pid = (DWORD) cygwin_internal (CW_CYGWIN_PID_TO_WINPID, pid);
    if (!child_pid)
      {
--      warn (0, "no such cygwin pid - %d", pid);
-+      warn (0, "no such msys pid - %d", pid);
++#ifdef __MSYS__
++      warn (0, "no such Msys pid - %d", pid);
++#else
+       warn (0, "no such cygwin pid - %d", pid);
++#endif
        child_pid = pid;
      }
    if (cygwin_internal (CW_STRACE_TOGGLE, child_pid))
+@@ -952,7 +970,13 @@ Trace system calls and signals\n\
+   -n, --crack-error-numbers    output descriptive text instead of error\n\
+ 			       numbers for Windows errors\n\
+   -o, --output=FILENAME        set output file to FILENAME\n\
+-  -p, --pid=n                  attach to executing program with cygwin pid n\n\
++  -p, --pid=n                  attach to executing program with "
++#ifdef __MSYS__
++"Msys"
++#else
++"cygwin"
++#endif
++" pid n\n\
+   -q, --quiet                  suppress messages about attaching, detaching, etc.\n\
+   -S, --flush-period=PERIOD    flush buffered strace output every PERIOD secs\n\
+   -t, --timestamp              use an absolute hh:mm:ss timestamp insted of \n\
 -- 
 2.18.0
 

--- a/msys2-runtime/0003-Add-functionality-for-converting-UNIX-paths-in-argum.patch
+++ b/msys2-runtime/0003-Add-functionality-for-converting-UNIX-paths-in-argum.patch
@@ -36,16 +36,20 @@ diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
 index 67ead1dde..851922d37 100644
 --- a/winsup/cygwin/environ.cc
 +++ b/winsup/cygwin/environ.cc
-@@ -1043,7 +1043,7 @@ env_compare (const void *key, const void *memb)
+@@ -1053,7 +1053,11 @@ env_compare (const void *key, const void *memb)
     to the child. */
  char ** __reg3
  build_env (const char * const *envp, PWCHAR &envblock, int &envc,
 -	   bool no_envblock, HANDLE new_token)
-+	   bool no_envblock, HANDLE new_token, bool keep_posix)
++	   bool no_envblock, HANDLE new_token
++#ifdef __MSYS__
++, bool keep_posix
++#endif
++)
  {
    PWCHAR cwinenv = NULL;
    size_t winnum = 0;
-@@ -1136,6 +1136,11 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
+@@ -1146,6 +1150,11 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
    for (srcp = envp, dstp = newenv, pass_dstp = pass_env; *srcp; srcp++)
      {
        bool calc_tl = !no_envblock;
@@ -82,10 +86,10 @@ index 269591a01..71c3f2208 100644
  #endif
  char ** __reg3 build_env (const char * const *envp, PWCHAR &envblock,
 -			  int &envc, bool need_envblock, HANDLE new_token);
-+			  int &envc, bool need_envblock, HANDLE new_token, bool keep_posix);
- 
++                         int &envc, bool need_envblock, HANDLE new_token, bool keep_posix);
+
  char ** __reg2 win32env_to_cygenv (PWCHAR rawenv, bool posify);
- 
+
 diff --git a/winsup/cygwin/external.cc b/winsup/cygwin/external.cc
 index 3a9130efd..6592eb394 100644
 --- a/winsup/cygwin/external.cc
@@ -124,11 +128,11 @@ index 000000000..74ebd2e0b
 @@ -0,0 +1,619 @@
 +/*
 +  The MSYS2 Path conversion source code is licensed under:
-+  
++
 +  CC0 1.0 Universal
-+  
++
 +  Official translations of this legal tool are available
-+  
++
 +  CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
 +  LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
 +  ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
@@ -137,14 +141,14 @@ index 000000000..74ebd2e0b
 +  PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
 +  THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
 +  HEREUNDER.
-+  
++
 +  Statement of Purpose
-+  
++
 +  The laws of most jurisdictions throughout the world automatically
 +  confer exclusive Copyright and Related Rights (defined below) upon the
 +  creator and subsequent owner(s) (each and all, an "owner") of an
 +  original work of authorship and/or a database (each, a "Work").
-+  
++
 +  Certain owners wish to permanently relinquish those rights to a Work
 +  for the purpose of contributing to a commons of creative, cultural and
 +  scientific works ("Commons") that the public can reliably and without
@@ -156,7 +160,7 @@ index 000000000..74ebd2e0b
 +  creative, cultural and scientific works, or to gain reputation or
 +  greater distribution for their Work in part through the use and
 +  efforts of others.
-+  
++
 +  For these and/or other purposes and motivations, and without any
 +  expectation of additional consideration or compensation, the person
 +  associating CC0 with a Work (the "Affirmer"), to the extent that he or
@@ -165,12 +169,12 @@ index 000000000..74ebd2e0b
 +  the Work under its terms, with knowledge of his or her Copyright and
 +  Related Rights in the Work and the meaning and intended legal effect
 +  of CC0 on those rights.
-+  
++
 +  1. Copyright and Related Rights. A Work made available under CC0 may
 +  be protected by copyright and related or neighboring rights
 +  ("Copyright and Related Rights"). Copyright and Related Rights
 +  include, but are not limited to, the following:
-+  
++
 +  the right to reproduce, adapt, distribute, perform, display,
 +  communicate, and translate a Work;
 +  moral rights retained by the original author(s) and/or performer(s);
@@ -188,7 +192,7 @@ index 000000000..74ebd2e0b
 +  other similar, equivalent or corresponding rights throughout the world
 +  based on applicable law or treaty, and any national implementations
 +  thereof.
-+  
++
 +  2. Waiver. To the greatest extent permitted by, but not in
 +  contravention of, applicable law, Affirmer hereby overtly, fully,
 +  permanently, irrevocably and unconditionally waives, abandons, and
@@ -206,7 +210,7 @@ index 000000000..74ebd2e0b
 +  revocation, rescission, cancellation, termination, or any other legal
 +  or equitable action to disrupt the quiet enjoyment of the Work by the
 +  public as contemplated by Affirmer's express Statement of Purpose.
-+  
++
 +  3. Public License Fallback. Should any part of the Waiver for any
 +  reason be judged legally invalid or ineffective under applicable law,
 +  then the Waiver shall be preserved to the maximum extent permitted
@@ -229,9 +233,9 @@ index 000000000..74ebd2e0b
 +  the Work or (ii) assert any associated claims and causes of action
 +  with respect to the Work, in either case contrary to Affirmer's
 +  express Statement of Purpose.
-+  
++
 +  4. Limitations and Disclaimers.
-+  
++
 +  No trademark or patent rights held by Affirmer are waived, abandoned,
 +  surrendered, licensed or otherwise affected by this document.
 +  Affirmer offers the Work as-is and makes no representations or
@@ -256,7 +260,7 @@ index 000000000..74ebd2e0b
 +    Ely Arzhannikov <iarzhannikov@gmail.com>
 +    Alexey Pavlov <alexpux@gmail.com>
 +    Ray Donnelly <mingw.android@gmail.com>
-+  
++
 +*/
 +
 +#include "winsup.h"
@@ -749,11 +753,11 @@ index 000000000..e1e5e8781
 @@ -0,0 +1,146 @@
 +/*
 +  The MSYS2 Path conversion source code is licensed under:
-+  
++
 +  CC0 1.0 Universal
-+  
++
 +  Official translations of this legal tool are available
-+  
++
 +  CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
 +  LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
 +  ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
@@ -762,14 +766,14 @@ index 000000000..e1e5e8781
 +  PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
 +  THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
 +  HEREUNDER.
-+  
++
 +  Statement of Purpose
-+  
++
 +  The laws of most jurisdictions throughout the world automatically
 +  confer exclusive Copyright and Related Rights (defined below) upon the
 +  creator and subsequent owner(s) (each and all, an "owner") of an
 +  original work of authorship and/or a database (each, a "Work").
-+  
++
 +  Certain owners wish to permanently relinquish those rights to a Work
 +  for the purpose of contributing to a commons of creative, cultural and
 +  scientific works ("Commons") that the public can reliably and without
@@ -781,7 +785,7 @@ index 000000000..e1e5e8781
 +  creative, cultural and scientific works, or to gain reputation or
 +  greater distribution for their Work in part through the use and
 +  efforts of others.
-+  
++
 +  For these and/or other purposes and motivations, and without any
 +  expectation of additional consideration or compensation, the person
 +  associating CC0 with a Work (the "Affirmer"), to the extent that he or
@@ -790,12 +794,12 @@ index 000000000..e1e5e8781
 +  the Work under its terms, with knowledge of his or her Copyright and
 +  Related Rights in the Work and the meaning and intended legal effect
 +  of CC0 on those rights.
-+  
++
 +  1. Copyright and Related Rights. A Work made available under CC0 may
 +  be protected by copyright and related or neighboring rights
 +  ("Copyright and Related Rights"). Copyright and Related Rights
 +  include, but are not limited to, the following:
-+  
++
 +  the right to reproduce, adapt, distribute, perform, display,
 +  communicate, and translate a Work;
 +  moral rights retained by the original author(s) and/or performer(s);
@@ -813,7 +817,7 @@ index 000000000..e1e5e8781
 +  other similar, equivalent or corresponding rights throughout the world
 +  based on applicable law or treaty, and any national implementations
 +  thereof.
-+  
++
 +  2. Waiver. To the greatest extent permitted by, but not in
 +  contravention of, applicable law, Affirmer hereby overtly, fully,
 +  permanently, irrevocably and unconditionally waives, abandons, and
@@ -831,7 +835,7 @@ index 000000000..e1e5e8781
 +  revocation, rescission, cancellation, termination, or any other legal
 +  or equitable action to disrupt the quiet enjoyment of the Work by the
 +  public as contemplated by Affirmer's express Statement of Purpose.
-+  
++
 +  3. Public License Fallback. Should any part of the Waiver for any
 +  reason be judged legally invalid or ineffective under applicable law,
 +  then the Waiver shall be preserved to the maximum extent permitted
@@ -854,9 +858,9 @@ index 000000000..e1e5e8781
 +  the Work or (ii) assert any associated claims and causes of action
 +  with respect to the Work, in either case contrary to Affirmer's
 +  express Statement of Purpose.
-+  
++
 +  4. Limitations and Disclaimers.
-+  
++
 +  No trademark or patent rights held by Affirmer are waived, abandoned,
 +  surrendered, licensed or otherwise affected by this document.
 +  Affirmer offers the Work as-is and makes no representations or
@@ -881,7 +885,7 @@ index 000000000..e1e5e8781
 +    Ely Arzhannikov <iarzhannikov@gmail.com>
 +    Alexey Pavlov <alexpux@gmail.com>
 +    Ray Donnelly <mingw.android@gmail.com>
-+  
++
 +*/
 +
 +#ifndef PATH_CONV_H_DB4IQBH3
@@ -920,7 +924,7 @@ index 6d8f76db5..cd544e0d8 100644
 +
 +  // Must return something ..
 +  size_t arglen = (arg ? strlen (arg): 0);
-+  
++
 +  if (arglen == 0 || !arg)
 +  {
 +    arg_result = (char *)malloc (sizeof (char));
@@ -973,16 +977,17 @@ index 6d8f76db5..cd544e0d8 100644
 +
 +
  /******************** Exported Path Routines *********************/
- 
+
  /* Cover functions to the path conversion routines.
 diff --git a/winsup/cygwin/spawn.cc b/winsup/cygwin/spawn.cc
 index 37db52608..d94167507 100644
 --- a/winsup/cygwin/spawn.cc
 +++ b/winsup/cygwin/spawn.cc
-@@ -261,6 +261,27 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
-   pid_t cygpid;
+@@ -260,6 +260,29 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
+   bool rc;
    int res = -1;
- 
+
++#ifdef __MSYS__
 +  /* Environment variable MSYS2_ARG_CONV_EXCL contains a list
 +     of ';' separated argument prefixes to pass un-modified..
 +     It isn't applied to env. variables; only spawn arguments.
@@ -1003,49 +1008,60 @@ index 37db52608..d94167507 100644
 +          msys2_arg_conv_excl_env = strchr ( msys2_arg_conv_excl_env + 1, ';' );
 +        }
 +    }
++#endif
 +
    /* Check if we have been called from exec{lv}p or spawn{lv}p and mask
       mode to keep only the spawn mode. */
    bool p_type_exec = !!(mode & _P_PATH_TYPE_EXEC);
-@@ -370,12 +391,26 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
+@@ -369,6 +392,29 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
  	      moreinfo->argc = newargv.argc;
  	      moreinfo->argv = newargv;
  	    }
--	  if ((wincmdln || !real_path.iscygexec ())
--	       && !cmd.fromargv (newargv, real_path.get_win32 (),
--				 real_path.iscygexec ()))
++#ifdef __MSYS__
 +	  else
- 	    {
--	      res = -1;
--	      __leave;
++            {
 +	      for (int i = 0; i < newargv.argc; i++)
-+	        {
++                {
 +	          //convert argv to win32
-+	          int newargvlen = strlen (newargv[i]);
-+	          char *tmpbuf = (char *)malloc (newargvlen + 1);
-+	          memcpy (tmpbuf, newargv[i], newargvlen + 1);
-+	          tmpbuf = arg_heuristic_with_exclusions(tmpbuf, msys2_arg_conv_excl, msys2_arg_conv_excl_count);
-+	          debug_printf("newargv[%d] = %s", i, newargv[i]);
-+	          newargv.replace (i, tmpbuf);
-+	          free (tmpbuf);
-+	        }
-+	      if ((wincmdln || !real_path.iscygexec ())
-+	            && !cmd.fromargv (newargv, real_path.get_win32 (),
++                  int newargvlen = strlen (newargv[i]);
++                  char *tmpbuf = (char *)malloc (newargvlen + 1);
++                  memcpy (tmpbuf, newargv[i], newargvlen + 1);
++                  tmpbuf = arg_heuristic_with_exclusions(tmpbuf, msys2_arg_conv_excl, msys2_arg_conv_excl_count);
++                  debug_printf("newargv[%d] = %s", i, newargv[i]);
++                  newargv.replace (i, tmpbuf);
++                  free (tmpbuf);
++                }
++              if ((wincmdln || !real_path.iscygexec ())
++                    && !cmd.fromargv (newargv, real_path.get_win32 (),
 +			        real_path.iscygexec ()))
-+	        {
-+	          res = -1;
-+	          __leave;
-+	        }
++                {
++                  res = -1;
++                  __leave;
++                }
++           }
++#else
+ 	  if ((wincmdln || !real_path.iscygexec ())
+ 	       && !cmd.fromargv (newargv, real_path.get_win32 (),
+ 				 real_path.iscygexec ()))
+@@ -376,7 +422,7 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
+ 	      res = -1;
+ 	      __leave;
  	    }
+-
++#endif
  
- 
-@@ -507,7 +542,8 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
+ 	  if (mode != _P_OVERLAY || !real_path.iscygexec ()
+ 	      || !DuplicateHandle (GetCurrentProcess (), myself.shared_handle (),
+@@ -506,7 +552,12 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
        moreinfo->envp = build_env (envp, envblock, moreinfo->envc,
  				  real_path.iscygexec (),
  				  switch_user ? ::cygheap->user.primary_token ()
--					      : NULL);
-+					      : NULL,
++#ifdef __MSYS__
++                                              : NULL,
 +				  real_path.iscygexec ());
++#else
+ 					      : NULL);
++#endif
        if (!moreinfo->envp || !envblock)
  	{
  	  set_errno (E2BIG);
@@ -1064,6 +1080,6 @@ index e3a65f8cc..1aeec8d9c 100644
    void dup_all ()
    {
      for (int i = calloced; i < argc; i++)
--- 
+--
 2.18.0
 

--- a/msys2-runtime/0004-Add-functionality-for-changing-OS-name-via-MSYSTEM-e.patch
+++ b/msys2-runtime/0004-Add-functionality-for-changing-OS-name-via-MSYSTEM-e.patch
@@ -42,7 +42,7 @@ index 851922d37..06aff56dd 100644
  	{
  	  debug_printf ("%s", newbuf + 1);
 +#ifdef __MSYS__
-+	  setenv ("MSYS", newbuf + 1, 1);
++          setenv ("MSYS", newbuf + 1, 1);
 +#else
  	  setenv ("CYGWIN", newbuf + 1, 1);
 +#endif
@@ -63,7 +63,7 @@ index 851922d37..06aff56dd 100644
  	{ NL("COMMONPROGRAMFILES=") },		// 0
  	{ NL("COMSPEC=") },
 +#ifdef __MSYS__
-+	{ NL("MSYSTEM=") },			// 2
++       { NL("MSYSTEM=") },			// 2
 +#endif /* __MSYS__ */
  	{ NL("PATH=") },			// 2
  	{ NL("PROGRAMFILES=") },
@@ -73,20 +73,20 @@ index 851922d37..06aff56dd 100644
  
  /* Set of first characters of the above list of variables. */
 -static const char idx_arr[] = "CPSTW";
-+static const char idx_arr[] = 
++static const char idx_arr[] =
 +#ifdef __MSYS__
-+	"CMPSTW";
++       "CMPSTW";
 +#else
-+	"CPSTW";
++       "CPSTW";
 +#endif
  /* Index into renv_arr at which the variables with this specific character
     starts. */
 -static const int start_at[] = { 0, 2, 4, 6, 8 };
 +static const int start_at[] = {
-+#ifdef __MSYS__ 
-+				0, 2, 3, 5, 7, 9
++#ifdef __MSYS__
++                               0, 2, 3, 5, 7, 9
 +#else
-+				0, 2, 4, 6, 8
++                               0, 2, 4, 6, 8
 +#endif
 +								};
  
@@ -133,19 +133,6 @@ index 851922d37..06aff56dd 100644
    {NL ("SYSTEMDRIVE="), false, true, NULL},
    {NL ("SYSTEMROOT="), true, true, &cygheap_user::env_systemroot},
    {NL ("USERDOMAIN="), false, false, &cygheap_user::env_domain},
-diff --git a/winsup/cygwin/include/sys/utsname.h b/winsup/cygwin/include/sys/utsname.h
-index e9dd019df..670cd2ead 100644
---- a/winsup/cygwin/include/sys/utsname.h
-+++ b/winsup/cygwin/include/sys/utsname.h
-@@ -15,7 +15,7 @@ extern "C" {
- 
- struct utsname
- {
--  char sysname[20];
-+  char sysname[21];
-   char nodename[20];
-   char release[20];
-   char version[20];
 diff --git a/winsup/cygwin/uname.cc b/winsup/cygwin/uname.cc
 index 778ca5738..cd5362b8a 100644
 --- a/winsup/cygwin/uname.cc

--- a/msys2-runtime/0005-Move-root-to-usr.-Change-sorting-mount-points.-Do-no.patch
+++ b/msys2-runtime/0005-Move-root-to-usr.-Change-sorting-mount-points.-Do-no.patch
@@ -6,21 +6,33 @@ Subject: [PATCH 05/23] - Move root to /usr. - Change sorting mount points. -
  read /etc/fstab with short mount point format.
 
 ---
- winsup/cygwin/cygheap.cc |  12 ++-
- winsup/cygwin/globals.cc |   2 +-
- winsup/cygwin/mount.cc   | 189 +++++++++++++++++++++++++++++++++------
- winsup/cygwin/mount.h    |   3 +-
- winsup/cygwin/uinfo.cc   |   2 +-
- 5 files changed, 177 insertions(+), 31 deletions(-)
+ winsup/cygwin/cygheap.cc |   22 +++++-
+ winsup/cygwin/globals.cc |    4 +
+ winsup/cygwin/mount.cc   |  219 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-
+ winsup/cygwin/mount.h    |    6 +
+ winsup/cygwin/uinfo.cc   |    4 +
+ 5 files changed, 253 insertions(+), 2 deletions(-)
 
 diff --git a/winsup/cygwin/cygheap.cc b/winsup/cygwin/cygheap.cc
-index 87a5eb964..d6dc063e5 100644
+index eb60cf279..854aeb953 100644
 --- a/winsup/cygwin/cygheap.cc
 +++ b/winsup/cygwin/cygheap.cc
-@@ -178,14 +178,22 @@ init_cygheap::init_installation_root ()
+@@ -141,7 +141,11 @@ init_cygheap::init_installation_root ()
+   ptrdiff_t len = 0;
+ 
+   if (!GetModuleFileNameW (cygwin_hmodule, installation_root_buf, PATH_MAX))
++#ifdef __MSYS__
++    api_fatal ("Can't initialize MSYS2 installation root dir.\n"
++#else
+     api_fatal ("Can't initialize Cygwin installation root dir.\n"
++#endif
+ 	       "GetModuleFileNameW(%p, %p, %u), %E",
+ 	       cygwin_hmodule, installation_root_buf, PATH_MAX);
+   PWCHAR p = installation_root_buf;
+@@ -179,15 +183,25 @@ init_cygheap::init_installation_root ()
  
    /* Strip off last path component ("\\cygwin1.dll") */
-   PWCHAR w = wcsrchr (installation_root, L'\\');
+   PWCHAR w = wcsrchr (installation_root_buf, L'\\');
 +#ifdef __MSYS__
 +  /* Back two folders to get root as we have all stuff in usr subfolder */
 +  for (int i=1; i >=0; --i)
@@ -29,186 +41,247 @@ index 87a5eb964..d6dc063e5 100644
    if (w)
      {
        *w = L'\0';
-       w = wcsrchr (installation_root, L'\\');
+       w = wcsrchr (installation_root_buf, L'\\');
      }
    if (!w)
--    api_fatal ("Can't initialize Cygwin installation root dir.\n"
-+    api_fatal ("Can't initialize MSYS2 installation root dir.\n"
- 	       "Invalid DLL path");
 +#ifdef __MSYS__
++    api_fatal ("Can't initialize MSYS2 installation root dir.\n"
++	       "Invalid DLL path");
 +  }
++#else
+     api_fatal ("Can't initialize Cygwin installation root dir.\n"
+ 	       "Invalid DLL path");
+-
 +#endif
- 
    /* Copy result into installation_dir before stripping off "bin" dir and
       revert to Win32 path.  This path is added to the Windows environment
-@@ -208,6 +216,7 @@ init_cygheap::init_installation_root ()
-   if (w > p)
-     *w = L'\0';
+      in build_env.  See there for a description. */
+@@ -211,6 +225,7 @@ init_cygheap::init_installation_root ()
+   RtlInitUnicodeString (&installation_root, installation_root_buf);
+   RtlInitUnicodeString (&installation_dir, installation_dir_buf);
  
 +#ifndef __MSYS__
    for (int i = 1; i >= 0; --i)
      {
        reg_key r (i, KEY_WRITE, _WIDE (CYGWIN_INFO_INSTALLATIONS_NAME),
-@@ -216,6 +225,7 @@ init_cygheap::init_installation_root ()
- 				    installation_root)))
+@@ -219,6 +234,7 @@ init_cygheap::init_installation_root ()
+ 				    installation_root_buf)))
  	break;
      }
 +#endif
  }
  
  void __stdcall
+@@ -298,7 +314,11 @@ _csbrk (int sbs)
+ 	  MEMORY_BASIC_INFORMATION m;
+ 	  if (!VirtualQuery (newbase, &m, sizeof m))
+ 	    system_printf ("couldn't get memory info, %E");
++#ifdef __MSYS__
++	  somekinda_printf ("Couldn't reserve/commit %ld bytes of space for MSYS2's heap, %E",
++#else
+ 	  somekinda_printf ("Couldn't reserve/commit %ld bytes of space for cygwin's heap, %E",
++#endif
+ 			    adjsbs);
+ 	  somekinda_printf ("AllocationBase %p, BaseAddress %p, RegionSize %lx, State %x\n",
+ 			    m.AllocationBase, m.BaseAddress, m.RegionSize, m.State);
 diff --git a/winsup/cygwin/globals.cc b/winsup/cygwin/globals.cc
-index 7c84eb637..9841c0e46 100644
+index ebe8b569f..58af9fa20 100644
 --- a/winsup/cygwin/globals.cc
 +++ b/winsup/cygwin/globals.cc
-@@ -65,7 +65,7 @@ int NO_COPY dynamically_loaded;
+@@ -65,7 +65,11 @@ int NO_COPY dynamically_loaded;
  
  /* Some CYGWIN environment variable variables. */
  bool allow_glob = true;
--bool dos_file_warning;
++#ifdef __MSYS__
 +bool dos_file_warning = false;
++#else
+ bool dos_file_warning;
++#endif
  bool ignore_case_with_glob;
  bool pipe_byte;
  bool reset_com;
 diff --git a/winsup/cygwin/mount.cc b/winsup/cygwin/mount.cc
-index c11ae5ace..77ea6e8e2 100644
+index e0349815d..3fbab18f2 100644
 --- a/winsup/cygwin/mount.cc
 +++ b/winsup/cygwin/mount.cc
-@@ -39,7 +39,6 @@ details. */
+@@ -39,7 +39,9 @@ details. */
    (path_prefix_p (proc, (path), proc_len, false))
  
  bool NO_COPY mount_info::got_usr_bin;
--bool NO_COPY mount_info::got_usr_lib;
++#ifndef __MSYS__
+ bool NO_COPY mount_info::got_usr_lib;
++#endif
  int NO_COPY mount_info::root_idx = -1;
  
  /* is_unc_share: Return non-zero if PATH begins with //server/share
-@@ -332,7 +331,6 @@ fs_info::update (PUNICODE_STRING upath, HANDLE in_vol)
+@@ -329,6 +331,18 @@ fs_info::update (PUNICODE_STRING upath, HANDLE in_vol)
+ /* These are the minimal flags supported by NTFS since Windows 2000.  Every
+    filesystem not supporting these flags is not a native NTFS.  We subsume
+    them under the filesystem type "cifs". */
++#ifdef __MSYS__
++#define MINIMAL_WIN_NTFS_FLAGS (FILE_CASE_SENSITIVE_SEARCH \
++				| FILE_CASE_PRESERVED_NAMES \
++				| FILE_UNICODE_ON_DISK \
++				| FILE_FILE_COMPRESSION \
++				| FILE_VOLUME_QUOTAS \
++				| FILE_SUPPORTS_SPARSE_FILES \
++				| FILE_SUPPORTS_REPARSE_POINTS \
++				| FILE_SUPPORTS_OBJECT_IDS \
++				| FILE_SUPPORTS_ENCRYPTION \
++				| FILE_NAMED_STREAMS)
++#else
  #define MINIMAL_WIN_NTFS_FLAGS (FILE_CASE_SENSITIVE_SEARCH \
  				| FILE_CASE_PRESERVED_NAMES \
  				| FILE_UNICODE_ON_DISK \
--				| FILE_PERSISTENT_ACLS \
- 				| FILE_FILE_COMPRESSION \
- 				| FILE_VOLUME_QUOTAS \
- 				| FILE_SUPPORTS_SPARSE_FILES \
-@@ -468,13 +466,13 @@ mount_info::create_root_entry (const PWCHAR root)
+@@ -340,6 +354,7 @@ fs_info::update (PUNICODE_STRING upath, HANDLE in_vol)
+ 				| FILE_SUPPORTS_OBJECT_IDS \
+ 				| FILE_SUPPORTS_ENCRYPTION \
+ 				| FILE_NAMED_STREAMS)
++#endif
+ #define FS_IS_WINDOWS_NTFS TEST_GVI(flags () & MINIMAL_WIN_NTFS_FLAGS, \
+ 				    MINIMAL_WIN_NTFS_FLAGS)
+ /* These are the exact flags of a real Windows FAT/FAT32 filesystem.
+@@ -473,13 +488,21 @@ mount_info::create_root_entry (const PWCHAR root)
    sys_wcstombs (native_root, PATH_MAX, root);
    assert (*native_root != '\0');
    if (add_item (native_root, "/",
--		MOUNT_SYSTEM | MOUNT_BINARY | MOUNT_IMMUTABLE | MOUNT_AUTOMATIC)
-+		MOUNT_SYSTEM | MOUNT_BINARY | MOUNT_IMMUTABLE | MOUNT_AUTOMATIC | MOUNT_NOACL)
++#ifdef __MSYS__
++		MOUNT_SYSTEM | MOUNT_IMMUTABLE | MOUNT_AUTOMATIC | MOUNT_NOACL)
++#else
+ 		MOUNT_SYSTEM | MOUNT_IMMUTABLE | MOUNT_AUTOMATIC)
++#endif
        < 0)
      api_fatal ("add_item (\"%s\", \"/\", ...) failed, errno %d", native_root, errno);
    /* Create a default cygdrive entry.  Note that this is a user entry.
       This allows to override it with mount, unless the sysadmin created
       a cygdrive entry in /etc/fstab. */
--  cygdrive_flags = MOUNT_BINARY | MOUNT_NOPOSIX | MOUNT_CYGDRIVE;
-+  cygdrive_flags = MOUNT_BINARY | MOUNT_NOPOSIX | MOUNT_CYGDRIVE | MOUNT_NOACL;
++#ifdef __MSYS__
++  cygdrive_flags = MOUNT_NOPOSIX | MOUNT_CYGDRIVE | MOUNT_NOACL;
++#else
+   cygdrive_flags = MOUNT_NOPOSIX | MOUNT_CYGDRIVE;
++#endif
    strcpy (cygdrive, CYGWIN_INFO_CYGDRIVE_DEFAULT_PREFIX "/");
    cygdrive_len = strlen (cygdrive);
  }
-@@ -494,25 +492,17 @@ mount_info::init (bool user_init)
+@@ -499,12 +522,20 @@ mount_info::init (bool user_init)
    pathend = wcpcpy (pathend, L"\\etc\\fstab");
    from_fstab (user_init, path, pathend);
  
 -  if (!user_init && (!got_usr_bin || !got_usr_lib))
-+
++#ifdef __MSYS__
 +  if (!user_init && !got_usr_bin)
++#else
++  if (!user_init && (!got_usr_bin || !got_usr_lib)
++#endif
      {
        char native[PATH_MAX];
        if (root_idx < 0)
--	api_fatal ("root_idx %d, user_shared magic %y, nmounts %d", root_idx, user_shared->version, nmounts);
-+        api_fatal ("root_idx %d, user_shared magic %y, nmounts %d", root_idx, user_shared->version, nmounts);
+ 	api_fatal ("root_idx %d, user_shared magic %y, nmounts %d", root_idx, user_shared->version, nmounts);
        char *p = stpcpy (native, mount[root_idx].native_path);
--      if (!got_usr_bin)
--      {
--	stpcpy (p, "\\bin");
--	add_item (native, "/usr/bin",
--		  MOUNT_SYSTEM | MOUNT_BINARY | MOUNT_AUTOMATIC);
--      }
--      if (!got_usr_lib)
--      {
--	stpcpy (p, "\\lib");
--	add_item (native, "/usr/lib",
--		  MOUNT_SYSTEM | MOUNT_BINARY | MOUNT_AUTOMATIC);
--      }
--    }
-+	stpcpy (p, "\\usr\\bin");
-+	add_item (native, "/bin",
-+		  MOUNT_SYSTEM | MOUNT_BINARY | MOUNT_AUTOMATIC | MOUNT_NOACL);
-+   }
++#ifdef __MSYS__
++      stpcpy (p, "\\usr\\bin");
++      add_item (native, "/bin", MOUNT_SYSTEM | MOUNT_AUTOMATIC | MOUNT_NOACL);
++#else
+       if (!got_usr_bin)
+       {
+ 	stpcpy (p, "\\bin");
+@@ -515,6 +546,7 @@ mount_info::init (bool user_init)
+ 	stpcpy (p, "\\lib");
+ 	add_item (native, "/usr/lib", MOUNT_SYSTEM | MOUNT_AUTOMATIC);
+       }
++#endif
+     }
  }
  
- static void
-@@ -608,6 +598,7 @@ mount_info::conv_to_win32_path (const char *src_path, char *dst, device& dev,
+@@ -595,6 +627,9 @@ mount_info::conv_to_win32_path (const char *src_path, char *dst, device& dev,
    /* See if this is a cygwin "device" */
    if (win32_device_name (src_path, dst, dev))
      {
++#ifdef __MSYS__
 +      debug_printf ("win32_device_name (%s)", src_path);
-       *flags = MOUNT_BINARY;	/* FIXME: Is this a sensible default for devices? */
++#endif
+       *flags = 0;
        rc = 0;
        goto out_no_chroot_check;
-@@ -638,6 +629,7 @@ mount_info::conv_to_win32_path (const char *src_path, char *dst, device& dev,
+@@ -625,6 +660,9 @@ mount_info::conv_to_win32_path (const char *src_path, char *dst, device& dev,
      }
    if (isproc (src_path))
      {
++#ifdef __MSYS__
 +      debug_printf ("isproc (%s)", src_path);
++#endif
        dev = *proc_dev;
        dev = fhandler_proc::get_proc_fhandler (src_path);
        if (dev == FH_NADA)
-@@ -659,6 +651,7 @@ mount_info::conv_to_win32_path (const char *src_path, char *dst, device& dev,
+@@ -646,7 +684,13 @@ mount_info::conv_to_win32_path (const char *src_path, char *dst, device& dev,
       off the prefix and transform it into an MS-DOS path. */
    else if (iscygdrive (src_path))
      {
-+      debug_printf ("iscygdrive (%s) mount_table->cygdrive %s", src_path, mount_table->cygdrive);
++#ifdef __MSYS__
++      debug_printf ("isproc (%s)", src_path);
++#endif
        int n = mount_table->cygdrive_len - 1;
++#ifdef __MSYS__
++      debug_printf ("iscygdrive (%s) mount_table->cygdrive %s", src_path, mount_table->cygdrive);
++#endif
        int unit;
  
-@@ -670,11 +663,15 @@ mount_info::conv_to_win32_path (const char *src_path, char *dst, device& dev,
+       if (!src_path[n])
+@@ -657,10 +701,16 @@ mount_info::conv_to_win32_path (const char *src_path, char *dst, device& dev,
  	}
        else if (cygdrive_win32_path (src_path, dst, unit))
  	{
-+      debug_printf ("cygdrive_win32_path (%s)", src_path);
- 	  set_flags (flags, (unsigned) cygdrive_flags);
++#ifdef __MSYS__
++          debug_printf ("cygdrive_win32_path (%s)", src_path);
++#endif
+ 	  *flags = cygdrive_flags;
  	  goto out;
  	}
        else if (mount_table->cygdrive_len > 1)
-+      {
-+          debug_printf ("mount_table->cygdrive_len > 1 (%s)", src_path);
++#ifdef __MSYS__
++        debug_printf ("mount_table->cygdrive_len > 1 (%s)", src_path);
++#endif
  	return ENOENT;
-+      }
      }
  
-   int chroot_pathlen;
-@@ -685,7 +682,9 @@ mount_info::conv_to_win32_path (const char *src_path, char *dst, device& dev,
+@@ -672,7 +722,12 @@ mount_info::conv_to_win32_path (const char *src_path, char *dst, device& dev,
        const char *path;
        int len;
  
--      mi = mount + posix_sorted[i];
++#ifdef __MSYS__
 +      mi = mount + shortest_native_sorted[i];
 +      debug_printf (" mount[%d] .. checking %s -> %s ", i, mi->posix_path, mi->native_path);
-+
++#else
+       mi = mount + posix_sorted[i];
++#endif
        if (!cygheap->root.exists ()
  	  || (mi->posix_pathlen == 1 && mi->posix_path[0] == '/'))
  	{
-@@ -916,7 +915,8 @@ mount_info::conv_to_posix_path (const char *src_path, char *posix_path,
+@@ -903,7 +958,12 @@ mount_info::conv_to_posix_path (const char *src_path, char *posix_path,
    int pathbuflen = tail - pathbuf;
    for (int i = 0; i < nmounts; ++i)
      {
--      mount_item &mi = mount[native_sorted[i]];
++#ifdef __MSYS__
 +      mount_item &mi = mount[longest_posix_sorted[i]];
 +      debug_printf (" mount[%d] .. checking %s -> %s ", i, mi.posix_path, mi.native_path);
++#else
+       mount_item &mi = mount[native_sorted[i]];
++#endif
        if (!path_prefix_p (mi.native_path, pathbuf, mi.native_pathlen,
  			  mi.flags & MOUNT_NOPOSIX))
  	continue;
-@@ -1144,8 +1144,17 @@ mount_info::from_fstab_line (char *line, bool user)
+@@ -1116,8 +1176,22 @@ mount_info::from_fstab_line (char *line, bool user)
    if (!*c)
      return true;
    cend = find_ws (c);
--  *cend = '\0';
++  #ifndef __MSYS__
+   *cend = '\0';
++  #endif
    posix_path = conv_fstab_spaces (c);
++  #ifdef __MSYS__
 +  if (!*cend)
 +   {
-+     unsigned mount_flags = MOUNT_SYSTEM | MOUNT_BINARY | MOUNT_NOPOSIX | MOUNT_NOACL;
++     unsigned mount_flags = MOUNT_SYSTEM | MOUNT_NOPOSIX | MOUNT_NOACL;
 +
 +     int res = mount_table->add_item (native_path, posix_path, mount_flags);
 +     if (res && get_errno () == EMFILE)
@@ -216,13 +289,15 @@ index c11ae5ace..77ea6e8e2 100644
 +     return true;
 +   }
 +  *cend = '\0';
++#endif
    /* Third field: FS type. */
    c = skip_ws (cend + 1);
    if (!*c)
-@@ -1374,16 +1383,145 @@ sort_by_native_name (const void *a, const void *b)
+@@ -1346,16 +1420,154 @@ sort_by_native_name (const void *a, const void *b)
    return res;
  }
  
++#ifdef __MSYS__
 +/* sort_by_longest_posix_name: qsort callback to sort the mount entries.
 +   Sort user mounts ahead of system mounts to the same POSIX path. */
 +/* FIXME: should the user should be able to choose whether to
@@ -323,17 +398,23 @@ index c11ae5ace..77ea6e8e2 100644
 +#define DISABLE_NEW_STUFF 0
 +#define ONLY_USE_NEW_STUFF 1
 +
++#endif
++
  void
  mount_info::sort ()
  {
    for (int i = 0; i < nmounts; i++)
--    native_sorted[i] = posix_sorted[i] = i;
++#ifdef __MSYS__
 +    native_sorted[i] = posix_sorted[i] = shortest_native_sorted[i] = longest_posix_sorted[i] = i;
++#else
+     native_sorted[i] = posix_sorted[i] = i;
++#endif
    /* Sort them into reverse length order, otherwise we won't
       be able to look for /foo in /.  */
    mounts_for_sort = mount;	/* ouch. */
    qsort (posix_sorted, nmounts, sizeof (posix_sorted[0]), sort_by_posix_name);
    qsort (native_sorted, nmounts, sizeof (native_sorted[0]), sort_by_native_name);
++#ifdef __MSYS__
 +  qsort (longest_posix_sorted, nmounts, sizeof (longest_posix_sorted[0]), sort_by_longest_posix_name);
 +  qsort (shortest_native_sorted, nmounts, sizeof (shortest_native_sorted[0]), sort_by_shortest_native_name);
 +  qsort (shortest_native_sorted, nmounts, sizeof (shortest_native_sorted[0]), sort_posix_subdirs_before_parents);
@@ -363,57 +444,65 @@ index c11ae5ace..77ea6e8e2 100644
 +      mount_item *mi = mount + longest_posix_sorted[i];
 +      debug_printf ("longest_posix_sorted[%d] %12s       %12s", i, mi->native_path, mi->posix_path);
 +  }
++#endif
  }
  
  /* Add an entry to the mount table.
-@@ -1474,12 +1612,9 @@ mount_info::add_item (const char *native, const char *posix,
+@@ -1446,11 +1658,16 @@ mount_info::add_item (const char *native, const char *posix,
    if (i == nmounts)
      nmounts++;
  
--  if (strcmp (posixtmp, "/usr/bin") == 0)
++#ifdef __MSYS__
 +  if (strcmp (posixtmp, "/bin") == 0)
++     got_usr_bin = true;
++#else
+   if (strcmp (posixtmp, "/usr/bin") == 0)
      got_usr_bin = true;
  
--  if (strcmp (posixtmp, "/usr/lib") == 0)
--    got_usr_lib = true;
--
+   if (strcmp (posixtmp, "/usr/lib") == 0)
+     got_usr_lib = true;
++#endif
+ 
    if (posixtmp[0] == '/' && posixtmp[1] == '\0' && !(mountflags & MOUNT_CYGDRIVE))
      root_idx = i;
- 
 diff --git a/winsup/cygwin/mount.h b/winsup/cygwin/mount.h
-index 0b392ca85..e6ca7fd82 100644
+index 122a679a8..16a5c8796 100644
 --- a/winsup/cygwin/mount.h
 +++ b/winsup/cygwin/mount.h
-@@ -169,7 +169,6 @@ class mount_info
+@@ -171,7 +171,9 @@ class mount_info
    mount_item mount[MAX_MOUNTS];
  
    static bool got_usr_bin;
--  static bool got_usr_lib;
++#ifndef __MSYS__
+   static bool got_usr_lib;
++#endif
    static int root_idx;
  
    /* cygdrive_prefix is used as the root of the path automatically
-@@ -181,6 +180,8 @@ class mount_info
+@@ -183,6 +185,10 @@ class mount_info
   private:
    int posix_sorted[MAX_MOUNTS];
    int native_sorted[MAX_MOUNTS];
++#ifdef __MSYS__
 +  int longest_posix_sorted[MAX_MOUNTS];
 +  int shortest_native_sorted[MAX_MOUNTS];
++#endif
  
   public:
    void init (bool);
 diff --git a/winsup/cygwin/uinfo.cc b/winsup/cygwin/uinfo.cc
-index c2f4803ce..0223265ed 100644
+index bfcce00da..89b435650 100644
 --- a/winsup/cygwin/uinfo.cc
 +++ b/winsup/cygwin/uinfo.cc
-@@ -2780,7 +2780,7 @@ pwdgrp::fetch_account_from_windows (fetch_user_arg_t &arg, cyg_ldap *pldap)
+@@ -2791,7 +2791,11 @@ pwdgrp::fetch_account_from_windows (fetch_user_arg_t &arg, cyg_ldap *pldap)
  		     dom, name,
  		     sid.string ((char *) sidstr),
  		     home ?: "/home/", home ? L"" : name,
--		     shell ?: "/bin/bash");
++#ifdef __MSYS__
 +		     shell ?: "/usr/bin/bash");
++#else
+ 		     shell ?: "/bin/bash");
++#endif
    if (gecos)
      free (gecos);
    if (home)
--- 
-2.18.0
-

--- a/msys2-runtime/0008-Do-not-convert-environment-for-strace.patch
+++ b/msys2-runtime/0008-Do-not-convert-environment-for-strace.patch
@@ -14,21 +14,21 @@ diff --git a/winsup/cygwin/spawn.cc b/winsup/cygwin/spawn.cc
 index d94167507..07b9e87c0 100644
 --- a/winsup/cygwin/spawn.cc
 +++ b/winsup/cygwin/spawn.cc
-@@ -539,11 +539,13 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
+@@ -549,12 +549,16 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
        bool switch_user = ::cygheap->user.issetuid ()
  			 && (::cygheap->user.saved_uid
  			     != ::cygheap->user.real_uid);
++#ifdef __MSYS__
 +      bool keep_posix = (iscmd (argv[0], "strace.exe")
 +			|| iscmd (argv[0], "strace")) ? true : real_path.iscygexec ();
++#endif
        moreinfo->envp = build_env (envp, envblock, moreinfo->envc,
  				  real_path.iscygexec (),
  				  switch_user ? ::cygheap->user.primary_token ()
- 					      : NULL,
+ #ifdef __MSYS__
+                                               : NULL,
 -				  real_path.iscygexec ());
 +				  keep_posix);
-       if (!moreinfo->envp || !envblock)
- 	{
- 	  set_errno (E2BIG);
--- 
-2.18.0
-
+ #else
+ 					      : NULL);
+ #endif

--- a/msys2-runtime/0015-Fix-converting-argument-looks-like-DVAR-str1-c-path1.patch
+++ b/msys2-runtime/0015-Fix-converting-argument-looks-like-DVAR-str1-c-path1.patch
@@ -17,7 +17,7 @@ index 34c4d26c5..c347bd4cb 100644
          it += 1;
          starts_with_minus_alpha = 1;
 +        if (memchr(it, ';', end - it)) {
-+        	return WINDOWS_PATH_LIST;
++               return WINDOWS_PATH_LIST;
 +        }
        }
      }

--- a/msys2-runtime/0019-strace.cc-Don-t-set-MSYS-noglob.patch
+++ b/msys2-runtime/0019-strace.cc-Don-t-set-MSYS-noglob.patch
@@ -29,10 +29,11 @@ diff --git a/winsup/utils/strace.cc b/winsup/utils/strace.cc
 index bf507981a..638b66293 100644
 --- a/winsup/utils/strace.cc
 +++ b/winsup/utils/strace.cc
-@@ -353,10 +353,28 @@ create_child (char **argv)
+@@ -357,6 +357,25 @@ create_child (char **argv)
    make_command_line (one_line, argv);
  
    SetConsoleCtrlHandler (NULL, 0);
++#ifndef __MSYS__
 +/* Commit message for this code was:
 +"* strace.cc (create_child): Set CYGWIN=noglob when starting new process so that
 +
@@ -46,27 +47,19 @@ index bf507981a..638b66293 100644
 +  The reason it badly breaks this use-case is because dcrt0.cc depends
 +  on globbing to happen to parse commandlines from Windows programs;
 +  irrespective of whether they contain any glob patterns or not.
-+  
++
 +  See quoted () comment:
 +  "This must have been run from a Windows shell, so preserve
 +     quotes for globify to play with later."
-+
-   const char *cygwin_env = getenv ("MSYS");
-   const char *space;
++ */
  
--  if (cygwin_env && strlen (cygwin_env) <= 256) /* sanity check */
-+  if (cygwin_env && strlen (cygwin_env) <= 256) // sanity check
-     space = " ";
-   else
-     space = cygwin_env = "";
-@@ -364,6 +382,7 @@ create_child (char **argv)
- 				  + strlen (space) + strlen (cygwin_env));
-   sprintf (newenv, "MSYS=noglob%s%s", space, cygwin_env);
+ #ifdef __MSYS__
+   const char *cygwin_env = getenv ("MSYS");
+@@ -379,6 +398,7 @@ create_child (char **argv)
+   sprintf (newenv, "CYGWIN=noglob%s%s", space, cygwin_env);
+ #endif
    _putenv (newenv);
-+*/
++#endif
    ret = CreateProcess (0, one_line.buf,	/* command line */
  		       NULL,	/* Security */
  		       NULL,	/* thread */
--- 
-2.18.0
-

--- a/msys2-runtime/0021-Add-debugging-for-strace-make_command_line.patch
+++ b/msys2-runtime/0021-Add-debugging-for-strace-make_command_line.patch
@@ -11,14 +11,16 @@ diff --git a/winsup/utils/strace.cc b/winsup/utils/strace.cc
 index 638b66293..ca148c372 100644
 --- a/winsup/utils/strace.cc
 +++ b/winsup/utils/strace.cc
-@@ -351,6 +351,7 @@ create_child (char **argv)
+@@ -351,6 +351,9 @@ create_child (char **argv)
      flags |= CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP;
  
    make_command_line (one_line, argv);
++#ifdef __MSYS__
 +  printf ("create_child: %s\n", one_line.buf);
++#endif
  
    SetConsoleCtrlHandler (NULL, 0);
- /* Commit message for this code was:
+ #ifndef __MSYS__
 -- 
 2.18.0
 

--- a/msys2-runtime/0022-environ.cc-New-facility-environment-variable-MSYS2_E.patch
+++ b/msys2-runtime/0022-environ.cc-New-facility-environment-variable-MSYS2_E.patch
@@ -28,7 +28,7 @@ diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
 index dc93fd59b..22c7e3663 100644
 --- a/winsup/cygwin/environ.cc
 +++ b/winsup/cygwin/environ.cc
-@@ -1166,6 +1166,10 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
+@@ -1180,6 +1180,10 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
  
    int tl = 0;
    char **pass_dstp;
@@ -39,7 +39,7 @@ index dc93fd59b..22c7e3663 100644
    char **pass_env = (char **) alloca (sizeof (char *)
  				      * (n + winnum + SPENVS_SIZE + 1));
    /* Iterate over input list, generating a new environment list and refreshing
-@@ -1174,9 +1178,18 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
+@@ -1188,9 +1192,18 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
      {
        bool calc_tl = !no_envblock;
  #ifdef __MSYS__
@@ -132,17 +132,16 @@ diff --git a/winsup/cygwin/spawn.cc b/winsup/cygwin/spawn.cc
 index 07b9e87c0..264249072 100644
 --- a/winsup/cygwin/spawn.cc
 +++ b/winsup/cygwin/spawn.cc
-@@ -262,8 +262,7 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
-   int res = -1;
+@@ -262,7 +262,7 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
  
+ #ifdef __MSYS__
    /* Environment variable MSYS2_ARG_CONV_EXCL contains a list
 -     of ';' separated argument prefixes to pass un-modified..
--     It isn't applied to env. variables; only spawn arguments.
 +     of ';' separated argument prefixes to pass un-modified.
+      It isn't applied to env. variables; only spawn arguments.
       A value of * means don't convert any arguments. */
    char* msys2_arg_conv_excl_env = getenv("MSYS2_ARG_CONV_EXCL");
-   char* msys2_arg_conv_excl = NULL;
-@@ -272,14 +271,7 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
+@@ -272,14 +272,7 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
      {
        msys2_arg_conv_excl = (char*)alloca (strlen(msys2_arg_conv_excl_env)+1);
        strcpy (msys2_arg_conv_excl, msys2_arg_conv_excl_env);
@@ -156,8 +155,8 @@ index 07b9e87c0..264249072 100644
 -        }
 +      msys2_arg_conv_excl_count = string_split_delimited (msys2_arg_conv_excl, ';');
      }
+ #endif
  
-   /* Check if we have been called from exec{lv}p or spawn{lv}p and mask
 -- 
 2.18.0
 

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
-pkgver=2.11.2
+pkgver=3.0.4
 pkgrel=1
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
@@ -50,28 +50,28 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0024-Fix-native-symbolic-link-spawn-passing-wrong-arg0.patch
 )
 sha256sums=('SKIP'
-            '3b16cf413fe49254902d18faf96787f206c1dbc992ffff9c4e4d4230485c1bf9'
-            '45484264acedba213c14a230137a10a937d4476e1930f66a6531c8fec9f2be37'
-            '57cfab9f43b12a7dc0fe120032d9c811ee0db6efdc6c88dc08c72d5f278a1d09'
-            'a35b0bd423a516a915651ec6474565eb70c8f52c04f6bbcfe63ad6f2e68a52d4'
-            'aeb7f3185277c81d8b0a7481588a531dcf3b04ae4336855fb7c692ca4b657d70'
+            'c911d6737753881c8f6b92e1861f523a7656d06b861c190ed970eedec689a773'
+            'f332e5c06a041716e832efdf71a977060f35760a43da8dbb5749fcced46556fa'
+            'ddfc2e871006eee23798f09bcca529fd5571be67fd92dea49165503eafe1604e'
+            '306c777cd434c3b725811f0b6b6e4b9b2b629953a85f2c2a670e74a5be6ce5d5'
+            'b5fc2660021cb0c3a18cd8d01005e24cee197cd2fde33f144b80f17a053adeaf'
             'c05bf13f03f88c1bbaa25451319c7e81a74fb4f487deac337af6e12febc9d91d'
             'd98ac11f1e483d2ed9adc30e6e9f4f70f2d8544f24ec79da0e15cb6a9fff272c'
-            '6c736e1efe35423bc6449374e2d33fac666ffa43ea2c8f5920c34e6fd74595a9'
+            '45228e1c48b5b11361d550c35bc327186d9fef4e5086a29799b93713a1585642'
             'ac92806d9e413ad1bbcedbb2eb701067765413cd528107e90d070ed640af0a7e'
             'e78cdb2410ed5c04c51fb28b4a0760ffb840f0ddf60b933de91d1da7dd5514e7'
             '85e6eaf55fe052960913293e4a901812b9dddece2a398e97dcc4e2e64ea5be4b'
             '80e4240155b5b93ffa87edde9eaffa2a47e6c0021d03858f99206aaa43403de0'
             'b975234d6aedb25f61f7a27c4953b96fd12412e1b4e8c4bd5c6a9aaf1c24ae29'
             '6a35ee32f7dd30553f735606d8efc9080a6d89f5972534545dd3e7097163f6b2'
-            '22a6b289fe7b2cc79254c08eb6a436e402ae67d7c0561ee790b73634ea22a8bb'
+            '95d5c52dacf7ce13814c45d46be46cfe0c7ad7da930259012804c86eaa04e6fd'
             'a75f07bb64328a2ae814b17d3dbc894f164a9169d70a402aaf6499604bc5b466'
             '2672c1abe34f43523d609cffce8db09c3e57dce15379acee70368421cc386f14'
             'def566a9cf65b77cd017603aaa1f20e0969ee0cbdcfd5908bcbb44b4cd5d2474'
-            'bab265d3a67d38cac15b9cb260dfaf48778388a879cba21744de7900b406151e'
+            '8f35c69dce0333fbdf188e5fe04e8c52ef2f69ac42032342b655b8fcb19dd276'
             '4edfc95f0a8b2be0981cfbfea6be662312331915899734a19de96703f4c2b4c7'
-            '65cc92f23946f76552be855f60b00cc518f5abc387cb71bd180a6a1e96719fbd'
-            '16a87c39f043da71b5f7095eaa697a3631782957ccb034cbf1d1d6d53a6ec9b2'
+            '427cc0f2433774591f2422011328387303ffd812b3d14d1b1a7ab3b15fb6b123'
+            '97cb7ce26cd2a7a681877a785bd5cd2a62c8635e04843fafc4f33fc92d2b9bdb'
             'a3dfc8f8320bcd224072ec2901cc8eaaff2b756ef9d038d387ec1316bc77832e'
             '50d8a52cc33501898e7a01b00e8e5965c1ef7f37f26039a4380788ce7639a04c')
 
@@ -105,7 +105,7 @@ del_file_exists() {
 prepare() {
   cd "${srcdir}"/msys2-runtime
   del_file_exists winsup/cygwin/msys2_path_conv.cc \
-    winsup/cygwin/msys2_path_conv.h 
+    winsup/cygwin/msys2_path_conv.h
  apply_git_am_with_msg 0001-Add-MSYS-triplets.patch \
   0002-Rename-DLL-from-cygwin-to-msys.patch \
   0003-Add-functionality-for-converting-UNIX-paths-in-argum.patch \
@@ -164,6 +164,11 @@ build() {
   #popd > /dev/null
 
   rm -rf "${srcdir}"/dest/etc
+}
+
+check() {
+  cd "${srcdir}"/build-${CHOST}
+  make check
 }
 
 package_msys2-runtime() {


### PR DESCRIPTION
This is an attempt to build MSYS @ run-time off of the newlib 3.0 version.  Unfortunately, after installing, it kept complaining about being unable to find libraries and executables.  I'm missing something with these patches..  THe version of newlib I was trying to use was  3.0.4.  In addition, I also got a warning about a  missing "_wait" function with newlib.

/home/jpmugaas/msys/msys2-runtime/src/msys2-runtime/newlib/libc/reent/execr.c: In function '_wait_r':
/home/jpmugaas/msys/msys2-runtime/src/msys2-runtime/newlib/libc/reent/execr.c:120:14: warning: implicit declaration of function '_wait'; did you mean 'wait'? [-Wimplicit-function-declaration]
   if ((ret = _wait (status)) == -1 && errno != 0)
              ^~~~~
              wait

TBH, I am at my whits wned but I hope someone can complete this wwork and eventually get this merged because we probably should be more current with what is in CygWin.  They may have done things that we can benefit from.  In adidon, I am also trying to IFDEF the modifications made to the newlib code so that if the CygWin developers want to merge it, they can.    And it would help people wanting to follow what is happening between the versions of newlib.