### PR TITLE
add libstdc++ weakrefs patch for msys gcc

### DIFF
--- a/gcc/0016-disable-weak-refs-in-libstdc++.patch
+++ b/gcc/0016-disable-weak-refs-in-libstdc++.patch
@@ -1,0 +1,10 @@
+--- gcc/libstdc++-v3/config/os/mingw32-w64/os_defines.h.orig	2016-01-04 14:30:49.999997000 +0000
++++ gcc/libstdc++-v3/config/os/mingw32-w64/os_defines.h	2016-07-24 20:45:37.352669700 +0100
+@@ -76,6 +76,7 @@
+ 
+ #ifdef __x86_64__
+ #define _GLIBCXX_LLP64 1
++#define _GLIBCXX_USE_WEAK_REF 0
+ #endif
+ 
+ // Enable use of GetModuleHandleEx (requires Windows XP/2003) in

--- a/gcc/PKGBUILD
+++ b/gcc/PKGBUILD
@@ -8,7 +8,7 @@
 pkgbase=gcc
 pkgname=('gcc' 'gcc-libs' 'gcc-fortran')
 pkgver=7.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="The GNU Compiler Collection"
 arch=('i686' 'x86_64')
 groups=('msys2-devel')
@@ -33,6 +33,7 @@ source=(https://ftp.gnu.org/gnu/gcc/gcc-${pkgver}/gcc-${pkgver}.tar.gz
         0014-64bit-Cygwin-uses-SEH.patch
         0015-define-RTS_CONTROL_ENABLE-and-DTR_CONTROL_ENABLE-for.patch
         0016-fix-some-implicit-declaration-warnings.patch
+        0016-disable-weak-refs-in-libstdc++.patch
         0017-__cxa-atexit-for-Cygwin.patch
         0018-prevent-modules-from-being-unloaded-before-their-dto.patch
         0020-cygwin-uses-cyg-lib-prefix-v3.patch
@@ -60,6 +61,7 @@ sha256sums=('cb8df68237b0bea3307217697ad749a0a0565584da259e8a944ef6cfc4dc4d3d'
             'ac7e9e08ea8b2b4b5fdb394e217ce9081352fe07746e19b9374a753ebf89a4a2'
             '84c8127f2e70f26a6bf0f7ff1fe06df4814096bc02f5fc19291a729c740887d7'
             '4d3030238181a6d28c1aff5e5b43db6d82517f3412309175e162f5da63f7cd00'
+            '7ca138a0076b31fe359d289670dd72872c12545d2f267d626a412266c5172421'
             '0e6a373a0911d81656d9bfd2d93085b817266538600eab14965f1bafb034bac8'
             'a277245cf7ccf6e3bd83a79945ff26ea5e41fb3ecf7fe0a473b2ec64d8c5b101'
             '277907dd3982c61dcd8d739231e49afebf3841cf687fc1fcf3e2ffbba419c904'
@@ -141,6 +143,9 @@ prepare() {
     0951-7.3.0-msys2-spec.patch \
     0953-7.3.0-testsuite-msys2.patch \
     0955-4.9.2-apply-hack-so-gcc_s-isnt-stripped.patch
+
+  # weakrefs patch for x86_64
+  apply_patch_with_msg 0016-disable-weak-refs-in-libstdc++.patch
   
   # Do not run fixincludes
   #sed -i 's@\./fixinc\.sh@-c true@' gcc/Makefile.in


### PR DESCRIPTION
This patch was in the 7 series of gccs for mingw, and it helps on msys
too.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>