### PR TITLE
new package: rlwrap-0.43

### DIFF
--- a/rlwrap/PKGBUILD
+++ b/rlwrap/PKGBUILD
@@ -1,0 +1,32 @@
+# Contributor: Rafael Kitover <rkitover@gmail.com>
+# Anyone is welcome to update this package, for new versions or patches or w/e.
+
+pkgname=('rlwrap')
+pkgver=0.43
+pkgrel=0
+pkgdesc='utility that uses the GNU readline library to allow the editing of keyboard input for any command'
+arch=('i686' 'x86_64')
+groups=('utilities')
+license=('GPL')
+url='https://github.com/hanslub42/rlwrap'
+depends=('libreadline')
+makedepends=('gcc' 'make' 'libreadline-devel')
+source=("https://github.com/hanslub42/rlwrap/releases/download/v0.43/rlwrap-${pkgver}.tar.gz")
+sha256sums=('8e86d0b7882d9b8a73d229897a90edc207b1ae7fa0899dca8ee01c31a93feb2f')
+
+build() {
+    cd ${srcdir}/${pkgname}-${pkgver}
+    ./configure --prefix=/usr
+    make
+    make install DESTDIR="${srcdir}/dest"
+}
+
+package_rlwrap() {
+    depends=('libreadline')
+    groups=('utilities')
+    install=rlwrap.install
+
+    mkdir -p ${pkgdir}/usr
+    cp -rf "${srcdir}"/dest/usr/bin   "${pkgdir}"/usr/
+    cp -rf "${srcdir}"/dest/usr/share "${pkgdir}"/usr/
+}

--- a/rlwrap/rlwrap.install
+++ b/rlwrap/rlwrap.install
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+post_install() {
+    cat <<EOF
+Message for rlwrap $1:
+
+Here is a nice configuration example for wrapping a command with rlwrap, the
+command in this example being sqlplus, this would go into your ~/.bashrc:
+
+    alias sqlplus="rlwrap -i -f ~/.sqlplus_history -H ~/.sqlplus_history -s 30000 sqlplus --"
+    touch ~/.sqlplus_history
+
+Enjoy!
+EOF
+}
+
+post_upgrade() {
+    post_install $1
+}


### PR DESCRIPTION
This is a very useful little utility that gives you readline editing for
any program with a prompt, and it works perfectly for native windows
programs as well (e.g. rlwrap powershell works fine.)

Can be a nice alternative to winpty for some things.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>