### PR TITLE
Add missing part of msysize patch for gdb

### DIFF
--- a/gdb/PKGBUILD
+++ b/gdb/PKGBUILD
@@ -34,7 +34,7 @@ sha256sums=('0a6a432907a03c5c8eaad3c3cffd50c00a40c3a5e3c4039440624bae703f2202'
             '7540630512c5fec56d330ffd05a8714d3a037080e1ff049eaa3c81aaae597708'
             'f46337e3b0750f562ad6dbd4ad28860df160e98583b541d609ad9fadaff357c9'
             '6e257ca1d46e76b87d2166f0cb302685a58ea0aa3a26ccdc3a6a17f730946db9'
-            '4b09f087d2e07a928e6ebd751302ff7c5ceff7ad67b783f27bb52252be09393a')
+            'bc8ecb4f7cb4213d653cd0d3811a8bfa771d8523f20fac33d7ae89b0361603b5')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}

--- a/gdb/gdb-7.11.1-msysize.patch
+++ b/gdb/gdb-7.11.1-msysize.patch
@@ -1918,3 +1918,15 @@ diff -Naur gdb-7.8.1-orig/sim/arm/configure gdb-7.8.1/sim/arm/configure
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
+diff --git a/gdb/defs.h b/gdb/defs.h
+index fc42170..905a8b0 100644
+--- a/gdb/defs.h
++++ b/gdb/defs.h
+@@ -487,6 +487,7 @@ enum gdb_osabi
+   GDB_OSABI_GO32,
+   GDB_OSABI_QNXNTO,
+   GDB_OSABI_CYGWIN,
++  GDB_OSABI_MSYS,
+   GDB_OSABI_AIX,
+   GDB_OSABI_DICOS,
+   GDB_OSABI_DARWIN,


### PR DESCRIPTION
`gdb_osabi` in `defs.h` and array of `osabi` strings in `osabi.c` must be synchronized otherwise gdb fails with internal error on start as it detects that the array and enumeration have diverged.

With this change `gdb` starts. There are multiple test failures, but without these changes tests couldn't pass for sure.