### PR TITLE
Rebuild of guile due to readline v7 -> v8 upgrade

### DIFF
--- a/guile/PKGBUILD
+++ b/guile/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=guile
 pkgname=("$pkgbase" "lib${pkgbase}" "lib${pkgbase}-devel")
 pkgver=2.2.4
-pkgrel=2
+pkgrel=3
 pkgdesc="a portable, embeddable Scheme implementation written in C"
 url="https://www.gnu.org/software/guile/"
 arch=(i686 x86_64)


### PR DESCRIPTION
guile requires a rebuild since readline was updated from v7 to v8
which caused libreadline has a different file name