### PR TITLE
brotli: drop python2-brotli

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,8 @@ jobs:
         displayName: Update MSYS2
       - script: |
           set PATH=%CD:~0,2%\$(MSYS_DIR)\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
-          %CD:~0,2%\$(MSYS_DIR)\usr\bin\pacman --noconfirm --needed -S git base-devel msys2-devel
+          %CD:~0,2%\$(MSYS_DIR)\usr\bin\pacman --noconfirm --needed -S git base base-devel msys2-devel
+          %CD:~0,2%\$(MSYS_DIR)\usr\bin\dash /usr/bin/rebaseall -p
         displayName: Install Toolchain
       - script: |
           set PATH=C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,7 @@ jobs:
       - script: |
           set PATH=%CD:~0,2%\$(MSYS_DIR)\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
           %CD:~0,2%\$(MSYS_DIR)\usr\bin\pacman --noconfirm -Syyuu
+          %CD:~0,2%\$(MSYS_DIR)\usr\bin\pacman --noconfirm -Syuu
         displayName: Update MSYS2
       - script: |
           set PATH=%CD:~0,2%\$(MSYS_DIR)\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem

--- a/brotli/PKGBUILD
+++ b/brotli/PKGBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 
 pkgbase=brotli
-pkgname=('brotli' 'brotli-devel' 'python-brotli' 'python2-brotli' 'brotli-testdata')
+pkgname=('brotli' 'brotli-devel' 'python-brotli' 'brotli-testdata')
 pkgver=1.0.7
-pkgrel=1
+pkgrel=2
 pkgdesc='Brotli compression library'
 arch=('i686' 'x86_64')
 license=('MIT')
 url='https://github.com/google/brotli'
 depends=('msys2-runtime' 'gcc-libs')
-makedepends=('cmake' 'python' 'python2')
+makedepends=('cmake' 'python' 'libcrypt-devel')
 source=("${pkgbase}-${pkgver}.tar.gz::https://github.com/google/$pkgbase/archive/v${pkgver}.tar.gz"
         brotli-rename-static-libs.patch)
 sha256sums=('4c61bfb0faca87219ea587326c467b95acb25555b53d1a421ffa3c8a9296ee2c'
@@ -19,16 +19,12 @@ prepare() {
   cd brotli-${pkgver}
   patch -p1 -i ${srcdir}/brotli-rename-static-libs.patch
   cd ..
-  cp -a brotli-${pkgver}{,-py2}
   mkdir -p build
 }
 
 build() {
   cd "${srcdir}"/brotli-${pkgver}
   python setup.py build
-
-  cd "${srcdir}"/brotli-${pkgver}-py2
-  python2 ./setup.py build
 
   cd "${srcdir}"/build
   cmake \
@@ -65,15 +61,6 @@ package_python-brotli() {
 
   python setup.py install --skip-build -O1 --root="${pkgdir}"
   install -D -m644 "${srcdir}"/brotli-${pkgver}/LICENSE "${pkgdir}"/usr/share/licenses/${pkgname}/LICENSE
-}
-
-package_python2-brotli() {
-  depends=('python2')
-
-  cd brotli-${pkgver}-py2
-
-  python2 setup.py install --skip-build -O1 --root="${pkgdir}"
-  install -D -m644 "$srcdir"/brotli-$pkgver/LICENSE "${pkgdir}"/usr/share/licenses/${pkgname}/LICENSE
 }
 
 package_brotli-testdata() {


### PR DESCRIPTION
Nothing depends on it and there is python-brotli for Python 3.

@OTLabs any objections?