### PR TITLE
man-db: fixing systemd timer files location

### DIFF
--- a/man-db/PKGBUILD
+++ b/man-db/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=man-db
 pkgver=2.8.5
-pkgrel=1
+pkgrel=2
 pkgdesc="A utility for reading man pages"
 arch=('i686' 'x86_64')
 url="http://www.nongnu.org/man-db/"
@@ -45,7 +45,8 @@ build() {
     --enable-mandirs=GNU \
     --enable-static \
     --disable-shared \
-    --with-sections="1 n l 8 3 0 2 5 4 9 6 7"
+    --with-sections="1 n l 8 3 0 2 5 4 9 6 7" \
+    --with-systemdsystemunitdir=/usr/lib/systemd/system
   make
 }
 


### PR DESCRIPTION
Fixes #1633 
Pls note: 4 checks are failing just as with the previous version
```
============================================================================
Testsuite summary for man-db 2.8.5
============================================================================
# TOTAL: 26
# PASS:  22
# SKIP:  0
# XFAIL: 0
# FAIL:  4
# XPASS: 0
# ERROR: 0
```