### PR TITLE
curl: fix slow operation error

### DIFF
--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -3,24 +3,26 @@
 pkgbase=curl
 pkgname=('curl' 'libcurl' 'libcurl-devel')
 pkgver=7.65.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Multi-protocol file transfer utility"
 arch=('i686' 'x86_64')
 url="https://curl.haxx.se"
 license=('MIT')
 depends=('ca-certificates')
-makedepends=('brotli-devel' 'heimdal-devel' 'libcrypt-devel' 'libidn2-devel' 'libmetalink-devel' 
-             'libnghttp2-devel' 'libpsl-devel' 'libssh2-devel' 'openssl-devel' 'zlib-devel') #  'libcares-devel'
+makedepends=('brotli-devel' 'heimdal-devel' 'libcrypt-devel' 'libidn2-devel' 'libmetalink-devel'
+             'libunistring-devel' 'libnghttp2-devel' 'libpsl-devel' 'libssh2-devel' 'openssl-devel' 'zlib-devel') #  'libcares-devel'
 options=('!libtool' 'strip' '!debug')
 source=("https://curl.haxx.se/download/${pkgname}-${pkgver}.tar.bz2"{,.asc}
         curl-7.55.1-msys2.patch
         curl-7.58.0-libpsl-static-libs.patch
-        curl-7.60.0-gssapi-static-libs.patch)
+        curl-7.60.0-gssapi-static-libs.patch
+        curl-7.65.0-revert-progress-curl_disable_progress_meter.patch)
 sha256sums=('ea47c08f630e88e413c85793476e7e5665647330b6db35f5c19d72b3e339df5c'
             'SKIP'
             '2e6e2245a10890f8a8b1ec84dbe86dd2415b05359a93e69be9c7b90768e6ccc0'
             'ad3d76013c2dd683c44ad4cdc5108ea5218056c87b66f6ed2a90502e785a39af'
-            'd58a94556c031e550403ed13691305983bf83493f15fb8c35615e59bf265bbf7')
+            'd58a94556c031e550403ed13691305983bf83493f15fb8c35615e59bf265bbf7'
+            'aa8fa27e6f838bca69f86e0b3242a75f0bd1c4f5069b2dea8c34d8bd3c060b78')
 validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2'   # Daniel Stenberg
               '914C533DF9B2ADA2204F586D78E11C6B279D5C91')  # Daniel Stenberg (old key)
 
@@ -29,6 +31,9 @@ prepare() {
   patch -p1 -i ${srcdir}/curl-7.58.0-libpsl-static-libs.patch
   patch -p1 -i ${srcdir}/curl-7.55.1-msys2.patch
   patch -p1 -i ${srcdir}/curl-7.60.0-gssapi-static-libs.patch
+
+  # From Arch
+  patch -p1 -i ${srcdir}/curl-7.65.0-revert-progress-curl_disable_progress_meter.patch
   autoreconf -fi
 }
 
@@ -65,7 +70,7 @@ build() {
 
 package_curl() {
   depends=('ca-certificates' 'libcurl' 'libcrypt' 'libmetalink' 
-           'libnghttp2' 'libpsl' 'openssl' 'zlib')
+           'libunistring' 'libnghttp2' 'libpsl' 'openssl' 'zlib')
   groups=('base')
 
   mkdir -p ${pkgdir}/usr/bin
@@ -79,7 +84,7 @@ package_curl() {
 package_libcurl() {
   pkgdesc="Multi-protocol file transfer library (runtime)"
   depends=('brotli' 'ca-certificates' 'heimdal-libs' 'libcrypt' 'libidn2' 'libmetalink'
-          'libnghttp2' 'libpsl' 'libssh2' 'openssl' 'zlib') #'libcares'
+          'libunistring' 'libnghttp2' 'libpsl' 'libssh2' 'openssl' 'zlib') #'libcares'
   groups=('libraries')
 
   mkdir -p ${pkgdir}/usr/bin
@@ -89,7 +94,7 @@ package_libcurl() {
 package_libcurl-devel() {
   pkgdesc="Libcurl headers and libraries"
   depends=("libcurl=${pkgver}" 'brotli-devel' 'heimdal-devel' 'libcrypt-devel' 'libidn2-devel' 'libmetalink-devel' 
-           'libnghttp2-devel' 'libpsl-devel' 'libssh2-devel' 'openssl-devel' 'zlib-devel') #'libcares-devel'
+           'libunistring-devel' 'libnghttp2-devel' 'libpsl-devel' 'libssh2-devel' 'openssl-devel' 'zlib-devel') #'libcares-devel'
   options=('staticlibs')
   groups=('development')
 

--- a/curl/curl-7.65.0-revert-progress-curl_disable_progress_meter.patch
+++ b/curl/curl-7.65.0-revert-progress-curl_disable_progress_meter.patch
@@ -1,0 +1,200 @@
+From c6b58137237a89081b4efc33ae0ecf7282e40132 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Wed, 22 May 2019 23:15:34 +0200
+Subject: [PATCH] Revert "progress: CURL_DISABLE_PROGRESS_METER"
+
+This reverts commit 3b06e68b7734cb10a555f9d7e804dd5d808236a4.
+
+Clearly this change wasn't good enough as it broke CURLOPT_LOW_SPEED_LIMIT +
+CURLOPT_LOW_SPEED_TIME
+
+Reported-by: Dave Reisner
+
+Fixes #3927
+Closes #3928
+---
+ lib/progress.c | 110 ++++++++++++++++++++++---------------------------
+ 1 file changed, 49 insertions(+), 61 deletions(-)
+
+diff --git a/lib/progress.c b/lib/progress.c
+index f586d59b4..fe9929bb9 100644
+--- a/lib/progress.c
++++ b/lib/progress.c
+@@ -5,7 +5,7 @@
+  *                            | (__| |_| |  _ <| |___
+  *                             \___|\___/|_| \_\_____|
+  *
+- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
++ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+  *
+  * This software is licensed as described in the file COPYING, which
+  * you should have received as part of this distribution. The terms
+@@ -31,7 +31,6 @@
+ /* check rate limits within this many recent milliseconds, at minimum. */
+ #define MIN_RATE_LIMIT_PERIOD 3000
+ 
+-#ifndef CURL_DISABLE_PROGRESS_METER
+ /* Provide a string that is 2 + 1 + 2 + 1 + 2 = 8 letters long (plus the zero
+    byte) */
+ static void time2str(char *r, curl_off_t seconds)
+@@ -120,7 +119,6 @@ static char *max5data(curl_off_t bytes, char *max5)
+ 
+   return max5;
+ }
+-#endif
+ 
+ /*
+ 
+@@ -364,13 +362,17 @@ void Curl_pgrsSetUploadSize(struct Curl_easy *data, curl_off_t size)
+   }
+ }
+ 
+-#ifndef CURL_DISABLE_PROGRESS_METER
+-static void progress_meter(struct connectdata *conn)
++/*
++ * Curl_pgrsUpdate() returns 0 for success or the value returned by the
++ * progress callback!
++ */
++int Curl_pgrsUpdate(struct connectdata *conn)
+ {
+   struct curltime now;
+   curl_off_t timespent;
+   curl_off_t timespent_ms; /* milliseconds */
+   struct Curl_easy *data = conn->data;
++  int nowindex = data->progress.speeder_c% CURR_TIME;
+   bool shownow = FALSE;
+   curl_off_t dl = data->progress.downloaded;
+   curl_off_t ul = data->progress.uploaded;
+@@ -397,9 +399,7 @@ static void progress_meter(struct connectdata *conn)
+   /* Calculations done at most once a second, unless end is reached */
+   if(data->progress.lastshow != now.tv_sec) {
+     int countindex; /* amount of seconds stored in the speeder array */
+-    int nowindex = data->progress.speeder_c% CURR_TIME;
+-    if(!(data->progress.flags & PGRS_HIDE))
+-      shownow = TRUE;
++    shownow = TRUE;
+ 
+     data->progress.lastshow = now.tv_sec;
+ 
+@@ -461,12 +461,8 @@ static void progress_meter(struct connectdata *conn)
+         data->progress.ulspeed + data->progress.dlspeed;
+ 
+   } /* Calculations end */
+-  if(!shownow)
+-    /* only show the internal progress meter once per second */
+-    return;
+-  else {
+-    /* If there's no external callback set, use internal code to show
+-       progress */
++
++  if(!(data->progress.flags & PGRS_HIDE)) {
+     /* progress meter has not been shut off */
+     char max5[6][10];
+     curl_off_t dlpercen = 0;
+@@ -481,6 +477,42 @@ static void progress_meter(struct connectdata *conn)
+     curl_off_t dlestimate = 0;
+     curl_off_t total_estimate;
+ 
++    if(data->set.fxferinfo) {
++      int result;
++      /* There's a callback set, call that */
++      Curl_set_in_callback(data, true);
++      result = data->set.fxferinfo(data->set.progress_client,
++                                   data->progress.size_dl,
++                                   data->progress.downloaded,
++                                   data->progress.size_ul,
++                                   data->progress.uploaded);
++      Curl_set_in_callback(data, false);
++      if(result)
++        failf(data, "Callback aborted");
++      return result;
++    }
++    if(data->set.fprogress) {
++      int result;
++      /* The older deprecated callback is set, call that */
++      Curl_set_in_callback(data, true);
++      result = data->set.fprogress(data->set.progress_client,
++                                   (double)data->progress.size_dl,
++                                   (double)data->progress.downloaded,
++                                   (double)data->progress.size_ul,
++                                   (double)data->progress.uploaded);
++      Curl_set_in_callback(data, false);
++      if(result)
++        failf(data, "Callback aborted");
++      return result;
++    }
++
++    if(!shownow)
++      /* only show the internal progress meter once per second */
++      return 0;
++
++    /* If there's no external callback set, use internal code to show
++       progress */
++
+     if(!(data->progress.flags & PGRS_HEADERS_OUT)) {
+       if(data->state.resume_from) {
+         fprintf(data->set.err,
+@@ -563,57 +595,13 @@ static void progress_meter(struct connectdata *conn)
+             time_total,    /* 8 letters */                /* total time */
+             time_spent,    /* 8 letters */                /* time spent */
+             time_left,     /* 8 letters */                /* time left */
+-            max5data(data->progress.current_speed, max5[5])
+-      );
++            max5data(data->progress.current_speed, max5[5]) /* current speed */
++            );
+ 
+     /* we flush the output stream to make it appear as soon as possible */
+     fflush(data->set.err);
+-  } /* don't show now */
+-}
+-#else
+- /* progress bar disabled */
+-#define progress_meter(x)
+-#endif
+-
+ 
+-/*
+- * Curl_pgrsUpdate() returns 0 for success or the value returned by the
+- * progress callback!
+- */
+-int Curl_pgrsUpdate(struct connectdata *conn)
+-{
+-  struct Curl_easy *data = conn->data;
+-  if(!(data->progress.flags & PGRS_HIDE)) {
+-    if(data->set.fxferinfo) {
+-      int result;
+-      /* There's a callback set, call that */
+-      Curl_set_in_callback(data, true);
+-      result = data->set.fxferinfo(data->set.progress_client,
+-                                   data->progress.size_dl,
+-                                   data->progress.downloaded,
+-                                   data->progress.size_ul,
+-                                   data->progress.uploaded);
+-      Curl_set_in_callback(data, false);
+-      if(result)
+-        failf(data, "Callback aborted");
+-      return result;
+-    }
+-    if(data->set.fprogress) {
+-      int result;
+-      /* The older deprecated callback is set, call that */
+-      Curl_set_in_callback(data, true);
+-      result = data->set.fprogress(data->set.progress_client,
+-                                   (double)data->progress.size_dl,
+-                                   (double)data->progress.downloaded,
+-                                   (double)data->progress.size_ul,
+-                                   (double)data->progress.uploaded);
+-      Curl_set_in_callback(data, false);
+-      if(result)
+-        failf(data, "Callback aborted");
+-      return result;
+-    }
+-  }
+-  progress_meter(conn);
++  } /* !(data->progress.flags & PGRS_HIDE) */
+ 
+   return 0;
+ }
+-- 
+2.21.0
+


### PR DESCRIPTION
This fixes #1658.

In addition, libunistring is added to depends to fix a configure check.