### PR TITLE
vim: upgrade to latest version

### DIFF
--- a/vim/PKGBUILD
+++ b/vim/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=vim
 _topver=8.1
-_patchlevel=1234
+_patchlevel=1561
 _versiondir="${pkgname}${_topver//./}"
 pkgver=${_topver}.${_patchlevel}
 pkgrel=1
@@ -20,7 +20,7 @@ source=(${pkgname}-${pkgver}.tar.gz::https://github.com/vim/vim/archive/v${pkgve
         'pretend-cygwin-msys.patch'
         'accept-crlf.patch'
         'vim-completion')
-sha256sums=('e7d5705157b63d65c641cdd1cab2e6eca249ebc5b6fc3b372f9ea0bcf82e020f'
+sha256sums=('20c5b4e6c8cc2cf512d6b1bcba9e5d5c14a6931ade9a9392810b56545857f897'
             'edd18e0756406ee7b659e4552e444c50c3a0c1e9fb4fce2ddd770c933ea6c7f5'
             'bca6e030d50c0d2468ab5c78aa0b359eb18a88a197de8406c593458ffedde922'
             '44d7738a8f801195898eeef766ff77506c717dd5d19145ade3c1c2349d4bc4fd'


### PR DESCRIPTION
This addresses CVE-2019-12735, and also brings us plenty of other goodies.