### PR TITLE
Remove retired Tea CI status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 MSYS2-packages
 ==============
-[![TeaCI status](https://tea-ci.org/api/badges/Alexpux/MSYS2-packages/status.svg)](https://tea-ci.org/Alexpux/MSYS2-packages)
 [![AppVeyor status](https://ci.appveyor.com/api/projects/status/github/Alexpux/MSYS2-packages?branch=master&svg=true)](https://ci.appveyor.com/project/Alexpux/MSYS2-packages)
 
 Package scripts for MSYS2.


### PR DESCRIPTION
Latest Drone CI supports Windows build natively, it's still not clear that if it is useful for MSYS2, I suggest to keep `.drone.yml`, `ci-build.sh` and `ci-library.sh` unchanged and revisit later.