### PR TITLE
Let the Azure Pipeline know that we moved from Alexpux to msys2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
           CHERE_INVOKING: yes
           BUILD_URL: dummy
           DEPLOY_PROVIDER: bintray
-          BINTRAY_ACCOUNT: Alexpux
+          BINTRAY_ACCOUNT: msys2
           PACMAN_REPOSITORY_NAME: ci.msys
       - task: PublishBuildArtifacts@1
         displayName: Publish packages


### PR DESCRIPTION
I was wondering why the artifacts were not published properly in https://dev.azure.com/msys2/mingw/_build/results?buildId=2600... turns out that the script verifies that the current account is `Alexpux` (when it really is `msys2`).

I can't say that I understand how that CI script works at all, though: it fetches `master` from https://github.com/msys2/MSYS2-packages and compares the commits between the fetched revision and the current revision. I have no idea why they are different, though, but it seems to work. @Alexpux do _you_ know why it works?

In any case, this should fix the problem where the build artifacts are not published in the CI build.