### PR TITLE
Fix pacman to work on Vista, fixes #1674, fixes #1181

### DIFF
--- a/libarchive/PKGBUILD
+++ b/libarchive/PKGBUILD
@@ -12,7 +12,7 @@ depends=('gcc-libs' 'libbz2' 'libiconv' 'libexpat' 'liblzma' 'liblz4' 'liblzo2' 
 makedepends=('libbz2-devel' 'libiconv-devel' 'libexpat-devel' 'liblzma-devel' 'liblz4-devel' 'liblzo2-devel' 'libnettle-devel' 'libxml2-devel' 'zlib-devel')
 options=('!strip' 'debug' 'libtool')
 # provides=('libarchive.so')
-source=("https://libarchive.org/downloads/$pkgname-$pkgver.tar.gz"
+source=("https://github.com/libarchive/libarchive/archive/v${pkgver}.tar.gz"
         'libarchive-3.3.2-bcrypt-fix.patch'
         'libarchive-3.3.1-msys2.patch')
 sha256sums=('c160d3c45010a51a924208f13f6b7b956dabdf8c5c60195df188a599028caa7c'
@@ -36,7 +36,11 @@ build() {
     --enable-shared \
     --enable-static \
     --without-libiconv-prefix \
-    --without-xml2
+    --without-xml2 \
+    --without-cng
+
+# CNG breaks pacman on Vista due to BCryptDeriveKeyPBKDF2
+
   make
   make DESTDIR="${srcdir}/dest" install
 }

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=5.1.3
-pkgrel=2
+pkgrel=3
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"


### PR DESCRIPTION
The issue is described in https://github.com/msys2/MSYS2-packages/issues/1674.

Libarchive uses Windows 7 API `BCryptDeriveKeyPBKDF2` to encrypt zip files. By disabling this, pacman works again on Windows Vista and Windows 2008.

