### PR TITLE
msys2-runtime: 0026-mkdir-always-check-for-existence.patch

### DIFF
--- a/msys2-runtime/0026-mkdir-always-check-for-existence.patch
+++ b/msys2-runtime/0026-mkdir-always-check-for-existence.patch
@@ -1,0 +1,37 @@
+From 604f64494bee31bcbce88ad539f66dca3bff3753 Mon Sep 17 00:00:00 2001
+From: Ben Wijen <ben@wijen.net>
+Date: Mon, 3 Jun 2019 20:15:50 +0200
+Subject: [PATCH] mkdir: always check-for-existence
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When using NtCreateFile when creating a directory that already exists,
+it will correctly return 'STATUS_OBJECT_NAME_COLLISION'.
+
+However using this function to create a directory (and all its parents)
+a normal use would be to start with mkdir(â??/cygdrive/câ??) which translates
+to â??C:\â?? for which it'll instead return â??STATUS_ACCESS_DENIEDâ??.
+---
+ winsup/cygwin/dir.cc | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/dir.cc b/winsup/cygwin/dir.cc
+index f43eae461..b757851d5 100644
+--- a/winsup/cygwin/dir.cc
++++ b/winsup/cygwin/dir.cc
+@@ -331,8 +331,10 @@ mkdir (const char *dir, mode_t mode)
+ 	  debug_printf ("got %d error from build_fh_name", fh->error ());
+ 	  set_errno (fh->error ());
+ 	}
++      else if (fh->exists ())
++	set_errno (EEXIST);
+       else if (has_dot_last_component (dir, true))
+-	set_errno (fh->exists () ? EEXIST : ENOENT);
++	set_errno (ENOENT);
+       else if (!fh->mkdir (mode))
+ 	res = 0;
+       delete fh;
+-- 
+2.21.0
+

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.0.7
-pkgrel=4
+pkgrel=5
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -41,6 +41,7 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0015-environ.cc-New-facility-environment-variable-MSYS2_E.patch
         0024-Fix-native-symbolic-link-spawn-passing-wrong-arg0.patch
         0025-QueryUnbiasedInterruptTime-must-be-load-from.patch
+        0026-mkdir-always-check-for-existence.patch
 )
 sha256sums=('SKIP'
             'df193299ab04aca8a049b2b98d025452caad95f27fba5a1f1b350f74a82c24f1'
@@ -59,7 +60,9 @@ sha256sums=('SKIP'
             '05cca683b21ba0c8d22135f1f1f01da134be175de49fe7076200d7fe3efa4dce'
             '5fd3bb0f943b9f6295c0ebeaf8fb2a4bce36780bba83e7c0ce2c3380c67acf4f'
             '50d8a52cc33501898e7a01b00e8e5965c1ef7f37f26039a4380788ce7639a04c'
-            'b31e2bee92561594bf2db52f361ab2507e979797bec82955dc00f521ebee72b5')
+            'b31e2bee92561594bf2db52f361ab2507e979797bec82955dc00f521ebee72b5'
+            'c68b687540668f0871a901143510666b8b9a59c12eae0ea9bef187d1af38c493'
+)
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -108,8 +111,8 @@ prepare() {
   0014-Add-debugging-for-strace-make_command_line.patch \
   0015-environ.cc-New-facility-environment-variable-MSYS2_E.patch \
   0024-Fix-native-symbolic-link-spawn-passing-wrong-arg0.patch \
-  0025-QueryUnbiasedInterruptTime-must-be-load-from.patch
-
+  0025-QueryUnbiasedInterruptTime-must-be-load-from.patch \
+  0026-mkdir-always-check-for-existence.patch
 }
 
 build() {


### PR DESCRIPTION
Temporary patch until cygwin 3.8.x is integrated.