### PR TITLE
man2html - 3.0.1 - new package

### DIFF
--- a/man2html/PKGBUILD
+++ b/man2html/PKGBUILD
@@ -1,0 +1,28 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+pkgbase='man2html'
+pkgname=${pkgbase}
+pkgver=3.0.1
+pkgrel=1
+pkgdesc="A Unix manpage-to-HTML converter"
+arch=('any')
+url="https://www.nongnu.org/man2html/"
+license=('GPL')
+depends=('man-db' 'perl')
+# https://www.cpan.org/authors/id/E/EH/EHOOD/CHECKSUMS
+source=(#http://www.oac.uci.edu/indiv/ehood/tar/$pkgname$pkgver.tar.gz
+        https://www.cpan.org/authors/id/E/EH/EHOOD/$pkgname$pkgver.tar.gz)
+sha256sums=('a3dd7fdd80785c14c2f5fa54a59bf93ca5f86f026612f68770a0507a3d4e5a29')
+
+# consider to move to Debians fork also used by Fedora
+# https://packages.debian.org/source/sid/man2html
+# http://pkgs.fedoraproject.org/cgit/rpms/man2html.git/tree/man2html.spec
+
+package() {
+  cd ${srcdir}/${pkgname}${pkgver}
+  install -d ${pkgdir}/usr/bin ${pkgdir}/usr/share/man/man1 
+  perl install.me -batch -binpath ${pkgdir}/usr/bin -manpath ${pkgdir}/usr/share/man
+  
+  sed -i "s:/usr/local:/usr:" man.cgi
+  install -m755 man.cgi ${pkgdir}/usr/bin/
+}


### PR DESCRIPTION
A Unix manpage-to-HTML converter