### PR TITLE
Add a package for LastPass CLI

### DIFF
--- a/lastpass-cli/PKGBUILD
+++ b/lastpass-cli/PKGBUILD
@@ -1,0 +1,28 @@
+# Maintainer: Joan Karadimov <joan.karadimov@gmail.com>
+
+pkgname=lastpass-cli
+pkgver=1.3.3
+pkgrel=1
+pkgdesc="LastPass command line interface tool"
+arch=('x86_64')
+url="https://lastpass.com/"
+license=('GPL2')
+depends=('openssl' 'libcurl' 'libxml2')
+makedepends=('asciidoc' 'cmake' 'openssl-devel' 'libcurl-devel' 'libxml2-devel')
+optdepends=('pinentry: securely read passwords')
+source=("https://github.com/lastpass/lastpass-cli/archive/v$pkgver/$pkgname-$pkgver.tar.gz")
+sha256sums=('f38e1ee7e06e660433a575a23b061c2f66ec666d746e988716b2c88de59aed73')
+
+build() {
+  cd "$srcdir"/$pkgname-$pkgver
+  cmake . -DCMAKE_INSTALL_PREFIX="/usr"
+  make
+}
+
+package() {
+  cd "$srcdir"/$pkgname-$pkgver
+  make DESTDIR="$pkgdir" install install-doc
+
+  install -Dm0644 contrib/lpass_zsh_completion "$pkgdir"/usr/share/zsh/site-functions/_lpass
+  install -Dm0644 contrib/completions-lpass.fish "$pkgdir"/usr/share/fish/completions/lpass.fish
+}


### PR DESCRIPTION
Based on the Arch package for [LastPass CLI](https://github.com/lastpass/lastpass-cli):
https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/lastpass-cli

Just the dependency names were changed.

If this gets merged, I'll add an MSYS2 section to the original project's README alongside the [Cygwin section](https://github.com/lastpass/lastpass-cli#installing-on-cygwin)

P.S.
Should I indicate in the code somehow the original PKGBUILD file on which this is based on?