### PR TITLE
pacman: Update pacman-contrib to 1.1.0, fix `pactree -s`

### DIFF
--- a/pacman/0101-contrib-pactree-gpgdir.patch
+++ b/pacman/0101-contrib-pactree-gpgdir.patch
@@ -1,0 +1,41 @@
+diff -Naur pacman-contrib-1.1.0/src/Makefile.am.orig pacman-contrib-1.1.0/src/Makefile.am
+--- pacman-contrib-1.1.0/src/Makefile.am.orig
++++ pacman-contrib-1.1.0/src/Makefile.am
+@@ -7,6 +7,7 @@
+ # paths set at make time
+ conffile  = ${sysconfdir}/pacman.conf
+ dbpath    = ${localstatedir}/lib/pacman/
++gpgdir    = ${sysconfdir}/pacman.d/gnupg/
+ 
+ bin_SCRIPTS = \
+ 	$(OURSCRIPTS)
+@@ -82,7 +83,8 @@
+ AM_CPPFLAGS = \
+ 	-DLOCALEDIR=\"@localedir@\" \
+ 	-DCONFFILE=\"$(conffile)\" \
+-	-DDBPATH=\"$(dbpath)\"
++	-DDBPATH=\"$(dbpath)\" \
++	-DGPGDIR=\"$(gpgdir)\"
+ 
+ AM_CFLAGS = \
+ 	-pedantic \
+diff -Naur pacman-contrib-1.1.0/src/pactree.c.orig pacman-contrib-1.1.0/src/pactree.c
+--- pacman-contrib-1.1.0/src/pactree.c.orig
++++ pacman-contrib-1.1.0/src/pactree.c
+@@ -117,6 +117,7 @@ static int unique = 0;
+ static int searchsyncs = 0;
+ static const char *dbpath = DBPATH;
+ static const char *configfile = CONFFILE;
++static const char *gpgdir = GPGDIR;
+
+ /* Trim whitespace and newlines from a string
+  */
+@@ -500,6 +501,8 @@
+ 		cleanup(1);
+ 	}
+ 
++	alpm_option_set_gpgdir(handle, gpgdir);
++
+ 	if(searchsyncs) {
+ 		if(register_syncs() != 0) {
+ 			cleanup(1);

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,8 @@
 
 pkgname=pacman
 pkgver=5.1.3
-pkgrel=3
+pkgrel=4
+contrib_ver=1.1.0
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -48,7 +49,7 @@ backup=("etc/pacman.conf"
         "etc/makepkg_mingw32.conf"
         "etc/makepkg_mingw64.conf")
 source=(https://sources.archlinux.org/other/pacman/${pkgname}-${pkgver}.tar.gz{,.sig}
-        https://git.archlinux.org/pacman-contrib.git/snapshot/pacman-contrib-1.0.0.tar.xz
+        https://git.archlinux.org/pacman-contrib.git/snapshot/${pkgname}-contrib-${contrib_ver}.tar.xz
         "pacman.conf"
         "makepkg.conf"
         "makepkg_clang32.conf"
@@ -69,11 +70,12 @@ source=(https://sources.archlinux.org/other/pacman/${pkgname}-${pkgver}.tar.gz{,
         "0009-msys-use-pipe-instead-socket.patch"
         "0050-fix-make-target-dependencies.patch"
         "0100-contrib.patch"
+        "0101-contrib-pactree-gpgdir.patch"
         "0010-filelist-strcasecmp.patch"
         "0011-bash-completion-fix-regex.patch")
 sha256sums=('10db61a0928d619871340c3f93a677d1541d6c52353c516aec4f8d96e830d4eb'
             'SKIP'
-            'd47240396476eaf126b2f2a3f6ac77d5b397f5cc80b1c3700ba4fa355c4786c8'
+            '3dd128207d197ed84f67fe176489c265c88a19eee8eb005543be4e18e9d48251'
             '6024bbf50cc92236b7b437430cb9e4180da91925cdc19a5a7910fe172931cfb6'
             '3d2f8a8c363a76ebd417e883cf28dc093e611b1360fe684d40e29540cbcb7ef2'
             'd00b1c829e82e028ab6e48a669b21d1653d48dde26b8da727ee3c901d03bfe61'
@@ -94,6 +96,7 @@ sha256sums=('10db61a0928d619871340c3f93a677d1541d6c52353c516aec4f8d96e830d4eb'
             '9e8fe5ee78192b0407e80ad2e52cb27569c35974b6c26e465e3d55e19c03d108'
             '5bd66342aff56343aa5e07dbf997d18cc3dcae691cc7d8f83e94fee12b5b61b8'
             '3bd0cd48d608b31d7df564c50e8d31df58dd38cfaaea9ec0fcceb42936486549'
+            '4ff3f10a99e894f3ae8576227f60bff7e21a1d7a775f89d936e43501693e9618'
             '93be4523fb8c3dd6b56eddfe0b09e666725a62eb43392fee336ba1a328f9ffdd'
             '1f164d20f55f17f832d8dbfac7e59044b11d806ea99e3233d2950766d89b4cf6')
 
@@ -115,8 +118,9 @@ prepare() {
 
   autoreconf -fi
 
-  cd ${srcdir}/${pkgname}-contrib-1.0.0
+  cd ${srcdir}/${pkgname}-contrib-${contrib_ver}
   patch -p1 -i ${srcdir}/0100-contrib.patch
+  patch -p1 -i ${srcdir}/0101-contrib-pactree-gpgdir.patch
   ./autogen.sh
 }
 
@@ -139,7 +143,7 @@ build() {
   # doxygen segfaults in the first run :( so build again
   make -j3 || make
 
-  cd ${srcdir}/${pkgname}-contrib-1.0.0
+  cd ${srcdir}/${pkgname}-contrib-${contrib_ver}
   ./configure \
     --prefix=/usr \
     --sysconfdir=/etc \
@@ -158,7 +162,7 @@ package() {
   cd ${srcdir}/${pkgname}-${pkgver}
   make -j1 DESTDIR=${pkgdir} install
 
-  cd ${srcdir}/${pkgname}-contrib-1.0.0
+  cd ${srcdir}/${pkgname}-contrib-${contrib_ver}
   make -j1 DESTDIR=${pkgdir} install
 
   # install Arch specific stuff


### PR DESCRIPTION
This is a quick fix for #1720, it hard-codes `pactree` to have a gpg key directory. Meanwhile I'm working on a more involved patch for upstream.