### PR TITLE
Add another libtool patch for picking up compiler-rt builtins from clang

### DIFF
--- a/libtool/0013-Allow-statically-linking-compiler-support-libraries-.patch
+++ b/libtool/0013-Allow-statically-linking-compiler-support-libraries-.patch
@@ -1,0 +1,38 @@
+From b9f77cae8cfbe850e58cac686fcb4d246b5bfc51 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Storsj=C3=B6?= <martin@martin.st>
+Date: Mon, 19 Aug 2019 13:34:51 +0300
+Subject: [PATCH] Allow statically linking compiler support libraries when
+ linking a library
+
+For cases with deplibs_check_method="file_magic ..." (as it is for mingw),
+there were previously no way that a static library could be accepted
+here.
+---
+ build-aux/ltmain.in | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/build-aux/ltmain.in b/build-aux/ltmain.in
+index e2fb2633..db4d775c 100644
+--- a/build-aux/ltmain.in
++++ b/build-aux/ltmain.in
+@@ -5870,8 +5870,15 @@ func_mode_link ()
+ 	  fi
+ 	  case $linkmode in
+ 	  lib)
+-	    # Linking convenience modules into shared libraries is allowed,
+-	    # but linking other static libraries is non-portable.
++	    # Linking convenience modules and compiler provided static libraries
++	    # into shared libraries is allowed, but linking other static
++	    # libraries is non-portable.
++	    case $deplib in
++	      */libgcc*.$libext | */libclang_rt*.$libext)
++		deplibs="$deplib $deplibs"
++		continue
++	      ;;
++	    esac
+ 	    case " $dlpreconveniencelibs " in
+ 	    *" $deplib "*) ;;
+ 	    *)
+-- 
+2.17.1
+

--- a/libtool/PKGBUILD
+++ b/libtool/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=('libtool' 'libltdl')
 pkgver=2.4.6
 _gccver=9.1.0
-pkgrel=7
+pkgrel=8
 pkgdesc="A generic library support script"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/libtool/"
@@ -20,7 +20,8 @@ source=(https://ftp.gnu.org/pub/gnu/libtool/${pkgname}-${pkgver}.tar.xz{,.sig}
         0009-libtool-2.4.2.418-msysize.patch
         0010-libtool-2.4.2-include-process-h.patch
         0011-Pick-up-clang_rt-static-archives-compiler-internal-l.patch
-        0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch)
+        0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
+        0013-Allow-statically-linking-compiler-support-libraries-.patch)
 sha256sums=('7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f'
             'SKIP'
             'fe8b80efd34f9385220ebc90aaec945e44de8c343c75719d6ac0d4e472a6eed5'
@@ -31,7 +32,8 @@ sha256sums=('7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f'
             'c7d7dccd4a0e7b8dfe6afc47cbaf3862b645179137a90afe1a15d2af606fcab8'
             '0f3defa657d353b9f55469f6d514abd96494ce7459ef76bbd63980d8994cafe9'
             'c727b2b017163cfdeca60820d3cff2dac8968c5630745602b150f92b159af313'
-            'c95a65e890b1ae6362807abc66809e72cf81aeea5f9f556e38f9752f974bf435')
+            'c95a65e890b1ae6362807abc66809e72cf81aeea5f9f556e38f9752f974bf435'
+            '8069e887aeeab7491f15e00547fa66d9b9e86407f5a23f37a6d8c7d165de752e')
 
 
 prepare() {
@@ -47,6 +49,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0010-libtool-2.4.2-include-process-h.patch
   patch -p1 -i ${srcdir}/0011-Pick-up-clang_rt-static-archives-compiler-internal-l.patch
   patch -p1 -i ${srcdir}/0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
+  patch -p1 -i ${srcdir}/0013-Allow-statically-linking-compiler-support-libraries-.patch
 
 }
 


### PR DESCRIPTION
The previous patch for the same issue (in
066ff9b4ae0bb8deb6fc158737a117f9541eeff8) works fine for VLC, which
manually overrides "lt_cv_deplibs_check_method=pass_all" in their
configure.ac to get rid of this check in libtool in general.

To fix linking other projects without such existing workarounds
in their configure scripts, we need to patch libtool to allow
statically linking the compiler-rt builtins.

This patch is under discussion upstream at
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=27866#65 (but doesn't
seem to be making any progress at the moment).