### PR TITLE
Fix #1759 - Add GitHub's hub package

### DIFF
--- a/hub/PKGBUILD
+++ b/hub/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Johannes Löthberg <johannes@kyriasis.com>
+# Maintainer: Eli Schwartz <eschwartz@archlinux.org>
+# Contributor: Daniel Wallace <danielwallace at gtmanfred dot com>
+# Contributor: Alfredo Palhares <masterkorp@masterkorp.net>
+
+pkgname=hub
+pkgver=2.12.8
+pkgrel=1
+
+pkgdesc="cli interface for Github"
+url="https://hub.github.com"
+arch=('x86_64')
+license=('MIT')
+
+depends=('git')
+
+source=("hub-$pkgver.tar.gz::https://github.com/github/hub/archive/v$pkgver.tar.gz")
+sha256sums=('72d09397967c85b118fc1be25dc0fc54353f4dea09f804687a287949c7de7ebe')
+b2sums=('25a0548a1ef18d941b1cfc8930e4c45d994b0705f723fd6b66495ae6d1d56cf85832e2d4e2721926afb6704322fdfc17683bed3a875332be5cea8e21147c02e2')
+
+build() {
+  cd "$srcdir"/hub-$pkgver
+
+  make
+  make man-pages
+}
+
+check() {
+  cd "$srcdir"/hub-$pkgver
+
+  make test
+}
+
+package() {
+  cd "$srcdir"/hub-$pkgver
+
+  make PREFIX="$pkgdir"/usr install
+
+  install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+  install -Dm644 etc/hub.bash_completion.sh "$pkgdir"/usr/share/bash-completion/completions/hub
+  install -Dm644 etc/hub.zsh_completion "$pkgdir"/usr/share/zsh/site-functions/_hub
+  install -Dm644 etc/hub.fish_completion "$pkgdir"/usr/share/fish/vendor_completions.d/hub.fish
+}
+


### PR DESCRIPTION
Imported the package from Arch Linux:  https://www.archlinux.org/packages/community/x86_64/hub/

Not sure how to define the dependency from the Go package in MSYS2