### PR TITLE
Fix curl command for pacman

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=5.2.1
-pkgrel=1
+pkgrel=2
 contrib_ver=1.2.0
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')

--- a/pacman/pacman.conf
+++ b/pacman/pacman.conf
@@ -15,7 +15,7 @@
 #LogFile     = /var/log/pacman.log
 #GPGDir      = /etc/pacman.d/gnupg/
 HoldPkg      = pacman
-#XferCommand = /usr/bin/curl -C - -f %u > %o
+#XferCommand = /usr/bin/curl -L -C - -f -o %o %u
 #XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
 #CleanMethod = KeepInstalled
 #UseDelta    = 0.7


### PR DESCRIPTION
This fixes database and package downloads, when using recent versions of curl.
Fixes #1774.