### PR TITLE
gawk(5.0.1): bug fix - set shared object extension to `dll`

### DIFF
--- a/gawk/PKGBUILD
+++ b/gawk/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=gawk
 pkgver=5.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU version of awk"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/gawk/"
@@ -13,15 +13,18 @@ makedepends=('gettext-devel' 'mpfr-devel' 'libreadline-devel')
 provides=('awk')
 install=gawk.install
 source=(https://ftp.gnu.org/pub/gnu/${pkgname}/${pkgname}-${pkgver}.tar.gz{,.sig}
-        gawk-4.2.1-msysize.patch)
+        gawk-4.2.1-msysize.patch
+        gawk-5.0.1-configure.ac-set-shared-object-extension-to-dll.patch)
 sha256sums=('625bf3718e25a84dc4486135d5cb5388174682362c70107fd13f21572f5603bb'
             'SKIP'
-            '303a1fa02fb3e5bf075319d6e9982986d37e156be630d0141a1148cd803c67c4')
+            '303a1fa02fb3e5bf075319d6e9982986d37e156be630d0141a1148cd803c67c4'
+            '5f24017432ca33d8646ca23f0681a87ba98f3efc6ddde89b9a553b93ea94df9c')
 validpgpkeys=('D1967C63788713177D861ED7DF597815937EC0D2')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
   patch -p1 -i ${srcdir}/gawk-4.2.1-msysize.patch
+  patch -p1 -i ${srcdir}/gawk-5.0.1-configure.ac-set-shared-object-extension-to-dll.patch
   autoreconf -fiv
 }
 

--- a/gawk/gawk-5.0.1-configure.ac-set-shared-object-extension-to-dll.patch
+++ b/gawk/gawk-5.0.1-configure.ac-set-shared-object-extension-to-dll.patch
@@ -1,0 +1,31 @@
+From d96728f621889a4e6a7ca57b41af8eca7c94ec70 Mon Sep 17 00:00:00 2001
+From: Jannick <thirdedition@gmx.net>
+Date: Sun, 22 Dec 2019 12:30:00 +0100
+Subject: [PATCH] configure.ac: set shared object extension to 'dll'
+
+This patch hardcodes the shared object extension to dll on Windows
+platforms, i.e.whenever EXEEXT is '.exe'.
+---
+ configure.ac | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index f353cea3..af3432cb 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -458,10 +458,12 @@ AH_BOTTOM([#include "custom.h"])
+ dnl Crude but small hack to make plug-ins work on Mac OS X
+ dnl We should really use the libtool value for shrext_cmds, but that
+ dnl is not available here, since we do not use libtool at the top level.
++AS_VAR_IF([EXEEXT],[.exe],[GAWKLIBEXT=dll],[
+ case $acl_shlibext in
+ dylib)	GAWKLIBEXT=so ;;	# MacOS uses .dylib for shared libraries, but libtool uses .so for modules
+ *) GAWKLIBEXT=$acl_shlibext ;;
+ esac
++])
+ AC_SUBST(GAWKLIBEXT)
+ 
+ AC_CONFIG_FILES(Makefile
+-- 
+2.24.1.windows.2
+


### PR DESCRIPTION
gawk is able to load extensions, i.e. shared objects, which on Windows
have extension dll. However, gawk sets it to `so`.

The patch added in this commit sets the extension to `dll` on Windows
systems (recognized if EXEEXT equals `.exe`).