### PR TITLE
perl: move 'libcrypt-devel' from makedepends to depends

### DIFF
--- a/perl/PKGBUILD
+++ b/perl/PKGBUILD
@@ -9,8 +9,8 @@ arch=(i686 x86_64)
 license=('GPL')
 url="https://www.perl.org/"
 groups=('base-devel')
-depends=('db' 'gdbm' 'libcrypt' 'coreutils' 'msys2-runtime' 'sh')
-makedepends=('libdb-devel' 'libgdbm-devel' 'libcrypt-devel')
+depends=('db' 'gdbm' 'libcrypt' 'coreutils' 'msys2-runtime' 'sh' 'libcrypt-devel')
+makedepends=('libdb-devel' 'libgdbm-devel')
 source=(https://www.cpan.org/src/5.0/perl-${pkgver}.tar.xz
         perlbin.sh
         perlbin.csh


### PR DESCRIPTION
Many perl packages, if not all, require the header file <crypt.h>
which is part of 'libcrypt-devel'.  Hence move it from makedepends to
depends.