### PR TITLE
pacman/makepkg: sync config files with upstream and support zstd

### DIFF
--- a/pacman/0000-pacman-msysize.patch
+++ b/pacman/0000-pacman-msysize.patch
@@ -479,18 +479,6 @@ diff -Naur pacman-5.1.0-orig/scripts/libmakepkg/tidy/strip.sh.in pacman-5.1.0/sc
  				*application/x-sharedlib*)  # Libraries (.so)
  					strip_flags="$STRIP_SHARED";;
  				*application/x-archive*)    # Libraries (.a)
-diff -Naur pacman-5.1.0-orig/scripts/libmakepkg/util/compress.sh.in pacman-5.1.0/scripts/libmakepkg/util/compress.sh.in
---- pacman-5.1.0-orig/scripts/libmakepkg/util/compress.sh.in	2018-03-18 05:51:17.000000000 +0300
-+++ pacman-5.1.0/scripts/libmakepkg/util/compress.sh.in	2018-06-21 13:37:44.296861300 +0300
-@@ -36,7 +36,7 @@
- 	case "$ext" in
- 		*.tar.gz)  ${COMPRESSGZ[@]:-gzip -c -f -n} ;;
- 		*.tar.bz2) ${COMPRESSBZ2[@]:-bzip2 -c -f} ;;
--		*.tar.xz)  ${COMPRESSXZ[@]:-xz -c -z -} ;;
-+		*.tar.xz)  ${COMPRESSXZ[@]:-xz -c -z -T0 -} ;;
- 		*.tar.zst) ${COMPRESSZST[@]:-zstd -c -z -q -} ;;
- 		*.tar.lrz) ${COMPRESSLRZ[@]:-lrzip -q} ;;
- 		*.tar.lzo) ${COMPRESSLZO[@]:-lzop -q} ;;
 diff -Naur pacman-5.1.0-orig/scripts/libmakepkg/util/pkgbuild.sh.in pacman-5.1.0/scripts/libmakepkg/util/pkgbuild.sh.in
 --- pacman-5.1.0-orig/scripts/libmakepkg/util/pkgbuild.sh.in	2018-05-12 16:15:04.000000000 +0300
 +++ pacman-5.1.0/scripts/libmakepkg/util/pkgbuild.sh.in	2018-06-21 12:53:58.872056200 +0300
@@ -528,9 +516,9 @@ diff -Naur pacman-5.1.0-orig/scripts/libmakepkg/utils_fixed_path.sh.in pacman-5.
 +                          'svn'
 +                          'tput'
 +                          'uncompress'
-+                          'upx'
 +                          'xargs'
 +                          'xz'
++                          'zstd'
 +                         )
 +
 +  for wrapper in ${UTILS_NAME[@]}; do

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=5.2.1
-pkgrel=4
+pkgrel=5
 contrib_ver=1.2.0
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
@@ -24,7 +24,8 @@ depends=('bash>=4.2.045'
          'msys2-keyring'
          'which'
          'bzip2'
-         'xz')
+         'xz'
+         'zstd')
 optdepends=('diffutils' 'vim')
 checkdepends=('python2')
 makedepends=('asciidoc'
@@ -73,18 +74,19 @@ source=(https://sources.archlinux.org/other/pacman/${pkgname}-${pkgver}.tar.gz{,
         "0010-filelist-strcasecmp.patch"
         "0011-update-ja-po-for-msys2.patch"
         Doxyfile.in)
+validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD')
 sha256sums=('1930c407265fd039cb3a8e6edc82f69e122aa9239d216d9d57b9d1b9315af312'
             'SKIP'
             '317f53819e35647a19138cb0d68e16206af4a80f52115a7cd622c4a367f914b7'
-            'ef81238669f3a9a092b1a809f0b5f873f9b755ff578fe0f1663e7223d394f7be'
-            '3d2f8a8c363a76ebd417e883cf28dc093e611b1360fe684d40e29540cbcb7ef2'
-            '1be68801760f8e175b4e3242ff42cb5091bbc3fb6de418d160ae53d101911eb2'
-            '07b999941aa27318594a1e55918d2b1bd7c0cbcd5c5ad8bd2fc941aa2a2f4246'
-            '7a345127473629fe79c99bb16194e201989b2ebae5de37af98b2ae2e5488f97d'
-            'f2d127a03c8e47660cd2b0017453e74402470824b23139e1003b8a081e98e3bd'
+            '7849538ac2b89f4e9881ad5db78a2aa37a2ddb936f87a0ede1c2322e515918fe'
+            '40a46147ebb9b85f74d60d53a1bf911dfb32d85c65c2ee6e57bfd6d3d4aac848'
+            'a5b4a80489fdbe1394bc64718bf9d95e5924786fcc72ca0bbfeaa0cb6fb26b96'
+            'c7e063d3159ea8c67c91db081857502aa16c6339b4efe1272b6f722d1aa5c352'
+            'a9d0556177f51166d47ba669932bdf17b2adcee7da1d06baa7aa0cd8b2d45f8d'
+            '877b0a4747f1b45b2dc5a197d86d0d42ac346bd37ef2883514fab93144234475'
             '8949cfd1fee9c965ec8afccee27937d4c15b4cccb2c367db4fb2b718bc66e74a'
             '684648d5b1246af9ce5b3afaadf201873269c5208057e8cbdbd409b4c0f22564'
-            'e1f880cbfea6e1d8d67cdb17bc07eaaa99421f65e688e6858ccbcbbb9a6b69d3'
+            '1f92a6dcb3ae631cb0bbf5e089417a2ff7b895e541739f3a49b126b80f185920'
             '24ea2c8dca37847e04894ebfd05d1cf5df49dc0c8089f5581c99caa19b77a7ef'
             '870b197b7d6379a9c1ebb5c449c902b21d75ec21e966a2e54af82501465180f7'
             '23132552a388b238acf8bf650b5c2aa08cf3de63c647e84ad551807c4edfeb1e'

--- a/pacman/makepkg.conf
+++ b/pacman/makepkg.conf
@@ -82,7 +82,7 @@ BUILDENV=(!distcc color !ccache check !sign)
 #   These are default values for the options=() settings
 #########################################################################
 #
-# Default: OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !upx !debug)
+# Default: OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !debug)
 #  A negated option will do the opposite of the comments below.
 #
 #-- strip:      Strip symbols from binaries/libraries
@@ -92,10 +92,9 @@ BUILDENV=(!distcc color !ccache check !sign)
 #-- emptydirs:  Leave empty directories in packages
 #-- zipman:     Compress manual (man and info) pages in MAN_DIRS with gzip
 #-- purge:      Remove files specified by PURGE_TARGETS
-#-- upx:        Compress binary executable files using UPX
 #-- debug:      Add debugging flags as specified in DEBUG_* variables
 #
-OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !upx !debug)
+OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !debug)
 
 #-- File integrity checks to use. Valid: md5, sha1, sha256, sha384, sha512
 INTEGRITY_CHECK=(md5)
@@ -138,9 +137,12 @@ PURGE_TARGETS=({,usr/}{,share}/info/dir mingw{32,64}/{,share}/info/dir .packlist
 COMPRESSGZ=(gzip -c -f -n)
 COMPRESSBZ2=(bzip2 -c -f)
 COMPRESSXZ=(xz -c -z -T0 -)
+COMPRESSZST=(zstd -c -T0 -19 -)
 COMPRESSLRZ=(lrzip -q)
 COMPRESSLZO=(lzop -q)
 COMPRESSZ=(compress -c -f)
+COMPRESSLZ4=(lz4 -q)
+COMPRESSLZ=(lzip -c -f)
 
 #########################################################################
 # EXTENSION DEFAULTS

--- a/pacman/makepkg_clang32.conf
+++ b/pacman/makepkg_clang32.conf
@@ -98,7 +98,7 @@ BUILDENV=(!distcc color !ccache check !sign)
 #   These are default values for the options=() settings
 #########################################################################
 #
-# Default: OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !upx !debug)
+# Default: OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !debug)
 #  A negated option will do the opposite of the comments below.
 #
 #-- strip:      Strip symbols from binaries/libraries
@@ -108,10 +108,9 @@ BUILDENV=(!distcc color !ccache check !sign)
 #-- emptydirs:  Leave empty directories in packages
 #-- zipman:     Compress manual (man and info) pages in MAN_DIRS with gzip
 #-- purge:      Remove files specified by PURGE_TARGETS
-#-- upx:        Compress binary executable files using UPX
 #-- debug:      Add debugging flags as specified in DEBUG_* variables
 #
-OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !upx !debug)
+OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !debug)
 
 #-- File integrity checks to use. Valid: md5, sha1, sha256, sha384, sha512
 INTEGRITY_CHECK=(md5)
@@ -154,9 +153,12 @@ PURGE_TARGETS=(clang32/{,share}/info/dir .packlist *.pod)
 COMPRESSGZ=(gzip -c -f -n)
 COMPRESSBZ2=(bzip2 -c -f)
 COMPRESSXZ=(xz -c -z -T0 -)
+COMPRESSZST=(zstd -c -T0 -19 -)
 COMPRESSLRZ=(lrzip -q)
 COMPRESSLZO=(lzop -q)
 COMPRESSZ=(compress -c -f)
+COMPRESSLZ4=(lz4 -q)
+COMPRESSLZ=(lzip -c -f)
 
 #########################################################################
 # EXTENSION DEFAULTS

--- a/pacman/makepkg_clang64.conf
+++ b/pacman/makepkg_clang64.conf
@@ -98,7 +98,7 @@ BUILDENV=(!distcc color !ccache check !sign)
 #   These are default values for the options=() settings
 #########################################################################
 #
-# Default: OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !upx !debug)
+# Default: OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !debug)
 #  A negated option will do the opposite of the comments below.
 #
 #-- strip:      Strip symbols from binaries/libraries
@@ -108,10 +108,9 @@ BUILDENV=(!distcc color !ccache check !sign)
 #-- emptydirs:  Leave empty directories in packages
 #-- zipman:     Compress manual (man and info) pages in MAN_DIRS with gzip
 #-- purge:      Remove files specified by PURGE_TARGETS
-#-- upx:        Compress binary executable files using UPX
 #-- debug:      Add debugging flags as specified in DEBUG_* variables
 #
-OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !upx !debug)
+OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !debug)
 
 #-- File integrity checks to use. Valid: md5, sha1, sha256, sha384, sha512
 INTEGRITY_CHECK=(md5)
@@ -154,9 +153,12 @@ PURGE_TARGETS=(clang64/{,share}/info/dir .packlist *.pod)
 COMPRESSGZ=(gzip -c -f -n)
 COMPRESSBZ2=(bzip2 -c -f)
 COMPRESSXZ=(xz -c -z -T0 -)
+COMPRESSZST=(zstd -c -T0 -19 -)
 COMPRESSLRZ=(lrzip -q)
 COMPRESSLZO=(lzop -q)
 COMPRESSZ=(compress -c -f)
+COMPRESSLZ4=(lz4 -q)
+COMPRESSLZ=(lzip -c -f)
 
 #########################################################################
 # EXTENSION DEFAULTS

--- a/pacman/makepkg_mingw32.conf
+++ b/pacman/makepkg_mingw32.conf
@@ -98,7 +98,7 @@ BUILDENV=(!distcc color !ccache check !sign)
 #   These are default values for the options=() settings
 #########################################################################
 #
-# Default: OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !upx !debug)
+# Default: OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !debug)
 #  A negated option will do the opposite of the comments below.
 #
 #-- strip:      Strip symbols from binaries/libraries
@@ -108,10 +108,9 @@ BUILDENV=(!distcc color !ccache check !sign)
 #-- emptydirs:  Leave empty directories in packages
 #-- zipman:     Compress manual (man and info) pages in MAN_DIRS with gzip
 #-- purge:      Remove files specified by PURGE_TARGETS
-#-- upx:        Compress binary executable files using UPX
 #-- debug:      Add debugging flags as specified in DEBUG_* variables
 #
-OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !upx !debug)
+OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !debug)
 
 #-- File integrity checks to use. Valid: md5, sha1, sha256, sha384, sha512
 INTEGRITY_CHECK=(md5)
@@ -154,9 +153,12 @@ PURGE_TARGETS=(mingw32/{,share}/info/dir .packlist *.pod)
 COMPRESSGZ=(gzip -c -f -n)
 COMPRESSBZ2=(bzip2 -c -f)
 COMPRESSXZ=(xz -c -z -T0 -)
+COMPRESSZST=(zstd -c -T0 -19 -)
 COMPRESSLRZ=(lrzip -q)
 COMPRESSLZO=(lzop -q)
 COMPRESSZ=(compress -c -f)
+COMPRESSLZ4=(lz4 -q)
+COMPRESSLZ=(lzip -c -f)
 
 #########################################################################
 # EXTENSION DEFAULTS

--- a/pacman/makepkg_mingw64.conf
+++ b/pacman/makepkg_mingw64.conf
@@ -98,7 +98,7 @@ BUILDENV=(!distcc color !ccache check !sign)
 #   These are default values for the options=() settings
 #########################################################################
 #
-# Default: OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !upx !debug)
+# Default: OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !debug)
 #  A negated option will do the opposite of the comments below.
 #
 #-- strip:      Strip symbols from binaries/libraries
@@ -108,10 +108,9 @@ BUILDENV=(!distcc color !ccache check !sign)
 #-- emptydirs:  Leave empty directories in packages
 #-- zipman:     Compress manual (man and info) pages in MAN_DIRS with gzip
 #-- purge:      Remove files specified by PURGE_TARGETS
-#-- upx:        Compress binary executable files using UPX
 #-- debug:      Add debugging flags as specified in DEBUG_* variables
 #
-OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !upx !debug)
+OPTIONS=(strip docs !libtool staticlibs emptydirs zipman purge !debug)
 
 #-- File integrity checks to use. Valid: md5, sha1, sha256, sha384, sha512
 INTEGRITY_CHECK=(md5)
@@ -154,9 +153,12 @@ PURGE_TARGETS=(mingw64/{,share}/info/dir .packlist *.pod)
 COMPRESSGZ=(gzip -c -f -n)
 COMPRESSBZ2=(bzip2 -c -f)
 COMPRESSXZ=(xz -c -z -T0 -)
+COMPRESSZST=(zstd -c -T0 -19 -)
 COMPRESSLRZ=(lrzip -q)
 COMPRESSLZO=(lzop -q)
 COMPRESSZ=(compress -c -f)
+COMPRESSLZ4=(lz4 -q)
+COMPRESSLZ=(lzip -c -f)
 
 #########################################################################
 # EXTENSION DEFAULTS

--- a/pacman/pacman.conf
+++ b/pacman/pacman.conf
@@ -18,7 +18,6 @@ HoldPkg      = pacman
 #XferCommand = /usr/bin/curl -L -C - -f -o %o %u
 #XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
 #CleanMethod = KeepInstalled
-#UseDelta    = 0.7
 Architecture = auto
 
 # Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup


### PR DESCRIPTION
* Add a dependency on zstd so that makepkg can use it
* Remove the upx option from the config because it was removed
  in pacman: https://git.archlinux.org/pacman.git/commit/?id=1a29744d0d
* Various other syncs and adjustments for zstd

This should make it possible for us to switch from xz to zstd, if we want.

Arch switched already: https://www.archlinux.org/news/now-using-zstandard-instead-of-xz-for-package-compression/