### PR TITLE
Add u-boot-tools package v2020.01

### DIFF
--- a/u-boot-tools/PKGBUILD
+++ b/u-boot-tools/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: Bin Meng <bmeng.cn@gmail.com>
+
+pkgname=u-boot-tools
+pkgver=2020.01
+pkgrel=1
+pkgdesc="U-Boot Tools"
+arch=('i686' 'x86_64')
+url="https://github.com/u-boot/u-boot"
+license=('GPL2')
+groups=('base')
+depends=('openssl')
+makedepends=('unzip' 'openssl-devel')
+source=("${pkgname}-{pkgver}.zip"::"https://github.com/u-boot/u-boot/archive/v${pkgver}.zip")
+noextract=("${pkgname}-{pkgver}.zip")
+sha256sums=('SKIP')
+
+prepare() {
+  # workaround an issue of bsdtar for extracting symbolic links in the tarball
+  unzip $srcdir/${pkgname}-{pkgver}.zip
+}
+
+build() {
+  cd ${srcdir}/u-boot-${pkgver}
+  make tools-only_defconfig tools-only NO_SDL=1
+}
+
+package() {
+  mkdir -p ${pkgdir}/usr/bin
+  cd ${srcdir}/u-boot-${pkgver}
+  cp -f tools/dumpimage.exe ${pkgdir}/usr/bin/
+  cp -f tools/fdtgrep.exe ${pkgdir}/usr/bin/
+  cp -f tools/fit_info.exe ${pkgdir}/usr/bin/
+  cp -f tools/fit_check_sign.exe ${pkgdir}/usr/bin/
+  cp -f tools/mkimage.exe ${pkgdir}/usr/bin/
+}


### PR DESCRIPTION
This adds a new package for MSYS2: u-boot-tools.

It includes various host tools from U-Boot, the universal bootloader.

The following tools are included:

  - dumpimage.exe
  - fdtgrep.exe
  - fit_info.exe
  - fit_check_sign.exe
  - mkimage.exe

Signed-off-by: Bin Meng <bmeng.cn@gmail.com>