### PR TITLE
Fix msys2_shell.cmd argument-handling with spaces

### DIFF
--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -4,7 +4,7 @@ setlocal EnableDelayedExpansion
 set "WD=%__CD__%"
 if NOT EXIST "%WD%msys-2.0.dll" set "WD=%~dp0usr\bin\"
 set "LOGINSHELL=bash"
-set /a shiftCounter=0
+set /a msys2_shiftCounter=0
 
 rem To activate windows native symlinks uncomment next line
 rem set MSYS=winsymlinks:nativestrict
@@ -35,19 +35,19 @@ if "x%~1" == "x/?" (
   exit /b %ERRORLEVEL%
 )
 rem Shell types
-if "x%~1" == "x-msys" shift& set /a shiftCounter+=1& set MSYSTEM=MSYS& goto :checkparams
-if "x%~1" == "x-msys2" shift& set /a shiftCounter+=1& set MSYSTEM=MSYS& goto :checkparams
-if "x%~1" == "x-mingw32" shift& set /a shiftCounter+=1& set MSYSTEM=MINGW32& goto :checkparams
-if "x%~1" == "x-mingw64" shift& set /a shiftCounter+=1& set MSYSTEM=MINGW64& goto :checkparams
-if "x%~1" == "x-mingw" shift& set /a shiftCounter+=1& (if exist "%WD%..\..\mingw64" (set MSYSTEM=MINGW64) else (set MSYSTEM=MINGW32))& goto :checkparams
+if "x%~1" == "x-msys" shift& set /a msys2_shiftCounter+=1& set MSYSTEM=MSYS& goto :checkparams
+if "x%~1" == "x-msys2" shift& set /a msys2_shiftCounter+=1& set MSYSTEM=MSYS& goto :checkparams
+if "x%~1" == "x-mingw32" shift& set /a msys2_shiftCounter+=1& set MSYSTEM=MINGW32& goto :checkparams
+if "x%~1" == "x-mingw64" shift& set /a msys2_shiftCounter+=1& set MSYSTEM=MINGW64& goto :checkparams
+if "x%~1" == "x-mingw" shift& set /a msys2_shiftCounter+=1& (if exist "%WD%..\..\mingw64" (set MSYSTEM=MINGW64) else (set MSYSTEM=MINGW32))& goto :checkparams
 rem Console types
-if "x%~1" == "x-mintty" shift& set /a shiftCounter+=1& set MSYSCON=mintty.exe& goto :checkparams
-if "x%~1" == "x-conemu" shift& set /a shiftCounter+=1& set MSYSCON=conemu& goto :checkparams
-if "x%~1" == "x-defterm" shift& set /a shiftCounter+=1& set MSYSCON=defterm& goto :checkparams
+if "x%~1" == "x-mintty" shift& set /a msys2_shiftCounter+=1& set MSYSCON=mintty.exe& goto :checkparams
+if "x%~1" == "x-conemu" shift& set /a msys2_shiftCounter+=1& set MSYSCON=conemu& goto :checkparams
+if "x%~1" == "x-defterm" shift& set /a msys2_shiftCounter+=1& set MSYSCON=defterm& goto :checkparams
 rem Other parameters
-if "x%~1" == "x-full-path" shift& set /a shiftCounter+=1& set MSYS2_PATH_TYPE=inherit& goto :checkparams
-if "x%~1" == "x-use-full-path" shift& set /a shiftCounter+=1& set MSYS2_PATH_TYPE=inherit& goto :checkparams
-if "x%~1" == "x-here" shift& set /a shiftCounter+=1& set CHERE_INVOKING=enabled_from_arguments& goto :checkparams
+if "x%~1" == "x-full-path" shift& set /a msys2_shiftCounter+=1& set MSYS2_PATH_TYPE=inherit& goto :checkparams
+if "x%~1" == "x-use-full-path" shift& set /a msys2_shiftCounter+=1& set MSYS2_PATH_TYPE=inherit& goto :checkparams
+if "x%~1" == "x-here" shift& set /a msys2_shiftCounter+=1& set CHERE_INVOKING=enabled_from_arguments& goto :checkparams
 if "x%~1" == "x-where" (
   if "x%~2" == "x" (
     echo Working directory is not specified for -where parameter. 1>&2
@@ -60,15 +60,15 @@ if "x%~1" == "x-where" (
   set CHERE_INVOKING=enabled_from_arguments
 
   rem Ensure parentheses in argument do not interfere with FOR IN loop below.
-  set arg="%~2"
-  call :substituteparens arg
-  call :removequotes arg
+  set msys2_arg="%~2"
+  call :substituteparens msys2_arg
+  call :removequotes msys2_arg
 
-  rem Increment shiftCounter by number of words in argument (as cmd.exe saw it).
+  rem Increment msys2_shiftCounter by number of words in argument (as cmd.exe saw it).
   rem (Note that this form of FOR IN loop uses same delimiters as parameters.)
-  for %%a in (!arg!) do set /a shiftCounter+=1
-)& shift& shift& set /a shiftCounter+=1& goto :checkparams
-if "x%~1" == "x-no-start" shift& set /a shiftCounter+=1& set MSYS2_NOSTART=yes& goto :checkparams
+  for %%a in (!msys2_arg!) do set /a msys2_shiftCounter+=1
+)& shift& shift& set /a msys2_shiftCounter+=1& goto :checkparams
+if "x%~1" == "x-no-start" shift& set /a msys2_shiftCounter+=1& set MSYS2_NOSTART=yes& goto :checkparams
 if "x%~1" == "x-shell" (
   if "x%~2" == "x" (
     echo Shell not specified for -shell parameter. 1>&2
@@ -76,23 +76,23 @@ if "x%~1" == "x-shell" (
   )
   set LOGINSHELL="%~2"
 
-  set arg="%~2"
-  call :substituteparens arg
-  call :removequotes arg
-  for %%a in (!arg!) do set /a shiftCounter+=1
-)& shift& shift& set /a shiftCounter+=1& goto :checkparams
+  set msys2_arg="%~2"
+  call :substituteparens msys2_arg
+  call :removequotes msys2_arg
+  for %%a in (!msys2_arg!) do set /a msys2_shiftCounter+=1
+)& shift& shift& set /a msys2_shiftCounter+=1& goto :checkparams
 
 rem Collect remaining command line arguments to be passed to shell
 rem Again, ensure that parentheses in %* do not interfere with FOR IN loop.
-set full_cmd="%*"
-call :substituteparens full_cmd
-call :removequotes full_cmd
-for /f "tokens=%shiftCounter%,* delims=,;=	 " %%i in ("!full_cmd!") do set SHELL_ARGS=%%j
+set msys2_full_cmd="%*"
+call :substituteparens msys2_full_cmd
+call :removequotes msys2_full_cmd
+for /f "tokens=%msys2_shiftCounter%,* delims=,;=	 " %%i in ("!msys2_full_cmd!") do set SHELL_ARGS=%%j
 
 rem Clean up working variables
-set arg=
-set shiftCounter=
-set full_cmd=
+set msys2_arg=
+set msys2_shiftCounter=
+set msys2_full_cmd=
 
 rem Setup proper title
 if "%MSYSTEM%" == "MINGW32" (

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -87,7 +87,7 @@ rem Again, ensure that parentheses in %* do not interfere with FOR IN loop.
 set full_cmd="%*"
 CALL :substituteparens full_cmd
 CALL :removequotes full_cmd
-for /f tokens^=%shiftCounter%*^ delims^=^,^;^^^=^	^  %%i in ("!full_cmd!") do set SHELL_ARGS=%%j
+for /f "tokens=%shiftCounter%,* delims=,;=	 " %%i in ("!full_cmd!") do set SHELL_ARGS=%%j
 
 rem Setup proper title
 if "%MSYSTEM%" == "MINGW32" (

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -83,10 +83,11 @@ if "x%~1" == "x-shell" (
 )& shift& shift& set /a msys2_shiftCounter+=1& goto :checkparams
 
 rem Collect remaining command line arguments to be passed to shell
+if %msys2_shiftCounter% equ 0 set SHELL_ARGS=%* & goto cleanvars
 set msys2_full_cmd=%*
 for /f "tokens=%msys2_shiftCounter%,* delims=,;=	 " %%i in ("!msys2_full_cmd!") do set SHELL_ARGS=%%j
 
-rem Clean up working variables
+:cleanvars
 set msys2_arg=
 set msys2_shiftCounter=
 set msys2_full_cmd=

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -109,9 +109,9 @@ if NOT EXIST "%WD%mintty.exe" goto startsh
 set MSYSCON=mintty.exe
 :startmintty
 if not defined MSYS2_NOSTART (
-  start "%CONTITLE%" "%WD%mintty" -i /msys2.ico -t "%CONTITLE%" "/usr/bin/%LOGINSHELL%" --login %SHELL_ARGS%
+  start "%CONTITLE%" "%WD%mintty" -i /msys2.ico -t "%CONTITLE%" "/usr/bin/%LOGINSHELL%" --login !SHELL_ARGS!
 ) else (
-  "%WD%mintty" -i /msys2.ico -t "%CONTITLE%" "/usr/bin/%LOGINSHELL%" --login %SHELL_ARGS%
+  "%WD%mintty" -i /msys2.ico -t "%CONTITLE%" "/usr/bin/%LOGINSHELL%" --login !SHELL_ARGS!
 )
 exit /b %ERRORLEVEL%
 
@@ -121,18 +121,18 @@ call :conemudetect || (
   exit /b 1
 )
 if not defined MSYS2_NOSTART (
-  start "%CONTITLE%" "%ComEmuCommand%" /Here /Icon "%WD%..\..\msys2.ico" /cmd "%WD%\%LOGINSHELL%" --login %SHELL_ARGS%
+  start "%CONTITLE%" "%ComEmuCommand%" /Here /Icon "%WD%..\..\msys2.ico" /cmd "%WD%\%LOGINSHELL%" --login !SHELL_ARGS!
 ) else (
-  "%ComEmuCommand%" /Here /Icon "%WD%..\..\msys2.ico" /cmd "%WD%\%LOGINSHELL%" --login %SHELL_ARGS%
+  "%ComEmuCommand%" /Here /Icon "%WD%..\..\msys2.ico" /cmd "%WD%\%LOGINSHELL%" --login !SHELL_ARGS!
 )
 exit /b %ERRORLEVEL%
 
 :startsh
 set MSYSCON=
 if not defined MSYS2_NOSTART (
-  start "%CONTITLE%" "%WD%\%LOGINSHELL%" --login %SHELL_ARGS%
+  start "%CONTITLE%" "%WD%\%LOGINSHELL%" --login !SHELL_ARGS!
 ) else (
-  "%WD%\%LOGINSHELL%" --login %SHELL_ARGS%
+  "%WD%\%LOGINSHELL%" --login !SHELL_ARGS!
 )
 exit /b %ERRORLEVEL%
 

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -61,8 +61,8 @@ if "x%~1" == "x-where" (
 
   rem Ensure parentheses in argument do not interfere with FOR IN loop below.
   set arg="%~2"
-  CALL :substituteparens arg
-  CALL :removequotes arg
+  call :substituteparens arg
+  call :removequotes arg
 
   rem Increment shiftCounter by number of words in argument (as cmd.exe saw it).
   rem (Note that this form of FOR IN loop uses same delimiters as parameters.)
@@ -77,16 +77,16 @@ if "x%~1" == "x-shell" (
   set LOGINSHELL="%~2"
 
   set arg="%~2"
-  CALL :substituteparens arg
-  CALL :removequotes arg
+  call :substituteparens arg
+  call :removequotes arg
   for %%a in (!arg!) do set /a shiftCounter+=1
 )& shift& shift& set /a shiftCounter+=1& goto :checkparams
 
 rem Collect remaining command line arguments to be passed to shell
 rem Again, ensure that parentheses in %* do not interfere with FOR IN loop.
 set full_cmd="%*"
-CALL :substituteparens full_cmd
-CALL :removequotes full_cmd
+call :substituteparens full_cmd
+call :removequotes full_cmd
 for /f "tokens=%shiftCounter%,* delims=,;=	 " %%i in ("!full_cmd!") do set SHELL_ARGS=%%j
 
 rem Clean up working variables

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -83,10 +83,7 @@ if "x%~1" == "x-shell" (
 )& shift& shift& set /a msys2_shiftCounter+=1& goto :checkparams
 
 rem Collect remaining command line arguments to be passed to shell
-rem Again, ensure that parentheses in %* do not interfere with FOR IN loop.
-set msys2_full_cmd="%*"
-call :substituteparens msys2_full_cmd
-call :removequotes msys2_full_cmd
+set msys2_full_cmd=%*
 for /f "tokens=%msys2_shiftCounter%,* delims=,;=	 " %%i in ("!msys2_full_cmd!") do set SHELL_ARGS=%%j
 
 rem Clean up working variables

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -89,6 +89,11 @@ CALL :substituteparens full_cmd
 CALL :removequotes full_cmd
 for /f "tokens=%shiftCounter%,* delims=,;=	 " %%i in ("!full_cmd!") do set SHELL_ARGS=%%j
 
+rem Clean up working variables
+set arg=
+set shiftCounter=
+set full_cmd=
+
 rem Setup proper title
 if "%MSYSTEM%" == "MINGW32" (
   set "CONTITLE=MinGW x32"


### PR DESCRIPTION
Commit 11ba641bed28 intended to preserve [`cmd.exe` delimiter characters](https://ss64.com/nt/syntax-esc.html#delimiters) in the command line passed on to `bash`, but broke the handling of `-where` directories with spaces in them. Fix this by:

 - Incrementing `shiftCounter` with any quoted arguments treated as separate words (after unquoting), because the `FOR /F ... IN`-loop at the end cannot treat them (in the full command) as single parameters.
 - Using the full list of `cmd.exe` delimiters in the `FOR /F ... IN`-loop when skipping the initial tokens.

Tested this with:

```
C:\msys2\msys2_shell.cmd -defterm -no-start -mingw64 -where <DIR> -shell bash -c $@ -- echo hello there, --world=windows
```

where `<DIR>` is the following:

 - `C:\Users`
 - `C:\Progra~1`
 - `"C:\Program Files"`
 - `"C:\Program Files (x86)"`
 - `"C:\Users\T-17\Documents\Projects and Learning\test,dir"`

Also:

 - Prevent a stray warning if the script is run without any arguments. (This was also introduced in 11ba641.)
 - Ensure (using [delayed expansion](https://ss64.com/nt/delayedexpansion.html)) that the non-option arguments passed on to Bash are intact, even if they contain spaces, parentheses or [`cmd.exe` metacharacters](https://ss64.com/nt/syntax-esc.html#escape).

Fixes #1826