### PR TITLE
libxml2: Fix dependencies (compile-time and run-time)

### DIFF
--- a/libxml2/PKGBUILD
+++ b/libxml2/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc="XML parsing library, version 2"
 arch=(i686 x86_64)
 license=('MIT')
 depends=('coreutils' 'icu>=59.1' 'liblzma' 'libreadline' 'zlib')
-makedepends=('python2' 'python3' 'icu-devel>=59.1' 'libreadline-devel' 'ncurses-devel' 'liblzma-devel' 'zlib-devel'
+makedepends=('python2' 'python3' 'icu-devel>=59.1' 'libreadline-devel' 'liblzma-devel' 'zlib-devel'
         'libcrypt-devel')
 url="http://www.xmlsoft.org/"
 source=(http://xmlsoft.org/sources/${pkgname}-${pkgver}.tar.gz
@@ -57,11 +57,11 @@ prepare() {
     libxml2-2.9.0-do-not-check-crc.patch \
     libxml2-2.7.3-doc-install.patch \
     libxml2-cygwin-reentrant.patch \
-    libxml2-2.9.1-msys2.patch 
+    libxml2-2.9.1-msys2.patch
 
   sed -e 's|/usr/bin/python -u|/usr/bin/python2 -u|g' -e 's|/usr/bin/python$|/usr/bin/python2|g' -i python/tests/*.py
 
-  autoreconf -fi
+  autoreconf -vfi
 }
 
 build() {
@@ -92,7 +92,7 @@ check() {
 }
 
 package_libxml2() {
-  depends=('coreutils' 'icu>=59.1' 'liblzma' 'libreadline' 'ncurses' 'zlib')
+  depends=('coreutils' 'icu>=59.1' 'liblzma' 'libreadline' 'zlib')
   groups=('libraries')
   install=libxml2.install
 
@@ -108,7 +108,7 @@ package_libxml2-devel() {
   pkgdesc="Libxml2 headers and libraries"
   groups=('development')
   options=('staticlibs')
-  depends=("libxml2=${pkgver}" 'icu-devel>=59.1' 'libreadline-devel' 'ncurses-devel' 'liblzma-devel' 'zlib-devel')
+  depends=("libxml2=${pkgver}" 'icu-devel>=59.1' 'libreadline-devel' 'liblzma-devel' 'zlib-devel')
 
   mkdir -p ${pkgdir}/usr/{bin,share}
   cp -f ${srcdir}/dest/usr/bin/*-config ${pkgdir}/usr/bin/

--- a/libxml2/PKGBUILD
+++ b/libxml2/PKGBUILD
@@ -2,11 +2,13 @@
 
 pkgname=('libxml2' 'libxml2-devel' 'libxml2-python')
 pkgver=2.9.10
-pkgrel=2
+pkgrel=3
 pkgdesc="XML parsing library, version 2"
 arch=(i686 x86_64)
 license=('MIT')
-makedepends=('python2' 'python3' 'icu-devel>=59.1' 'libreadline-devel' 'ncurses-devel' 'liblzma-devel' 'zlib-devel')
+depends=('coreutils' 'icu>=59.1' 'liblzma' 'libreadline' 'zlib')
+makedepends=('python2' 'python3' 'icu-devel>=59.1' 'libreadline-devel' 'ncurses-devel' 'liblzma-devel' 'zlib-devel'
+        'libcrypt-devel')
 url="http://www.xmlsoft.org/"
 source=(http://xmlsoft.org/sources/${pkgname}-${pkgver}.tar.gz
         https://www.w3.org/XML/Test/xmlts20130923.tar.gz

--- a/libxml2/libxml2.install
+++ b/libxml2/libxml2.install
@@ -1,6 +1,16 @@
-post_install() {
+#! /usr/bin/sh
+catalog_add () {
   if test ! -f etc/xml/catalog; then
     mkdir -p etc/xml
     usr/bin/xmlcatalog --noout --create etc/xml/catalog
   fi
 }
+
+catalog_remove () {
+  test -f etc/xml/catalog && rm -fv etc/xml/catalog
+}
+
+post_install () { catalog_add;    }
+pre_upgrade  () { catalog_remove; }
+post_upgrade () { catalog_add;    }
+post_remove  () { catalog_remove; }


### PR DESCRIPTION
The post_install hook of the package calls 'xmlcatalog.exe' which is part
of the package.  This commit fixes run-time dependency errors which occur
upon installing and using the package.

* libxml2/PKGBUILD:
  - add required package dependencies, implied by make-dependencies
  - remove trailing white spaces