### PR TITLE
Remove double quotes of the LOGINSHELL

### DIFF
--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -75,7 +75,8 @@ if "x%~1" == "x-shell" (
     exit /b 2
   )
   set LOGINSHELL="%~2"
-
+  call :removequotes LOGINSHELL
+  
   set msys2_arg="%~2"
   call :substituteparens msys2_arg
   call :removequotes msys2_arg

--- a/filesystem/profile
+++ b/filesystem/profile
@@ -137,6 +137,7 @@ elif [ ! "x${ZSH_VERSION}" = "x" ]; then
   profile_d sh
   profile_d zsh
   PS1='(%n@%m)[%h] %~ %% '
+  SHELL=`which zsh`
 elif [ ! "x${POSH_VERSION}" = "x" ]; then
   HOSTNAME="$(exec /usr/bin/hostname)"
   PS1="$ "


### PR DESCRIPTION
When set shell arguments, LOGINSHELL has double quotes.
In the default, L6: set "LOGINSHELL=bash". 
I followed the format it.

The task I encountered are shown below.
![fig1](https://user-images.githubusercontent.com/359823/75124299-b57a0000-56f1-11ea-81ae-a721a688c744.jpg)

![fig2](https://user-images.githubusercontent.com/359823/75124303-bf036800-56f1-11ea-9215-f27f110ab4a3.jpg)
