### PR TITLE
Add value to $SHELL for zsh

### DIFF
--- a/filesystem/profile
+++ b/filesystem/profile
@@ -137,6 +137,7 @@ elif [ ! "x${ZSH_VERSION}" = "x" ]; then
   profile_d sh
   profile_d zsh
   PS1='(%n@%m)[%h] %~ %% '
+  SHELL=`which zsh`
 elif [ ! "x${POSH_VERSION}" = "x" ]; then
   HOSTNAME="$(exec /usr/bin/hostname)"
   PS1="$ "


### PR DESCRIPTION
Issue:
1. Run, C:\msys64\msys2_shell.cmd -mingw64 -shell zsh
2. echo $SHELL
3. Nothing

Image is here:
![Annotation 2020-02-24 112546](https://user-images.githubusercontent.com/359823/75125434-71d6c480-56f8-11ea-9e4c-4838cc4c5716.jpg)
