### PR TITLE
setuptools: split package into Python 2 and Python 3 versions

### DIFF
--- a/python2-setuptools/PKGBUILD
+++ b/python2-setuptools/PKGBUILD
@@ -1,18 +1,17 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 _realname=setuptools
-pkgbase="python-${_realname}"
-pkgname=("python-${_realname}")
+pkgbase="python2-${_realname}"
+pkgname=("python2-${_realname}")
 pkgver=41.6.0
 pkgrel=2
 pkgdesc="Easily download, build, install, upgrade, and uninstall Python packages"
 arch=('any')
 license=('PSF')
+depends=('python2')
+provides=('python2-distribute')
+replaces=('python2-distribute')
 url="https://pypi.python.org/pypi/setuptools"
-depends=('python3')
-provides=("python3-${_realname}" 'python3-distribute')
-replaces=("python3-${_realname}" 'python3-distribute')
-conflicts=("python3-${_realname}")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/pypa/setuptools/archive/v${pkgver}.tar.gz")
 sha512sums=('27dd6762afb7cc5cf302c4086d5142490d90fcba1d4886a6c9d3c7d4bf35cd7670081f103f6f6218b5fdce13a1c461ae7b9d917d0dc60669860e581f1945478a')
 
@@ -26,16 +25,17 @@ prepare() {
       -i setuptools-${pkgver}/setup.cfg
 
   cd "${srcdir}"/setuptools-${pkgver}
-  sed -i -e "s|^#\!.*/usr/bin/env python|#!/usr/bin/env python3|" setuptools/command/easy_install.py
+  sed -i -e "s|^#\!.*/usr/bin/env python|#!/usr/bin/env python2|" setuptools/command/easy_install.py
+  sed -i -e "s|'pip'|'pip2'|" setuptools/tests/{test_develop.py,test_namespaces.py}
 
   export SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES=0
 }
 
 build() {
-  # Build python 3 module
+  # Build python 2 module
   cd "${srcdir}"/setuptools-${pkgver}
-  python3 bootstrap.py
-  python3 setup.py build
+  python2 bootstrap.py
+  python2 setup.py build
 }
 
 check() { (
@@ -45,13 +45,14 @@ check() { (
   # https://github.com/pypa/setuptools/pull/810
   export PYTHONDONTWRITEBYTECODE=1
 
-  # Check python3 module
+  # Check python2 module
   # cd "${srcdir}"/setuptools-${pkgver}
-  # python3 setup.py pytest
+  # python2 setup.py pytest
 )}
 
 package() {
   cd "${srcdir}"/setuptools-${pkgver}
 
-  python3 setup.py install --prefix=/usr --root="${pkgdir}" --optimize=1 --skip-build
+  python2 setup.py install --prefix=/usr --root="${pkgdir}" --optimize=1 --skip-build
+  rm "${pkgdir}"/usr/bin/easy_install
 }


### PR DESCRIPTION
Also remove all dependencies, setuptools bundles all dependencies
by itself anyway.

python3-setuptools -> python-setuptools