### PR TITLE
Make `rebaseall` more useful, especially with regards to `./configure`

### DIFF
--- a/rebase/001-rebase-4.4.1-msys2.patch
+++ b/rebase/001-rebase-4.4.1-msys2.patch
@@ -243,7 +243,7 @@ diff -urN rebase-4.4.1.orig/rebaseall.in rebase-4.4.1/rebaseall.in
      done
 +	# some interpreters include a method for installing addons outside of the
 +    # package manager, such as CPAN and RubyGems.
-+    for d in /usr/lib/perl5/site_perl /usr/lib/py*/site-packages \
++    for d in /usr/lib/perl5/*_perl /usr/lib/py*/site-packages \
 +             /usr/lib/php /usr/lib/R/site-library /usr/lib/rub*/gems \
 +             /usr/lib/octave/site
 +    do

--- a/rebase/002-rebaseall-add-python-exts.patch
+++ b/rebase/002-rebaseall-add-python-exts.patch
@@ -3,7 +3,7 @@
 @@ -218,6 +218,7 @@
      # some interpreters include a method for installing addons outside of the
      # package manager, such as CPAN and RubyGems.
-     for d in /usr/lib/perl5/site_perl /usr/lib/py*/site-packages \
+     for d in /usr/lib/perl5/*_perl /usr/lib/py*/site-packages \
 +             /usr/lib/py*/lib-dynload \
               /usr/lib/php /usr/lib/R/site-library /usr/lib/rub*/gems \
               /usr/lib/octave/site

--- a/rebase/003-allow-non-database-mode-when-__CYGWIN__-__MSYS__.patch
+++ b/rebase/003-allow-non-database-mode-when-__CYGWIN__-__MSYS__.patch
@@ -198,7 +198,7 @@ diff -urN rebase-4.4.1.orig/rebaseall.in rebase-4.4.1/rebaseall.in
 +          -e '/\/d\?ash\.exe$/d' -e '/\/rebase\.exe$/d' >>"${TmpFile}"
      # some interpreters include a method for installing addons outside of the
      # package manager, such as CPAN and RubyGems.
-     for d in /usr/lib/perl5/site_perl /usr/lib/py*/site-packages \
+     for d in /usr/lib/perl5/*_perl /usr/lib/py*/site-packages \
 @@ -257,20 +267,11 @@
      ;;
  esac


### PR DESCRIPTION
I've seen my share of failures of this form:

```
      0 [main] perl 5228 child_info_fork::abort: address space needed by 'Cwd.dll' (0x30000) is already occupied
Can't fork, trying again in 5 seconds at /usr/share/autoconf/Autom4te/General.pm line 307.
```

The reason seems that `Cwd.dll` was omitted when rebasing. Let's not omit it from now on, or for that matter, all other native Perl modules.