### PR TITLE
Set PROMPT in /etc/zsh/zshenv

### DIFF
--- a/zsh/PKGBUILD
+++ b/zsh/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=zsh
 pkgname=('zsh' 'zsh-doc')
 pkgver=5.8
-pkgrel=2
+pkgrel=3
 arch=('i686' 'x86_64')
 url='https://www.zsh.org/'
 license=('custom')

--- a/zsh/PKGBUILD
+++ b/zsh/PKGBUILD
@@ -13,6 +13,7 @@ source=("https://www.zsh.org/pub/zsh-${pkgver}.tar.xz"{,.asc}
         'config.guess::https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
         'config.sub::https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
         'zprofile'
+        'zshenv'
         Makefile.in.patch
         add-pwd-W-option.patch
         msysize.patch
@@ -25,6 +26,7 @@ sha256sums=('dcc4b54cc5565670a65581760261c163d720991f0d06486da61f8d839b52de27'
             'c081ced2d645e3b107fbf864529cc0e5954399a09b87a4f1d300470854b6dea4'
             'f08fe8f207c0fa6d722312774c28365024682333f5547c8192d0547957b000af'
             '230832038c3b8f67fdb1b284ac5f68d709cdb7f1bc752b0e60657b9b9d091045'
+            '06c05faa800cb7385b606fd2b3c9aa24cfac07d1dde7f0d2f017c11ede9b2ac8'
             '971e48433ec40e0c2fb64584b5555367b4f997156aa9acbd06c67d7bdacd6c59'
             'b3f74a10a27eff498124adc96bc8c5cced7bb15e18c2603d7c3490a81e3c2e48'
             'b879d33cc60fc0c44361189eef1ee95a3bd0b8f9e8b32c81e439950483c151aa'
@@ -86,12 +88,13 @@ build() {
 package_zsh() {
   pkgdesc='A very advanced and programmable command interpreter (shell) for UNIX'
   depends=('ncurses' 'pcre' 'libiconv' 'gdbm')
-  backup=('etc/zsh/zprofile')
+  backup=('etc/zsh/zprofile' 'etc/zsh/zshenv')
   install=zsh.install
 
   cd "${srcdir}/${pkgbase}-${pkgver}"
   make DESTDIR="${pkgdir}/" install
   install -D -m644 "${srcdir}/zprofile" "${pkgdir}/etc/zsh/zprofile"
+  install -D -m644 "${srcdir}/zshenv" "${pkgdir}/etc/zsh/zshenv"
   install -D -m644 LICENCE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }
 

--- a/zsh/zshenv
+++ b/zsh/zshenv
@@ -1,0 +1,2 @@
+# Default PROMPT
+PROMPT="%F{green}%n@%m%f %F{magenta}${MSYSTEM}%f %F{yellow}%~%f %# "


### PR DESCRIPTION
## Overview

Merging this PR resolves the following issues:

- #1285
- #1624

By setting PROMPT in /etc/zsh/zshenv, added no unintended PROMPT viewing
when running interactive zsh from bash.

Set PROMPT in /etc/zsh/zshenv to prevent unintentional format on PROMPT display 
when running an interactive zsh from bash. See also https://github.com/msys2/MSYS2-packages/pull/1897#issuecomment-602273511

This PR doesn't conflict the `grml-zsh-config` package. 
Because the package doesn't provide /etc/zsh/zshenv.

## Related works

- #1897
- #1899