### PR TITLE
Fix building failure texinfo 

### DIFF
--- a/texinfo/PKGBUILD
+++ b/texinfo/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('texinfo' 'info' 'texinfo-tex')
 pkgver=6.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Utilities to work with and produce manuals, ASCII text, and on-line documentation from a single source file"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/texinfo/"
@@ -21,6 +21,7 @@ sha256sums=('9bb9ca00da53f26a7e5725eee49689cd4a1e18d25d5b061ac8b2053018d93d66'
             'db2c67546da5f11dc8e374dbf70269227a0df15045dc3456f7a9e74c353083d5'
             'ccf696f2777ebd2c85c4cb311a4735957ffa40952ecbe50c7031b9f05dc6cdee'
             'e5b18f11d9a5d99f96f9228266e6204cfb2e076e2d9c336db0eceb72e2252873')
+validpgpkeys=('EAF669B31E31E1DECBD11513DDBC579DAB37FBA9') # Gavin Smith
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}


### PR DESCRIPTION
## Overview

Merging this PR resolves the following issues:

- building failure texinfo package

texinfo v6.6 is on https://packages.msys2.org/outofdate page. 
So, i bumped up pkgrel and updated PKGBUILD file.

## Notes

In this modification, PKGBUILD has a PKG key.
Therefore, when you build in the local, please execute the following command.

```
gpg --recv-keys EAF669B31E31E1DECBD11513DDBC579DAB37FBA9
```