### PR TITLE
procps-ng: Update to 3.3.16

### DIFF
--- a/procps-ng/PKGBUILD
+++ b/procps-ng/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=procps-ng
-pkgver=3.3.15
+pkgver=3.3.16
 pkgrel=1
 pkgdesc='Utilities for monitoring your system and its processes'
 arch=('i686' 'x86_64')
@@ -14,7 +14,7 @@ provides=('procps')
 #replaces=('procps')
 source=("https://downloads.sourceforge.net/project/${pkgname}/Production/${pkgname}-${pkgver}.tar.xz"
          procps-ng-3.3.12-msys2.patch)
-sha256sums=('10bd744ffcb3de2d591d2f6acf1a54a7ba070fdcc432a855931a5057149f0465'
+sha256sums=('925eacd65dedcf9c98eb94e8978bbfb63f5de37294cc1047d81462ed477a20af'
             'e2d692b45dd2ba9840ec5cd6a25a9106bd0ac3ca36d1b4a120288be6575c6977')
 
 prepare() {

--- a/procps-ng/PKGBUILD
+++ b/procps-ng/PKGBUILD
@@ -39,6 +39,11 @@ build() {
     --disable-kill
     # kill is provided by util-linux
 
+  # Workaround. 
+  # See https://github.com/msys2/MSYS2-packages/pull/1908#issuecomment-605453647
+  make proc/libprocps.la
+  make install-libLTLIBRARIES
+
   make -j1
 }
 

--- a/procps-ng/PKGBUILD
+++ b/procps-ng/PKGBUILD
@@ -41,9 +41,8 @@ build() {
 
   # Workaround. 
   # See https://github.com/msys2/MSYS2-packages/pull/1908#issuecomment-605453647
-  make proc/libprocps.la
-  make install-libLTLIBRARIES
-
+  make -j proc/libprocps.la
+  
   make -j1
 }
 


### PR DESCRIPTION
## Overview

Merging this PR resolves the following issues:

- procps-ng v3.3.15 is outofdate (See https://packages.msys2.org/outofdate)

## Note

Ref #1914