### PR TITLE
luit: Add version 20190106

### DIFF
--- a/luit/PKGBUILD
+++ b/luit/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Alec Su <ae40515@yahoo.com.tw>
+
+pkgname=luit
+pkgver=20190106
+pkgrel=1
+pkgdesc="Luit is a filter that can be run between an arbitrary application and a UTF-8 terminal emulator."
+arch=('i686' 'x86_64')
+url='https://invisible-island.net/luit/luit.html'
+license=('MIT')
+source=(ftp://ftp.invisible-island.net/luit/luit-${pkgver}.tgz
+        luit-20190106-fix-ldflags.patch)
+depends=('gcc-libs' 'libiconv' 'zlib')
+makedepends=('diffutils' 'gcc' 'libiconv-devel' 'make' 'patch' 'zlib-devel')
+sha256sums=('2b900f65ccdc38f8bfc11c6020069d055ba63fce6f90baefe8efc222a5ca3920'
+            'b2384d6801841d30830354c0806356be993ff86e9c8f1dfdca80a1de011da981')
+
+prepare() {
+    cd "${srcdir}/luit-${pkgver}"
+    patch -p0 -i "${srcdir}/luit-20190106-fix-ldflags.patch"
+}
+
+build() {
+    cd "${srcdir}/luit-${pkgver}"
+    ./configure --prefix=/usr 
+    make
+}
+
+package() {
+    cd "${srcdir}/luit-${pkgver}"
+    make DESTDIR="${pkgdir}" install
+
+    install -Dm644 COPYING "${pkgdir}/usr/share/licenses/${pkgname}/COPYING"
+}

--- a/luit/luit-20190106-fix-ldflags.patch
+++ b/luit/luit-20190106-fix-ldflags.patch
@@ -1,0 +1,10 @@
+--- configure.in.orig	2018-06-26 17:21:54.000000000 +0800
++++ configure.in	2019-02-13 16:11:00.378262500 +0800
+@@ -179,6 +179,7 @@
+ 	AM_ICONV
+ 	AC_DEFINE(USE_ICONV,1,[Define to 1 if iconv-libraries should be used])
+ 	CF_ADD_LIBS($LIBICONV)
++	AM_LDFLAGS = -liconv
+ 	EXTRASRCS="$EXTRASRCS luitconv.c  builtin.c"
+ 	EXTRAOBJS="$EXTRAOBJS luitconv\$o builtin\$o"
+ fi


### PR DESCRIPTION
luit is a tool which can convert outputs of applications from other encoding to UTF-8. It's useful when using some non-Unicode programs without changing the encoding of mintty such as Windows built-in commands.

![image](https://user-images.githubusercontent.com/9132996/77838235-99f88e00-71a4-11ea-90b5-6e6b25d54905.png)
