### PR TITLE
[W.I.P] subversion: Update to 1.13.0

### DIFF
--- a/subversion/17-fix-test-link.patch
+++ b/subversion/17-fix-test-link.patch
@@ -76,7 +76,7 @@ index d87f66b..018dbb8 100644
         libsvn_subr apriconv apr
  msvc-force-static = yes
  
-@@ -825,30 +826,30 @@ msvc-force-static = yes
+@@ -811,30 +811,30 @@ msvc-force-static = yes
  [fs-fs-pack-test]
  description = Test fsfs packing in libsvn_fs_fs
  type = exe
@@ -111,7 +111,7 @@ index d87f66b..018dbb8 100644
 +path = subversion/tests
 +sources = libsvn_fs_fs/fs-fs-private-test.c svn_test_fs.c svn_test_main.c
  install = test
--libs = libsvn_test libsvn_fs libsvn_fs_fs libsvn_delta
+-libs = libsvn_test libsvn_fs libsvn_delta
 +libs = libsvn_repos libsvn_fs libsvn_delta libsvn_subr aprutil apriconv apr libsvn_fs libsvn_fs_fs libsvn_delta
         libsvn_repos libsvn_subr apriconv apr
  msvc-force-static = yes

--- a/subversion/PKGBUILD
+++ b/subversion/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=subversion
-pkgver=1.12.2
+pkgver=1.13.0
 pkgrel=1
 pkgdesc="A Modern Concurrent Version Control System"
 arch=('i686' 'x86_64')
@@ -41,7 +41,7 @@ source=(https://archive.apache.org/dist/subversion/subversion-${pkgver}.tar.bz2{
         subversion-1.9.1-msys2.patch
         remove-checking-symlink.patch
         90-use-copy-instead-symlink.patch)
-sha256sums=('3bd0b5c8e4c5175263dc9a92fd9aef94ce917e80af034f26fe5c45fde7e0f771'
+sha256sums=('bc50ce2c3faa7b1ae9103c432017df98dfd989c4239f9f8270bb3a314ed9e5bd'
             'SKIP'
             'b09dd041aba0078c8d50df130ef2f96c3ef8486279a620532fef4fe48ef9961e'
             'dfbd7b00ebdb3208614dc8622a99d3b12c0fd774f3207ac4d0e3b2d8a84b2a9e'
@@ -60,13 +60,15 @@ sha256sums=('3bd0b5c8e4c5175263dc9a92fd9aef94ce917e80af034f26fe5c45fde7e0f771'
             '4d3c427c3bb423cd2a3ac244cd76694c9849035373c09018d0e0f2bffc595c54'
             'd480726924809f3586d6145433efc9e1633db751c28fc7be13abfd83328f1a20'
             '8682d9f7da2ba8607ed15daf3beec92e5dacda3a6e4c07baaef8991264eb44cd'
-            '7152e0213f8e8e7a1b50349aaca57e7331b3eb239ada1afed617c22a7617578a'
+            '5cb126ea7d28a7fca00638fb4b2e368d223a26d577341b91a2e46fd5985cf55a'
             '484bf6d7f1440d7a8ee4a0bb00366937990694ed9a4a0f662225435df949aebc'
             'c7ebf4320b0147256a6b5ebab459603cbb7b8beb32da70b2ad85e6fb33609e30'
             '0e9a0f483bf53a105f3f53244ce3d03d6ed8c02f70cab1423e9e7c5ba44882e9'
             'f3d2e7e6ca97c8310fb59ce82430005fcd9e508b4a2a3f4ec7208011bf32a0a8'
             'd821304ee957ef4adbb0a8dec9cea3fe62ad7163aef132317d28f70ea25162ca'
             'fc545e375d8af4ef6d8afad453453480664b6a2ff74915f94b8a7da7de14155b')
+
+validpgpkeys=('3F8E467CB3366E3013E1120D583F00ADF981C39F') # Nathan Hartman (CODE SIGNING KEY)
 
 PYTHON_SITELIB=$(/usr/bin/python2 -c 'from distutils.sysconfig import * ; print(get_python_lib(0,0));')
 


### PR DESCRIPTION
## Overview

Merging this PR brings the package up to date.

- Add PGP key of Nathan Hartman
- Update 17-fix-test-link.patch

## Note

Failed build.
Researching "undefined reference to `svn_delta_noop_window_handler'" now.

```
/usr/lib/gcc/x86_64-pc-msys/9.3.0/../../../../x86_64-pc-msys/bin/ld: /home/hiro/hiroakit-MSYS2-packages/subversion/src/subversion-1.13.0/subversion/bindings/swig/perl/libsvn_swig_perl/.libs/libsvn_swig_perl-1.a(swigutil_pl.o):swigutil_pl.c:(.rdata$.refptr.svn_delta_noop_window_handler[.refptr.svn_delta_noop_window_handler]+0x0): undefined reference to `svn_delta_noop_window_handler'
collect2: エラー: ld はステータス 1 で終了しました
make[1]: *** [Makefile:499: blib/arch/auto/SVN/_Core/_Core.dll] エラー 1
make[1]: ディレクトリ '/home/hiro/hiroakit-MSYS2-packages/subversion/src/subversion-1.13.0/subversion/bindings/swig/perl/native' から出ます
make: *** [Makefile:891: swig-pl] エラー 2
==> エラー: build() で問題が発生しました。
    中止...
```