### PR TITLE
dtc: Add libyaml to the dependency

### DIFF
--- a/dtc/PKGBUILD
+++ b/dtc/PKGBUILD
@@ -2,13 +2,14 @@
 
 pkgname=dtc
 pkgver=1.6.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Device Tree Compiler"
 arch=('i686' 'x86_64')
 url="https://git.kernel.org/pub/scm/utils/dtc/dtc/git"
 license=('GPL2')
 groups=('base')
-makedepends=('python' 'swig' 'libcrypt-devel')
+depends=('libyaml')
+makedepends=('python' 'swig' 'libcrypt-devel' 'libyaml-devel')
 source=("https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/${pkgname}-${pkgver}.tar.gz"
         01-correct-shared-library-extension.patch
         02-pyext-install.patch)


### PR DESCRIPTION
With a fresh installation of MSYS2, running dtc I got:

$ dtc
C:/msys64/usr/bin/dtc.exe: error while loading shared libraries:
msys-yaml-0-2.dll: cannot open shared object file: No such file or directory

Add libyaml to the dependency to fix it.

Signed-off-by: Bin Meng <bmeng.cn@gmail.com>