### PR TITLE
Python 3 porting:  libxml2, itstool, libxslt

### DIFF
--- a/itstool/PKGBUILD
+++ b/itstool/PKGBUILD
@@ -2,12 +2,12 @@
 
 pkgname=itstool
 pkgver=2.0.6
-pkgrel=1
+pkgrel=2
 pkgdesc="XML to PO and back again"
 arch=('i686' 'x86_64')
 url="http://itstool.org/"
 license=("GPL3")
-depends=("python2" "libxml2" "libxml2-python")
+depends=("python" "libxml2" "libxml2-python")
 source=(http://files.itstool.org/itstool/${pkgname}-${pkgver}.tar.bz2
         fix-segfault.patch
         itstool-2.0.5-fix-crash-wrong-encoding.patch)
@@ -17,17 +17,16 @@ sha256sums=('6233cc22726a9a5a83664bf67d1af79549a298c23185d926c3677afa917b92a9'
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
-   patch -p1 -i ${srcdir}/itstool-2.0.5-fix-crash-wrong-encoding.patch
+  patch -p1 -i ${srcdir}/itstool-2.0.5-fix-crash-wrong-encoding.patch
   patch -p1 -i ${srcdir}/fix-segfault.patch
-  sed -i '1s|#!/usr/bin/python|&2|' itstool itstool.in
-  sed -i 's/| python/&2/' configure.ac
+
   autoreconf -fi
 }
 
 build() {
   mkdir -p "${srcdir}/build-${CHOST}"
   cd "${srcdir}/build-${CHOST}"
-    PYTHON=/usr/bin/python2 \
+    PYTHON=/usr/bin/python \
     ../${pkgname}-${pkgver}/configure \
     --prefix=/usr \
     --build=${CHOST} \
@@ -44,5 +43,4 @@ check() {
 package() {
   cd "${srcdir}/build-${CHOST}"
   make DESTDIR="${pkgdir}" install
-  sed -e "s|/usr/bin/python |/usr/bin/python2 |g" -i ${pkgdir}/usr/bin/itstool
 }

--- a/libxml2/PKGBUILD
+++ b/libxml2/PKGBUILD
@@ -2,11 +2,11 @@
 
 pkgname=('libxml2' 'libxml2-devel' 'libxml2-python')
 pkgver=2.9.10
-pkgrel=3
+pkgrel=4
 pkgdesc="XML parsing library, version 2"
 arch=(i686 x86_64)
 license=('MIT')
-makedepends=('python2' 'python3' 'icu-devel>=59.1' 'libreadline-devel' 'ncurses-devel' 'liblzma-devel' 'zlib-devel' 'libcrypt-devel')
+makedepends=('python3' 'icu-devel>=59.1' 'libreadline-devel' 'ncurses-devel' 'liblzma-devel' 'zlib-devel' 'libcrypt-devel')
 url="http://www.xmlsoft.org/"
 source=(http://xmlsoft.org/sources/${pkgname}-${pkgver}.tar.gz
         https://www.w3.org/XML/Test/xmlts20130923.tar.gz
@@ -20,9 +20,6 @@ sha256sums=('aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f'
             'bff6790eadec6d7b3affd2d3a7385ce7f80cec2cf4abbd2ed83e9cb297a614a9'
             'fbd5ddb92e3cd0ab0f1f058436ca73b677f12fa00f65d634be7ef791e3706e33'
             '19be37833b77a5c46cf266fdb4b9bcd068e301e4d26583d307ce22688ffb7587')
-
-PYTHON_SITELIB=/usr/lib/python2.7/site-packages
-PYTHON_LIB=/usr/lib/python2.7
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -57,8 +54,6 @@ prepare() {
     libxml2-cygwin-reentrant.patch \
     libxml2-2.9.1-msys2.patch 
 
-  sed -e 's|/usr/bin/python -u|/usr/bin/python2 -u|g' -e 's|/usr/bin/python$|/usr/bin/python2|g' -i python/tests/*.py
-
   autoreconf -fi
 }
 
@@ -75,12 +70,13 @@ build() {
     --enable-ipv6 \
     --with-history \
     --with-icu \
-    --with-python=/usr/bin/python2 \
+    --with-python=/usr/bin/python3 \
     --with-html-dir=/usr/share/doc \
     --with-html-subdir=libxml2/html
   make
   make DESTDIR=${srcdir}/dest install
 
+  PYTHON_SITELIB="$(python -c 'import site, sys; sys.stdout.write(site.getsitepackages()[0])')"
   mv ${srcdir}/dest${PYTHON_SITELIB}/${pkgname/lib/msys-}mod.dll ${srcdir}/dest${PYTHON_SITELIB}/${pkgname}mod.dll
   sed -i -e "s:${pkgname/lib/msys-}mod:${PN}mod:g" ${srcdir}/dest${PYTHON_SITELIB}/${pkgname}mod.la
 }
@@ -109,6 +105,7 @@ package_libxml2-devel() {
   options=('staticlibs')
   depends=("libxml2=${pkgver}" 'icu-devel>=59.1' 'libreadline-devel' 'ncurses-devel' 'liblzma-devel' 'zlib-devel')
 
+  PYTHON_SITELIB="$(python -c 'import site, sys; sys.stdout.write(site.getsitepackages()[0])')"
   mkdir -p ${pkgdir}/usr/{bin,share}
   cp -f ${srcdir}/dest/usr/bin/*-config ${pkgdir}/usr/bin/
   cp -rf ${srcdir}/dest/usr/include ${pkgdir}/usr/
@@ -127,6 +124,7 @@ package_libxml2-python(){
   options=('staticlibs')
   install=libxml2-python.install
 
+  PYTHON_SITELIB="$(python -c 'import site, sys; sys.stdout.write(site.getsitepackages()[0])')"
   mkdir -p ${pkgdir}/${PYTHON_SITELIB}
   mkdir -p ${pkgdir}/usr/share/doc
   cp -rf ${srcdir}/dest${PYTHON_SITELIB}/* ${pkgdir}${PYTHON_SITELIB}/

--- a/libxml2/PKGBUILD
+++ b/libxml2/PKGBUILD
@@ -2,11 +2,11 @@
 
 pkgname=('libxml2' 'libxml2-devel' 'libxml2-python')
 pkgver=2.9.10
-pkgrel=2
+pkgrel=3
 pkgdesc="XML parsing library, version 2"
 arch=(i686 x86_64)
 license=('MIT')
-makedepends=('python2' 'python3' 'icu-devel>=59.1' 'libreadline-devel' 'ncurses-devel' 'liblzma-devel' 'zlib-devel')
+makedepends=('python2' 'python3' 'icu-devel>=59.1' 'libreadline-devel' 'ncurses-devel' 'liblzma-devel' 'zlib-devel' 'libcrypt-devel')
 url="http://www.xmlsoft.org/"
 source=(http://xmlsoft.org/sources/${pkgname}-${pkgver}.tar.gz
         https://www.w3.org/XML/Test/xmlts20130923.tar.gz
@@ -63,6 +63,7 @@ prepare() {
 }
 
 build() {
+  export lt_cv_deplibs_check_method='pass_all'
   cd ${pkgname}-${pkgver}
   ./configure \
     --prefix=/usr \

--- a/libxslt/PKGBUILD
+++ b/libxslt/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('libxslt' 'libxslt-devel' 'libxslt-python')
 pkgver=1.1.34
-pkgrel=1
+pkgrel=2
 pkgdesc="XML stylesheet transformation library"
 arch=('i686' 'x86_64')
 url="http://xmlsoft.org/XSLT/"
@@ -35,6 +35,7 @@ prepare() {
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   sed -e 's|/usr/bin/python -u|/usr/bin/python2 -u|g' -e 's|/usr/bin/python$|/usr/bin/python2|g' -i python/tests/*.py
+  export lt_cv_deplibs_check_method='pass_all'
   ./configure --build=${CHOST} --host=${CHOST} --target=${CHOST} \
     --prefix=/usr \
     --sysconfdir=/etc \

--- a/libxslt/PKGBUILD
+++ b/libxslt/PKGBUILD
@@ -1,13 +1,13 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
-pkgname=('libxslt' 'libxslt-devel' 'libxslt-python')
+pkgname=('libxslt' 'libxslt-devel')
 pkgver=1.1.34
-pkgrel=2
+pkgrel=3
 pkgdesc="XML stylesheet transformation library"
 arch=('i686' 'x86_64')
 url="http://xmlsoft.org/XSLT/"
 license=('custom')
-makedepends=('gcc' 'python2' 'libxml2-devel' 'libgcrypt-devel')
+makedepends=('gcc' 'libxml2-devel' 'libgcrypt-devel')
 checkdepends=('docbook-xml')
 options=('!libtool')
 source=(http://xmlsoft.org/sources/${pkgname}-${pkgver}.tar.gz
@@ -18,9 +18,6 @@ sha256sums=('98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f'
             '0f17e189adf57b2ff4085049555b91ac4fd0a9b11dc1e8100cfb1e1f7938e877'
             'c02cd8437064db0921c08e63245c403dad12410d2997715aa7aa36600bfaa895'
             'f57629d5f2ce0ab441dc548fa023aee09780eb2940986a44b4423ba253e190bb')
-
-PYTHON_SITELIB=/usr/lib/python2.7/site-packages
-PYTHON_LIB=/usr/lib/python2.7
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
@@ -34,7 +31,7 @@ prepare() {
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
-  sed -e 's|/usr/bin/python -u|/usr/bin/python2 -u|g' -e 's|/usr/bin/python$|/usr/bin/python2|g' -i python/tests/*.py
+
   export lt_cv_deplibs_check_method='pass_all'
   ./configure --build=${CHOST} --host=${CHOST} --target=${CHOST} \
     --prefix=/usr \
@@ -46,16 +43,10 @@ build() {
     --with-debugger \
     --with-html-dir=/usr/share/doc \
     --with-html-subdir=libxslt/html \
-    --with-python=/usr/bin/python2
+    --with-python=no
 
   make
   make DESTDIR=${srcdir}/dest install
-
-#  mv ${srcdir}/dest${PYTHON_SITELIB}/${pkgname/lib/msys-}mod.dll ${srcdir}/dest${PYTHON_SITELIB}/${pkgname}mod.dll
-  sed -i -e "s:${pkgname/lib/msys-}mod:${PN}mod:g" ${srcdir}/dest${PYTHON_SITELIB}/${pkgname}mod.la
-
-#  mv ${srcdir}/dest/usr/share/doc/${pkgname}-python-${pkgver} ${srcdir}/dest/usr/share/doc/python-${pkgname}
-  # rm -f ${srcdir}/dest/usr/lib/python*/site-packages/*.a
 }
 
 check() {
@@ -84,22 +75,7 @@ package_libxslt-devel() {
   cp -f ${srcdir}/dest/usr/bin/*-config ${pkgdir}/usr/bin/
   cp -rf ${srcdir}/dest/usr/include ${pkgdir}/usr/
   cp -rf ${srcdir}/dest/usr/lib ${pkgdir}/usr/
-  rm -rf ${pkgdir}${PYTHON_SITELIB}
   cp -rf ${srcdir}/dest/usr/share/aclocal ${pkgdir}/usr/share/
   cp -rf ${srcdir}/dest/usr/share/doc ${pkgdir}/usr/share/
   rm -rf ${pkgdir}/usr/share/doc/libxslt-python-${pkgver}
-}
-
-package_libxslt-python() {
-  pkgdesc="Libxslt python modules"
-  groups=('python-modules')
-  options=('staticlibs')
-  install=libxslt-python.install
-  depends=("libxslt=${pkgver}" 'python2')
-
-  mkdir -p ${pkgdir}/${PYTHON_SITELIB}
-  mkdir -p ${pkgdir}/usr/share/doc
-  cp -rf ${srcdir}/dest${PYTHON_SITELIB}/* ${pkgdir}${PYTHON_SITELIB}/
-  cp -rf ${srcdir}/dest/usr/share/doc/libxslt-python-${pkgver} ${pkgdir}/usr/share/doc/
-  
 }

--- a/rarian/PKGBUILD
+++ b/rarian/PKGBUILD
@@ -2,13 +2,13 @@
 
 pkgname=rarian
 pkgver=0.8.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Documentation meta-data library, designed as a replacement for Scrollkeeper."
 arch=('i686' 'x86_64')
 url="https://rarian.freedesktop.org/"
 license=('GPL')
 depends=('gcc-libs')
-makedepends=('libxslt-python')
+makedepends=('libxslt')
 source=(https://download.gnome.org/sources/${pkgname}/0.8/${pkgname}-${pkgver}.tar.bz2
         user-segfault.patch
         msysize.patch

--- a/yelp-tools/PKGBUILD
+++ b/yelp-tools/PKGBUILD
@@ -2,14 +2,14 @@
 
 pkgname=yelp-tools
 pkgver=3.32.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Tools for creating Yelp documentation"
 arch=('any')
 license=('GPL')
 url="https://www.gnome.org"
-depends=("yelp-xsl" "itstool" "libxslt-python" "libxml2-python")
+depends=("yelp-xsl" "itstool" "libxml2-python")
 options=('strip' '!libtool' 'staticlibs')
-makedepends=("libxml2-python" "libxslt-python" "intltool" "itstool")
+makedepends=("libxml2-python" "intltool" "itstool")
 source=(https://download.gnome.org/sources/${pkgname}/${pkgver:0:4}/${pkgname}-$pkgver.tar.xz
         yelp-no-symlinks.patch)
 sha256sums=('183856b5ed0b0bb2c05dd1204af023946ed436943e35e789afb0295e5e71e8f9'
@@ -23,7 +23,7 @@ prepare() {
 
 build() {
   mkdir -p ${srcdir}/build-${CHOST} && cd ${srcdir}/build-${CHOST}
-  export PYTHON=/usr/bin/python2
+
   ${srcdir}/${pkgname}-${pkgver}/configure \
     --prefix=/usr \
     --build=${CHOST} \

--- a/yelp-xsl/PKGBUILD
+++ b/yelp-xsl/PKGBUILD
@@ -2,13 +2,13 @@
 
 pkgname=yelp-xsl
 pkgver=3.36.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Stylesheets for Yelp"
 arch=('any')
 license=('GPL')
 url="https://www.gnome.org"
 options=('strip' '!libtool' 'staticlibs')
-makedepends=("libxml2-python" "libxslt-python" "intltool" "itstool")
+makedepends=("libxml2-python" "intltool" "itstool")
 source=(https://download.gnome.org/sources/${pkgname}/${pkgver:0:4}/${pkgname}-${pkgver}.tar.xz)
 sha256sums=('4fe51c0233b79a4c204c68498d45f09b342c30ed02c4e418506c0e35f0904ec3')
 


### PR DESCRIPTION
* Move libxml2 and itstool to Python 3
* Drop the python 2 bindings from libxslt, looks like nothing really needs them