### PR TITLE
msys2-runtime: rebuild (and package with xz)

### DIFF
--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.1.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"


### PR DESCRIPTION
The last installer release can't handle zst packages. Of those 8 packages in the core system update only msys2-runtime is using zst. It needs to be rebuild with xz:

```
:: Starting core system upgrade...
warning: terminate other MSYS2 programs before proceeding
resolving dependencies...
looking for conflicting packages...

Packages (8) bash-4.4.023-2  filesystem-2020.02-2  libzstd-1.4.4-2  mintty-1~3.1.4-1  msys2-runtime-3.1.4-1  pacman-5.2.1-6  pacman-mirrors-20200329-1  zstd-1.4.4-2

Total Installed Size:  65.76 MiB
Net Upgrade Size:      -3.96 MiB

:: Proceed with installation? [Y/n] 
checking keyring...
checking package integrity...
loading package files...
error: could not open file /var/cache/pacman/pkg/msys2-runtime-3.1.4-1-x86_64.pkg.tar.zst: Child process exited with status 127
error: failed to commit transaction (cannot open package file)
Errors occurred, no packages were upgraded.
```