### PR TITLE
msys2-runtime: demote the "pseudo console" support to opt-in

### DIFF
--- a/msys2-runtime/0018-fixup-Do-not-create-cygwin-symlinks.-Instead-use-dee.patch
+++ b/msys2-runtime/0018-fixup-Do-not-create-cygwin-symlinks.-Instead-use-dee.patch
@@ -1,4 +1,4 @@
-From 1c0448cdd02bfa7a25449cb36a58bfd74c93531e Mon Sep 17 00:00:00 2001
+From 8eac6ec23b8d784674f691650f65520648be3cc8 Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Sat, 16 May 2020 15:31:05 +0200
 Subject: [PATCH 18/N] fixup! Do not create cygwin symlinks. Instead use deep

--- a/msys2-runtime/0019-strace-quiet-be-really-quiet.patch
+++ b/msys2-runtime/0019-strace-quiet-be-really-quiet.patch
@@ -1,4 +1,4 @@
-From 7aa2b2ef9af919a58a94ca6846a79b5fa3b6110e Mon Sep 17 00:00:00 2001
+From e5a15d8e24f57bf9306f373cff0a34b371e5d4d0 Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Wed, 17 May 2017 18:13:32 +0200
 Subject: [PATCH 19/N] strace --quiet: be *really* quiet

--- a/msys2-runtime/0020-Work-around-backward-incompatible-bfd_-changes.patch
+++ b/msys2-runtime/0020-Work-around-backward-incompatible-bfd_-changes.patch
@@ -1,4 +1,4 @@
-From bc4e92009e77165c63027f5fbf58fe64c6028928 Mon Sep 17 00:00:00 2001
+From e966d67297fe0e56d14efc72675cba16381ce4dc Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Mon, 27 Apr 2020 19:42:10 +0200
 Subject: [PATCH 20/N] Work around backward-incompatible bfd_*() changes

--- a/msys2-runtime/0021-setup_pseudoconsole-handle-missing-incorrect-helper-.patch
+++ b/msys2-runtime/0021-setup_pseudoconsole-handle-missing-incorrect-helper-.patch
@@ -1,4 +1,4 @@
-From 73fd29d0cec132301a5e8a509cc592f48dc75176 Mon Sep 17 00:00:00 2001
+From cc8ec6da9f63017050d0ad75347bae5323c319c1 Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Thu, 30 Apr 2020 17:10:33 +0200
 Subject: [PATCH 21/N] setup_pseudoconsole(): handle missing/incorrect helper

--- a/msys2-runtime/0022-Default-to-disable_pcon.patch
+++ b/msys2-runtime/0022-Default-to-disable_pcon.patch
@@ -1,0 +1,54 @@
+From 22ba7ac08035c470a3927fa53805bcdcdfe5fc21 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 19 May 2020 13:24:55 +0200
+Subject: [PATCH 22/N] Default to `disable_pcon`
+
+The pseudo console support is just a bit too buggy still:
+
+- When typing anything in an interactive Bash session before the prompt
+  is shown, frequently the keystrokes are then replayed _twice_ when the
+  prompt is active.
+
+  Even worse: it seems that under certain circumstances (e.g. when
+  spawning `less.exe` from a MINGW process), keystrokes are recorded
+  while a process is active that wants to consume them but those
+  recorded keystrokes are then replayed once the process finished (e.g.
+  the `q` keystroke to exit `less.exe` will then be misinterpreted for
+  interactive input in the Bash session).
+
+- When `vim` is called from a MINGW process, it seems that the terminal
+  loses the `onlcr` property after the `vim` process finished, i.e.
+  subsequently printed lines do not start at the beginning of the line
+  anymore, but precisely where the previous line ended.
+
+- In `vim`, when selecting text visually (via the `v` keystroke), it
+  seems that the selection is frequently reset while navigating with the
+  arrow keys.
+
+There are probably quite a few more rough edges in the pseudo console
+feature, unfortunately.
+
+In light of these issues, it makes most sense to disable the pseudo
+console support and make it opt-in rather than opt-out.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/globals.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/globals.cc b/winsup/cygwin/globals.cc
+index 942bd1c..da82320 100644
+--- a/winsup/cygwin/globals.cc
++++ b/winsup/cygwin/globals.cc
+@@ -70,7 +70,7 @@ bool pipe_byte;
+ bool reset_com;
+ bool wincmdln;
+ winsym_t allow_winsymlinks = WSYM_sysfile;
+-bool disable_pcon;
++bool disable_pcon = true;
+ 
+ bool NO_COPY in_forkee;
+ 
+-- 
+2.26.2
+

--- a/msys2-runtime/0023-Introduce-the-enable_pcon-value-for-MSYS.patch
+++ b/msys2-runtime/0023-Introduce-the-enable_pcon-value-for-MSYS.patch
@@ -1,0 +1,57 @@
+From 8a167e61d3312580a9c58742d5e5ec03c12a782e Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 19 May 2020 13:49:37 +0200
+Subject: [PATCH 23/N] Introduce the `enable_pcon` value for `MSYS`
+
+It is simply the negation of `disable_pcon`, i.e. `MSYS=enable_pcon` is
+equivalent to `MSYS=nodisable_pcon` (the former is slightly more
+intuitive than the latter) and likewise `MSYS=noenable_pcon` is
+equivalent to `MSYS=disable_pcon` (here, the latter is definitely more
+intuitive than the former).
+
+This is needed because we just demoted the pseudo console feature to be
+opt-in instead of opt-out, and it would be awkward to recommend to users
+to use "nodisable_pcon"... "nodisable" is not even a verb.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/environ.cc | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index 4b03836..3d57e34 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -42,6 +42,7 @@ enum settings
+     isfunc,
+     setdword,
+     setbool,
++    setnegbool,
+     setbit
+   };
+ 
+@@ -120,6 +121,7 @@ static struct parse_thing
+   {"wincmdln", {&wincmdln}, setbool, NULL, {{false}, {true}}},
+   {"winsymlinks", {func: set_winsymlinks}, isfunc, NULL, {{0}, {0}}},
+   {"disable_pcon", {&disable_pcon}, setbool, NULL, {{false}, {true}}},
++  {"enable_pcon", {&disable_pcon}, setnegbool, NULL, {{true}, {false}}},
+   {NULL, {0}, setdword, 0, {{0}, {0}}}
+ };
+ 
+@@ -237,6 +239,13 @@ parse_options (const char *inbuf)
+ 		  *k->setting.b = !!strtol (eq, NULL, 0);
+ 		debug_printf ("%s%s", *k->setting.b ? "" : "no", k->name);
+ 		break;
++	      case setnegbool:
++		if (!istrue || !eq)
++		  *k->setting.b = k->values[istrue].i;
++		else
++		  *k->setting.b = !strtol (eq, NULL, 0);
++		debug_printf ("%s%s", !*k->setting.b ? "" : "no", k->name);
++		break;
+ 	      case setbit:
+ 		*k->setting.x &= ~k->values[istrue].i;
+ 		if (istrue || (eq && strtol (eq, NULL, 0)))
+-- 
+2.26.2
+

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.1.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -44,7 +44,9 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0018-fixup-Do-not-create-cygwin-symlinks.-Instead-use-dee.patch
         0019-strace-quiet-be-really-quiet.patch
         0020-Work-around-backward-incompatible-bfd_-changes.patch
-        0021-setup_pseudoconsole-handle-missing-incorrect-helper-.patch)
+        0021-setup_pseudoconsole-handle-missing-incorrect-helper-.patch
+        0022-Default-to-disable_pcon.patch
+        0023-Introduce-the-enable_pcon-value-for-MSYS.patch)
 sha256sums=('SKIP'
             'f05c08ef2b6647a2f66c63bda5e077f1443cad7cd0edabfcf8d752021bc9aea6'
             '0dccf2f4c949b0b12d4460b085334678eda37e957f4829c3b59e98499b4f55d8'
@@ -63,10 +65,12 @@ sha256sums=('SKIP'
             'e81c59bde16b9f063477795feef72641b2888929fa3095548c06404032341a48'
             '16c6300aa283a7db894cd95e1973be2fbe6c06afeadc6fe49dc4a932cab77880'
             'e96a3ac2f57418c37dab0ce20f43a9e39c5c3a6cb729e20c000115955e901519'
-            '4ec5228284eb998e16ddf7ec652ad32776cffdeb9389a523e35ebf81ec647d19'
-            'b04ec46783519c736395396a0cac133ee638d745e5640dbea159e0e9c1e8d7b0'
-            '56607d900cea247526d335d741af0652a9da7ab151db66ce0c14fbd7b69cf454'
-            '0e4fc0d76625c6d4b7a682a08f1f4099c606c10b219242dcb638eaed015c5a40')
+            '84ddcb863ed12afafddea4693a66aa7a923742f02342316212b682c09c92376c'
+            'f5130841a101816fe4e45ff54e34aeead0568389d0833c4e4cc968af64a9c736'
+            'a8c26f752f635d33668eeb0f3b9694d2d30e8a92603f290c17bba4b91f654b6b'
+            '95903731da28f48f14b65e66d0855950a2a2cf67953007b0aee40b83c1ce3944'
+            '3cedd2577d450f3c0e9938079fb794bb72d4ab1e3787133d882c0004727bafb2'
+            'b6e94eebe4491fb1076b7f56793dc34ee678b63a5f0a112bd4c6a2e434d8b729')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -124,7 +128,9 @@ prepare() {
   0018-fixup-Do-not-create-cygwin-symlinks.-Instead-use-dee.patch \
   0019-strace-quiet-be-really-quiet.patch \
   0020-Work-around-backward-incompatible-bfd_-changes.patch \
-  0021-setup_pseudoconsole-handle-missing-incorrect-helper-.patch
+  0021-setup_pseudoconsole-handle-missing-incorrect-helper-.patch \
+  0022-Default-to-disable_pcon.patch \
+  0023-Introduce-the-enable_pcon-value-for-MSYS.patch
 }
 
 build() {


### PR DESCRIPTION
To make it easier to experiment with it, we now also support `MSYS=enable_pcon` (in addition to the equivalent but unintuitive `MSYS=nodisable_pcon`).

This is a companion PR to https://github.com/msys2/Cygwin/pull/6