### PR TITLE
WIP: pacman: kill all msys processes after a core upgrade

### DIFF
--- a/pacman/0000-pacman-msysize.patch
+++ b/pacman/0000-pacman-msysize.patch
@@ -1185,24 +1185,77 @@ diff -Naur pacman-5.1.0-orig/src/pacman/sync.c pacman-5.1.0/src/pacman/sync.c
  #include <alpm.h>
  #include <alpm_list.h>
 
-@@ -671,8 +677,75 @@
+@@ -680,8 +686,131 @@
  	return ret;
  }
-
+ 
 +#ifdef __MSYS__
-+static int wait_indefinitely(void)
-+{
-+	struct termios term;
 +
-+	/* disable input printing */
-+	if(tcgetattr(STDIN_FILENO, &term) == 0) {
-+		term.c_lflag &= ~ECHO;
-+		tcsetattr(STDIN_FILENO, TCSAFLUSH, &term);
++/* Tries to kill all cygwin processes except this one */
++static int kill_all_other_msys_processes() {
++	DIR *dir;
++	struct dirent *ent;
++	char kill_command[PATH_MAX];
++	char self_winpid[PATH_MAX];
++	int found_one = 0;
++	FILE *self = NULL;
++	char** args = NULL;
++
++	self = fopen("/proc/self/winpid", "r");
++	if (self == NULL)
++		return -1;
++	safe_fgets(self_winpid, sizeof(self_winpid), self);
++	strtrim(self_winpid);
++	fclose(self);
++
++	strcpy(kill_command, "taskkill /f");
++
++	dir = opendir ("/proc");
++	if (dir != NULL) {
++		while (ent = readdir (dir)) {
++			FILE *fp = NULL;
++			char winpid[PATH_MAX];
++
++			strcpy(winpid, "/proc/");
++			strcat(winpid, ent->d_name);
++			strcat(winpid, "/winpid");
++
++			fp = fopen(winpid, "r");
++			if (fp != NULL) {
++				char winpid[PATH_MAX];
++
++				safe_fgets(winpid, sizeof(winpid), fp);
++				strtrim(winpid);
++				if (strcmp(winpid, self_winpid) != 0) {
++					strcat(kill_command, " /pid ");
++					strcat(kill_command, winpid);
++					found_one = 1;
++				}
++
++				fclose(fp);
++			}
++		}
++
++		closedir (dir);
++	} else {
++		return -1;
 +	}
 +
-+	while (1) {
-+		getchar();
++	if (!found_one)
++		return 0;
++
++	args = wordsplit(kill_command);
++	if (args == NULL)
++		return -1;
++
++	setenv("MSYS2_ARG_CONV_EXCL", "*", 1);
++	if (execvp(args[0], args + 1) == -1) {
++		wordsplit_free(args);
++		return -1;
 +	}
++	wordsplit_free(args);
++
++	return 0;
 +}
 +
 +static int core_update(int *needed)
@@ -1241,13 +1294,16 @@ diff -Naur pacman-5.1.0-orig/src/pacman/sync.c pacman-5.1.0/src/pacman/sync.c
 +	pm_printf(ALPM_LOG_WARNING, _("terminate other MSYS2 programs before proceeding\n"));
 +	retval = sync_prepare_execute();
 +	if(retval == 0) {
-+		pm_printf(ALPM_LOG_WARNING, _("terminate MSYS2 without returning to shell and check for updates again\n"));
-+		pm_printf(ALPM_LOG_WARNING, _("for example close your terminal window instead of calling exit"));
-+		if(config->noconfirm) {
-+			fprintf(stdout, "\n");
-+			return 0;
++		int response = 0;
++		do {
++			response = yesno("To complete this update all MSYS2 processes including this terminal will be closed. Confirm to proceed");
++		} while(!response);
++
++		if (kill_all_other_msys_processes() != 0) {
++			pm_printf(ALPM_LOG_WARNING, _("terminating MSYS2 processes failed\n"));
++			exit(1);
 +		}
-+		wait_indefinitely();
++		exit(0);
 +	}
 +	return retval;
 +}
@@ -1260,7 +1316,7 @@ diff -Naur pacman-5.1.0-orig/src/pacman/sync.c pacman-5.1.0/src/pacman/sync.c
 +#endif
  	int retval = 0;
  	alpm_list_t *i;
-
+ 
 @@ -695,6 +767,14 @@
  	}
 

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=5.2.1
-pkgrel=7
+pkgrel=8
 contrib_ver=1.2.0
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
@@ -93,7 +93,7 @@ sha256sums=('1930c407265fd039cb3a8e6edc82f69e122aa9239d216d9d57b9d1b9315af312'
             '70c01a440acc2ddfff1c3d5d52f48865a8a33c3f8b494fc77974c398aa5be8e0'
             '8949cfd1fee9c965ec8afccee27937d4c15b4cccb2c367db4fb2b718bc66e74a'
             '684648d5b1246af9ce5b3afaadf201873269c5208057e8cbdbd409b4c0f22564'
-            'ef839af3cf4676deb6937c3c61d446b8d1955f773aaf7eae4b40cae2023bf9f7'
+            'b8ae396f6f4f083389b8536a6f769fa5c74089fa71a841d1869a7243cfc0ae13'
             '24ea2c8dca37847e04894ebfd05d1cf5df49dc0c8089f5581c99caa19b77a7ef'
             '870b197b7d6379a9c1ebb5c449c902b21d75ec21e966a2e54af82501465180f7'
             '23132552a388b238acf8bf650b5c2aa08cf3de63c647e84ad551807c4edfeb1e'


### PR DESCRIPTION
After a core upgrade instead of waiting endlessly and hoping that
the user closes all remaining msys processes ask the user if we should
kill them and then just do it.

This iterates over /proc/*/winpid and passes the list to taskkill
which kills all processes, except pacman itself which exits manually.

In case of --noconfirm things get killed automatically.