### PR TITLE
Add a base package

### DIFF
--- a/base/PKGBUILD
+++ b/base/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=base
 pkgver=1
-pkgrel=1
+pkgrel=2
 pkgdesc='Minimal package set to define a basic MSYS2 installation'
 url='https://www.msys2.org'
 arch=('any')
@@ -49,7 +49,9 @@ depends=(
   'ttyrec'
   'tzcode'
   'util-linux'
+  'wget'
   'which'
+  'zstd'
 )
 source=('README.md')
 sha256sums=('46702e24eebde5cf8fbb3d412a524736ef10d16e9c85efa0fc8d256cccf00484')

--- a/base/PKGBUILD
+++ b/base/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+pkgname=base
+pkgver=1
+pkgrel=1
+pkgdesc='Minimal package set to define a basic MSYS2 installation'
+url='https://www.msys2.org'
+arch=('any')
+license=('GPL')
+depends=(
+  'bash'
+  'bash-completion'
+  'bsdcpio'
+  'bsdtar'
+  'bzip2'
+  'coreutils'
+  'curl'
+  'dash'
+  'dtc'
+  'file'
+  'filesystem'
+  'findutils'
+  'flex'
+  'gawk'
+  'gcc-libs'
+  'getent'
+  'getopt'
+  'grep'
+  'gzip'
+  'inetutils'
+  'info'
+  'less'
+  'libargp'
+  'lndir'
+  'mintty'
+  'msys2-keyring'
+  'msys2-launcher'
+  'msys2-runtime'
+  'ncurses'
+  'pacman'
+  'pacman-mirrors'
+  'pactoys'
+  'pax'
+  'pkgfile'
+  'rebase'
+  'sed'
+  'tftp-hpa'
+  'time'
+  'ttyrec'
+  'tzcode'
+  'util-linux'
+  'which'
+)
+source=('README.md')
+sha256sums=('46702e24eebde5cf8fbb3d412a524736ef10d16e9c85efa0fc8d256cccf00484')

--- a/base/README.md
+++ b/base/README.md
@@ -1,0 +1,2 @@
+This meta package depends on all packages needed for a basic MSYS2 installation
+and is used by the msys2-installer.


### PR DESCRIPTION
This is meant as a replacement for the base group and contains the
same packages. If a user has the base package installed (the installer
will do this in the future) then we can add new packages to the base
and users with existing installations will get those packages installed
automatically.

This follows what Arch did last year:
https://www.archlinux.org/news/base-group-replaced-by-mandatory-base-package-manual-intervention-required/

See #1976