### PR TITLE
zstd: Use tar.xz to install the zstd package from old MSYS2

### DIFF
--- a/zstd/PKGBUILD
+++ b/zstd/PKGBUILD
@@ -1,9 +1,10 @@
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 
+PKGEXT='.pkg.tar.xz'
 pkgbase=zstd
 pkgname=('zstd' 'libzstd' 'libzstd-devel')
 pkgver=1.4.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Zstandard - Fast real-time compression algorithm"
 arch=('i686' 'x86_64')
 url='https://facebook.github.io/zstd/'


### PR DESCRIPTION
This is related to https://github.com/msys2/MSYS2-packages/pull/1969 .