### PR TITLE
pacman: Update ja translation

### DIFF
--- a/pacman/0000-pacman-msysize.patch
+++ b/pacman/0000-pacman-msysize.patch
@@ -1296,7 +1296,7 @@ diff -Naur pacman-5.1.0-orig/src/pacman/sync.c pacman-5.1.0/src/pacman/sync.c
 +	if(retval == 0) {
 +		int response = 0;
 +		do {
-+			response = yesno("To complete this update all MSYS2 processes including this terminal will be closed. Confirm to proceed");
++			response = yesno(_("To complete this update all MSYS2 processes including this terminal will be closed. Confirm to proceed"));
 +		} while(!response);
 +
 +		if (kill_all_other_msys_processes() != 0) {

--- a/pacman/0011-update-ja-po-for-msys2.patch
+++ b/pacman/0011-update-ja-po-for-msys2.patch
@@ -1,29 +1,32 @@
---- pacman-5.2.1-orig/src/pacman/po/ja.po	2019-11-15 21:15:19.934578400 +0900
-+++ pacman-5.2.1/src/pacman/po/ja.po	2019-11-15 21:32:57.921215600 +0900
-@@ -1439,6 +1439,27 @@
+--- pacman-5.2.1-orig/src/pacman/po/ja.po	2019-11-01 09:52:52.000000000 +0900
++++ pacman-5.2.1/src/pacman/po/ja.po	2020-06-02 16:29:18.220253600 +0900
+@@ -1439,6 +1439,30 @@
  msgstr ""
  "'%s' はファイルです、あなたが行いたいのは %s で %s ではありませんか？\n"
  
-+#: src/pacman/sync.c:711
++#: src/pacman/sync.c:764
 +#, c-format
 +msgid "Starting core system upgrade...\n"
 +msgstr "コアシステムの更新を開始...\n"
 +
-+#: src/pacman/sync.c:738
++#: src/pacman/sync.c:791
 +#, c-format
 +msgid "terminate other MSYS2 programs before proceeding\n"
 +msgstr "続行する前に他の MSYS2 プログラムを終了してください\n"
 +
-+#: src/pacman/sync.c:741
++#: src/pacman/sync.c:796
 +#, c-format
 +msgid ""
-+"terminate MSYS2 without returning to shell and check for updates again\n"
-+msgstr "シェルに戻る前に MSYS2 を終了し、更新を再度チェックしてください\n"
++"To complete this update all MSYS2 processes including this terminal will be "
++"closed. Confirm to proceed"
++msgstr ""
++"更新を完了するために、この端末を含む全ての MSYS2 プロセスが閉じられます。続行"
++"しますか？"
 +
-+#: src/pacman/sync.c:742
++#: src/pacman/sync.c:800
 +#, c-format
-+msgid "for example close your terminal window instead of calling exit"
-+msgstr "exit を呼ぶのではなく、例えば端末ウィンドウを閉じてください"
++msgid "terminating MSYS2 processes failed\n"
++msgstr "MSYS2 プロセスの終了に失敗しました\n"
 +
  #: src/pacman/sync.c:708
  #, c-format

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -5,7 +5,7 @@
 PKGEXT='.pkg.tar.xz'
 pkgname=pacman
 pkgver=5.2.1
-pkgrel=9
+pkgrel=10
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -82,7 +82,7 @@ sha256sums=('1930c407265fd039cb3a8e6edc82f69e122aa9239d216d9d57b9d1b9315af312'
             '70c01a440acc2ddfff1c3d5d52f48865a8a33c3f8b494fc77974c398aa5be8e0'
             '8949cfd1fee9c965ec8afccee27937d4c15b4cccb2c367db4fb2b718bc66e74a'
             '684648d5b1246af9ce5b3afaadf201873269c5208057e8cbdbd409b4c0f22564'
-            '1ee416608d34c8f44becb6f30f3a03383f28df7c3c41bc5507b626ad05e0404c'
+            'c1a0bf706be2a0e9a57dbb0c36b57fa7edd6d1fc0ed24e729339fc9b2a2d2989'
             '24ea2c8dca37847e04894ebfd05d1cf5df49dc0c8089f5581c99caa19b77a7ef'
             '870b197b7d6379a9c1ebb5c449c902b21d75ec21e966a2e54af82501465180f7'
             '23132552a388b238acf8bf650b5c2aa08cf3de63c647e84ad551807c4edfeb1e'
@@ -92,7 +92,7 @@ sha256sums=('1930c407265fd039cb3a8e6edc82f69e122aa9239d216d9d57b9d1b9315af312'
             'e4f6e17af19e17e745a9f1c6b8402f5896229062c82167cb61f8e7d29eda716c'
             '9e8fe5ee78192b0407e80ad2e52cb27569c35974b6c26e465e3d55e19c03d108'
             '93be4523fb8c3dd6b56eddfe0b09e666725a62eb43392fee336ba1a328f9ffdd'
-            '205b1655ea4cfac248aa8d268017979db0644ff2f627e5969c30547fdc9bcd8e'
+            '558919a5e4632512fa42690bd5ea96e72766213ae6943408f7010daa486de929'
             'c242202f3526d5eaa21d321a1d0fa472697c50e8288175ebe93212356c78d1f1'
             '7cec4688b83df9f8ab56f5ab5e162383fe8928ff88b76d753a2cea935f30ec93'
             'b84310fd8fb9a98258c55ed9628226b14f55d6e42304df4d2a5bd8d8445c03b3'


### PR DESCRIPTION
Some new messages were added by #1971. Update the Japanese translation
for them.

Additionally, one of the new messages was not translatable. Make it
translatable.

Related: #1786
