### PR TITLE
pacman: Fix core update killall behavior

### DIFF
--- a/pacman/0000-pacman-msysize.patch
+++ b/pacman/0000-pacman-msysize.patch
@@ -1251,7 +1251,7 @@ diff -Naur pacman-5.1.0-orig/src/pacman/sync.c pacman-5.1.0/src/pacman/sync.c
 +		return 0;
 +
 +	setenv("MSYS2_ARG_CONV_EXCL", "*", 1);
-+	if (execvp(args[0], args + 1) == -1) {
++	if (execvp(args[0], args) == -1) {
 +		return -1;
 +	}
 +

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -5,7 +5,7 @@
 PKGEXT='.pkg.tar.xz'
 pkgname=pacman
 pkgver=5.2.1
-pkgrel=10
+pkgrel=11
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -81,7 +81,7 @@ sha256sums=('1930c407265fd039cb3a8e6edc82f69e122aa9239d216d9d57b9d1b9315af312'
             '70c01a440acc2ddfff1c3d5d52f48865a8a33c3f8b494fc77974c398aa5be8e0'
             '8949cfd1fee9c965ec8afccee27937d4c15b4cccb2c367db4fb2b718bc66e74a'
             '684648d5b1246af9ce5b3afaadf201873269c5208057e8cbdbd409b4c0f22564'
-            'c1a0bf706be2a0e9a57dbb0c36b57fa7edd6d1fc0ed24e729339fc9b2a2d2989'
+            '452d95270ca76ae587107ade4534d8de9684db4860be4c0c9e986e135eaf2e74'
             '24ea2c8dca37847e04894ebfd05d1cf5df49dc0c8089f5581c99caa19b77a7ef'
             '870b197b7d6379a9c1ebb5c449c902b21d75ec21e966a2e54af82501465180f7'
             '23132552a388b238acf8bf650b5c2aa08cf3de63c647e84ad551807c4edfeb1e'


### PR DESCRIPTION
This addresses #1991 as I understand it. [The documentation](https://linux.die.net/man/3/execvp) is not very clear on this, but `execvp()`'s argv appears to start at 0, not 1, so "/F" was not being passed at all. Now it kills all the consoles without asking again. :)