### PR TITLE
Add nkf 2.1.5

### DIFF
--- a/nkf/LICENSE
+++ b/nkf/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 1987, Fujitsu LTD. (Itaru ICHIKAWA).
+Copyright (c) 1996-2013, The nkf Project.
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+claim that you wrote the original software. If you use this software
+in a product, an acknowledgment in the product documentation would be
+appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be
+misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source distribution.

--- a/nkf/PKGBUILD
+++ b/nkf/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Yasuhiro Kimura <yasu@utahime.org>
+
+pkgname=nkf
+pkgver=2.1.5
+pkgrel=1
+pkgdesc='Network Kanji Filter'
+url='https://osdn.net/projects/nkf/'
+license=('custom')
+source=(${pkgname}-${pkgver}.tar.gz::https://osdn.net/dl/nkf/${pkgname}-${pkgver}.tar.gz
+        'msys2-local.patch'
+        'LICENSE')
+sha256sums=('d1a7df435847a79f2f33a92388bca1d90d1b837b1b56523dcafc4695165bad44'
+            '173052e7eb527bbe54a81eea7fe3c3302e11b85bc6d2adb60a816d7773646fad'
+            '361183549590b512d3a37687a59835091e07b4518d5bc1ba7a834a60002f53ca')
+arch=('i686' 'x86_64')
+makedepends=('libiconv')
+
+prepare() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  patch -p1 -i "${srcdir}/msys2-local.patch"
+}
+
+build() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  make
+}
+
+package() {
+  pushd "${srcdir}/${pkgname}-${pkgver}"
+  make prefix="/usr" DESTDIR="${pkgdir}" install
+  popd
+  install -d "${pkgdir}/usr/share/license/nkf"
+  install -m 644 LICENSE "${pkgdir}/usr/share/license/nkf"
+}
+
+# Local Variables:
+# mode: Shell-Script
+# sh-basic-offset: 2
+# indent-tabs-mode: nil
+# End:

--- a/nkf/msys2-local.patch
+++ b/nkf/msys2-local.patch
@@ -1,0 +1,40 @@
+diff --git a/Makefile b/Makefile
+index 1cfb459..db8c05a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -6,7 +6,7 @@ SHAR = shar
+ PERL = perl
+ RM = rm -rf
+ VERSION = 2.1.5
+-MKDIR = mkdir
++MKDIR = mkdir -p
+ prefix = /usr/local
+ PYTHON2 = python
+ PYTHON3 = python
+@@ -46,18 +46,18 @@ python3:
+ install: install-main install-man install-man-ja
+ 
+ install-main:
+-	-$(MKDIR) $(prefix)/bin
+-	cp -f nkf $(prefix)/bin/
++	-$(MKDIR) $(DESTDIR)$(prefix)/bin
++	cp -f nkf $(DESTDIR)$(prefix)/bin/
+ 
+ install-man:
+-	-$(MKDIR) $(prefix)/man
+-	-$(MKDIR) $(prefix)/man/man1
+-	cp -f nkf.1 $(prefix)/man/man1/
++	-$(MKDIR) $(DESTDIR)$(prefix)/share/man
++	-$(MKDIR) $(DESTDIR)$(prefix)/share/man/man1
++	cp -f nkf.1 $(DESTDIR)$(prefix)/share/man/man1/
+ 
+ install-man-ja:
+-	-$(MKDIR) $(prefix)/man/ja
+-	-$(MKDIR) $(prefix)/man/ja/man1
+-	cp -f nkf.1j $(prefix)/man/ja/man1/nkf.1
++	-$(MKDIR) $(DESTDIR)$(prefix)/share/man/ja
++	-$(MKDIR) $(DESTDIR)$(prefix)/share/man/ja/man1
++	iconv -f ISO-2022-JP -t UTF-8  nkf.1j > $(DESTDIR)$(prefix)/share/man/ja/man1/nkf.1
+ 
+ shar:
+ 	-mkdir nkf-$(VERSION)


### PR DESCRIPTION
Nkf (Network Kanji Filter) is character set conversion filter for
Japanese language. Main featurs are:

* Conversion between ISO-2022-JP, Shift_JIS, EUC-JP, UTF-8, UTF-16 and  UTF-32.
* Auto detection of input character set.
* MIME encode/decode.
* Line break conversion.