### PR TITLE
file: fix install path of magic.py

### DIFF
--- a/file/PKGBUILD
+++ b/file/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=file
 pkgver=5.38
-pkgrel=3
+pkgrel=4
 pkgdesc="File type identification utility"
 arch=('i686' 'x86_64')
 license=('custom')
@@ -46,7 +46,7 @@ package() {
   PYTHON_SITELIB=$(/usr/bin/python -c 'from distutils.sysconfig import * ; print(get_python_lib(0,0));')
 
   mkdir -p ${pkgdir}/${PYTHON_SITELIB}
-  cp -f ${srcdir}/${pkgname}-${pkgver}/python/magic.py ${pkgdir}/$PYTHON3_SITELIB
+  cp -f ${srcdir}/${pkgname}-${pkgver}/python/magic.py ${pkgdir}/$PYTHON_SITELIB
 
   cat ${srcdir}/${pkgname}-${pkgver}/magic/Magdir/* > ${pkgdir}/usr/share/misc/magic
   cp -rf ${pkgdir}/usr/share/misc/magic ${pkgdir}/usr/share/magic


### PR DESCRIPTION
It got copied to the root dir instead of the Python site-packages