### PR TITLE
filesystem: Make msystem compatible with POSIX compliant shells.

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -6,7 +6,7 @@
 PKGEXT='.pkg.tar.xz'
 pkgname=filesystem
 pkgver=2020.02
-pkgrel=2
+pkgrel=3
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -60,7 +60,7 @@ sha256sums=('742a7d66b7a5ebd2b8461728c5b44a46b2305fd2116208eecae5f45828938ea0'
             '387ca1e86c1a18a143eb077ca194ad44c0a2faf98795a0d437f2d210d5a6df18'
             '7d6994d7caf52a459b562cfb0da1d758a4b7bca478d1df00de3a96686e59008e'
             'db6738b88e6cf8092522fd794779059b3082ed1f4f72259d92df9df50b9c9cd4'
-            '3c1da9bf6ff791c32f17e49db0047b3c9cbaacd44d6d0b92696cdeacebf8f947'
+            '65f59306dfe6437ea2694d50ed4e2fe95937148549157809ad3daac5d7e11ddf'
             '91f1f918cf13deab0124082086e990786113b0e710dbda4678d8fc14905ad94d'
             '21d545a1c6f3d5dbe07b80645c09320bb709df627a82d02bbdf63e444376feb8'
             '6c0ca979c7b146b3750103b1296a399764f4e1b222ee091d3aa072b6da16c1a5'

--- a/filesystem/msystem
+++ b/filesystem/msystem
@@ -45,8 +45,8 @@ case "${MSYSTEM}" in
         ;;
     *)
         MSYSTEM_PREFIX='/usr'
-        MSYSTEM_CARCH="${HOSTTYPE}"
-        MSYSTEM_CHOST="${MACHTYPE}"
+        MSYSTEM_CARCH="$(/usr/bin/uname -m)"
+        MSYSTEM_CHOST="$(/usr/bin/uname -m)-pc-msys"
         CONFIG_SITE="/etc/config.site"
         export MSYSTEM_PREFIX MSYSTEM_CARCH MSYSTEM_CHOST CONFIG_SITE
         ;;


### PR DESCRIPTION
Behavior about the value of HOSTTYPE and MACHTYPE is not compatible between various POSIX compliant shells. For example zsh doesn't set HOSTTYPE at all and set MACHTYPE to that of HOSTTYPE in bash. I checked source tree of bash and found that HOSTTYPE is set to the result of `uname -m` and that MACHTYPE is set to the result of `uname -m` plus "-pc-msys".So change code  accordingly.

This fixes issue #2008.
