### PR TITLE
openssl: Add a separate openssl-docs package

### DIFF
--- a/openssl/PKGBUILD
+++ b/openssl/PKGBUILD
@@ -1,10 +1,10 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
-pkgname=('openssl' 'libopenssl' 'openssl-devel')
+pkgname=('openssl' 'libopenssl' 'openssl-devel' 'openssl-docs')
 _ver=1.1.1g
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
-pkgrel=1
+pkgrel=2
 pkgdesc='The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
 arch=('i686' 'x86_64')
 url='https://www.openssl.org'
@@ -76,9 +76,18 @@ package_openssl() {
   mkdir -p ${pkgdir}/usr/bin
   cp -f ${srcdir}/dest/usr/bin/*.exe ${pkgdir}/usr/bin/
   cp -f ${srcdir}/dest/usr/bin/c_rehash ${pkgdir}/usr/bin/
-  cp -rf ${srcdir}/dest/usr/share ${pkgdir}/usr/
+  mkdir -p ${pkgdir}/usr/share/man
+  cp -rf ${srcdir}/dest/usr/share/man/man1 ${pkgdir}/usr/share/man
+  cp -rf ${srcdir}/dest/usr/share/man/man5 ${pkgdir}/usr/share/man
+  cp -rf ${srcdir}/dest/usr/share/man/man7 ${pkgdir}/usr/share/man
   cp -rf ${srcdir}/dest/usr/ssl ${pkgdir}/usr/
   install -D -m644 ${srcdir}/${pkgname}-${_ver}/LICENSE ${pkgdir}/usr/share/licenses/${pkgname}/LICENSE
+}
+
+package_openssl-docs() {
+  mkdir -p ${pkgdir}/usr/share/man
+  cp -rf ${srcdir}/dest/usr/share/man/man3 ${pkgdir}/usr/share/man
+  cp -rf ${srcdir}/dest/usr/share/doc ${pkgdir}/usr/share
 }
 
 package_libopenssl() {


### PR DESCRIPTION
This contains the htmls docs/manpages and the level 3 man pages (API docs).
openssl is part of base and all these docs make up 7800 files, which is a third
of all files in base.

Since they are rarely needed and contain so many files I think it makes sense to split them out.