### PR TITLE
filesystem: fix upgrade

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -6,11 +6,13 @@
 PKGEXT='.pkg.tar.xz'
 pkgname=filesystem
 pkgver=2020.02
-pkgrel=3
+pkgrel=4
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
 url='https://sourceforge.net/projects/msys2/'
+provides=('msys2-base')
+replaces=('msys2-base')
 backup=('etc/fstab' 'etc/shells' 'etc/profile'
         etc/bash.bash{rc,_logout} etc/skel/.bash{rc,_profile,_logout}
         etc/nsswitch.conf)


### PR DESCRIPTION
msys2-base was removed from dash and filesystem, but filesystem gets updated
first and then fails beause it would break dash which hasn't been updated yet.

So add the provides back.

This fixes:

error: failed to prepare transaction (could not satisfy dependencies)
:: installing filesystem (2020.02-3) breaks dependency 'msys2-base' required by dash