### PR TITLE
[RFC] rebase: always kill all running msys2 processes

### DIFF
--- a/rebase/autorebase.bat
+++ b/rebase/autorebase.bat
@@ -1,4 +1,8 @@
 @echo off
 
+set dir=%~dp0
+set dll=%dir%usr\bin\msys-2.0.dll
+powershell /c "Get-Process | Where-Object {($_.Modules | Where-Object {$_.FileName -like '"%dll%"'}).Length -gt 0} | Stop-Process -Force"
+
 set PATH=%~dp0\usr\bin;%PATH%
 %~dp0\usr\bin\dash /usr/bin/rebaseall -p


### PR DESCRIPTION
By using powershell to find and kill all processes using the dll, we can ensure that the rebase will actually work.

A bit of testing is needed with someone on Windows Vista. We should also maybe come up with a switch to disable killing, since the search takes time.