### PR TITLE
binutils: Install libiberty headers

### DIFF
--- a/binutils/PKGBUILD
+++ b/binutils/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=binutils
 pkgver=2.34
-pkgrel=3
+pkgrel=4
 pkgdesc="A set of programs to assemble and manipulate binary and object files"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/binutils/"
@@ -47,6 +47,7 @@ build() {
     --disable-werror \
     --disable-sim \
     --enable-64-bit-bfd \
+    --enable-install-libiberty \
     --without-libiconv-prefix \
     --without-libintl-prefix
 


### PR DESCRIPTION
Done in MinGW, but not in MSYS