### PR TITLE
python: Fix socket.TCP_NODELAY missing

### DIFF
--- a/python/930-fix-missing-tcp-include.patch
+++ b/python/930-fix-missing-tcp-include.patch
@@ -1,0 +1,13 @@
+--- Python-3.8.5/Modules/socketmodule.h.orig	2020-07-20 15:01:32.000000000 +0200
++++ Python-3.8.5/Modules/socketmodule.h	2020-07-23 09:32:42.727747500 +0200
+@@ -8,9 +8,7 @@
+ #   include <sys/socket.h>
+ # endif
+ # include <netinet/in.h>
+-# if !defined(__CYGWIN__)
+-#  include <netinet/tcp.h>
+-# endif
++# include <netinet/tcp.h>
+ 
+ #else /* MS_WINDOWS */
+ # include <winsock2.h>

--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=python
 pkgname=python
 pkgver=3.8.5
-pkgrel=1
+pkgrel=2
 _pybasever=${pkgver%.*}
 pkgdesc="Next generation of the python high-level scripting language"
 arch=('i686' 'x86_64')
@@ -36,7 +36,8 @@ source=(https://www.python.org/ftp/python/${pkgver%rc*}/Python-${pkgver}.tar.xz
         026-3.7-mpdec-msys.patch
         027-install-import-library.patch
         900-msysize.patch
-        920-allow-win-drives-in-os-path-isabs.patch)
+        920-allow-win-drives-in-os-path-isabs.patch
+        930-fix-missing-tcp-include.patch)
 sha256sums=('e3003ed57db17e617acb382b0cade29a248c6026b1bd8aad1f976e9af66a83b0'
             'be96ddaca58a39ddaf1e3e5bb7900b34c0e6d00e9b64c4e0f8a3565a74a44e84'
             '4044827af3cf0e91a8ddd44cd588f17ea4e17619512edd299b5688ec6e112ad4'
@@ -57,7 +58,8 @@ sha256sums=('e3003ed57db17e617acb382b0cade29a248c6026b1bd8aad1f976e9af66a83b0'
             'fc6164a90f0ca2a9341aaf4448b4334c3393459ca5cbad6d7149f8bcf70da5fe'
             'b4042475c5c75e0b4c7c08ccad2891eb8098c066c5ba524a988a0519102e8e5d'
             'e833cb6ab8a3d35296f52ad327df7eb4cc4eab94413085bded2943a290cba16d'
-            '387a2b7931fb4958e2526991760d85677f44fa13cff0aeb0f41a267f1f7fd214')
+            '387a2b7931fb4958e2526991760d85677f44fa13cff0aeb0f41a267f1f7fd214'
+            '17e4ac1b5f0fa8a6c410fb80d1ad99ec9185efef51b8450a31932b553c354ed1')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -104,6 +106,10 @@ prepare() {
     900-msysize.patch \
     920-allow-win-drives-in-os-path-isabs.patch
   
+  # https://bugs.python.org/issue41374
+  apply_patch_with_msg \
+    930-fix-missing-tcp-include.patch
+
   # Incomplete patch from Ray Donnelly
   # patch -p1 -i ${srcdir}/3.3.2-allow-windows-paths-for-executable.patch
 
@@ -143,7 +149,7 @@ build() {
 
 check() {
   cd "${srcdir}/Python-${pkgver}"
-  "${srcdir}/Python-${pkgver}/python" -m test.regrtest -x test_posixpath test_logging
+  "${srcdir}/Python-${pkgver}/python.exe" -m test.regrtest -x test_posixpath test_logging
 }
 
 package() {


### PR DESCRIPTION
Upstream bug: https://bugs.python.org/issue41374

Fixes #2050