### PR TITLE
dash: depend on filesystem

### DIFF
--- a/dash/PKGBUILD
+++ b/dash/PKGBUILD
@@ -2,12 +2,12 @@
 
 pkgname=dash
 pkgver=0.5.11.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A POSIX compliant shell that aims to be as small as possible"
 arch=('i686' 'x86_64')
 url="http://gondor.apana.org.au/~herbert/dash/"
 license=('BSD')
-depends=('grep' 'sed')
+depends=('grep' 'sed' 'filesystem')
 install=dash.install
 source=("http://gondor.apana.org.au/~herbert/dash/files/${pkgname}-${pkgver}.tar.gz")
 sha256sums=('73c881f146e329ac54962766760fd62cb8bdff376cd6c2f5772eecc1570e1611')


### PR DESCRIPTION
The included install script depends on /etc/shells

Fixes #2049