### PR TITLE
db: fix gcc __atomic_compare_exchange ambiguation.

### DIFF
--- a/db/PKGBUILD
+++ b/db/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('db' 'libdb' 'libdb-devel' 'db-docs')
 pkgver=5.3.28
-pkgrel=2
+pkgrel=3
 pkgdesc="The Berkeley DB embedded database system"
 url="https://www.oracle.com/technetwork/database/database-technologies/berkeleydb/overview/index.html"
 license=('custom')
@@ -13,12 +13,14 @@ source=(http://download.oracle.com/berkeley-db/db-${pkgver}.tar.gz
         5.3-java.patch
         5.3-tcl.patch
         5.3-vpath.patch
+        https://src.fedoraproject.org/rpms/libdb/raw/d6841b3b46a51db98c162347211a5a64d154ea37/f/db-5.3.28-atomic_compare_exchange.patch
         db-5.3.28-msys2.patch)
 options=('!makeflags')
 sha256sums=('e0a992d740709892e81f9d93f06daf305cf73fb81b545afe72478043172c3628'
             'a925b88e58cff6d4aeed3eecfa2cf4c606f2ed469607d8fd0c5c0a9c4b5a8bd1'
             '2166bac574f60d42fe6dd6c03223d6595accf303375be397e277b38676b8cb08'
             '7614933d2770c2aa6864cd731c114b90a4e4c1a8a988daabd9b6f203ab8f1f21'
+            'eb58b5764e16c6f81df8ff80964ef2e071ca5cbb9e24d37f45a831107afb68cc'
             '42ae2995fefbd06853278db1620e8a15dbfd580e1a26c7f26e6d81e734e064cd')
 
 prepare() {
@@ -27,6 +29,7 @@ prepare() {
   patch -Np2 -i ${srcdir}/5.3-java.patch
   patch -Np2 -i ${srcdir}/5.3-tcl.patch
   patch -Np2 -i ${srcdir}/5.3-vpath.patch
+  patch -Np1 -i ${srcdir}/db-5.3.28-atomic_compare_exchange.patch
   patch -Np1 -i ${srcdir}/db-5.3.28-msys2.patch
 
   cd dist


### PR DESCRIPTION
Patch from Fedora project.

Fixed compile error:
error: definition of 'int __atomic_compare_exchange(db_atomic_t*, atomic_value_t, atomic_value_t)' ambiguates built-in declaration 'bool __atomic_compare_exchange(unsigned int, volatile void*, void*, void*, int, int)'