### PR TITLE
reflex: Update to 20200715

### DIFF
--- a/reflex/PKGBUILD
+++ b/reflex/PKGBUILD
@@ -1,7 +1,7 @@
 
 _realname=reflex
 pkgname=${_realname}
-pkgver=20191123
+pkgver=20200715
 pkgrel=1
 pkgdesc="A variant of the flex fast lexical scanner"
 arch=('i686' 'x86_64')
@@ -9,32 +9,32 @@ url="https://invisible-island.net/reflex"
 license=('BSD')
 groups=('base-devel')
 
-source=("${_realname}-${pkgver}.tar.gz::https://invisible-island.net/datafiles/release/${_realname}.tar.gz")
-sha256sums=('5623f4a520fa2f51abb23037fbb6b2aafac0e9cc60ddaa70ba727e0e01ef053f')
+# source=("${_realname}-${pkgver}.tar.gz::https://invisible-island.net/datafiles/release/${_realname}.tar.gz")
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/ThomasDickey/${_realname}-snapshots/archive/t${pkgver}.tar.gz")
+sha256sums=('80ebbadd26e96a95cc7e4c752608c7dfec7fe9a569258a3dc5f0e4de9a36ffc7')
+
+
+_src_dir=${_realname}-snapshots-t${pkgver}
+_build_dir=build-${pkgver}-${MSYSTEM_CHOST}
 
 
 prepare() {
-  cd ${_realname}-${pkgver}
-  autoreconf -vfi
+  autoreconf -vfi ${_src_dir}
 }
 
 build() {
-  cd ${_realname}-${pkgver}
-  mkdir -p build-${MSYSTEM_CHOST}
-  pushd build-${MSYSTEM_CHOST}
-  ../configure -C
+  mkdir -p ${_build_dir}
+  cd ${_build_dir}
+  ../${_src_dir}/configure -C
   make
 }
 
 check() {
-  cd ${_realname}-${pkgver}/build-${MSYSTEM_CHOST}
-  make check
+  make -C ${_build_dir} check
 }
 
 package() {
-  cd ${_realname}-${pkgver}
   mkdir -p "${pkgdir}/usr/share/licenses/${pkgname}"
-  cp -pv package/debian/copyright "${pkgdir}/usr/share/licenses/${pkgname}"
-  cd build-${MSYSTEM_CHOST}
-  make DESTDIR=${pkgdir} install
+  cp -pv ${_src_dir}/package/debian/copyright "${pkgdir}/usr/share/licenses/${pkgname}"
+  make -C ${_build_dir} DESTDIR=${pkgdir} install
 }


### PR DESCRIPTION
* reflex/PKGBUILD:
  - update version to 20200715
  - change to github releases whose unzipped packages have a different
    folder name.
  - add variables _src_dir and _build_dir for better maintenance.