### PR TITLE
perl-Alien-Build: makedepend on libcrypt-devel

### DIFF
--- a/perl-Alien-Build/PKGBUILD
+++ b/perl-Alien-Build/PKGBUILD
@@ -3,14 +3,14 @@
 _realname=Alien-Build
 pkgname=perl-${_realname}
 pkgver=2.26
-pkgrel=1
+pkgrel=2
 pkgdesc="Build external dependencies for use in CPAN"
 arch=('any')
 license=('PerlArtistic')
 url="https://metacpan.org/release/Alien-Build"
 groups=('perl-modules')
 depends=('perl-Capture-Tiny' 'perl-FFI-CheckLib' 'perl-File-chdir' 'perl-File-Which')
-makedepends=('perl-Test2-Suite')
+makedepends=('perl-Test2-Suite' 'libcrypt-devel')
 #checkdepends=('perl-Alien-Base-ModuleBuild' 'perl-Alien-cmake3' 'perl-Env-ShellWords'
 #              'perl-PkgConfig' 'perl-PkgConfig-LibPkgConf' 'perl-Readonly' 'perl-Sort-Versions')
 options=(!emptydirs)


### PR DESCRIPTION
This seems to more properly be a dependency of things that compile against perl, so maybe if a perl-devel package existed it would be a dependency of that