### PR TITLE
Fix perl modules makedepends

### DIFF
--- a/perl-Alien-Build/PKGBUILD
+++ b/perl-Alien-Build/PKGBUILD
@@ -3,14 +3,14 @@
 _realname=Alien-Build
 pkgname=perl-${_realname}
 pkgver=2.26
-pkgrel=1
+pkgrel=2
 pkgdesc="Build external dependencies for use in CPAN"
 arch=('any')
 license=('PerlArtistic')
 url="https://metacpan.org/release/Alien-Build"
 groups=('perl-modules')
 depends=('perl-Capture-Tiny' 'perl-FFI-CheckLib' 'perl-File-chdir' 'perl-File-Which')
-makedepends=('perl-Test2-Suite')
+makedepends=('perl-Test2-Suite' 'libcrypt-devel')
 #checkdepends=('perl-Alien-Base-ModuleBuild' 'perl-Alien-cmake3' 'perl-Env-ShellWords'
 #              'perl-PkgConfig' 'perl-PkgConfig-LibPkgConf' 'perl-Readonly' 'perl-Sort-Versions')
 options=(!emptydirs)

--- a/perl-Compress-Bzip2/PKGBUILD
+++ b/perl-Compress-Bzip2/PKGBUILD
@@ -3,11 +3,11 @@
 _realname=Compress-Bzip2
 pkgname=perl-${_realname}
 pkgver=2.28
-pkgrel=1
+pkgrel=2
 pkgdesc="Interface to Bzip2 compression library"
 arch=('i686' 'x86_64')
 license=(GPL2)
-makedepends=('libbz2-devel')
+makedepends=('libcrypt-devel' 'libbz2-devel')
 depends=('perl' 'libbz2')
 groups=('perl-modules')
 url="https://metacpan.org/release/Compress-Bzip2"

--- a/perl-Crypt-SSLeay/PKGBUILD
+++ b/perl-Crypt-SSLeay/PKGBUILD
@@ -3,12 +3,13 @@
 _realname=Crypt-SSLeay
 pkgname=perl-${_realname}
 pkgver=0.73_06
-pkgrel=4
+pkgrel=5
 pkgdesc="OpenSSL glue that provides LWP https support"
 arch=('i686' 'x86_64')
 url="https://metacpan.org/release/Crypt-SSLeay"
 groups=('perl-modules')
 license=('GPL' 'PerlArtistic')
+makedepends=('openssl-devel' 'libcrypt-devel')
 depends=('perl-LWP-Protocol-https' 'perl-Try-Tiny' 'perl-Path-Class')
 options=('!emptydirs')
 source=(https://www.cpan.org/CPAN/authors/id/N/NA/NANIS/Crypt-SSLeay-${pkgver}.tar.gz

--- a/perl-DBI/PKGBUILD
+++ b/perl-DBI/PKGBUILD
@@ -3,13 +3,14 @@
 _realname=DBI
 pkgname=perl-${_realname}
 pkgver=1.643
-pkgrel=2
+pkgrel=3
 pkgdesc="Database independent interface for Perl"
 arch=('i686' 'x86_64')
 url="https://metacpan.org/release/DBI"
 groups=('perl-modules')
 license=('GPL' 'PerlArtistic')
 depends=('perl')
+makedepends=('libcrypt-devel')
 options=('!emptydirs')
 source=("https://www.cpan.org/authors/id/T/TI/TIMB/${_realname}-${pkgver}.tar.gz"
         'DBI-1.627.patch')

--- a/perl-HTML-Parser/PKGBUILD
+++ b/perl-HTML-Parser/PKGBUILD
@@ -3,13 +3,14 @@
 _realname=HTML-Parser
 pkgname=perl-${_realname}
 pkgver=3.72
-pkgrel=5
+pkgrel=6
 pkgdesc="Perl HTML parser class"
 arch=('i686' 'x86_64')
 license=('PerlArtistic')
 url="https://metacpan.org/release/HTML-Parser"
 groups=('perl-modules')
 depends=('perl-HTML-Tagset' 'perl')
+makedepends=('libcrypt-devel')
 checkdepends=('perl-Test-Pod')
 options=('!emptydirs')
 source=(https://www.cpan.org/authors/id/G/GA/GAAS/${_realname}-${pkgver}.tar.gz)

--- a/perl-List-MoreUtils-XS/PKGBUILD
+++ b/perl-List-MoreUtils-XS/PKGBUILD
@@ -3,12 +3,13 @@
 _realname=List-MoreUtils-XS
 pkgname=perl-${_realname}
 pkgver=0.428
-pkgrel=4
+pkgrel=5
 pkgdesc="Provide the stuff missing in List::Util"
 arch=('i686' 'x86_64')
 license=('GPL' 'PerlArtistic')
 url="https://metacpan.org/release/List-MoreUtils"
 depends=('perl')
+makedepends=('libcrypt-devel')
 groups=('perl-modules')
 options=('!emptydirs')
 source=(https://www.cpan.org/authors/id/R/RE/REHSACK/${_realname}-${pkgver}.tar.gz)

--- a/perl-Locale-Gettext/PKGBUILD
+++ b/perl-Locale-Gettext/PKGBUILD
@@ -3,13 +3,14 @@
 _realname=Locale-Gettext
 pkgname=perl-${_realname}
 pkgver=1.07
-pkgrel=5
+pkgrel=6
 groups=('perl-modules')
 pkgdesc="Permits access from Perl to the gettext() family of functions"
 arch=('i686' 'x86_64')
 license=('GPL' 'PerlArtistic')
 url="https://metacpan.org/${_realname}/"
 depends=('gettext' 'perl')
+makedepends=('libcrypt-devel')
 options=(!emptydirs)
 source=(${_realname}-${pkgver}.tar.gz::"https://www.cpan.org/authors/id/P/PV/PVANDRY/gettext-${pkgver}.tar.gz")
 sha256sums=('909d47954697e7c04218f972915b787bd1244d75e3bd01620bc167d5bbc49c15')

--- a/perl-Math-Int64/PKGBUILD
+++ b/perl-Math-Int64/PKGBUILD
@@ -3,12 +3,13 @@
 _realname=Math-Int64
 pkgname=perl-${_realname}
 pkgver=0.54
-pkgrel=4
+pkgrel=5
 pkgdesc="Math::Int64 - Manipulate 64 bits integers in Perl"
 arch=('any')
 license=('GPL' 'PerlArtistic')
 url="https://metacpan.org/release/Math-Int64"
 depends=('perl')
+makedepends=('libcrypt-devel')
 groups=('perl-modules')
 options=('!emptydirs')
 source=("https://www.cpan.org/authors/id/S/SA/SALVA/${_realname}-${pkgver}.tar.gz")

--- a/perl-Net-SSLeay/PKGBUILD
+++ b/perl-Net-SSLeay/PKGBUILD
@@ -3,13 +3,13 @@
 _realname=Net-SSLeay
 pkgname=perl-${_realname}
 pkgver=1.89_01
-pkgrel=1
+pkgrel=2
 pkgdesc="Perl extension for using OpenSSL"
 arch=('i686' 'x86_64')
 license=('custom:BSD')
 url="https://metacpan.org/${_realname}/"
 groups=('perl-modules')
-makedepends=('openssl-devel')
+makedepends=('openssl-devel' 'libcrypt-devel')
 depends=('openssl')
 options=(!emptydirs)
 replaces=('net-ssleay')

--- a/perl-Socket6/PKGBUILD
+++ b/perl-Socket6/PKGBUILD
@@ -3,12 +3,13 @@
 _realname=Socket6
 pkgname="perl-${_realname}"
 pkgver=0.29
-pkgrel=3
+pkgrel=4
 pkgdesc="A getaddrinfo/getnameinfo support module"
 arch=('i686' 'x86_64')
 url='https://metacpan.org/release/Socket6'
 license=('PerlArtistic' 'GPL')
 depends=('perl')
+makedepends=('libcrypt-devel')
 options=('!emptydirs')
 source=(https://www.cpan.org/authors/id/U/UM/UMEMOTO/Socket6-$pkgver.tar.gz)
 sha256sums=('468915fa3a04dcf6574fc957eff495915e24569434970c91ee8e4e1459fc9114')

--- a/perl-Sys-CPU/PKGBUILD
+++ b/perl-Sys-CPU/PKGBUILD
@@ -3,14 +3,14 @@
 _realname=Sys-CPU
 pkgname=perl-${_realname}
 pkgver=0.61
-pkgrel=7
+pkgrel=8
 pkgdesc="Provide commonly requested regular expressions"
 arch=('i686' 'x86_64')
 url="https://metacpan.org/author/MZSANFORD${_realname}-${pkgver}"
 groups=('perl-modules')
 depends=('perl' 'libcrypt-devel')
 license=('GPL' 'PerlArtistic')
-source=("https://www.cpan.org/authors/id/M/MZ/MZSANFORD/${_realname}-${pkgver}.tar.gz"
+source=("https://cpan.metacpan.org/authors/id/M/MZ/MZSANFORD/${_realname}-${pkgver}.tar.gz"
         "0001-Cygwin-is-as-per-Windows.patch")
 sha256sums=('250a86b79c231001c4ae71d2f66428092a4fbb2070971acafd471aa49739c9e4'
             '3dc075609561da40044c6547274cb463c92d458e59839972a291ea0830193bc8')

--- a/perl-XML-LibXML/PKGBUILD
+++ b/perl-XML-LibXML/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=XML-LibXML
 pkgname=perl-${_realname}
 pkgver=2.0205
-pkgrel=2
+pkgrel=3
 pkgdesc="Interface to the libxml library"
 arch=('i686' 'x86_64')
 license=('GPL' 'PerlArtistic')
@@ -11,7 +11,7 @@ url="https://search.cpan.org/dist/XML-LibXML"
 groups=('perl-modules')
 depends=('perl' 'perl-Alien-Libxml2' 'perl-XML-SAX' 'perl-XML-NamespaceSupport')
 #checkdepends=('perl-Test-Pod' 'perl-Test-LeakTrace' 'perl-CPAN-Changes' 'perl-URI')
-makedepends=('libxml2-devel')
+makedepends=('libcrypt-devel' 'libxml2-devel' 'perl-Path-Tiny')
 #replaces=('perlxml')
 #provides=("perlxml=${pkgver}")
 install=perl-xml-libxml.install

--- a/perl-YAML-Syck/PKGBUILD
+++ b/perl-YAML-Syck/PKGBUILD
@@ -3,12 +3,13 @@
 _realname=YAML-Syck
 pkgname=perl-YAML-Syck
 pkgver=1.32
-pkgrel=2
+pkgrel=3
 pkgdesc="Fast, lightweight YAML loader and dumper"
 arch=('i686' 'x86_64')
 url="https://metacpan.org/release/YAML-Syck"
 license=('BSD' 'custom')
 depends=('perl')
+makedepends=('libcrypt-devel')
 groups=('perl-modules')
 options=('!emptydirs')
 source=(https://www.cpan.org/authors/id/T/TO/TODDR/YAML-Syck-${pkgver}.tar.gz


### PR DESCRIPTION
This seems to more properly be a dependency of things that compile against perl, so maybe if a perl-devel package existed it would be a dependency of that.

Replacement for PR #2078