### PR TITLE
gdb: add libcrypt-devel to makedepends

### DIFF
--- a/gdb/PKGBUILD
+++ b/gdb/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=gdb
 pkgver=9.2
-pkgrel=1
+pkgrel=2
 _gcc_ver=9.3.0
 pkgdesc="GNU Debugger (MSYS2 version)"
 arch=('i686' 'x86_64')
@@ -11,7 +11,7 @@ url="https://www.gnu.org/software/gdb/"
 groups=('base-devel')
 depends=("libiconv" "zlib" "expat" "python" "libexpat" "libreadline" "mpfr")
 #checkdepends=('dejagnu' 'bc')
-makedepends=("libiconv-devel" "zlib-devel" "ncurses-devel" "liblzma-devel" "mpfr-devel" "libexpat-devel" "libreadline-devel")
+makedepends=("libiconv-devel" "zlib-devel" "ncurses-devel" "liblzma-devel" "mpfr-devel" "libexpat-devel" "libreadline-devel" "libcrypt-devel")
 options=('staticlibs' '!distcc' '!ccache')
 source=("https://ftp.gnu.org/gnu/gdb/gdb-${pkgver}.tar.xz"{,.sig}
         'gdbinit'


### PR DESCRIPTION
Otherwise configure fails trying to include Python.h