### PR TITLE
python: add libcrypt-devel to makedepends

### DIFF
--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -4,14 +4,14 @@
 pkgbase=python
 pkgname=python
 pkgver=3.8.5
-pkgrel=2
+pkgrel=3
 _pybasever=${pkgver%.*}
 pkgdesc="Next generation of the python high-level scripting language"
 arch=('i686' 'x86_64')
 license=('custom')
 url="https://www.python.org/"
 depends=('libbz2' 'libexpat' 'libffi' 'liblzma' 'ncurses' 'libopenssl' 'libreadline' 'mpdecimal' 'libsqlite' 'zlib')
-makedepends=('libbz2-devel' 'libexpat-devel'  'mpdecimal-devel' 'libsqlite-devel' 'libffi-devel' 'ncurses-devel' 'libreadline-devel' 'liblzma-devel' 'openssl-devel' 'zlib-devel')
+makedepends=('libbz2-devel' 'libcrypt-devel' 'libexpat-devel'  'mpdecimal-devel' 'libsqlite-devel' 'libffi-devel' 'ncurses-devel' 'libreadline-devel' 'liblzma-devel' 'openssl-devel' 'zlib-devel')
 #optdepends=('tk: for tkinter' 'sqlite')
 provides=('python3')
 replaces=('python3')


### PR DESCRIPTION
The 'crypt' module was no longer being built, which was a regression.