### PR TITLE
msys2-runtime: Fix leaked handles during "symlink" creation

### DIFF
--- a/msys2-runtime/0006-Do-not-create-cygwin-symlinks.-Instead-use-deep-copy.patch
+++ b/msys2-runtime/0006-Do-not-create-cygwin-symlinks.-Instead-use-deep-copy.patch
@@ -1,4 +1,4 @@
-From 5396bbfebc7bdaec21692b63350ed1b929658144 Mon Sep 17 00:00:00 2001
+From 321dd67c2dfb2718d879522f20b4dc2b2c49daf3 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=D0=90=D0=BB=D0=B5=D0=BA=D1=81=D0=B5=D0=B8=CC=86=20=D0=9F?=
  =?UTF-8?q?=D0=B0=D0=B2=D0=BB=D0=BE=D0=B2?= <alexey.pawlow@gmail.com>
 Date: Sun, 14 Apr 2019 21:47:21 +0300
@@ -6,14 +6,14 @@ Subject: [PATCH 06/N] Do not create cygwin symlinks. Instead use deep copy of
  files/folders.
 
 ---
- winsup/cygwin/path.cc | 147 ++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 147 insertions(+)
+ winsup/cygwin/path.cc | 151 ++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 151 insertions(+)
 
 diff --git a/winsup/cygwin/path.cc b/winsup/cygwin/path.cc
-index bfc916a..39b9c03 100644
+index e56b69d30..e593a6fe6 100644
 --- a/winsup/cygwin/path.cc
 +++ b/winsup/cygwin/path.cc
-@@ -1643,6 +1643,86 @@ conv_path_list (const char *src, char *dst, size_t size,
+@@ -1643,6 +1643,90 @@ conv_path_list (const char *src, char *dst, size_t size,
  
  /********************** Symbolic Link Support **************************/
  
@@ -61,7 +61,7 @@ index bfc916a..39b9c03 100644
 +          dstpos + 1 + filelen >= MAX_PATH)
 +        {
 +          set_errno (ENAMETOOLONG);
-+          goto done;
++          goto finish;
 +        }
 +      strcpy (&src[srcpos+1], dHfile.cFileName);
 +      strcpy (&dst[dstpos+1], dHfile.cFileName);
@@ -72,7 +72,7 @@ index bfc916a..39b9c03 100644
 +          debug_printf("%s <-> %s", src, origpath);
 +          if (strcmp (src, origpath)) // avoids endless recursion
 +            if (recursiveCopy (src, dst, origpath))
-+              goto done;
++              goto finish;
 +        }
 +      else
 +        {
@@ -80,7 +80,7 @@ index bfc916a..39b9c03 100644
 +          if (!CopyFile (src, dst, FALSE))
 +            {
 +              __seterrno ();
-+              goto done;
++              goto finish;
 +            }
 +        }
 +      findfiles = FindNextFile (dH, &dHfile);
@@ -88,9 +88,13 @@ index bfc916a..39b9c03 100644
 +  if (GetLastError() != ERROR_NO_MORE_FILES)
 +    {
 +      __seterrno ();
-+      goto done;
++      goto finish;
 +    }
 +  res = 0;
++
++finish:
++
++  FindClose (dH);
 +
 +done:
 +
@@ -100,7 +104,7 @@ index bfc916a..39b9c03 100644
  /* Create a symlink from FROMPATH to TOPATH. */
  
  extern "C" int
-@@ -2071,6 +2151,73 @@ symlink_worker (const char *oldpath, path_conv &win32_newpath, bool isdevice)
+@@ -2175,6 +2259,73 @@ symlink_worker (const char *oldpath, path_conv &win32_newpath, bool isdevice)
  	}
        else
  	{
@@ -175,5 +179,5 @@ index bfc916a..39b9c03 100644
  	  buf = tp.t_get ();
  	  cp = stpcpy (buf, SYMLINK_COOKIE);
 -- 
-2.26.2
+2.27.0
 

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -5,7 +5,7 @@ PKGEXT='.pkg.tar.xz'
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.1.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -53,7 +53,7 @@ sha256sums=('SKIP'
             'eab0333a201436f79996283260b58dcc2267bad4b7500f2d45d4a35772284195'
             'f106ded5f17931afb72fc3b24f86b99ca81a2f4d70ae74e356e6d749d4d51a03'
             'b9a61d14b2d7965f513f26cda7fc62d931af332388921ed6de5f4e626bdab6fa'
-            'c0c1b55cb84cf93fef757ae04c5d142bd871fd9b47b0565e7967c1f94ba64ef6'
+            'b12961b813080e9628ad65b16e7532d4ae66885ed930ae0264a67e5f1c96bc83'
             '9562520215825b6aa8b8ea80ac578dc796cd5a21ad7b0ccad9b5018b92b6ca05'
             '7e0ebf8797f5ea77ffcd8be89680122f65af85e0186aeeb624aa295c2a66886b'
             '9ade2875b1cad19cb452ca94b9abd544be5008a9cad40101a51acc31a4059cc0'


### PR DESCRIPTION
A simple fix for #2060.