### PR TITLE
python: fail build if any modules fail to build.

### DIFF
--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=python
 pkgname=python
 pkgver=3.8.5
-pkgrel=3
+pkgrel=4
 _pybasever=${pkgver%.*}
 pkgdesc="Next generation of the python high-level scripting language"
 arch=('i686' 'x86_64')
@@ -144,7 +144,8 @@ build() {
     --without-ensurepip \
     ac_cv_func_bind_textdomain_codeset=yes
 
-  LC_CTYPE=en_US.UTF-8 make EXTRA_CFLAGS="$CFLAGS"
+  LC_CTYPE=en_US.UTF-8 make EXTRA_CFLAGS="$CFLAGS" > >(tee make-python.log)
+  sed -ne '/^\s*Failed to build these modules/,$ {p; /^\s*$/q42}' make-python.log
 }
 
 check() {


### PR DESCRIPTION
See https://github.com/msys2/MSYS2-packages/pull/2082#issuecomment-667709021

Tees stdout from make to a file (in a way that doesn't suppress an error
exit from make from failing the build), and runs a sed script over that
file which looks for a list of failed modules, outputs it to ensure it
isn't lost in the build output, and exits with an error code to cause
the build to fail.

I don't know if github allows others to view this, but I did a test run with the libcrypt-devel makedepends removed from python's PKGBUILD to demonstrate how/that this works:
https://github.com/jeremyd2019/MSYS2-packages/runs/947110802?check_suite_focus=true#step:4:1458