### PR TITLE
openssl: move LICENSE file to libopenssl

### DIFF
--- a/openssl/PKGBUILD
+++ b/openssl/PKGBUILD
@@ -4,7 +4,7 @@ pkgname=('openssl' 'libopenssl' 'openssl-devel' 'openssl-docs')
 _ver=1.1.1g
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
-pkgrel=2
+pkgrel=3
 pkgdesc='The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
 arch=('i686' 'x86_64')
 url='https://www.openssl.org'
@@ -81,7 +81,6 @@ package_openssl() {
   cp -rf ${srcdir}/dest/usr/share/man/man5 ${pkgdir}/usr/share/man
   cp -rf ${srcdir}/dest/usr/share/man/man7 ${pkgdir}/usr/share/man
   cp -rf ${srcdir}/dest/usr/ssl ${pkgdir}/usr/
-  install -D -m644 ${srcdir}/${pkgname}-${_ver}/LICENSE ${pkgdir}/usr/share/licenses/${pkgname}/LICENSE
 }
 
 package_openssl-docs() {
@@ -100,6 +99,8 @@ package_libopenssl() {
   mkdir -p ${pkgdir}/usr/lib/openssl
   cp -rf ${srcdir}/dest/usr/lib/openssl/engines-1.1 ${pkgdir}/usr/lib/openssl/
   chmod -R 755 ${pkgdir}/usr/lib/openssl/engines-1.1
+
+  install -D -m644 ${srcdir}/openssl-${_ver}/LICENSE ${pkgdir}/usr/share/licenses/${pkgname}/LICENSE
 }
 
 package_openssl-devel() {


### PR DESCRIPTION
As suggested in https://github.com/msys2/MINGW-packages/issues/6658

The directory name is different, so there is no conflict moving it.