### PR TITLE
filesystem: Override %SHELL% for bash

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -6,7 +6,7 @@
 PKGEXT='.pkg.tar.xz'
 pkgname=filesystem
 pkgver=2020.02
-pkgrel=6
+pkgrel=7
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -67,7 +67,7 @@ sha256sums=('742a7d66b7a5ebd2b8461728c5b44a46b2305fd2116208eecae5f45828938ea0'
             'db6738b88e6cf8092522fd794779059b3082ed1f4f72259d92df9df50b9c9cd4'
             '65f59306dfe6437ea2694d50ed4e2fe95937148549157809ad3daac5d7e11ddf'
             '91f1f918cf13deab0124082086e990786113b0e710dbda4678d8fc14905ad94d'
-            '6a94deb45d8ad783dfe277f8eb5f38ef16ed3a3ab30f0c1329c278797a2c6fe8'
+            '43172d66ee40a02d96c587a35e78fe0cb4e2e3d1cc96710b9ea06a0a909fdfbe'
             '6c0ca979c7b146b3750103b1296a399764f4e1b222ee091d3aa072b6da16c1a5'
             'cbec90c9403826bf6d8dd1fed16240b9d8695ec15df5dcdab7e485bb46c016ab'
             '2087410bf7ead6fa586628ea7fc97c53f5ea3ce16d1ee91ecc15ccc18ab53094'

--- a/filesystem/profile
+++ b/filesystem/profile
@@ -126,6 +126,7 @@ done
 
 if [ ! "x${BASH_VERSION}" = "x" ]; then
   HOSTNAME="$(exec /usr/bin/hostname)"
+  SHELL=`which bash`
   profile_d sh
   [ -f "/etc/bash.bashrc" ] && . "/etc/bash.bashrc"
 elif [ ! "x${KSH_VERSION}" = "x" ]; then


### PR DESCRIPTION
Fixes #2089.

In the event that `%SHELL%` is set in the Windows environment, the shell which msys2_shell.cmd starts (bash by default) and the value of `$SHELL` may differ. Thus when we detect bash in `filesystem/profile`, set `$SHELL` to bash, just to be sure.