### PR TITLE
Update to version 6.0.0 of git-extras

### DIFF
--- a/git-extras/PKGBUILD
+++ b/git-extras/PKGBUILD
@@ -3,7 +3,7 @@ _realname=git-extras
 pkgname=${_realname}
 replaces=("${_realname}-git")
 conflicts=("${_realname}-git")
-pkgver=5.1.0
+pkgver=6.0.0
 pkgrel=1
 pkgdesc="GIT utilities -- repo summary, commit counting, repl, changelog population and more"
 arch=('any')
@@ -12,7 +12,7 @@ url='https://github.com/tj/git-extras'
 depends=('git')
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/tj/git-extras/archive/$pkgver.tar.gz")
 noextract=("${_realname}-${pkgver}.tar.gz")
-sha256sums=('432f73f178345b69d98fb48ccdc04839bafb605f2f8cc3e5bb8f87d497ef3e7d')
+sha256sums=('a823c12e4bf74e2f07ee80e597500e5f5120dcd8fa345e67e2c03544fd706ffe')
 
 build(){
   cd "${srcdir}"


### PR DESCRIPTION
6.0.0 is the latest release. It was released on June 21, 2020