### PR TITLE
Add sqlite-vfslog to sqlite dependencies

### DIFF
--- a/sqlite/PKGBUILD
+++ b/sqlite/PKGBUILD
@@ -14,6 +14,7 @@ arch=('i686' 'x86_64')
 license=(PublicDomain)
 url="https://www.sqlite.org/"
 makedepends=('libreadline-devel' 'icu-devel' 'zlib-devel' 'tcl')
+depends=('sqlite-vfslog')
 source=( # tarball containing the amalgamation for SQLite >= 3.7.5 together with a configure script and makefile for building it; includes now also the Tcl Extension Architecture (TEA)
         https://www.sqlite.org/2020/sqlite-autoconf-${_amalgamationver}.tar.gz
         https://www.sqlite.org/2020/sqlite-doc-${_docver}.zip


### PR DESCRIPTION
Can't run sqlite without it. This closes #1707.