### PR TITLE
Add GN, google's metabuilder for Ninja.

### DIFF
--- a/gn/PKGBUILD
+++ b/gn/PKGBUILD
@@ -1,0 +1,42 @@
+
+pkgname=gn
+pkgver=1822
+pkgrel=1
+pkgdesc="GN is a meta-build system that generates build files for Ninja."
+arch=('i686' 'x86_64')
+url='https://gn.googlesource.com/gn/+/refs/heads/master/README.md'
+license=('BSD')
+depends=('ninja')
+makedepends=('python' 'ninja' 'git')
+source=('gn::git+https://gn.googlesource.com/gn')
+sha256sums=('SKIP')
+
+prepare()
+{
+  cd gn
+  git config advice.detachedHead false
+  git checkout 0649bd9
+  chmod 755 build/gen.py
+  python build/gen.py --platform=msys
+}
+
+build()
+{
+  cd gn
+  ninja -C out
+}
+
+check()
+{
+  cd gn
+  out/gn_unittests
+}
+
+package()
+{
+  cd gn
+  install -d ${pkgdir}/usr/bin
+  install -Dm755 -s out/gn.exe ${pkgdir}/usr/bin
+  install -d ${pkgdir}/usr/share/licenses/gn
+  install -m644 LICENSE ${pkgdir}/usr/share/licenses/gn
+}


### PR DESCRIPTION
GN is the metabuilder used to build chromium and v8.

This is part of an effort to also provide scripts to build native mingw v8.

The msys support patch is under review at google at:
https://gn-review.googlesource.com/c/gn/+/9660

if/once the patch gets merged, it can be removed, but since a specific tag is being checked out, there should be no conflicts with upstream even if the patch is merged.
