### PR TITLE
msys2-runtime: fix `MSYS=wincmdln` and turn it on by default

### DIFF
--- a/msys2-runtime/0027-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+++ b/msys2-runtime/0027-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
@@ -1,0 +1,47 @@
+From 7b8896963f0a76cde532db9cb95e508422822e26 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 11 Aug 2020 21:12:54 +0200
+Subject: [PATCH 27/N] fixup! Add functionality for converting UNIX paths in
+ arguments and environment variables to Windows form for native Win32
+ applications.
+
+This reinstates the MSYS=wincmdln functionality that was inadvertently
+broken by the patch: with that setting, all processes spawned by MSYS2
+are supposed to fill the CommandLine field in the process information so
+that e.g. `wmic process list` can see it (otherwise, only the executable
+itself is listed in the command line, but all the arguments are
+missing).
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/spawn.cc | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/winsup/cygwin/spawn.cc b/winsup/cygwin/spawn.cc
+index 0c7f645..f95038e 100644
+--- a/winsup/cygwin/spawn.cc
++++ b/winsup/cygwin/spawn.cc
+@@ -412,13 +412,13 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
+ 	          newargv.replace (i, tmpbuf);
+ 	          free (tmpbuf);
+ 	        }
+-	      if ((wincmdln || !real_path.iscygexec ())
+-	            && !cmd.fromargv (newargv, real_path.get_win32 (),
+-			        real_path.iscygexec ()))
+-	        {
+-	          res = -1;
+-	          __leave;
+-	        }
++	    }
++	  if ((wincmdln || !real_path.iscygexec ())
++	        && !cmd.fromargv (newargv, real_path.get_win32 (),
++		    real_path.iscygexec ()))
++	    {
++	      res = -1;
++	      __leave;
+ 	    }
+ 
+ 
+-- 
+2.27.0
+

--- a/msys2-runtime/0028-Expose-full-command-lines-to-other-Win32-processes-b.patch
+++ b/msys2-runtime/0028-Expose-full-command-lines-to-other-Win32-processes-b.patch
@@ -1,0 +1,56 @@
+From 5f10a64eb1bef10897c52dd5b13b4b1c8d3c3123 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 12 Aug 2020 12:22:38 +0200
+Subject: [PATCH 28/N] Expose full command-lines to other Win32 processes by
+ default
+
+In the Cygwin project, it was decided that the command-line of Cygwin
+processes, as shown in the output of `wmic process list`, would suffer
+from being truncated to 32k (and is transmitted to the child process via
+a different mechanism, anyway), and therefore only the absolute path of
+the executable is shown by default.
+
+Users who would like to see the full command-line (even if it is
+truncated) are expected to set `CYGWIN=wincmdln` (or, in MSYS2's case,
+`MSYS=wincmdln`).
+
+Seeing as MSYS2 tries to integrate much better with the surrounding
+Win32 ecosystem than Cygwin, it makes sense to turn this on by default.
+
+Users who wish to suppress it can still set `MSYS=nowincmdln`.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/globals.cc | 2 +-
+ winsup/doc/cygwinenv.xml | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/winsup/cygwin/globals.cc b/winsup/cygwin/globals.cc
+index da82320..24999d9 100644
+--- a/winsup/cygwin/globals.cc
++++ b/winsup/cygwin/globals.cc
+@@ -68,7 +68,7 @@ bool allow_glob = true;
+ bool ignore_case_with_glob;
+ bool pipe_byte;
+ bool reset_com;
+-bool wincmdln;
++bool wincmdln = true;
+ winsym_t allow_winsymlinks = WSYM_sysfile;
+ bool disable_pcon = true;
+ 
+diff --git a/winsup/doc/cygwinenv.xml b/winsup/doc/cygwinenv.xml
+index f549fee..17a8b18 100644
+--- a/winsup/doc/cygwinenv.xml
++++ b/winsup/doc/cygwinenv.xml
+@@ -68,7 +68,7 @@ time and when handles are inherited.  Defaults to set.</para>
+ <listitem>
+ <para><envar>(no)wincmdln</envar> - if set, the windows complete command
+ line (truncated to ~32K) will be passed on any processes that it creates
+-in addition to the normal UNIX argv list.  Defaults to not set.</para>
++in addition to the normal UNIX argv list.  Defaults to set.</para>
+ </listitem>
+ 
+ <listitem>
+-- 
+2.27.0
+

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -5,7 +5,7 @@ PKGEXT='.pkg.tar.xz'
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.1.6
-pkgrel=2
+pkgrel=3
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -49,7 +49,9 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0023-popen-call-usr-bin-sh-instead-of-bin-sh.patch
         0024-CI-add-a-GHA-for-doing-a-basic-build-test.patch
         0025-Set-up-a-GitHub-Action-to-keep-in-sync-with-Cygwin.patch
-        0026-recursiveCopy-Always-close-the-used-handle-with-Find.patch)
+        0026-recursiveCopy-Always-close-the-used-handle-with-Find.patch
+        0027-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+        0028-Expose-full-command-lines-to-other-Win32-processes-b.patch)
 sha256sums=('SKIP'
             '52c78022ec6504103a8daa334ed330472905ebbf58438d9379b33fc7a9841d23'
             '590b7c9f9002d4d0d3dc8bd9bf2dd855aeb91de70ad9736361f25a5f7a4682c9'
@@ -76,7 +78,9 @@ sha256sums=('SKIP'
             'a1e2bf8dfb9ad47468b1295f11784f90820857e733ac352b7a9b35411134456e'
             '2679dde3632a0fad925d6010ad81055dce1671b10a13ef288168594773ac4c1b'
             'f1461123ed89e0cf0ff19eeb84179fe0652ebe72bf9930bcaf331ef41717b687'
-            '43bbe321dc90b58a2bb66ded2c7ab55d88a21536e99f88a97c4ec2644eeecee5')
+            '43bbe321dc90b58a2bb66ded2c7ab55d88a21536e99f88a97c4ec2644eeecee5'
+            '2bf4beb2420f247c2ac5970f799f9e4c6a47cb733dc6d06b4452666dedd82666'
+            '5ac52c87aeec3bf3a61e53afd7cc8d5fdf6e6b3223ba3c20bccb383bad3de7e9')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -139,7 +143,9 @@ prepare() {
   0023-popen-call-usr-bin-sh-instead-of-bin-sh.patch \
   0024-CI-add-a-GHA-for-doing-a-basic-build-test.patch \
   0025-Set-up-a-GitHub-Action-to-keep-in-sync-with-Cygwin.patch \
-  0026-recursiveCopy-Always-close-the-used-handle-with-Find.patch
+  0026-recursiveCopy-Always-close-the-used-handle-with-Find.patch \
+  0027-fixup-Add-functionality-for-converting-UNIX-paths-in.patch \
+  0028-Expose-full-command-lines-to-other-Win32-processes-b.patch
 }
 
 build() {


### PR DESCRIPTION
This is the companion to https://github.com/msys2/Cygwin/pull/10 to _actually_ get these patches into MSYS2.