### PR TITLE
CI: remove matrix.msystem variable reference

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - name: "Upload binaries"
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.msystem }}-packages
+          name: packages
           path: artifacts/*.pkg.tar.*
 
       - name: "Upload sources"


### PR DESCRIPTION
There is currently no matrix in MSYS2-packages.

See https://github.com/msys2/MSYS2-packages/commit/3be05f6f79ab0b865d80769634c3583aab9d0209#r41492756