### PR TITLE
[RFC] rebase: add a pacman hook on i686.

### DIFF
--- a/rebase/PKGBUILD
+++ b/rebase/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=rebase
 pkgver=4.4.4
-pkgrel=3
+pkgrel=4
 pkgdesc="The Cygwin rebase distribution contains four utilities, rebase, rebaseall, peflags, and peflagsall"
 arch=('i686' 'x86_64')
 license=('custom')
@@ -18,7 +18,8 @@ source=(${pkgname}-${pkgver}::git://sourceware.org/git/cygwin-apps/rebase.git#ta
         '005-make-verbose-give-a-reason.patch'
         '006-fix-some-errors.patch'
         '007-peflags-high-entropy-va.patch'
-        'autorebase.bat')
+        'autorebase.bat'
+        'rebase.hook')
 sha256sums=('SKIP'
             '6e25bfaae229062b20bed52b79824cfd1145de10c2ce50cd72b5a82fff9fbacf'
             'b06d561d82e7c32573082cf0207ca80275bab241c61debf2d3d8cc10cf79e31b'
@@ -27,7 +28,8 @@ sha256sums=('SKIP'
             '01bc185bebc0bd8f4ac04207b0c07ee9f8da035eacf0e2ec8019150253597ee7'
             'a8b1b5cc6ab188d17dc9f353fa9c6593e2f82e998ce45a8662ff5f3294cb5f7c'
             'd8269f1f99c968afe20eae020de92dae12483cefc03e0393aa1367a92c61d1dc'
-            '8e4099a29107a1d03031b198c3d142bbc31a40ff19298d6e099d9bcffd31b1b0')
+            '8e4099a29107a1d03031b198c3d142bbc31a40ff19298d6e099d9bcffd31b1b0'
+            'a50a8bfdb28c47c1742f400287a8a7ba65f9893dee74c109aad517d46afed2a1')
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
@@ -62,4 +64,8 @@ package() {
 
   make DESTDIR=${pkgdir} install
   cp -f ${srcdir}/autorebase.bat ${pkgdir}
+  if [ "${CARCH}" == "i686" ]; then
+    mkdir -p ${pkgdir}/usr/share/libalpm/hooks
+    cp -f ${srcdir}/rebase.hook ${pkgdir}/usr/share/libalpm/hooks
+  fi
 }

--- a/rebase/rebase.hook
+++ b/rebase/rebase.hook
@@ -1,0 +1,18 @@
+[Trigger]
+Type = Path
+Operation = Install
+Operation = Upgrade
+Target = usr/lib/*.dll
+Target = usr/lib/*.so
+Target = usr/lib/*.oct
+Target = usr/bin/*.dll
+Target = usr/bin/*.so
+Target = usr/bin/*.oct
+Target = !usr/bin/msys-2.0.dll
+
+[Action]
+Description = Rebasing DLLs
+When = PostTransaction
+Depends = rebase
+Exec = /usr/bin/rebase -snT -
+NeedsTargets


### PR DESCRIPTION
It will rebase any *.{dll,so,oct} except usr/bin/msys-2.0.dll.  Note it
requires the rebase db to be present, so essentially it requires
rebaseall to have been run (probably at install).