### PR TITLE
python: enable makeflags option

### DIFF
--- a/python/960-fix-parallel-make.patch
+++ b/python/960-fix-parallel-make.patch
@@ -1,0 +1,11 @@
+--- Python-3.8.5/Makefile.pre.in.orig	2020-08-14 12:32:57.031236300 -0700
++++ Python-3.8.5/Makefile.pre.in	2020-08-14 12:33:19.884645300 -0700
+@@ -1256,7 +1256,7 @@
+ 			$(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE); \
+ 	fi
+ 
+-bininstall: altbininstall
++bininstall: altbininstall commoninstall
+ 	if test ! -d $(DESTDIR)$(LIBPC); then \
+ 		echo "Creating directory $(LIBPC)"; \
+ 		$(INSTALL) -d -m $(DIRMODE) $(DESTDIR)$(LIBPC); \

--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -15,7 +15,6 @@ makedepends=('libbz2-devel' 'libcrypt-devel' 'libexpat-devel'  'mpdecimal-devel'
 #optdepends=('tk: for tkinter' 'sqlite')
 provides=('python3')
 replaces=('python3')
-options=('!makeflags')
 source=(https://www.python.org/ftp/python/${pkgver%rc*}/Python-${pkgver}.tar.xz
         001-3.1-enable-new-dtags.patch
         002-3.2-getpath-exe-extension.patch
@@ -37,7 +36,8 @@ source=(https://www.python.org/ftp/python/${pkgver%rc*}/Python-${pkgver}.tar.xz
         027-install-import-library.patch
         900-msysize.patch
         920-allow-win-drives-in-os-path-isabs.patch
-        930-fix-missing-tcp-include.patch)
+        930-fix-missing-tcp-include.patch
+        960-fix-parallel-make.patch)
 sha256sums=('e3003ed57db17e617acb382b0cade29a248c6026b1bd8aad1f976e9af66a83b0'
             'be96ddaca58a39ddaf1e3e5bb7900b34c0e6d00e9b64c4e0f8a3565a74a44e84'
             '4044827af3cf0e91a8ddd44cd588f17ea4e17619512edd299b5688ec6e112ad4'
@@ -59,7 +59,8 @@ sha256sums=('e3003ed57db17e617acb382b0cade29a248c6026b1bd8aad1f976e9af66a83b0'
             'b4042475c5c75e0b4c7c08ccad2891eb8098c066c5ba524a988a0519102e8e5d'
             'e833cb6ab8a3d35296f52ad327df7eb4cc4eab94413085bded2943a290cba16d'
             '387a2b7931fb4958e2526991760d85677f44fa13cff0aeb0f41a267f1f7fd214'
-            '17e4ac1b5f0fa8a6c410fb80d1ad99ec9185efef51b8450a31932b553c354ed1')
+            '17e4ac1b5f0fa8a6c410fb80d1ad99ec9185efef51b8450a31932b553c354ed1'
+            'c59025ca9d1219bbb42d620ca8d19398610737c5754f1873db07d55c47b2dad1')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -104,7 +105,8 @@ prepare() {
     026-3.7-mpdec-msys.patch \
     027-install-import-library.patch \
     900-msysize.patch \
-    920-allow-win-drives-in-os-path-isabs.patch
+    920-allow-win-drives-in-os-path-isabs.patch \
+    960-fix-parallel-make.patch
   
   # https://bugs.python.org/issue41374
   apply_patch_with_msg \


### PR DESCRIPTION
It mostly worked out of the box, except for some ln failures in make install due to not
being able to create a broken symlink to a file to be created later.
Fixed by making the make rule that ln's depend on the rule that creates
the files.