### PR TITLE
CI: don't attempt to install known-troublesome packages.

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -31,7 +31,7 @@ execute 'Approving recipe quality' check_recipe_quality
 for package in "${packages[@]}"; do
     execute 'Building binary' makepkg --noconfirm --noprogressbar --nocheck --syncdeps --rmdeps --cleanbuild
     execute 'Building source' makepkg --noconfirm --noprogressbar --allsource
-    execute 'Installing' yes:pacman --noprogressbar --upgrade *.pkg.tar.*
+    grep -qFx "$(<../ci-dont-install-list.txt)" <<< "${package}" || execute 'Installing' yes:pacman --noprogressbar --upgrade *.pkg.tar.*
     execute 'Checking dll depencencies' list_dll_deps ./pkg
     mv "${package}"/*.pkg.tar.* artifacts
     mv "${package}"/*.src.tar.gz artifacts

--- a/ci-dont-install-list.txt
+++ b/ci-dont-install-list.txt
@@ -1,0 +1,2 @@
+msys2-runtime
+bash


### PR DESCRIPTION
Namely, msys2-runtime and bash.  Currently, msys2-runtime always fails CI.