### PR TITLE
CI: disable update-srcinfo on forks

### DIFF
--- a/.github/workflows/generate-srcinfo.yml
+++ b/.github/workflows/generate-srcinfo.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-srcinfo:
     runs-on: windows-latest
-    if: ${{ github.repository == 'msys2/MSYS2-packages' }}
+    if: ${{ github.repository == 'msys2/MSYS2-packages' || github.event_name == 'workflow_dispatch' }}
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
This workflow is meant to generate a file that msys2-web consumes, and just generates meaningless errors on forks.  The main/build workflow is useful on forks, but github seems to only allow you to turn all actions on or off for a repo, not only one.