### PR TITLE
Add a python-devel package

### DIFF
--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -2,19 +2,15 @@
 # Contributor: Ray Donnelly <mingw.android@gmail.com>
 
 pkgbase=python
-pkgname=python
+pkgname=('python' 'python-devel')
 pkgver=3.8.5
-pkgrel=4
+pkgrel=5
 _pybasever=${pkgver%.*}
 pkgdesc="Next generation of the python high-level scripting language"
 arch=('i686' 'x86_64')
 license=('custom')
 url="https://www.python.org/"
-depends=('libbz2' 'libexpat' 'libffi' 'liblzma' 'ncurses' 'libopenssl' 'libreadline' 'mpdecimal' 'libsqlite' 'zlib')
 makedepends=('libbz2-devel' 'libcrypt-devel' 'libexpat-devel'  'mpdecimal-devel' 'libsqlite-devel' 'libffi-devel' 'ncurses-devel' 'libreadline-devel' 'liblzma-devel' 'openssl-devel' 'zlib-devel')
-#optdepends=('tk: for tkinter' 'sqlite')
-provides=('python3')
-replaces=('python3')
 source=(https://www.python.org/ftp/python/${pkgver%rc*}/Python-${pkgver}.tar.xz
         001-3.1-enable-new-dtags.patch
         002-3.2-getpath-exe-extension.patch
@@ -155,7 +151,12 @@ check() {
   "${srcdir}/Python-${pkgver}/python.exe" -m test.regrtest -x test_posixpath test_logging
 }
 
-package() {
+package_python() {
+  #optdepends=('tk: for tkinter' 'sqlite')
+  depends=('libbz2' 'libexpat' 'libffi' 'liblzma' 'ncurses' 'libopenssl' 'libreadline' 'mpdecimal' 'libsqlite' 'zlib')
+  provides=('python3')
+  replaces=('python3')
+
   cd "${srcdir}/Python-${pkgver}"
   make DESTDIR="${pkgdir}" EXTRA_CFLAGS="$CFLAGS" install
 
@@ -178,4 +179,9 @@ package() {
 
   # fix permissons
   find ${pkgdir}/usr -type f \( -name *.dll -o -name *.exe \) | xargs chmod 0755
+}
+
+package_python-devel() {
+  pkgdesc="Python headers and dev dependencies"
+  depends=("python=${pkgver}" 'libcrypt-devel')
 }


### PR DESCRIPTION
This doesn't contain anything and just depends on python itself and
libcrypt-devel which it uses in Python.h.

This allows packages building against Python to makedepend on this without
having to specify libcrypt-devel etc.