### PR TITLE
gamin: Drop gamin-python

### DIFF
--- a/gamin/PKGBUILD
+++ b/gamin/PKGBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgbase=gamin
-pkgname=("gamin" "gamin-devel" "gamin-python")
+pkgname=("gamin" "gamin-devel")
 pkgver=0.1.10
-pkgrel=3
+pkgrel=4
 pkgdesc="File and directory monitoring system defined to be a subset of the FAM (File Alteration Monitor)"
 arch=('i686' 'x86_64')
 url="https://people.gnome.org/~veillard/gamin/"
 license=('LGPL')
 groups=('libraries')
-makedepends=('gcc' 'gtk-doc' 'glib2-devel' 'pcre-devel' 'python2')
+makedepends=('gcc' 'gtk-doc' 'glib2-devel' 'pcre-devel')
 source=("https://download.gnome.org/sources/$pkgname/${pkgver%.*}/$pkgname-$pkgver.tar.bz2"
         001-no-undefined.patch
         002-fix-deprecated-const.patch
@@ -33,7 +33,7 @@ build() {
     --prefix=/usr \
     --libexecdir=/usr/lib/gamin \
     --disable-server \
-    --with-python=/usr/bin/python2
+    --without-python
   make
   make DESTDIR="$srcdir/dest" install
 }
@@ -59,13 +59,4 @@ package_gamin-devel() {
   mkdir -p $pkgdir/usr/lib
   cp -rf $srcdir/dest/usr/lib/pkgconfig $pkgdir/usr/lib/
   cp -f $srcdir/dest/usr/lib/*.a $pkgdir/usr/lib/
-}
-
-package_gamin-python() {
-  pkgdesc="Gamin python modules"
-  depends=("gamin=${pkgver}" "python2")
-  groups=('python-modules')
-
-  mkdir -p $pkgdir/usr/lib
-  cp -rf $srcdir/dest/usr/lib/python* $pkgdir/usr/lib/
 }


### PR DESCRIPTION
Nothing depends on it and it's using Python 2 which want to get rid of.