### PR TITLE
automake: Don't depend on Python 2

### DIFF
--- a/automake1.10/PKGBUILD
+++ b/automake1.10/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=automake1.10
 pkgver=1.10.3
-pkgrel=3
+pkgrel=4
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
@@ -10,15 +10,14 @@ url="https://www.gnu.org/software/automake"
 groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf')
-checkdepends=('dejagnu' 'python2')
+checkdepends=('dejagnu')
 install=automake.install
-source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.bz2{,.sig}
+source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.bz2
         automake-1.10-msys2.patch
         automake1.10-documentation.patch
         automake-1.10-makeinfo-fix.patch
         automake-1.10-perl-escape-curly-bracket.patch)
 sha256sums=('e98ab43bb839c31696a4202e5b6ff388b391659ef2387cf9365019fad17e1adc'
-            'SKIP'
             'f5e091d83ed5e9451148ce6629f7f8bf92d17890d132aacb7eba1ca6662547fb'
             '9cafa4e6a652331a56780ea5941413eaae96a9b8c8c9abbf9f68bd01ea07aaf1'
             '1378dc7c1ffd88730aabed052b1843cfd3fb55040c10a988171a5a37a1efa612'

--- a/automake1.11/PKGBUILD
+++ b/automake1.11/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=automake1.11
 pkgver=1.11.6
-pkgrel=3
+pkgrel=4
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
@@ -10,15 +10,14 @@ url="https://www.gnu.org/software/automake"
 groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf')
-checkdepends=('dejagnu' 'python2')
+checkdepends=('dejagnu')
 install=automake.install
-source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.xz{,.sig}
+source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.xz
         automake-1.11-msys2.patch
         automake1.11-documentation.patch
         automake-1.11-makeinfo-fix.patch
         automake-1.11-perl-escape-curly-bracket.patch)
 sha256sums=('1ffbc6cc41f0ea6c864fbe9485b981679dc5e350f6c4bc6c3512f5a4226936b5'
-            'SKIP'
             '41cbfaa428a8e7a90836df4fcfc76f5eeb32d04a4cac446bdb8eb712d51a3f89'
             '0d003623915b7580b170008a3070e100645ff6d4f28887ad1af7058bfa214a39'
             '9161475f1ae3fe4905f6e537d233f04bd55d86e7d79ce4626f38d9516fdac284'

--- a/automake1.12/PKGBUILD
+++ b/automake1.12/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=automake1.12
 pkgver=1.12.6
-pkgrel=3
+pkgrel=4
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
@@ -10,14 +10,13 @@ url="https://www.gnu.org/software/automake"
 groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf')
-checkdepends=('dejagnu' 'python2')
+checkdepends=('dejagnu')
 install=automake.install
-source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.xz{,.sig}
+source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.xz
         automake-1.14-msys2.patch
         automake1.12-documentation.patch
         automake-1.12-perl-escape-curly-bracket.patch)
 sha256sums=('f834ab2145b1ee24bd85387950044f5cb418dd0af2b84c52e60c2bf29162dbfa'
-            'SKIP'
             '76ac48cce5b6d48dfbd2659e3aeb10144acc932269c94fbed8d6335da773090b'
             '0f0df05d1e9ba59362e6a9484db117e922d0c531836eccf434c5569edb68bf38'
             'dc3566c450efe446799800b88185101f625ef4091d7f39bcb05325eaf4604f5c')

--- a/automake1.13/PKGBUILD
+++ b/automake1.13/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=automake1.13
 pkgver=1.13.4
-pkgrel=4
+pkgrel=5
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
@@ -10,14 +10,13 @@ url="https://www.gnu.org/software/automake"
 groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf')
-checkdepends=('dejagnu' 'python2')
+checkdepends=('dejagnu')
 install=automake.install
-source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.xz{,.sig}
+source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.xz
         automake-1.14-msys2.patch
         automake1.13-documentation.patch
         automake-1.13-perl-escape-curly-bracket.patch)
 sha256sums=('89ce4933f59b8f0c20115c39cfe450a595cca74ede27b6881e88ec27720d1d66'
-            'SKIP'
             '76ac48cce5b6d48dfbd2659e3aeb10144acc932269c94fbed8d6335da773090b'
             'ab0bba1beba0a9160d56bb46fd52449aa01ed9e1c3a5e75cc2d095d5513a8ecf'
             '6538290dc53c6f8da0dd67567ca2466c7155095619547e3988da4dc492e3bdd6')

--- a/automake1.14/PKGBUILD
+++ b/automake1.14/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=automake1.14
 pkgver=1.14.1
-pkgrel=3
+pkgrel=4
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
@@ -10,14 +10,13 @@ url="https://www.gnu.org/software/automake"
 groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf')
-checkdepends=('dejagnu' 'python2')
+checkdepends=('dejagnu')
 install=automake.install
-source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.xz{,.sig}
+source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.xz
         automake1.14-documentation.patch
         automake-1.14-msys2.patch
         automake-1.14-perl-escape-curly-bracket.patch)
 sha256sums=('a9b4f04b8b69cac2e832a38a718943aa976dbdad0097211f8b3448afdacf0669'
-            'SKIP'
             'd08bf56f22e948896a93fb33c81a2a1b3c469487d99b56da60fa915b61cafb09'
             '76ac48cce5b6d48dfbd2659e3aeb10144acc932269c94fbed8d6335da773090b'
             '34ec3ef555b78e8f19cd87d582102f07a705cd3b98919489274f2dabbd6aade6')

--- a/automake1.15/PKGBUILD
+++ b/automake1.15/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=automake1.15
 pkgver=1.15.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
@@ -10,14 +10,13 @@ url="https://www.gnu.org/software/automake"
 groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf')
-checkdepends=('dejagnu' 'python2')
+checkdepends=('dejagnu')
 install=automake.install
-source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.xz{,.sig}
+source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.xz
         automake1.15-documentation.patch
         automake-1.15.1-msys2.patch
         automake-1.15.1-perl-escape-curly-bracket.patch)
 sha256sums=('af6ba39142220687c500f79b4aa2f181d9b24e4f8d8ec497cea4ba26c64bedaf'
-            'SKIP'
             'e5ca855db96fab8106239cec2dcee48ea3f7d2ab5745b116f7d85dfd962b7553'
             '0c2560b6c58446f43552e3cd43f2f9d82f1bbe6ff993d358365a77a4b460ae37'
             '18073dbcf0939419906cdb9714171f5da0ad899af229304e50321d07a19e0d26')

--- a/automake1.16/PKGBUILD
+++ b/automake1.16/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=automake1.16
 pkgver=1.16.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
@@ -10,7 +10,7 @@ url="https://www.gnu.org/software/automake"
 groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf')
-checkdepends=('dejagnu' 'python2')
+checkdepends=('dejagnu')
 install=automake.install
 source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.xz{,.sig}
         automake-1.16.1-documentation.patch
@@ -20,7 +20,8 @@ sha256sums=('ccc459de3d710e066ab9e12d2f119bd164a08c9341ca24ba22c9adaa179eedd0'
             '18129ade01c1b1be3cb60e20349db0c08e7ea7fae7e72b937b1317c5f36dda41'
             'fe7bf1235399d2b1ff0e6a74eef96693449bf06e71a1a18c2a995fd41abbe6ce')
 validpgpkeys=('E1622F96D2BB4E58018EEF9860F906016E407573'   # Stefano Lattarini
-              'F2A38D7EEB2B66405761070D0ADEE10094604D37')  # Mathieu Lirzin
+              'F2A38D7EEB2B66405761070D0ADEE10094604D37'   # Mathieu Lirzin
+              '155D3FC500C834486D1EEA677FD9FCCB000BEEEE')  # Jim Meyering
 replace=('automake')
 
 # Helper macros to help make tasks easier #

--- a/automake1.6/PKGBUILD
+++ b/automake1.6/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=automake1.6
 pkgver=1.6.3
-pkgrel=2
+pkgrel=3
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
@@ -10,7 +10,7 @@ url="https://www.gnu.org/software/automake"
 groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf')
-checkdepends=('dejagnu' 'python2')
+checkdepends=('dejagnu')
 install=automake.install
 source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.bz2
         automake1.6-add-dirlist-support.patch

--- a/automake1.7/PKGBUILD
+++ b/automake1.7/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=automake1.7
 pkgver=1.7.9
-pkgrel=2
+pkgrel=3
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
@@ -10,15 +10,14 @@ url="https://www.gnu.org/software/automake"
 groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf')
-checkdepends=('dejagnu' 'python2')
+checkdepends=('dejagnu')
 install=automake.install
-source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.bz2{,.sig}
+source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.bz2
         automake-1.7.9-gentoo-test-fixes.patch
         automake1.7-cygwin-test-fixes.patch
         automake1.7-documentation.patch
         automake-1.7-msys2.patch)
 sha256sums=('32c13b6ad38ed5e7bfd1756cbc19cf5efd67b7ade2d06000a4c99b0ce94bd46d'
-            'SKIP'
             '44221e4c945b0cb61663cb2857a3238e50800d228e7612203529726c53272dbb'
             '3c9a2fb1f54af14730308e5a06b4b507f91f63eacb6655fd771a4e554895023b'
             'c5f4c7119e484cb3f8dcbb55b2deaa682247ee2d8fab934013cc612e3e273274'

--- a/automake1.8/PKGBUILD
+++ b/automake1.8/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=automake1.8
 pkgver=1.8.5
-pkgrel=3
+pkgrel=4
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
@@ -10,16 +10,15 @@ url="https://www.gnu.org/software/automake"
 groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf')
-checkdepends=('dejagnu' 'python2')
+checkdepends=('dejagnu')
 install=automake.install
-source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.bz2{,.sig}
+source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.bz2
         automake-1.8.5-gentoo-test-fixes.patch
         automake1.8-vs-modern-libtool.patch
         automake1.8-documentation.patch
         automake1.8-cygwin-test-fixes.patch
         automake-1.8-msys2.patch)
 sha256sums=('84c93aaa3c3651a9e7474b721b0e6788318592509e7de604bafe4ea8049dc410'
-            'SKIP'
             '1a94bcc5a8e33b4c187e6291ad672daf3dca7b2e2995586d6af39f653678cebd'
             'c0ca85be7ad22ff5cb03e80ea580b8fef1c3298d542f8f830bd2c58b7bb7d6d7'
             'dfe9e2f80dd62d882e45f8e85e53d6a8e1d3cdb02009a1ccc425c671ba540324'

--- a/automake1.9/PKGBUILD
+++ b/automake1.9/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=automake1.9
 pkgver=1.9.6
-pkgrel=2
+pkgrel=3
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
@@ -10,9 +10,9 @@ url="https://www.gnu.org/software/automake"
 groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf')
-checkdepends=('dejagnu' 'python2')
+checkdepends=('dejagnu')
 install=automake.install
-source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.bz2{,.sig}
+source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.bz2
         automake-1.9.6-gentoo-aclocal7-test-sleep.patch
         automake-1.9.6-gentoo-ignore-comments.patch
         automake-1.9.6-gentoo-include-dir-prefix.patch
@@ -24,7 +24,6 @@ source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.bz2{,.sig}
         automake-1.9-msys2.patch
         automake-1.9-makeinfo-fix.patch)
 sha256sums=('8eccaa98e1863d10e4a5f861d8e2ec349a23e88cb12ad10f6b6f79022ad2bb8d'
-            'SKIP'
             '9bc281d49a753a6135c65b80642b03a6056538a6e944aeb344f1ed460be2904e'
             '28b80f088b53a72935f15c7d845919f474224ece83847d7b3bae5f2236fe30fe'
             '01d85d830875aa05eec4ad209033473f3f8603f66781fdd9fd9b3cbb07ecbbd2'


### PR DESCRIPTION
This also removes the pgp checks for everything except 1.16 because
they don't contain the full key ID and can't be auto fetched by gnupg.
Since we have the checksums and they wont be updated in the future anyway
this shouldn't be a problem.

The tests didn't work anyway, so removing Python 2 doesn't change much.