### PR TITLE
makepkg-mingw: Enable hardening linker flags by default

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -5,7 +5,7 @@
 PKGEXT='.pkg.tar.xz'
 pkgname=pacman
 pkgver=5.2.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -70,15 +70,16 @@ source=(https://sources.archlinux.org/other/pacman/${pkgname}-${pkgver}.tar.gz{,
         "0017-excise-sudo.patch"
         "0018-use-msys-tools.patch"
         Doxyfile.in)
-validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD')
+validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@archlinux.org>
+              'B8151B117037781095514CA7BBDFFC92306B1121') # Andrew Gregory (pacman) <andrew@archlinux.org>
 sha256sums=('bb201a9f2fb53c28d011f661d50028efce6eef2c1d2a36728bdd0130189349a0'
             'SKIP'
             '7849538ac2b89f4e9881ad5db78a2aa37a2ddb936f87a0ede1c2322e515918fe'
             '822af13248f04690377cd193370f33ac2f00a41234ead9cf3b7e5d5aba8bd0c5'
             '4469ac36c628d123c46feacc34db7ab763a7bfcfb860461846200c68a7d62e2e'
             '13b20f6833df76a34ca38376469e275f93552ef9063d9ca06fc3c9ef5e87aa0b'
-            '9334a89f67b8f4f3427d8cf60969fb4fa9794b12c21c002f823270c45c63784d'
-            '70c01a440acc2ddfff1c3d5d52f48865a8a33c3f8b494fc77974c398aa5be8e0'
+            '8cab0f9fadcb53a9856a586ea63b7284eebd60666842bfaf535417483311af54'
+            '560b03d9a2b7b969bd90dfcc65c6fb87a25704241c69e8a4d7c8ba7b89e7ef0d'
             'b50166ba89277459dcf4c18603e57b387b931e5252068fefcb3d2579ebe2dfa4'
             '501c38b95fcb6938c79a4cff11913fa257d1751d1f6ea6c482ce95999c3fd3b3'
             'cf6d18d4ba5cfa78837dae2a949c794c78d67a7bd321f49b02d32b6ef9d955cf'

--- a/pacman/makepkg_mingw32.conf
+++ b/pacman/makepkg_mingw32.conf
@@ -59,9 +59,9 @@ DXSDK_DIR=${MINGW_PREFIX}/${MINGW_CHOST}
 CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
 CFLAGS="-march=i686 -mtune=generic -O2 -pipe"
 CXXFLAGS="-march=i686 -mtune=generic -O2 -pipe"
-LDFLAGS="-pipe"
-# Uncomment to enable hardening (ASLR, DEP)
-#LDFLAGS="-pipe -Wl,--dynamicbase,--nxcompat"
+LDFLAGS="-pipe -Wl,--dynamicbase,--nxcompat"
+# Uncomment to disable hardening (ASLR, DEP)
+#LDFLAGS="-pipe"
 #-- Make Flags: change this for DistCC/SMP systems
 MAKEFLAGS="-j$(($(nproc)+1))"
 #-- Debugging flags

--- a/pacman/makepkg_mingw64.conf
+++ b/pacman/makepkg_mingw64.conf
@@ -59,9 +59,9 @@ DXSDK_DIR=${MINGW_PREFIX}/${MINGW_CHOST}
 CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
 CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe"
 CXXFLAGS="-march=x86-64 -mtune=generic -O2 -pipe"
-LDFLAGS="-pipe"
-# Uncomment to enable hardening (ASLR, High entropy ASLR, DEP)
-#LDFLAGS="-pipe -Wl,--dynamicbase,--high-entropy-va,--nxcompat"
+LDFLAGS="-pipe -Wl,--dynamicbase,--high-entropy-va,--nxcompat"
+# Uncomment to disable hardening (ASLR, High entropy ASLR, DEP)
+#LDFLAGS="-pipe"
 #-- Make Flags: change this for DistCC/SMP systems
 MAKEFLAGS="-j$(($(nproc)+1))"
 #-- Debugging flags


### PR DESCRIPTION
This enables ASLR, DEP by default.

The goal here is to give these a try for our own package builds and
if there are problems disable some flags again in the respective PKGBUILDs.

Once most of our packages work fine we can think about enabling it
in binutils directly for all users.

Related ASLR change for binutils: https://github.com/msys2/MINGW-packages/pull/6880
Related discussion: https://github.com/msys2/MINGW-packages/issues/6674