### PR TITLE
mc: Recognize Win32 absolute paths

### DIFF
--- a/mc/0003-vfs-win32-absolute-paths.patch
+++ b/mc/0003-vfs-win32-absolute-paths.patch
@@ -1,0 +1,34 @@
+--- lib/vfs/path.c.orig	2020-07-05 21:35:07.000000000 +0200
++++ lib/vfs/path.c	2020-08-27 14:41:35.802799500 +0200
+@@ -142,11 +142,19 @@
+ 
+     if (!IS_PATH_SEP (*path))
+     {
+-        /* Relative to current directory */
+-
+         char *local;
+ 
+-        if (g_str_has_prefix (path, VFS_ENCODING_PREFIX))
++        if (path[0] != NULL && isalpha (path[0]) &&
++            path[1] != NULL && path[1] == ':' &&
++            IS_PATH_SEP (path[2]))
++        {
++            /* Win32 absolute path */
++            local = g_strdup (path);
++            /* Transform "X:/" into "/X/" */
++            local[1] = local[0];
++            local[0] = local[2];
++        }
++        else if (g_str_has_prefix (path, VFS_ENCODING_PREFIX))
+         {
+             /*
+                encoding prefix placed at start of string without the leading slash
+@@ -156,6 +164,8 @@
+         }
+         else
+         {
++            /* Relative to current directory */
++
+             const char *curr_dir;
+ 
+             curr_dir = vfs_get_current_dir ();

--- a/mc/PKGBUILD
+++ b/mc/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=mc
 pkgver=4.8.25
-pkgrel=1
+pkgrel=2
 pkgdesc="Midnight Commander is a text based filemanager/shell that emulates Norton Commander"
 arch=('i686' 'x86_64')
 url="https://www.midnight-commander.org/"
@@ -29,10 +29,12 @@ backup=('etc/mc/edit.indent.rc'
         'etc/mc/sfs.ini')
 source=(${pkgname}-${pkgver}.tar.gz::"https://github.com/MidnightCommander/${pkgname}/archive/${pkgver}.tar.gz"
         4.7.5.2-ncursesw-term.h.patch
-        mc-4.8.19-msys2.patch)
+        mc-4.8.19-msys2.patch
+        0003-vfs-win32-absolute-paths.patch)
 sha256sums=('8a4aa1556a528fbe9140c47aa3d0665155187468a17c3b80a824de5fcbbebae1'
             '49e9a7d918088c8760b0090e99cd6257fa56efa3a4d3e6c9166270cda9c2e8e3'
-            '513a015f237a6907bbbf92bcc13351d831740163a0b8a508a99ba647dea64981')
+            '513a015f237a6907bbbf92bcc13351d831740163a0b8a508a99ba647dea64981'
+            'dad59dada28d12d262389b23b7972703cb75da48e95f90102a9c30fc2174521a')
 noextract=(${pkgname}-${pkgver}.tar.gz)
 
 prepare() {
@@ -46,6 +48,7 @@ prepare() {
   
   patch -Np2 -i "${srcdir}/4.7.5.2-ncursesw-term.h.patch"
   patch -Np1 -i "${srcdir}/mc-4.8.19-msys2.patch"
+  patch -Np0 -i "${srcdir}/0003-vfs-win32-absolute-paths.patch"
 
   autoreconf -fi
 


### PR DESCRIPTION
Running `mcedit C:/foo/bar` would result in a message like _Cannot open /usr/bin/C:/foo/bar_.  This patch fixes this use case.