### PR TITLE
pacman: add --no-seh to ming32 LDFLAGS.

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -5,7 +5,7 @@
 PKGEXT='.pkg.tar.xz'
 pkgname=pacman
 pkgver=5.2.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -78,7 +78,7 @@ sha256sums=('bb201a9f2fb53c28d011f661d50028efce6eef2c1d2a36728bdd0130189349a0'
             '822af13248f04690377cd193370f33ac2f00a41234ead9cf3b7e5d5aba8bd0c5'
             '4469ac36c628d123c46feacc34db7ab763a7bfcfb860461846200c68a7d62e2e'
             '13b20f6833df76a34ca38376469e275f93552ef9063d9ca06fc3c9ef5e87aa0b'
-            '8cab0f9fadcb53a9856a586ea63b7284eebd60666842bfaf535417483311af54'
+            '0e484f00a427f030c95f7ebcab3e0de1e637e55d01531438de9165d1f520cf81'
             '560b03d9a2b7b969bd90dfcc65c6fb87a25704241c69e8a4d7c8ba7b89e7ef0d'
             'b50166ba89277459dcf4c18603e57b387b931e5252068fefcb3d2579ebe2dfa4'
             '501c38b95fcb6938c79a4cff11913fa257d1751d1f6ea6c482ce95999c3fd3b3'

--- a/pacman/makepkg_mingw32.conf
+++ b/pacman/makepkg_mingw32.conf
@@ -59,7 +59,7 @@ DXSDK_DIR=${MINGW_PREFIX}/${MINGW_CHOST}
 CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
 CFLAGS="-march=i686 -mtune=generic -O2 -pipe"
 CXXFLAGS="-march=i686 -mtune=generic -O2 -pipe"
-LDFLAGS="-pipe -Wl,--dynamicbase,--nxcompat"
+LDFLAGS="-pipe -Wl,--dynamicbase,--nxcompat,--no-seh"
 # Uncomment to disable hardening (ASLR, DEP)
 #LDFLAGS="-pipe"
 #-- Make Flags: change this for DistCC/SMP systems


### PR DESCRIPTION
As mentioned in https://github.com/msys2/MINGW-packages/issues/6674#issuecomment-683138852 a different exception mechanism is used by gcc on 32-bit Windows, and this is already the default in lld.