### PR TITLE
po4a: update to 0.61

### DIFF
--- a/po4a/PKGBUILD
+++ b/po4a/PKGBUILD
@@ -1,29 +1,30 @@
 # Maintainer: Peter Budai <peterbudai at hotmail dot com>
+# Contributor: Biswapriyo Nath <nathbappai@gmail.com>
 
 pkgname=po4a
-pkgver=0.59.1
+pkgver=0.61
 pkgrel=1
-pkgdesc="The po4a (PO for anything) project goal is to ease translations (and more interestingly, the maintenance of translations) using gettext tools on areas where they were not expected like documentation"
+pkgdesc="Tools for helping translation of documentation"
 arch=('any')
 url="https://po4a.org/"
 license=('GPL')
-depends=("perl" "gettext" 'perl-Text-WrapI18N' 'perl-Locale-Gettext' 
-         'perl-TermReadKey' 'perl-sgmls'
+depends=("perl" "gettext" 'perl-YAML-Tiny' 'perl-Text-WrapI18N'
+         'perl-Locale-Gettext' 'perl-TermReadKey' 'perl-sgmls'
          'perl-Unicode-GCString')
-makedepends=('perl-Module-Build' 'docbook-xsl')
+makedepends=('perl-Module-Build' 'docbook-xsl' 'perl-Pod-Parser')
 options=('!emptydirs')
-source=(https://github.com/mquinson/po4a/releases/download/v${pkgver}/${pkgname}-v${pkgver}.tar.gz
+source=(https://github.com/mquinson/po4a/releases/download/v${pkgver}/${pkgname}-${pkgver}.tar.gz
         001-fix-man-names.patch)
-sha256sums=('a906fd82a6cc3a8898c1fe55d14076f3376fa6879ce9b1828b8b125e2dbe495b'
+sha256sums=('62954cb0537eff33124a45fa194ae3b92552ee6f6eef74f4953a577f640b86db'
             'b2dc4f9cd6aa1ee38fa5a32b6f36847c34d876ce8852011e462c2ce7c6149aff')
 
 prepare() {
-  cd "${srcdir}/${pkgname}-v${pkgver}"
+  cd "${srcdir}/${pkgname}-${pkgver}"
   patch -p1 -i ${srcdir}/001-fix-man-names.patch
 }
 
 build() {
-  cd "${srcdir}/${pkgname}-v${pkgver}"
+  cd "${srcdir}/${pkgname}-${pkgver}"
 
   perl Build.PL INSTALLDIRS=vendor create_packlist=0
   # The script expects a UTF-8 locale
@@ -31,7 +32,7 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/${pkgname}-v${pkgver}"
+  cd "${srcdir}/${pkgname}-${pkgver}"
   perl Build destdir="${pkgdir}" install
 
   # remove perllocal.pod and .packlist


### PR DESCRIPTION
Changes:
* Choose a concise package description.
* Add 'perl-YAML-Tiny' as dependency and 'perl-Pod-Parser' as make dependency.
* Source tarball file name has changed. So, remove 'v' from source directory.