### PR TITLE
python: rebuild

### DIFF
--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=python
 pkgname=('python' 'python-devel')
 pkgver=3.8.5
-pkgrel=5
+pkgrel=6
 _pybasever=${pkgver%.*}
 pkgdesc="Next generation of the python high-level scripting language"
 arch=('i686' 'x86_64')


### PR DESCRIPTION
We currently have an issue where python was replaced in the pacman repo, leading
to install errors with existing caches containing the old version (CI caches etc).

Bump pkgrel to fix things.

To prevent this in the future see https://github.com/msys2/msys2-autobuild/issues/16