### PR TITLE
po4a: add missing runtime dependency (perl-Pod-Parser)

### DIFF
--- a/po4a/PKGBUILD
+++ b/po4a/PKGBUILD
@@ -3,15 +3,15 @@
 
 pkgname=po4a
 pkgver=0.61
-pkgrel=1
+pkgrel=2
 pkgdesc="Tools for helping translation of documentation"
 arch=('any')
 url="https://po4a.org/"
 license=('GPL')
 depends=("perl" "gettext" 'perl-YAML-Tiny' 'perl-Text-WrapI18N'
          'perl-Locale-Gettext' 'perl-TermReadKey' 'perl-sgmls'
-         'perl-Unicode-GCString')
-makedepends=('perl-Module-Build' 'docbook-xsl' 'perl-Pod-Parser')
+         'perl-Unicode-GCString' 'perl-Pod-Parser')
+makedepends=('perl-Module-Build' 'docbook-xsl')
 options=('!emptydirs')
 source=(https://github.com/mquinson/po4a/releases/download/v${pkgver}/${pkgname}-${pkgver}.tar.gz
         001-fix-man-names.patch)


### PR DESCRIPTION
`perl-Pod-Parser` is actually a runtime dependency.

Without it po4a fails with cryptic messages like the following (the module loading error is only printed in verbose mode):
```
$ po4a-updatepo -f pod -m inkscape.pod.in -m inkview.pod.in -p man.pot --verbose
Unknown format type: pod.
po4a::chooser: Module loading error: Can't locate Pod/Parser.pm in @INC (you may need to install the Pod::Parser
               module) (@INC contains: /usr/lib/perl5/site_perl /usr/share/perl5/site_perl
               /usr/lib/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib/perl5/core_perl
               /usr/share/perl5/core_perl) at /usr/share/perl5/site_perl/Locale/Po4a/Pod.pm line 14.
               BEGIN failed--compilation aborted at /usr/share/perl5/site_perl/Locale/Po4a/Pod.pm line 14.
               Compilation failed in require at (eval 37) line 1.
               BEGIN failed--compilation aborted at (eval 37) line 1.

List of valid formats:
  - asciidoc: AsciiDoc format.
  - dia: uncompressed Dia diagrams.
  - docbook: DocBook XML.
  - guide: Gentoo Linux's XML documentation format.
  - ini: INI format.
  - kernelhelp: Help messages of each kernel compilation option.
  - latex: LaTeX format.
  - man: Good old manual page format.
  - pod: Perl Online Documentation format.
  - rubydoc: Ruby Documentation (RD) format.
  - sgml: either DebianDoc or DocBook DTD.
  - texinfo: The info page format.
  - tex: generic TeX documents (see also latex).
  - text: simple text document.
  - wml: WML documents.
  - xhtml: XHTML documents.
  - xml: generic XML documents (see also docbook).
  - yaml: YAML documents.
```