### PR TITLE
gnupg: update to 2.2.23 for CVE-2020-25125.

### DIFF
--- a/gnupg/PKGBUILD
+++ b/gnupg/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=gnupg
-pkgver=2.2.21
+pkgver=2.2.23
 pkgrel=1
 pkgdesc='Complete and free implementation of the OpenPGP standard'
 provides=('dirmngr' "gnupg2=${pkgver}")
@@ -47,7 +47,7 @@ depends=('bzip2'
         )
 source=("https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2"{,.sig}
         'gnupg-2.2.8-msys2.patch')
-sha256sums=('61e83278fb5fa7336658a8b73ab26f379d41275bb1c7c6e694dd9f9a6e8e76ec'
+sha256sums=('10b55e49d78b3e49f1edb58d7541ecbdad92ddaeeb885b6f486ed23d1cd1da5c'
             'SKIP'
             'cb23f1a61fd213c25e85b6ba8afb190b7da14a8cfa59cc56ce82df941db8c3c9')
 validpgpkeys=('D8692123C4065DEA5E0F3AB5249B39D24F25E3B6'

--- a/gnupg/gnupg.install
+++ b/gnupg/gnupg.install
@@ -1,25 +1,7 @@
-info_dir=usr/share/info
-info_files="gnupg.info gnupg.info-1 gnupg.info-2"
-
-post_install() {
-  [ -x usr/bin/install-info ] || return 0
-  for f in ${info_files}; do
-    usr/bin/install-info ${info_dir}/$f.gz ${info_dir}/dir 2> /dev/null
-  done
-}
-
 post_upgrade() {
-  post_install $1
   # See FS#42798 and FS#47371
   dirmngr </dev/null &>/dev/null
   if usr/bin/pacman-key -l >/dev/null 2>&1; then
     usr/bin/pacman-key --populate msys2
   fi
-}
-
-pre_remove() {
-  [ -x usr/bin/install-info ] || return 0
-  for f in $info_files; do
-    usr/bin/install-info --delete ${info_dir}/$f.gz ${info_dir}/dir 2> /dev/null
-  done
 }


### PR DESCRIPTION
Per https://lists.gnupg.org/pipermail/gnupg-announce/2020q3/000448.html, gnupg-2.2.23 fixes "a *critical security bug* in
versions 2.2.21 and 2.2.22."

mingw-w64-gnupg is still 2.2.20, so unaffected.

Also removed info install/uninstall handling from install script.