### PR TITLE
patchutils: Update to 0.4.2

### DIFF
--- a/patchutils/PKGBUILD
+++ b/patchutils/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Andrea Zagli <andrea.zagli.free@gmail.com>
 
 pkgname=patchutils
-pkgver=0.3.4
+pkgver=0.4.2
 pkgrel=1
 pkgdesc="Utilities to work with patches"
 arch=('i686' 'x86_64')
@@ -9,27 +9,42 @@ url="http://cyberelk.net/tim/software/patchutils/"
 license=('GPL')
 groups=('base-devel')
 source=(http://cyberelk.net/tim/data/patchutils/stable/${pkgname}-${pkgver}.tar.xz)
-sha256sums=('cf55d4db83ead41188f5b6be16f60f6b76a87d5db1c42f5459d596e81dabe876')
+sha256sums=('8875b0965fe33de62b890f6cd793be7fafe41a4e552edbf641f1fed5ebbf45ed')
+depends=('pcre2')
+makedepends=('pcre2-devel')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
 
-  autoreconf -fi
+  autoreconf -vfi
 }
 
 build() {
-  cd ${srcdir}/${pkgname}-${pkgver}
+  mkdir -p ${srcdir}/build-${pkgname}-${pkgver}
+  cd ${srcdir}/build-${pkgname}-${pkgver}
 
-  ./configure \
+  ../${pkgname}-${pkgver}/configure -C \
     --build=${CHOST} \
     --host=${CHOST} \
     --target=${CHOST} \
-    --prefix=/usr
+    --prefix=/usr \
+    --with-pcre2
 
   make
 }
 
+check() {
+  cd ${srcdir}/build-${pkgname}-${pkgver}
+  # patchutils 0.4.2: all tests succeed.
+  make check
+}
+
 package() {
-  cd ${srcdir}/${pkgname}-${pkgver}
+  cd ${srcdir}/build-${pkgname}-${pkgver}
   make DESTDIR=$pkgdir install
+
+  # license
+  mkdir -p ${pkgdir}/usr/share/licenses/${pkgname}/
+  cd ${srcdir}/${pkgname}-${pkgver}/
+  cp -v COPYING ${pkgdir}/usr/share/licenses/${pkgname}/
 }


### PR DESCRIPTION
NB: This commit adds an implicit run-time dependency to pcre2 for enhanced
pattern searches.

* patchutils/PKGBUILD:
  - update to 0.4.2
  - add dependency to pcre2/pcre2-devel (new feature since 0.4.0)
  - run build in separate directory
  - add function check (NB: patchutils 0.4.2: all checks succeed.)
  - add license to package