### PR TITLE
makepkg: Add --default-image-base-high to LDFLAGS

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -5,7 +5,7 @@
 PKGEXT='.pkg.tar.xz'
 pkgname=pacman
 pkgver=5.2.2
-pkgrel=3
+pkgrel=4
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -79,7 +79,7 @@ sha256sums=('bb201a9f2fb53c28d011f661d50028efce6eef2c1d2a36728bdd0130189349a0'
             '4469ac36c628d123c46feacc34db7ab763a7bfcfb860461846200c68a7d62e2e'
             '13b20f6833df76a34ca38376469e275f93552ef9063d9ca06fc3c9ef5e87aa0b'
             '0e484f00a427f030c95f7ebcab3e0de1e637e55d01531438de9165d1f520cf81'
-            '560b03d9a2b7b969bd90dfcc65c6fb87a25704241c69e8a4d7c8ba7b89e7ef0d'
+            'c26dba8f9ac285efa33708e58ca29b4ad0fd9a1d6f4e82cbe433782b180799ee'
             'b50166ba89277459dcf4c18603e57b387b931e5252068fefcb3d2579ebe2dfa4'
             '501c38b95fcb6938c79a4cff11913fa257d1751d1f6ea6c482ce95999c3fd3b3'
             'cf6d18d4ba5cfa78837dae2a949c794c78d67a7bd321f49b02d32b6ef9d955cf'

--- a/pacman/makepkg_mingw64.conf
+++ b/pacman/makepkg_mingw64.conf
@@ -59,7 +59,7 @@ DXSDK_DIR=${MINGW_PREFIX}/${MINGW_CHOST}
 CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
 CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe"
 CXXFLAGS="-march=x86-64 -mtune=generic -O2 -pipe"
-LDFLAGS="-pipe -Wl,--dynamicbase,--high-entropy-va,--nxcompat"
+LDFLAGS="-pipe -Wl,--dynamicbase,--high-entropy-va,--nxcompat,--default-image-base-high"
 # Uncomment to disable hardening (ASLR, High entropy ASLR, DEP)
 #LDFLAGS="-pipe"
 #-- Make Flags: change this for DistCC/SMP systems


### PR DESCRIPTION
This will allow us to change the default to low in binutils, so that our
built packages get proper ASLR support, while users get the same behaviour as
with an older binutils with the old defaults.

See https://github.com/msys2/MINGW-packages/issues/7023#issuecomment-698246859