### PR TITLE
pacman-mirrors: fix SJTUG msys mirror URL

### DIFF
--- a/pacman-mirrors/PKGBUILD
+++ b/pacman-mirrors/PKGBUILD
@@ -2,7 +2,7 @@
 
 PKGEXT='.pkg.tar.xz'
 pkgname=pacman-mirrors
-pkgver=20200930
+pkgver=20201003
 pkgrel=1
 pkgdesc="MSYS2 mirror list for use by pacman"
 arch=('any')
@@ -11,7 +11,7 @@ license=('GPL')
 source=(mirrorlist.msys
         mirrorlist.mingw32
         mirrorlist.mingw64)
-sha256sums=('98961f42c1529fecc327acfbe25a1157362967316e2a5403d0ee6df96392ca50'
+sha256sums=('c91fbe6e53d055f8ce4790f5db9834c7f690ee5669943e7a63479b1774946bee'
             '3f93b82fedea9977a586beebeacdc72c4cac1488938ba5ea326044a36e51b0bc'
             'e4c9e1753c1ca8807e775042ebb4bb5b438572314c2d96f67ec7daf0826a38dd')
 

--- a/pacman-mirrors/mirrorlist.msys
+++ b/pacman-mirrors/mirrorlist.msys
@@ -12,4 +12,4 @@ Server = https://mirrors.tuna.tsinghua.edu.cn/msys2/msys/$arch/
 Server = http://mirrors.ustc.edu.cn/msys2/msys/$arch/
 Server = http://mirror.bit.edu.cn/msys2/msys/$arch/
 Server = https://mirror.selfnet.de/msys2/msys/$arch/
-Server = https://mirrors.sjtug.sjtu.edu.cn/msys2/$arch/
+Server = https://mirrors.sjtug.sjtu.edu.cn/msys2/msys/$arch/


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

https://github.com/msys2/MSYS2-packages/pull/2164 Introduced SJTUG mirror, but the msys2 URL is wrong. In this PR, I fixed the URL.