### PR TITLE
pacman-mirrors: Remove repo.msys2.org

### DIFF
--- a/pacman-mirrors/PKGBUILD
+++ b/pacman-mirrors/PKGBUILD
@@ -2,18 +2,18 @@
 
 PKGEXT='.pkg.tar.xz'
 pkgname=pacman-mirrors
-pkgver=20201003
+pkgver=20201007
 pkgrel=1
 pkgdesc="MSYS2 mirror list for use by pacman"
 arch=('any')
-url="https://msys2.sourceforge.io/"
+url="https://www.msys2.org/dev/mirrors/"
 license=('GPL')
 source=(mirrorlist.msys
         mirrorlist.mingw32
         mirrorlist.mingw64)
-sha256sums=('c91fbe6e53d055f8ce4790f5db9834c7f690ee5669943e7a63479b1774946bee'
-            '3f93b82fedea9977a586beebeacdc72c4cac1488938ba5ea326044a36e51b0bc'
-            'e4c9e1753c1ca8807e775042ebb4bb5b438572314c2d96f67ec7daf0826a38dd')
+sha256sums=('31b0aeca01a83510d69decbead7fdc4189b80e5ebc9f46a9b5b7438251bc449a'
+            'dae63407256ddf7a2d0c89d75dbf6ff1189c68b6e99592f30d62f07e15bd87f8'
+            '7e436f1260efa569dea133d5e7aeeac62523b3c6ff13707dfffbef83db71467a')
 
 package() {
   mkdir -p ${pkgdir}/etc/pacman.d

--- a/pacman-mirrors/mirrorlist.mingw32
+++ b/pacman-mirrors/mirrorlist.mingw32
@@ -4,7 +4,6 @@
 
 ## Primary
 ## msys2.org
-Server = http://repo.msys2.org/mingw/i686/
 Server = https://sourceforge.net/projects/msys2/files/REPOS/MINGW/i686/
 Server = https://www2.futureware.at/~nickoe/msys2-mirror/mingw/i686/
 Server = https://mirror.yandex.ru/mirrors/msys2/mingw/i686/

--- a/pacman-mirrors/mirrorlist.mingw64
+++ b/pacman-mirrors/mirrorlist.mingw64
@@ -4,7 +4,6 @@
 
 ## Primary
 ## msys2.org
-Server = http://repo.msys2.org/mingw/x86_64/
 Server = https://sourceforge.net/projects/msys2/files/REPOS/MINGW/x86_64/
 Server = https://www2.futureware.at/~nickoe/msys2-mirror/mingw/x86_64/
 Server = https://mirror.yandex.ru/mirrors/msys2/mingw/x86_64/

--- a/pacman-mirrors/mirrorlist.msys
+++ b/pacman-mirrors/mirrorlist.msys
@@ -4,7 +4,6 @@
 
 ## Primary
 ## msys2.org
-Server = http://repo.msys2.org/msys/$arch/
 Server = https://sourceforge.net/projects/msys2/files/REPOS/MSYS2/$arch/
 Server = https://www2.futureware.at/~nickoe/msys2-mirror/msys/$arch/
 Server = https://mirror.yandex.ru/mirrors/msys2/msys/$arch/


### PR DESCRIPTION
We moved the primary to a smaller hosting and there's probably enough
mirrors now.