### PR TITLE
filesystem: use matching icon for console

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -5,8 +5,8 @@
 
 PKGEXT='.pkg.tar.xz'
 pkgname=filesystem
-pkgver=2020.02
-pkgrel=7
+pkgver=2020.10
+pkgrel=1
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -64,7 +64,7 @@ sha256sums=('742a7d66b7a5ebd2b8461728c5b44a46b2305fd2116208eecae5f45828938ea0'
             '40a10a03382b93f196464b11ec179f903b9af6d281a9327472b4fb9693b0ca8f'
             'be368cc325f33db9035dc4839bb967bebe9b896bdd7582749124245ccbc38c9f'
             '7d6994d7caf52a459b562cfb0da1d758a4b7bca478d1df00de3a96686e59008e'
-            'db6738b88e6cf8092522fd794779059b3082ed1f4f72259d92df9df50b9c9cd4'
+            '01a9355fe15a0a48b99b6bc0194d48f7c4bc632033137c9ddeb7bf0cf96516c1'
             '65f59306dfe6437ea2694d50ed4e2fe95937148549157809ad3daac5d7e11ddf'
             '91f1f918cf13deab0124082086e990786113b0e710dbda4678d8fc14905ad94d'
             '43172d66ee40a02d96c587a35e78fe0cb4e2e3d1cc96710b9ea06a0a909fdfbe'

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -93,13 +93,16 @@ set msys2_arg=
 set msys2_shiftCounter=
 set msys2_full_cmd=
 
-rem Setup proper title
+rem Setup proper title and icon
 if "%MSYSTEM%" == "MINGW32" (
   set "CONTITLE=MinGW x32"
+  set "CONICON=mingw32.ico"
 ) else if "%MSYSTEM%" == "MINGW64" (
   set "CONTITLE=MinGW x64"
+  set "CONICON=mingw64.ico"
 ) else (
   set "CONTITLE=MSYS2 MSYS"
+  set "CONICON=msys2.ico"
 )
 
 if "x%MSYSCON%" == "xmintty.exe" goto startmintty
@@ -110,9 +113,9 @@ if NOT EXIST "%WD%mintty.exe" goto startsh
 set MSYSCON=mintty.exe
 :startmintty
 if not defined MSYS2_NOSTART (
-  start "%CONTITLE%" "%WD%mintty" -i /msys2.ico -t "%CONTITLE%" "/usr/bin/%LOGINSHELL%" --login !SHELL_ARGS!
+  start "%CONTITLE%" "%WD%mintty" -i "/%CONICON%" -t "%CONTITLE%" "/usr/bin/%LOGINSHELL%" --login !SHELL_ARGS!
 ) else (
-  "%WD%mintty" -i /msys2.ico -t "%CONTITLE%" "/usr/bin/%LOGINSHELL%" --login !SHELL_ARGS!
+  "%WD%mintty" -i "/%CONICON%" -t "%CONTITLE%" "/usr/bin/%LOGINSHELL%" --login !SHELL_ARGS!
 )
 exit /b %ERRORLEVEL%
 
@@ -122,9 +125,9 @@ call :conemudetect || (
   exit /b 1
 )
 if not defined MSYS2_NOSTART (
-  start "%CONTITLE%" "%ComEmuCommand%" /Here /Icon "%WD%..\..\msys2.ico" /cmd "%WD%\%LOGINSHELL%" --login !SHELL_ARGS!
+  start "%CONTITLE%" "%ComEmuCommand%" /Here /Icon "%WD%..\..\%CONICON%" /cmd "%WD%\%LOGINSHELL%" --login !SHELL_ARGS!
 ) else (
-  "%ComEmuCommand%" /Here /Icon "%WD%..\..\msys2.ico" /cmd "%WD%\%LOGINSHELL%" --login !SHELL_ARGS!
+  "%ComEmuCommand%" /Here /Icon "%WD%..\..\%CONICON%" /cmd "%WD%\%LOGINSHELL%" --login !SHELL_ARGS!
 )
 exit /b %ERRORLEVEL%
 


### PR DESCRIPTION
Helps identifying window thumbnails when switching between MSYS and MINGW64 consoles