### PR TITLE
pkgconf/pkg-config: some cleanups/updates, make it possible to install pkgconf as an alternative

### DIFF
--- a/pkg-config/PKGBUILD
+++ b/pkg-config/PKGBUILD
@@ -2,16 +2,13 @@
 
 pkgname=pkg-config
 pkgver=0.29.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A system for managing library compile/link flags"
 arch=('i686' 'x86_64')
 url="https://www.freedesktop.org/wiki/Software/pkg-config/"
 license=('GPL')
 groups=('base-devel')
 depends=('glib2')
-provides=("pkgconfig=${pkgver}")
-conflicts=('pkgconfig')
-replaces=('pkgconfig' 'pkgconf')
 source=(https://pkgconfig.freedesktop.org/releases/${pkgname}-${pkgver}.tar.gz
         glib-cygwin.patch
         pkg-config-0.28-msys2.patch

--- a/pkg-config/PKGBUILD
+++ b/pkg-config/PKGBUILD
@@ -2,13 +2,13 @@
 
 pkgname=pkg-config
 pkgver=0.29.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A system for managing library compile/link flags"
 arch=('i686' 'x86_64')
 url="https://www.freedesktop.org/wiki/Software/pkg-config/"
 license=('GPL')
 groups=('base-devel')
-depends=('glib2')
+depends=('libiconv')
 source=(https://pkgconfig.freedesktop.org/releases/${pkgname}-${pkgver}.tar.gz
         glib-cygwin.patch
         pkg-config-0.28-msys2.patch

--- a/pkgconf/001-no-cygpath-conv.patch
+++ b/pkgconf/001-no-cygpath-conv.patch
@@ -1,0 +1,11 @@
+--- pkgconf-1.7.1/libpkgconf/path.c.orig	2019-07-12 13:10:54.000000000 +0200
++++ pkgconf-1.7.1/libpkgconf/path.c	2020-10-16 19:56:17.512930500 +0200
+@@ -320,7 +320,7 @@
+ bool
+ pkgconf_path_relocate(char *buf, size_t buflen)
+ {
+-#if defined(HAVE_CYGWIN_CONV_PATH) && defined(__MSYS__)
++#if defined(HAVE_CYGWIN_CONV_PATH) && defined(__MSYS__) && 0
+ 	ssize_t size;
+ 	char *tmpbuf, *ti;
+ 

--- a/pkgconf/PKGBUILD
+++ b/pkgconf/PKGBUILD
@@ -1,30 +1,44 @@
 # Maintainer: Bartlomiej Piotrowski <nospam@bpiotrowski.pl>
 
 pkgname=pkgconf
-pkgver=0.9.11
+pkgver=1.7.1
 pkgrel=1
 pkgdesc='pkg-config compatible utility which does not depend on glib'
-url='https://github.com/nenolod/pkgconf'
+url='https://github.com/pkgconf/pkgconf'
 arch=('i686' 'x86_64')
 license=('ISC')
-#makedepends=('popt')
+makedepends=('meson'
+             'ninja')
 conflicts=('pkg-config')
 provides=('pkg-config')
-source=(http://rabbit.dereferenced.org/~nenolod/distfiles//$pkgname-$pkgver.tar.bz2)
-sha256sums=('3bdae1b2672133943dc0dda694ed57074f8b03c3fea10efb215d76d3cabe2c3b')
+source=(https://distfiles.dereferenced.org/pkgconf/$pkgname-$pkgver.tar.xz
+        001-no-cygpath-conv.patch)
+sha256sums=('a1a3e2ddca34551600b51a1ef2c1b77198065f34f4d2eeb35fe668187c86c349'
+            '3bbff179662d718c703c11b0ec34c118c73dc39fab05a90e7a55fccf15c2eb93')
+
+prepare() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+
+  patch -p1 -i ${srcdir}/001-no-cygpath-conv.patch
+}
 
 build() {
-  cd $pkgname-$pkgver
-  ./configure --prefix=/usr \
-    --sysconfdir=/etc \
-    --mandir=/usr/share/man \
-    --infodir=/usr/share/info \
-    --localstatedir=/var
-  make
+  mkdir "${srcdir}"/build && cd "${srcdir}"/build
+
+  meson \
+    --buildtype=plain \
+     --prefix=/usr \
+     -Dtests=false \
+    "../${pkgname}-${pkgver}"
+
+  meson compile
 }
 
 package() {
-  cd $pkgname-$pkgver
-  make DESTDIR="$pkgdir" install
+  cd "${srcdir}"/build
+
+  DESTDIR="$pkgdir" meson install
+
+  cp "$pkgdir"/usr/bin/pkgconf "$pkgdir/usr/bin/$(gcc -dumpmachine)-pkg-config"
   cp "$pkgdir"/usr/bin/pkgconf "$pkgdir"/usr/bin/pkg-config
 }


### PR DESCRIPTION
Maybe we can default to pkgconf in the future, like Arch.