### PR TITLE
add ragel package

### DIFF
--- a/ragel/PKGBUILD
+++ b/ragel/PKGBUILD
@@ -1,0 +1,33 @@
+# MSYS2 Maintainer: Kelvin Sherlock <ksherlock@gmail.com>
+# Arch Maintainer: Timothy Redaelli <timothy.redaelli@gmail.com>
+# Contributor: Michael P <ptchinster@archlinux.us>
+# Contributor: Roberto Alsina <ralsina@kde.org>
+# Contributor: Will Chappell <mr.chapendi@gmail.com>
+# Contributor: Jesse Young <jesse.young@gmail.com>
+# Contributor: Gustavo Alvarez <sl1pkn07@gmail.com>
+
+pkgname=ragel
+pkgver=6.10
+pkgrel=3
+pkgdesc="Compiles finite state machines from regular languages into executable C, C++, Objective-C, or D code."
+arch=('i686' 'x86_64')
+url="http://www.complang.org/ragel/"
+license=('GPL')
+depends=('gcc-libs')
+source=(https://www.colm.net/files/$pkgname/$pkgname-$pkgver.tar.gz)
+md5sums=('748cae8b50cffe9efcaa5acebc6abf0d')
+sha256sums=('5f156edb65d20b856d638dd9ee2dfb43285914d9aa2b6ec779dac0270cd56c3f')
+
+build() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  ./configure --prefix=/usr CXXFLAGS="$CXXFLAGS -std=gnu++98" 
+  make
+}
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  make DESTDIR="$pkgdir/" install
+  install -m0644 -D ragel.vim "$pkgdir"/usr/share/vim/vimfiles/syntax/ragel.vim
+}


### PR DESCRIPTION
There is already a mingw64 ragel package already but it would be better to have it in msys2 so it's available for mingw32, 64, and msys2.

ragel generates code and the generated code is identical everywhere so one binary can service them all.