### PR TITLE
Switch from pkg-config to pkgconf

### DIFF
--- a/pkg-config/PKGBUILD
+++ b/pkg-config/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=pkg-config
 pkgver=0.29.2
-pkgrel=3
+pkgrel=4
 pkgdesc="A system for managing library compile/link flags"
 arch=('i686' 'x86_64')
 url="https://www.freedesktop.org/wiki/Software/pkg-config/"
 license=('GPL')
-groups=('base-devel')
 depends=('libiconv')
 source=(https://pkgconfig.freedesktop.org/releases/${pkgname}-${pkgver}.tar.gz
         glib-cygwin.patch

--- a/pkgconf/PKGBUILD
+++ b/pkgconf/PKGBUILD
@@ -2,15 +2,17 @@
 
 pkgname=pkgconf
 pkgver=1.7.3
-pkgrel=1
+pkgrel=2
 pkgdesc='pkg-config compatible utility which does not depend on glib'
 url='https://github.com/pkgconf/pkgconf'
 arch=('i686' 'x86_64')
 license=('ISC')
+groups=('base-devel')
 makedepends=('meson'
              'ninja')
 conflicts=('pkg-config')
 provides=('pkg-config')
+replaces=('pkg-config')
 source=(https://distfiles.dereferenced.org/pkgconf/$pkgname-$pkgver.tar.xz
         001-no-cygpath-conv.patch
         002-meson-write-pc-file.patch)


### PR DESCRIPTION
pkgconf is maintained, doesn't include glib and supports more pkg-config
features and builds faster.

Arch and Fedora have switched long ago, so we should too.