### PR TITLE
python: rebase dlls during build (for i686)

### DIFF
--- a/python/940-rebase-python-dll.patch
+++ b/python/940-rebase-python-dll.patch
@@ -1,0 +1,13 @@
+--- Python-3.8.5/Makefile.pre.in.orig	2020-08-10 16:49:23.697127200 -0700
++++ Python-3.8.5/Makefile.pre.in	2020-08-10 16:51:30.546101400 -0700
+@@ -667,6 +667,10 @@
+ 	if test -n "$(DLLLIBRARY)"; then \
+ 		$(LDSHARED) -Wl,--out-implib=$@ -o $(DLLLIBRARY) $^ \
+ 			$(LIBS) $(MODLIBS) $(SYSLIBS); \
++		if [[ `uname -m` == i?86 ]]; then \
++			rebase -sO $(DLLLIBRARY); \
++		else true; \
++		fi; \
+ 	else true; \
+ 	fi
+ 

--- a/python/950-rebase-dlls.patch
+++ b/python/950-rebase-dlls.patch
@@ -1,0 +1,10 @@
+--- Python-3.8.5/Makefile.pre.in.orig	2020-08-13 17:35:32.636969100 -0700
++++ Python-3.8.5/Makefile.pre.in	2020-08-13 23:24:10.054938400 -0700
+@@ -609,6 +609,7 @@
+ 	$(RUNSHARED) CC='$(CC)' LDSHARED='$(BLDSHARED)' OPT='$(OPT)' \
+ 		_TCLTK_INCLUDES='$(TCLTK_INCLUDES)' _TCLTK_LIBS='$(TCLTK_LIBS)' \
+ 		$(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build
++	[[ `uname -m` == i?86 ]] && find . -name \*.dll | rebase -sOT - || true
+ 
+ libpython$(LDVERSION).so: $(LIBRARY_OBJS) $(DTRACE_OBJS)
+ 	if test $(INSTSONAME) != $(LDLIBRARY); then \

--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -33,6 +33,7 @@ source=(https://www.python.org/ftp/python/${pkgver%rc*}/Python-${pkgver}.tar.xz
         900-msysize.patch
         920-allow-win-drives-in-os-path-isabs.patch
         930-fix-missing-tcp-include.patch
+        940-rebase-python-dll.patch
         950-rebase-dlls.patch
         960-fix-parallel-make.patch)
 sha256sums=('a9e0b79d27aa056eb9cce8d63a427b5f9bab1465dee3f942dcfdb25a82f4ab8a'
@@ -57,6 +58,7 @@ sha256sums=('a9e0b79d27aa056eb9cce8d63a427b5f9bab1465dee3f942dcfdb25a82f4ab8a'
             'e833cb6ab8a3d35296f52ad327df7eb4cc4eab94413085bded2943a290cba16d'
             '387a2b7931fb4958e2526991760d85677f44fa13cff0aeb0f41a267f1f7fd214'
             '17e4ac1b5f0fa8a6c410fb80d1ad99ec9185efef51b8450a31932b553c354ed1'
+            'b439ff4f0a1f13858f8fb596414b74ed2c14fc3103d90287bb8e461ee89288b9'
             '612bc5bcbe24c2f623713172d318c65a69ae601d72bcc5a170fe7c4eee458d18'
             'c59025ca9d1219bbb42d620ca8d19398610737c5754f1873db07d55c47b2dad1')
 
@@ -104,6 +106,7 @@ prepare() {
     027-install-import-library.patch \
     900-msysize.patch \
     920-allow-win-drives-in-os-path-isabs.patch \
+    940-rebase-python-dll.patch \
     950-rebase-dlls.patch \
     960-fix-parallel-make.patch
   

--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -33,6 +33,7 @@ source=(https://www.python.org/ftp/python/${pkgver%rc*}/Python-${pkgver}.tar.xz
         900-msysize.patch
         920-allow-win-drives-in-os-path-isabs.patch
         930-fix-missing-tcp-include.patch
+        950-rebase-dlls.patch
         960-fix-parallel-make.patch)
 sha256sums=('a9e0b79d27aa056eb9cce8d63a427b5f9bab1465dee3f942dcfdb25a82f4ab8a'
             'be96ddaca58a39ddaf1e3e5bb7900b34c0e6d00e9b64c4e0f8a3565a74a44e84'
@@ -56,6 +57,7 @@ sha256sums=('a9e0b79d27aa056eb9cce8d63a427b5f9bab1465dee3f942dcfdb25a82f4ab8a'
             'e833cb6ab8a3d35296f52ad327df7eb4cc4eab94413085bded2943a290cba16d'
             '387a2b7931fb4958e2526991760d85677f44fa13cff0aeb0f41a267f1f7fd214'
             '17e4ac1b5f0fa8a6c410fb80d1ad99ec9185efef51b8450a31932b553c354ed1'
+            '612bc5bcbe24c2f623713172d318c65a69ae601d72bcc5a170fe7c4eee458d18'
             'c59025ca9d1219bbb42d620ca8d19398610737c5754f1873db07d55c47b2dad1')
 
 apply_patch_with_msg() {
@@ -102,6 +104,7 @@ prepare() {
     027-install-import-library.patch \
     900-msysize.patch \
     920-allow-win-drives-in-os-path-isabs.patch \
+    950-rebase-dlls.patch \
     960-fix-parallel-make.patch
   
   # https://bugs.python.org/issue41374


### PR DESCRIPTION
It turns out that the calculated auto-image-bases for `msys-python3.8.dll` and `array.cpython-38-i386-msys.dll` overlapped on i686.  I patched in rebase calls after building the python dll and after building the module dlls, which allows the build to succeed on my local machine.  For some unknown reason, it still fails for me in GHA no matter what I tried ☹️ .

I've been keeping this in a branch and rebasing for a couple of python updates, but figured I'd offer it up as a pull request.