### PR TITLE
fixes for packages that failed to build in msys2-autobuild

### DIFF
--- a/gnutls/PKGBUILD
+++ b/gnutls/PKGBUILD
@@ -4,7 +4,7 @@ pkgbase=gnutls
 pkgname=('gnutls' 'libgnutls' 'libgnutls-devel')
 _base_ver=3.6.15
 pkgver=${_base_ver}
-pkgrel=1
+pkgrel=2
 pkgdesc="A library which provides a secure layer over a reliable transport layer"
 arch=('x86_64' 'i686')
 license=('GPL3' 'LGPL2.1')
@@ -24,10 +24,9 @@ source=(https://gnupg.org/ftp/gcrypt/gnutls/v${_base_ver%.*}/${pkgname}-${pkgver
 sha256sums=('0ea8c3283de8d8335d7ae338ef27c53a916f15f382753b174c18b45ffd481558'
             'SKIP'
             '3b0b347d207033bdc21d5f9b9186f6819ad1f4a575f775fbbf5cb671130b4e68')
-validpgpkeys=('0424D4EE81A0E3D119C6F835EDA21E94B565716F'
-              '1F42418905D8206AA754CCDC29EE58B996865171')
-               # "Simon Josefsson <simon@josefsson.org>"
-               # "Nikos Mavrogiannopoulos <nmav@gnutls.org>
+validpgpkeys=('0424D4EE81A0E3D119C6F835EDA21E94B565716F' # "Simon Josefsson <simon@josefsson.org>"
+              '1F42418905D8206AA754CCDC29EE58B996865171' # "Nikos Mavrogiannopoulos <nmav@gnutls.org>
+              '462225C3B46F34879FC8496CD605848ED7E69871') # "Daiki Ueno <ueno@unixuser.org>"
 
 prepare() {
   cd "${srcdir}"/${pkgname}-${_base_ver}

--- a/less/PKGBUILD
+++ b/less/PKGBUILD
@@ -2,16 +2,19 @@
 
 pkgname=less
 pkgver=563
-pkgrel=1
+pkgrel=2
 pkgdesc="A terminal based program for viewing text files"
 license=('GPL3')
 arch=('i686' 'x86_64')
 url="http://www.greenwoodsoftware.com/less"
 depends=('ncurses' 'libpcre')
 makedepends=('ncurses-devel' 'pcre-devel')
-source=(http://www.greenwoodsoftware.com/${pkgname}/${pkgname}-${pkgver}{.tar.gz,.sig})
-sha256sums=('ce5b6d2b9fc4442d7a07c93ab128d2dff2ce09a1d4f2d055b95cf28dd0dc9a9a'
-            'SKIP')
+source=("http://www.greenwoodsoftware.com/${pkgname}/${pkgname}-${pkgver}.tar.gz")
+# pgp check still fails with FAILED (unknown public key F153A7C833235259)
+#        "$pkgname-$pkgver.tar.gz.sig::http://www.greenwoodsoftware.com/$pkgname/$pkgname-$pkgver.sig")
+sha256sums=('ce5b6d2b9fc4442d7a07c93ab128d2dff2ce09a1d4f2d055b95cf28dd0dc9a9a')
+#            'SKIP')
+validpgpkeys=('AE27252BD6846E7D6EAE1DD6F153A7C833235259') # Mark Nudelman
 
 build() {
   cd ${srcdir}/${pkgname}-${pkgver}

--- a/libpipeline/PKGBUILD
+++ b/libpipeline/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('libpipeline' 'libpipeline-devel')
 pkgver=1.5.3
-pkgrel=1
+pkgrel=2
 pkgdesc="a C library for manipulating pipelines of subprocesses in a flexible and convenient way"
 url="http://libpipeline.nongnu.org/"
 groups=('libraries')
@@ -15,6 +15,7 @@ source=(https://download.savannah.gnu.org/releases/libpipeline/libpipeline-$pkgv
 sha256sums=('5dbf08faf50fad853754293e57fd4e6c69bb8e486f176596d682c67e02a0adb0'
             'SKIP'
             'd3e18828f4918260329984139e890ab79f434ef601eec9cd3a69450d3b857621')
+validpgpkeys=('AC0A4FF12611B6FCCF01C111393587D97D86500B') # Colin Watson <cjwatson@debian.org>
 
 prepare() {
   cd "${pkgname}-${pkgver}"

--- a/libpsl/PKGBUILD
+++ b/libpsl/PKGBUILD
@@ -3,13 +3,13 @@
 pkgbase=libpsl
 pkgname=("${pkgbase}" "${pkgbase}-devel")
 pkgver=0.21.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Public Suffix List library'
 url='https://github.com/rockdaboot/libpsl'
 arch=('i686' 'x86_64')
 license=('MIT')
 makedepends=('libxslt' 'python' 'libidn2-devel' 'publicsuffix-list' 'libunistring-devel')
-source=(https://github.com/rockdaboot/libpsl/releases/download/${pkgname}-${pkgver}/${pkgname}-${pkgver}.tar.gz
+source=(https://github.com/rockdaboot/libpsl/releases/download/${pkgver}/${pkgname}-${pkgver}.tar.gz
         0.16.0-install-dafsa.patch 
         0.16.1-make-dafsa-setlocale.patch
         019.1-implement-private-libs.patch)

--- a/mksh/PKGBUILD
+++ b/mksh/PKGBUILD
@@ -4,7 +4,7 @@ pkgname=mksh
 _ver=59
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
-pkgrel=1
+pkgrel=2
 pkgdesc="The MirBSD Korn Shell"
 arch=("i686" "x86_64")
 url="https://www.mirbsd.org/mksh.htm"
@@ -17,7 +17,7 @@ install=mksh.install
 source=("https://www.mirbsd.org/MirOS/dist/mir/${pkgname}/${pkgname}-R${_ver}.tgz"
         "https://www.mirbsd.org/TaC-mksh.txt")
 sha256sums=('592a28ba67bea8a285f003d7a5d21b65e718546c8fcb375d7d696f3d5dd390ba'
-            '92ea3319925b35081cb30ff3ef112dc6eff733cf63455b06c8eaae0adc03a400')
+            '8a53fe4d643fb7341e6c94653d63d3d813d8d849fc1d9dfe5dc49ab2fb48aee9')
 
 build() {
   cd "${srcdir}/${pkgname}"

--- a/whois/PKGBUILD
+++ b/whois/PKGBUILD
@@ -2,13 +2,13 @@
 
 pkgname=whois
 pkgver=5.5.7
-pkgrel=1
+pkgrel=2
 pkgdesc="The whois client by Marco d'Itri"
 arch=('i686' 'x86_64')
 url="https://www.linux.it/~md/software/"
 license=('GPL')
-depends=('libcrypt' 'libidn2' 'libiconv')
-makedepends=('perl' 'libcrypt-devel' 'libidn2-devel' 'libiconv-devel')
+depends=('libcrypt' 'libidn2' 'libiconv' 'libunistring')
+makedepends=('perl' 'libcrypt-devel' 'libidn2-devel' 'libiconv-devel' 'libunistring-devel')
 backup=('etc/whois.conf')
 source=("http://ftp.debian.org/debian/pool/main/w/whois/${pkgname}_${pkgver}.tar.xz"
         "whois-libiconv.patch")


### PR DESCRIPTION
Assorted fixes for packages that failed to build in https://github.com/msys2/msys2-autobuild/runs/1300765313?check_suite_focus=true

`less` is a pgp nightmare. It was missing validpgpkeys, and the .sig file was named without the .tar.gz extension, and even with both of those fixed it still failed to validate, I assume it failed to retrieve the key.  I commented out the sig file so it could build.