### PR TITLE
gnutls-devel: add depends on other -devel packages

### DIFF
--- a/emacs/PKGBUILD
+++ b/emacs/PKGBUILD
@@ -2,14 +2,14 @@
 
 pkgname=emacs
 pkgver=27.1
-pkgrel=1
+pkgrel=2
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (msys2)"
 url="https://www.gnu.org/software/${pkgname}/"
 license=('GPL3')
 arch=('i686' 'x86_64')
 depends=('ncurses' 'zlib' 'libxml2' 'libiconv' 'libcrypt' 'libgnutls' 'glib2' 'libhogweed')
 groups=('editors')
-makedepends=('gawk' 'libiconv-devel' 'libxml2-devel' 'libiconv-devel' 'ncurses-devel' 'libcrypt-devel' 'libgnutls-devel')
+makedepends=('gawk' 'libiconv-devel' 'libxml2-devel' 'libiconv-devel' 'ncurses-devel' 'libcrypt-devel' 'libgnutls-devel' 'libunistring-devel')
 options=('strip')
 source=("https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz"{,.sig}
         'configure.ac.diff')

--- a/gnutls/PKGBUILD
+++ b/gnutls/PKGBUILD
@@ -4,7 +4,7 @@ pkgbase=gnutls
 pkgname=('gnutls' 'libgnutls' 'libgnutls-devel')
 _base_ver=3.6.15
 pkgver=${_base_ver}
-pkgrel=2
+pkgrel=3
 pkgdesc="A library which provides a secure layer over a reliable transport layer"
 arch=('x86_64' 'i686')
 license=('GPL3' 'LGPL2.1')
@@ -82,7 +82,11 @@ package_libgnutls() {
 package_libgnutls-devel() {
   pkgdesc="Libgnutls headers and libraries"
   groups=('development')
-  depends=("libgnutls=${pkgver}")
+  depends=("libgnutls=${pkgver}"
+           'libidn2-devel'
+           'libnettle-devel'
+           'libp11-kit-devel'
+           'libtasn1-devel')
 
   mkdir -p ${pkgdir}/usr/lib
   cp -rf ${srcdir}/dest/usr/include ${pkgdir}/usr/

--- a/lftp/PKGBUILD
+++ b/lftp/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=lftp
 pkgver=4.9.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Sophisticated command line based FTP client (net-utils)"
 arch=('i686' 'x86_64')
 license=('GPL3')


### PR DESCRIPTION
`pkg-config --exists --print-errors gnutls` fails if those .pc files are missing.

Rebuild lftp and emacs after this update, as they were failing due to this.  Also added libunistring-devel as a makedepends on emacs to fix its build.