### PR TITLE
rcs: makedepends on ed

### DIFF
--- a/rcs/PKGBUILD
+++ b/rcs/PKGBUILD
@@ -2,12 +2,12 @@
 
 pkgname=rcs
 pkgver=5.10.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Revision Control System: manages multiple revisions of files'
 url='https://www.gnu.org/software/rcs/'
 license=('GPL3')
 arch=('i686' 'x86_64')
-makedepends=('groff')
+makedepends=('groff' 'ed')
 source=("https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz"
         rcs-5.10.0-msysize.patch)
 sha256sums=('3a0d9f958c7ad303e475e8634654974edbe6deb3a454491f3857dc1889bac5c5'


### PR DESCRIPTION
Configure looks for it, but the comment says it's only needed if diff3
isn't 'sane'.  Since our diff3 is GNU diff3, it is 'sane', so ed isn't
required at runtime, but configure still checks for it so make it a
makedepends.