### PR TITLE
mingw-w64-cross-*: hardcode the commit hash in the version

### DIFF
--- a/mingw-w64-cross-crt-git/PKGBUILD
+++ b/mingw-w64-cross-crt-git/PKGBUILD
@@ -12,7 +12,7 @@ replaces=("${_mingw_suff}-${_realname}")
 provides=("${_mingw_suff}-${_realname}")
 conflicts=("${_mingw_suff}-${_realname}")
 pkgver=9.0.0.6029.ecb4ff54
-pkgrel=1
+pkgrel=2
 pkgdesc='MinGW-w64 CRT for cross-compiler'
 arch=('i686' 'x86_64')
 url='https://mingw-w64.sourceforge.io/'
@@ -46,7 +46,7 @@ pkgver() {
   local _major=$(head -n 16 mingw-w64-headers/crt/_mingw_mac.h | grep '__MINGW64_VERSION_MAJOR' | sed -e 's/.* //' | tr '\n' '.' | sed 's/.$/\n/')
   local _minor=$(head -n 16 mingw-w64-headers/crt/_mingw_mac.h | grep '__MINGW64_VERSION_MINOR' | sed -e 's/.* //' | tr '\n' '.' | sed 's/.$/\n/')
   local _rev=0
-  printf "%s.%s.%s.%s.%s" ${_major} ${_minor} ${_rev} "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+  printf "%s.%s.%s.%s.%s" ${_major} ${_minor} ${_rev} "$(git rev-list --count $_commit)" "$(git rev-parse --short $_commit)"
 }
 
 prepare() {

--- a/mingw-w64-cross-headers-git/PKGBUILD
+++ b/mingw-w64-cross-headers-git/PKGBUILD
@@ -9,7 +9,7 @@ provides=("${_mingw_suff}-${_realname}")
 conflicts=("${_mingw_suff}-${_realname}")
 pkgdesc="MinGW-w64 headers for cross-compiler"
 pkgver=9.0.0.6029.ecb4ff54
-pkgrel=1
+pkgrel=2
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
 license=('custom')
@@ -27,7 +27,7 @@ pkgver() {
   local _major=$(head -n 16 mingw-w64-headers/crt/_mingw_mac.h | grep '__MINGW64_VERSION_MAJOR' | sed -e 's/.* //' | tr '\n' '.' | sed 's/.$/\n/')
   local _minor=$(head -n 16 mingw-w64-headers/crt/_mingw_mac.h | grep '__MINGW64_VERSION_MINOR' | sed -e 's/.* //' | tr '\n' '.' | sed 's/.$/\n/')
   local _rev=0
-  printf "%s.%s.%s.%s.%s" ${_major} ${_minor} ${_rev} "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+  printf "%s.%s.%s.%s.%s" ${_major} ${_minor} ${_rev} "$(git rev-list --count $_commit)" "$(git rev-parse --short $_commit)"
 }
 
 prepare() {

--- a/mingw-w64-cross-tools-git/PKGBUILD
+++ b/mingw-w64-cross-tools-git/PKGBUILD
@@ -9,7 +9,7 @@ provides=("${_mingw_suff}-${_realname}")
 conflicts=("${_mingw_suff}-${_realname}")
 pkgdesc="MinGW-w64 headers for cross-compiler"
 pkgver=9.0.0.6029.ecb4ff54
-pkgrel=1
+pkgrel=2
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
 license=('custom')
@@ -28,7 +28,7 @@ pkgver() {
   local _major=$(head -n 16 mingw-w64-headers/crt/_mingw_mac.h | grep '__MINGW64_VERSION_MAJOR' | sed -e 's/.* //' | tr '\n' '.' | sed 's/.$/\n/')
   local _minor=$(head -n 16 mingw-w64-headers/crt/_mingw_mac.h | grep '__MINGW64_VERSION_MINOR' | sed -e 's/.* //' | tr '\n' '.' | sed 's/.$/\n/')
   local _rev=0
-  printf "%s.%s.%s.%s.%s" ${_major} ${_minor} ${_rev} "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+  printf "%s.%s.%s.%s.%s" ${_major} ${_minor} ${_rev} "$(git rev-list --count $_commit)" "$(git rev-parse --short $_commit)"
 }
 
 prepare() {

--- a/mingw-w64-cross-winpthreads-git/PKGBUILD
+++ b/mingw-w64-cross-winpthreads-git/PKGBUILD
@@ -6,8 +6,8 @@ pkgname="${_mingw_suff}-${_realname}-git"
 replaces=("${_mingw_suff}-${_realname}")
 provides=("${_mingw_suff}-${_realname}")
 conflicts=("${_mingw_suff}-${_realname}")
-pkgver=9.0.0.6030.24a0f940
-pkgrel=1
+pkgver=9.0.0.6029.ecb4ff54
+pkgrel=2
 pkgdesc="MinGW-w64 winpthreads library for cross-compiler"
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
@@ -31,7 +31,7 @@ pkgver() {
   local _major=$(head -n 16 mingw-w64-headers/crt/_mingw_mac.h | grep '__MINGW64_VERSION_MAJOR' | sed -e 's/.* //' | tr '\n' '.' | sed 's/.$/\n/')
   local _minor=$(head -n 16 mingw-w64-headers/crt/_mingw_mac.h | grep '__MINGW64_VERSION_MINOR' | sed -e 's/.* //' | tr '\n' '.' | sed 's/.$/\n/')
   local _rev=0
-  printf "%s.%s.%s.%s.%s" ${_major} ${_minor} ${_rev} "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+  printf "%s.%s.%s.%s.%s" ${_major} ${_minor} ${_rev} "$(git rev-list --count $_commit)" "$(git rev-parse --short $_commit)"
 }
 
 prepare() {

--- a/mingw-w64-cross-winstorecompat-git/PKGBUILD
+++ b/mingw-w64-cross-winstorecompat-git/PKGBUILD
@@ -7,7 +7,7 @@ replaces=("${_mingw_suff}-${_realname}")
 provides=("${_mingw_suff}-${_realname}")
 conflicts=("${_mingw_suff}-${_realname}")
 pkgver=9.0.0.6029.ecb4ff54
-pkgrel=1
+pkgrel=2
 pkgdesc="MinGW-w64 winRT compat library"
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
@@ -29,7 +29,7 @@ pkgver() {
   local _major=$(head -n 16 mingw-w64-headers/crt/_mingw_mac.h | grep '__MINGW64_VERSION_MAJOR' | sed -e 's/.* //' | tr '\n' '.' | sed 's/.$/\n/')
   local _minor=$(head -n 16 mingw-w64-headers/crt/_mingw_mac.h | grep '__MINGW64_VERSION_MINOR' | sed -e 's/.* //' | tr '\n' '.' | sed 's/.$/\n/')
   local _rev=0
-  printf "%s.%s.%s.%s.%s" ${_major} ${_minor} ${_rev} "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+  printf "%s.%s.%s.%s.%s" ${_major} ${_minor} ${_rev} "$(git rev-list --count $_commit)" "$(git rev-parse --short $_commit)"
 }
 
 build() {


### PR DESCRIPTION
Otherwise "git am" used in prepare() wil change HEAD and as a result pkgver().
Also when "git am" is used the hash in the version isn't in the upstream repo
which makes it hard to figure out where it was built from.

Just hardcode to the commit that was checkedd out initially.