### PR TITLE
curl: don't build with --enable-debug by default

### DIFF
--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=curl
 pkgname=('curl' 'libcurl' 'libcurl-devel')
 pkgver=7.73.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Multi-protocol file transfer utility"
 arch=('i686' 'x86_64')
 url="https://curl.haxx.se"
@@ -36,12 +36,17 @@ prepare() {
 build() {
   cd "${pkgname}-${pkgver}"
 
+  declare -a extra_config
+  if check_option "debug" "y"; then
+    extra_config+=("--enable-debug")
+  fi
+
   ./configure \
     --build=${CHOST} \
     --prefix=/usr \
     --enable-shared \
     --enable-static \
-    --enable-debug \
+    "${extra_config[@]}" \
     --enable-optimize \
     --enable-ipv6 \
     --disable-hidden-symbols \


### PR DESCRIPTION
It changes the behaviour of curl, so better only use it when the debug flag is enabled.

Fixes #2223