### PR TITLE
nano-syntax-highlighting: don't conflict with self

### DIFF
--- a/nano-syntax-highlighting/PKGBUILD
+++ b/nano-syntax-highlighting/PKGBUILD
@@ -8,7 +8,6 @@ pkgrel=2
 pkgdesc="Nano editor syntax highlighting enhancements"
 arch=('any')
 depends=('nano')
-makedepends=('git')
 url="https://github.com/scopatz/nanorc"
 license=('custom')
 install=nano-syntax-highlighting.install

--- a/nano-syntax-highlighting/PKGBUILD
+++ b/nano-syntax-highlighting/PKGBUILD
@@ -4,7 +4,7 @@ pkgname=nano-syntax-highlighting
 conflicts=(${pkgname}-git)
 replaces=(${pkgname}-git)
 pkgver=2020.10.10
-pkgrel=1
+pkgrel=2
 pkgdesc="Nano editor syntax highlighting enhancements"
 arch=('any')
 depends=('nano')
@@ -12,8 +12,6 @@ makedepends=('git')
 url="https://github.com/scopatz/nanorc"
 license=('custom')
 install=nano-syntax-highlighting.install
-provides=('nano-syntax-highlighting')
-conflicts=('nano-syntax-highlighting')
 source=(https://github.com/scopatz/nanorc/releases/download/2020.10.10/nanorc-${pkgver}.tar.gz
         'nanorc.sample')
 sha256sums=('cd674e9eb230e4ba306b418c22d1891d93a3d2ffdf22234748d3398da50dfe64'


### PR DESCRIPTION
provides/conflicts seem to be left over from -git package.

	failure: nano-syntax-highlighting: circular reference nano-syntax-highlighting in provided packages
	failure: nano-syntax-highlighting: circular reference nano-syntax-highlighting in conflicted packages