### PR TITLE
Remove Gaphor DigitalOcean mirror

### DIFF
--- a/pacman-mirrors/PKGBUILD
+++ b/pacman-mirrors/PKGBUILD
@@ -2,7 +2,7 @@
 
 PKGEXT='.pkg.tar.xz'
 pkgname=pacman-mirrors
-pkgver=20201202
+pkgver=20201208
 pkgrel=1
 pkgdesc="MSYS2 mirror list for use by pacman"
 arch=('any')
@@ -11,9 +11,9 @@ license=('GPL')
 source=(mirrorlist.msys
         mirrorlist.mingw32
         mirrorlist.mingw64)
-sha256sums=('40c95fe552127b06ee090089892368067c2aad868c1dcf6f727908651f1c3b31'
-            '7e0b1ca850889b660e54bb7b537dfd15184d720aecc75b1cf63aa4ff5c48ac99'
-            '7cfeadc69eefc97e8a14675464df60922e6433a80d1a5239a4e0e05a695551a2')
+sha256sums=('61bf7e7fc186bfd8539b9b54c72207912c59ce7d3cae3ff926c2d8962990e4f2'
+            'c6bc5df4b9f89cd198a6bc54744e9fcea9329745cadf500a22e5046fa3ad7448'
+            'c6f6abda856c7863581978882edafb976cd57834ded646345c1b92092b349029')
 
 package() {
   mkdir -p ${pkgdir}/etc/pacman.d

--- a/pacman-mirrors/mirrorlist.md
+++ b/pacman-mirrors/mirrorlist.md
@@ -144,13 +144,6 @@ Access URLs:
 
 Contact: [Cameron Weinfurt](mailto:weinfuc@clarkson.edu)
 
-#### Gaphor Project Mirror
-Access URLs:
-
-- <https://msys2.nyc3.digitaloceanspaces.com/>
-
-Contact: [Dan Yeaw](mailto:dan@yeaw.me)
-
 ### Oregon
 #### Oregon State University
 Access URLS:

--- a/pacman-mirrors/mirrorlist.mingw32
+++ b/pacman-mirrors/mirrorlist.mingw32
@@ -12,7 +12,6 @@ Server = http://mirrors.ustc.edu.cn/msys2/mingw/i686/
 Server = http://mirror.bit.edu.cn/msys2/mingw/i686/
 Server = https://mirror.selfnet.de/msys2/mingw/i686/
 Server = https://mirrors.sjtug.sjtu.edu.cn/msys2/mingw/i686/
-Server = https://msys2.nyc3.digitaloceanspaces.com/mingw/i686/
 Server = https://mirror.jmu.edu/pub/msys2/mingw/i686/
 Server = https://ftp.cc.uoc.gr/mirrors/msys2/mingw/i686/
 Server = https://ftp.acc.umu.se/mirror/msys2.org/mingw/i686/

--- a/pacman-mirrors/mirrorlist.mingw64
+++ b/pacman-mirrors/mirrorlist.mingw64
@@ -12,7 +12,6 @@ Server = http://mirrors.ustc.edu.cn/msys2/mingw/x86_64/
 Server = http://mirror.bit.edu.cn/msys2/mingw/x86_64/
 Server = https://mirror.selfnet.de/msys2/mingw/x86_64/
 Server = https://mirrors.sjtug.sjtu.edu.cn/msys2/mingw/x86_64/
-Server = https://msys2.nyc3.digitaloceanspaces.com/mingw/x86_64/
 Server = https://mirror.jmu.edu/pub/msys2/mingw/x86_64/
 Server = https://ftp.cc.uoc.gr/mirrors/msys2/mingw/x86_64/
 Server = https://ftp.acc.umu.se/mirror/msys2.org/mingw/x86_64/

--- a/pacman-mirrors/mirrorlist.msys
+++ b/pacman-mirrors/mirrorlist.msys
@@ -12,7 +12,6 @@ Server = http://mirrors.ustc.edu.cn/msys2/msys/$arch/
 Server = http://mirror.bit.edu.cn/msys2/msys/$arch/
 Server = https://mirror.selfnet.de/msys2/msys/$arch/
 Server = https://mirrors.sjtug.sjtu.edu.cn/msys2/msys/$arch/
-Server = https://msys2.nyc3.digitaloceanspaces.com/msys/$arch/
 Server = https://mirror.jmu.edu/pub/msys2/msys/$arch/
 Server = https://ftp.cc.uoc.gr/mirrors/msys2/msys/$arch/
 Server = https://ftp.acc.umu.se/mirror/msys2.org/msys/$arch/


### PR DESCRIPTION
Now that we have expanded the number of mirrors, I am shutting down my mirror on DigitalOcean because I don't think it is needed any longer.