### PR TITLE
Changed Sourceforge mirror to be faster

### DIFF
--- a/pacman-mirrors/PKGBUILD
+++ b/pacman-mirrors/PKGBUILD
@@ -11,9 +11,9 @@ license=('GPL')
 source=(mirrorlist.msys
         mirrorlist.mingw32
         mirrorlist.mingw64)
-sha256sums=('94995ae1b850fbbdd57d9324dc6b441011bbf43cc1cca925ff6159c4852f7297'
-            'bea6d3f160b57b96f3b7e33b4d684beed53fefaafba5edaf57a822174c2b5faa'
-            '35556fec27d2ea877a3a2e7fafb770ecb19299495009f61fd03b3e50329c6770')
+sha256sums=('40c95fe552127b06ee090089892368067c2aad868c1dcf6f727908651f1c3b31'
+            '7e0b1ca850889b660e54bb7b537dfd15184d720aecc75b1cf63aa4ff5c48ac99'
+            '7cfeadc69eefc97e8a14675464df60922e6433a80d1a5239a4e0e05a695551a2')
 
 package() {
   mkdir -p ${pkgdir}/etc/pacman.d

--- a/pacman-mirrors/PKGBUILD
+++ b/pacman-mirrors/PKGBUILD
@@ -11,9 +11,9 @@ license=('GPL')
 source=(mirrorlist.msys
         mirrorlist.mingw32
         mirrorlist.mingw64)
-sha256sums=('abc41516adeaca59aee820d223e62f40b6514b7897c75695c985a6cfe6c41c66'
-            '635bcbad2057a0ff254b9cce14eaa2cc76210639de9d59ef3409fc52d4209a97'
-            '054cf20bf3e4c7cfc64c64494f3a460c531f03e9b0c2749ef7453d0ba4e22b5f')
+sha256sums=('94995ae1b850fbbdd57d9324dc6b441011bbf43cc1cca925ff6159c4852f7297'
+            'bea6d3f160b57b96f3b7e33b4d684beed53fefaafba5edaf57a822174c2b5faa'
+            '35556fec27d2ea877a3a2e7fafb770ecb19299495009f61fd03b3e50329c6770')
 
 package() {
   mkdir -p ${pkgdir}/etc/pacman.d

--- a/pacman-mirrors/PKGBUILD
+++ b/pacman-mirrors/PKGBUILD
@@ -2,7 +2,7 @@
 
 PKGEXT='.pkg.tar.xz'
 pkgname=pacman-mirrors
-pkgver=20201028
+pkgver=20201202
 pkgrel=1
 pkgdesc="MSYS2 mirror list for use by pacman"
 arch=('any')

--- a/pacman-mirrors/mirrorlist.md
+++ b/pacman-mirrors/mirrorlist.md
@@ -131,7 +131,7 @@ Contact: <ftp-adm@acc.umu.se>
 
 Access URLs:
 
-- <https://prdownloads.sourceforge.net/msys2/>
+- <https://downloads.sourceforge.net/project/msys2/>
 
 Contact: David Macek @elieux
 

--- a/pacman-mirrors/mirrorlist.md
+++ b/pacman-mirrors/mirrorlist.md
@@ -131,7 +131,7 @@ Contact: <ftp-adm@acc.umu.se>
 
 Access URLs:
 
-- <https://sourceforge.net/projects/msys2/files/REPOS/>
+- <https://prdownloads.sourceforge.net/msys2/>
 
 Contact: David Macek @elieux
 

--- a/pacman-mirrors/mirrorlist.mingw32
+++ b/pacman-mirrors/mirrorlist.mingw32
@@ -4,7 +4,7 @@
 
 ## Primary
 ## msys2.org
-Server = https://prdownloads.sourceforge.net/msys2/REPOS/MINGW/i686/
+Server = https://downloads.sourceforge.net/project/msys2/REPOS/MINGW/i686/
 Server = https://www2.futureware.at/~nickoe/msys2-mirror/mingw/i686/
 Server = https://mirror.yandex.ru/mirrors/msys2/mingw/i686/
 Server = https://mirrors.tuna.tsinghua.edu.cn/msys2/mingw/i686/

--- a/pacman-mirrors/mirrorlist.mingw32
+++ b/pacman-mirrors/mirrorlist.mingw32
@@ -4,7 +4,7 @@
 
 ## Primary
 ## msys2.org
-Server = https://sourceforge.net/projects/msys2/files/REPOS/MINGW/i686/
+Server = https://prdownloads.sourceforge.net/msys2/REPOS/MINGW/i686/
 Server = https://www2.futureware.at/~nickoe/msys2-mirror/mingw/i686/
 Server = https://mirror.yandex.ru/mirrors/msys2/mingw/i686/
 Server = https://mirrors.tuna.tsinghua.edu.cn/msys2/mingw/i686/

--- a/pacman-mirrors/mirrorlist.mingw64
+++ b/pacman-mirrors/mirrorlist.mingw64
@@ -4,7 +4,7 @@
 
 ## Primary
 ## msys2.org
-Server = https://prdownloads.sourceforge.net/msys2/REPOS/MINGW/x86_64/
+Server = https://downloads.sourceforge.net/project/msys2/REPOS/MINGW/x86_64/
 Server = https://www2.futureware.at/~nickoe/msys2-mirror/mingw/x86_64/
 Server = https://mirror.yandex.ru/mirrors/msys2/mingw/x86_64/
 Server = https://mirrors.tuna.tsinghua.edu.cn/msys2/mingw/x86_64/

--- a/pacman-mirrors/mirrorlist.mingw64
+++ b/pacman-mirrors/mirrorlist.mingw64
@@ -4,7 +4,7 @@
 
 ## Primary
 ## msys2.org
-Server = https://sourceforge.net/projects/msys2/files/REPOS/MINGW/x86_64/
+Server = https://prdownloads.sourceforge.net/msys2/REPOS/MINGW/x86_64/
 Server = https://www2.futureware.at/~nickoe/msys2-mirror/mingw/x86_64/
 Server = https://mirror.yandex.ru/mirrors/msys2/mingw/x86_64/
 Server = https://mirrors.tuna.tsinghua.edu.cn/msys2/mingw/x86_64/

--- a/pacman-mirrors/mirrorlist.msys
+++ b/pacman-mirrors/mirrorlist.msys
@@ -4,7 +4,7 @@
 
 ## Primary
 ## msys2.org
-Server = https://sourceforge.net/projects/msys2/files/REPOS/MSYS2/$arch/
+Server = https://prdownloads.sourceforge.net/msys2/REPOS/MSYS2/$arch/
 Server = https://www2.futureware.at/~nickoe/msys2-mirror/msys/$arch/
 Server = https://mirror.yandex.ru/mirrors/msys2/msys/$arch/
 Server = https://mirrors.tuna.tsinghua.edu.cn/msys2/msys/$arch/

--- a/pacman-mirrors/mirrorlist.msys
+++ b/pacman-mirrors/mirrorlist.msys
@@ -4,7 +4,7 @@
 
 ## Primary
 ## msys2.org
-Server = https://prdownloads.sourceforge.net/msys2/REPOS/MSYS2/$arch/
+Server = https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/$arch/
 Server = https://www2.futureware.at/~nickoe/msys2-mirror/msys/$arch/
 Server = https://mirror.yandex.ru/mirrors/msys2/msys/$arch/
 Server = https://mirrors.tuna.tsinghua.edu.cn/msys2/msys/$arch/


### PR DESCRIPTION
Changed sourceforge mirror URL so it has less redirections:
-   Old Sourceforge mirror: sourceforge.net
-   New Sourceforge mirror: downloads.sourceforge.net

Tested and it works fine for me.