### PR TITLE
curl: rebuild with libzstd; fix+rebuild pacman

### DIFF
--- a/curl/0001-more-static-fixes.patch
+++ b/curl/0001-more-static-fixes.patch
@@ -1,0 +1,10 @@
+--- curl-7.74.0/libcurl.pc.in.orig	2020-12-15 00:25:37.098392800 +0100
++++ curl-7.74.0/libcurl.pc.in	2020-12-15 00:25:44.117463900 +0100
+@@ -34,6 +34,7 @@
+ URL: https://curl.se/
+ Description: Library to transfer files with ftp, http, etc.
+ Version: @CURLVERSION@
++Requires.private: libidn2 libbrotlidec
+ Libs: -L${libdir} -lcurl @LIBCURL_NO_SHARED@
+ Libs.private: @LIBCURL_LIBS@
+ Cflags: -I${includedir} @CPPFLAG_CURL_STATICLIB@

--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -3,14 +3,14 @@
 pkgbase=curl
 pkgname=('curl' 'libcurl' 'libcurl-devel')
 pkgver=7.74.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Multi-protocol file transfer utility"
 arch=('i686' 'x86_64')
 url="https://curl.haxx.se"
 license=('MIT')
 depends=('ca-certificates')
 makedepends=('brotli-devel' 'heimdal-devel' 'libcrypt-devel' 'libidn2-devel' 'libmetalink-devel'
-             'libunistring-devel' 'libnghttp2-devel' 'libpsl-devel' 'libssh2-devel' 'openssl-devel' 'zlib-devel') #  'libcares-devel'
+             'libunistring-devel' 'libnghttp2-devel' 'libpsl-devel' 'libssh2-devel' 'openssl-devel' 'zlib-devel' 'libzstd-devel') #  'libcares-devel'
 options=('!libtool' 'strip' '!debug')
 source=("https://curl.haxx.se/download/${pkgname}-${pkgver}.tar.bz2"{,.asc}
         curl-7.55.1-msys2.patch
@@ -84,7 +84,7 @@ package_curl() {
 package_libcurl() {
   pkgdesc="Multi-protocol file transfer library (runtime)"
   depends=('brotli' 'ca-certificates' 'heimdal-libs' 'libcrypt' 'libidn2' 'libmetalink'
-          'libunistring' 'libnghttp2' 'libpsl' 'libssh2' 'openssl' 'zlib') #'libcares'
+          'libunistring' 'libnghttp2' 'libpsl' 'libssh2' 'openssl' 'zlib' 'libzstd') #'libcares'
   groups=('libraries')
 
   mkdir -p ${pkgdir}/usr/bin

--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=curl
 pkgname=('curl' 'libcurl' 'libcurl-devel')
 pkgver=7.74.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Multi-protocol file transfer utility"
 arch=('i686' 'x86_64')
 url="https://curl.haxx.se"
@@ -15,12 +15,14 @@ options=('!libtool' 'strip' '!debug')
 source=("https://curl.haxx.se/download/${pkgname}-${pkgver}.tar.bz2"{,.asc}
         curl-7.55.1-msys2.patch
         curl-7.58.0-libpsl-static-libs.patch
-        curl-7.60.0-gssapi-static-libs.patch)
+        curl-7.60.0-gssapi-static-libs.patch
+        0001-more-static-fixes.patch)
 sha256sums=('0f4d63e6681636539dc88fa8e929f934cd3a840c46e0bf28c73be11e521b77a5'
             'SKIP'
             'e5ba067afcfd726403cf7e6cb2349ff3fe6fe093c2853a4196a8f57f9f56d8d6'
             'ad3d76013c2dd683c44ad4cdc5108ea5218056c87b66f6ed2a90502e785a39af'
-            'd58a94556c031e550403ed13691305983bf83493f15fb8c35615e59bf265bbf7')
+            'd58a94556c031e550403ed13691305983bf83493f15fb8c35615e59bf265bbf7'
+            '870a91d09480cd0d1dc74119376350fc430e5223e2d4b3c0606af17793ecc310')
 validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2'   # Daniel Stenberg
               '914C533DF9B2ADA2204F586D78E11C6B279D5C91')  # Daniel Stenberg (old key)
 
@@ -29,6 +31,9 @@ prepare() {
   patch -p1 -i ${srcdir}/curl-7.58.0-libpsl-static-libs.patch
   patch -p1 -i ${srcdir}/curl-7.55.1-msys2.patch
   patch -p1 -i ${srcdir}/curl-7.60.0-gssapi-static-libs.patch
+
+  # https://github.com/curl/curl/discussions/6324
+  patch -p1 -i ${srcdir}/0001-more-static-fixes.patch
 
   autoreconf -fiv
 }

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -5,7 +5,7 @@
 PKGEXT='.pkg.tar.xz'
 pkgname=pacman
 pkgver=5.2.2
-pkgrel=4
+pkgrel=5
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"


### PR DESCRIPTION
somehow the libcurl.pc was missing libraries in Libs.private, but rebuilding it locally helped.. let's try again in CI.