### PR TITLE
base: depend on nano

### DIFF
--- a/base/PKGBUILD
+++ b/base/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
 
 pkgname=base
-pkgver=2020.05
-pkgrel=2
+pkgver=2020.12
+pkgrel=1
 pkgdesc='Minimal package set to define a basic MSYS2 installation'
 url='https://www.msys2.org'
 arch=('any')
@@ -29,6 +29,7 @@ depends=(
   'msys2-keyring'
   'msys2-launcher'
   'msys2-runtime'
+  'nano'
   'pacman'
   'pacman-contrib'
   'pacman-mirrors'


### PR DESCRIPTION
It's nice to have at least one CLI editor in the base install, to
edit config files, write commit messages etc.

Fixes #2244