### PR TITLE
mingw-w64-cross-compiler-rt: set ASMFLAGS

### DIFF
--- a/mingw-w64-cross-compiler-rt/PKGBUILD
+++ b/mingw-w64-cross-compiler-rt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=compiler-rt
 _mingw_suff=mingw-w64-cross
 pkgname=("${_mingw_suff}-${_realname}")
 pkgver=11.0.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Compiler runtime libraries for cross clang"
 arch=('i686' 'x86_64')
 url="https://llvm.org"
@@ -32,7 +32,9 @@ build() {
   mkdir build-${CARCH} && cd build-${CARCH}
 
   export CC="clang" CXX="clang++" AS="clang" AR="llvm-ar" RANLIB="llvm-ranlib" DLLTOOL="llvm-dlltool" LD="clang"
+  export ASMFLAGS
 
+  ASMFLAGS+=" -target ${_target} --sysroot=/opt/${_target}"
   CFLAGS+=" -target ${_target} --sysroot=/opt/${_target}"
   CPPFLAGS+=" -target ${_target} --sysroot=/opt/${_target}"
   CXXFLAGS+=" -target ${_target} --sysroot=/opt/${_target}"


### PR DESCRIPTION
like CFLAGS et al, -target should be set for clang when used as an assembler.

This does not appear to be necessary for mingw-w64-cross-clang based on looking at `compile_commands.json`