### PR TITLE
Add guile 3.0 (3.0.4) but in separate package dir than guile(2)

### DIFF
--- a/guile3/0002-Remove-version-in-file-name-of-dynamic-library-guile.patch
+++ b/guile3/0002-Remove-version-in-file-name-of-dynamic-library-guile.patch
@@ -1,0 +1,31 @@
+From dd6c5b70fa0dc66b569a1aacd84b45e417af0372 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hannes=20M=C3=BCller?= <h.c.f.mueller@gmx.de>
+Date: Wed, 26 Apr 2017 10:41:47 +0200
+Subject: [PATCH] Remove version in file name of dynamic library guile-readline
+To: guile-devel@gnu.org
+
+* guile-readline/Makefile.am: Add -avoid-version to guile_readline_la_LDFLAGS.
+Dynamic library guile-readline resides in a "major-version"."minor-version"
+directory. Therefore no additional versioning is required. The patch allows
+standard installation on MSYS2, which is done without .la files.
+---
+ guile-readline/Makefile.am | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/guile-readline/Makefile.am b/guile-readline/Makefile.am
+index ade7dd09d..36c2f5415 100644
+--- a/guile-readline/Makefile.am
++++ b/guile-readline/Makefile.am
+@@ -51,7 +51,8 @@ guile_readline_la_LIBADD =				\
+   $(READLINE_LIBS)					\
+   ../libguile/libguile-@GUILE_EFFECTIVE_VERSION@.la ../lib/libgnu.la
+ 
+-guile_readline_la_LDFLAGS = -export-dynamic -no-undefined -module
++guile_readline_la_LDFLAGS = -export-dynamic		\
++			    -no-undefined -module -avoid-version
+ 
+ BUILT_SOURCES = readline.x
+ 
+-- 
+2.12.1
+

--- a/guile3/0101-In-tests-add-dynamic-link-to-msys-2.0-for-host-type-msys.patch
+++ b/guile3/0101-In-tests-add-dynamic-link-to-msys-2.0-for-host-type-msys.patch
@@ -1,0 +1,42 @@
+From 35904c82828ec1ba285385192f0578f6cd9f7792 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hannes=20M=C3=BCller?= <h.c.f.mueller@gmx.de>
+Date: Tue, 17 Oct 2017 18:42:51 +0200
+Subject: [PATCH] In tests add dynamic-link to msys-2.0 for host-type msys
+
+MSYS2 behaves like Cygwin. Therefore treat them alike.
+---
+ test-suite/standalone/test-ffi                | 3 +++
+ test-suite/standalone/test-foreign-object-scm | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/test-suite/standalone/test-ffi b/test-suite/standalone/test-ffi
+index 0e6ab45d1..eb0a0d28f 100755
+--- a/test-suite/standalone/test-ffi
++++ b/test-suite/standalone/test-ffi
+@@ -269,6 +269,9 @@ exec guile -q -s "$0" "$@"
+                  ;; into linked DLLs. Thus one needs to link to the core
+                  ;; C library DLL explicitly.
+                  (dynamic-link "cygwin1"))
++                ((string-contains %host-type "msys")
++                 ;; MSYS2 behaves like Cygwin
++                 (dynamic-link "msys-2.0"))
+                 (else
+                  (dynamic-link))))
+ 
+diff --git a/test-suite/standalone/test-foreign-object-scm b/test-suite/standalone/test-foreign-object-scm
+index fd4669aa9..0c4114d2a 100755
+--- a/test-suite/standalone/test-foreign-object-scm
++++ b/test-suite/standalone/test-foreign-object-scm
+@@ -35,6 +35,9 @@ exec guile -q -s "$0" "$@"
+                          ;; needs to link to the core C library DLL
+                          ;; explicitly.
+                          (dynamic-link "cygwin1"))
++                        ((string-contains %host-type "msys")
++                         ;; MSYS2 behaves like Cygwin
++                         (dynamic-link "msys-2.0"))
+                         (else
+                          (dynamic-link)))))
+     (lambda (k . args)
+-- 
+2.14.2
+

--- a/guile3/0102-Skip-tests-using-setrlimit-for-MSYS-as-done-for-Cygwin.patch
+++ b/guile3/0102-Skip-tests-using-setrlimit-for-MSYS-as-done-for-Cygwin.patch
@@ -1,0 +1,52 @@
+From a64825ffa6be30bcb876557383dbdd106da51c99 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hannes=20M=C3=BCller?= <h.c.f.mueller@gmx.de>
+Date: Tue, 17 Oct 2017 19:12:41 +0200
+Subject: [PATCH] Skip tests using setrlimit for MSYS as done for Cygwin
+
+MSYS2 behaves like Cygwin. Therefore treat them alike.
+---
+ test-suite/standalone/test-out-of-memory  | 8 ++++++++
+ test-suite/standalone/test-stack-overflow | 8 ++++++++
+ 2 files changed, 16 insertions(+)
+
+diff --git a/test-suite/standalone/test-out-of-memory b/test-suite/standalone/test-out-of-memory
+index 221651270..4e5ecc81f 100755
+--- a/test-suite/standalone/test-out-of-memory
++++ b/test-suite/standalone/test-out-of-memory
+@@ -23,6 +23,14 @@ exec guile -q -s "$0" "$@"
+   ;; test-stack-overflow.
+   (exit 77)) ; unresolved
+ 
++(when (string-contains-ci (vector-ref (uname) 0) "MSYS_NT")
++  ;; attempting to use setrlimit for memory RLIMIT_AS will always
++  ;; produce an invalid argument error on MSYS2 (tested on
++  ;; MSYS_NT-6.1-WOW DLL v2.9.0).  Proceeding with the test would fill
++  ;; all available memory and probably end in a crash.  See also
++  ;; test-stack-overflow.
++  (exit 77)) ; unresolved
++
+ (catch #t
+   ;; Silence GC warnings.
+   (lambda ()
+diff --git a/test-suite/standalone/test-stack-overflow b/test-suite/standalone/test-stack-overflow
+index dd54249d8..83e929159 100755
+--- a/test-suite/standalone/test-stack-overflow
++++ b/test-suite/standalone/test-stack-overflow
+@@ -23,6 +23,14 @@ exec guile -q -s "$0" "$@"
+   ;; test-out-of-memory.
+   (exit 77)) ; unresolved
+ 
++(when (string-contains-ci (vector-ref (uname) 0) "MSYS_NT")
++  ;; attempting to use setrlimit for memory RLIMIT_AS will always
++  ;; produce an invalid argument error on MSYS2 (tested on
++  ;; MSYS_NT-6.1-WOW DLL v2.9.0).  Proceeding with the test would fill
++  ;; all available memory and probably end in a crash.  See also
++  ;; test-out-of-memory.
++  (exit 77)) ; unresolved
++
+ ;; 100 MB.
+ (define *limit* (* 100 1024 1024))
+ 
+-- 
+2.14.2
+

--- a/guile3/0103-Activate-test-pthread-create-secondary-for-CYGWIN-MSYS.patch
+++ b/guile3/0103-Activate-test-pthread-create-secondary-for-CYGWIN-MSYS.patch
@@ -1,0 +1,35 @@
+From 6620b25a564f01468ab4aaa895cfcd4f75424f08 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hannes=20M=C3=BCller?= <h.c.f.mueller@gmx.de>
+Date: Tue, 17 Oct 2017 19:23:39 +0200
+Subject: [PATCH] Activate test-pthread-create-secondary for CYGWIN/MSYS
+
+This test is passed on CYGWIN/MSYS
+---
+ test-suite/standalone/test-pthread-create-secondary.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/test-suite/standalone/test-pthread-create-secondary.c b/test-suite/standalone/test-pthread-create-secondary.c
+index 14ea240a4..aedb3b8fb 100644
+--- a/test-suite/standalone/test-pthread-create-secondary.c
++++ b/test-suite/standalone/test-pthread-create-secondary.c
+@@ -39,7 +39,7 @@
+    Maidanski.  See <http://thread.gmane.org/gmane.lisp.guile.bugs/5340>
+    for details.  */
+ 
+-#if defined __linux__						\
++#if (defined __linux__ || defined __CYGWIN__)			\
+   && (GC_VERSION_MAJOR > 7					\
+       || (GC_VERSION_MAJOR == 7 && GC_VERSION_MINOR > 2)	\
+       || (GC_VERSION_MAJOR == 7 && GC_VERSION_MINOR == 2	\
+@@ -78,7 +78,7 @@ main (int argc, char *argv[])
+ }
+ 
+ 
+-#else /* Linux && GC < 7.2alpha5 */
++#else /* !(Linux || Cygwin) || GC < 7.2alpha5 */
+ 
+ int
+ main (int argc, char *argv[])
+-- 
+2.14.2
+

--- a/guile3/PKGBUILD
+++ b/guile3/PKGBUILD
@@ -1,0 +1,101 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+pkgbase=guile
+# don't forget to update package_libguilex.y below with guilever manually
+guilever=3.0
+pkgname=("${pkgbase}" "lib${pkgbase}${guilever}" "lib${pkgbase}-devel")
+pkgver=${guilever}.4
+pkgrel=1
+pkgdesc="a portable, embeddable Scheme implementation written in C"
+url="https://www.gnu.org/software/guile/"
+arch=(i686 x86_64)
+license=('GPL')
+makedepends=('libltdl' 'gmp-devel' 'ncurses-devel' 'libunistring-devel' 'libgc-devel' 'libffi-devel' 'texinfo' 'libreadline-devel>=7.0.0')
+source=("https://ftp.gnu.org/pub/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz"
+        0002-Remove-version-in-file-name-of-dynamic-library-guile.patch
+        0101-In-tests-add-dynamic-link-to-msys-2.0-for-host-type-msys.patch
+        0102-Skip-tests-using-setrlimit-for-MSYS-as-done-for-Cygwin.patch
+        0103-Activate-test-pthread-create-secondary-for-CYGWIN-MSYS.patch)
+options=('!libtool')
+sha256sums=('6b7947dc2e3d115983846a268b8f5753c12fd5547e42fbf2b97d75a3b79f0d31'
+            '440d31e6100bf896fcd5d65209da42bfeec43f154fa023fceeae911194ecb15c'
+            '7b06f92cca1b10f1006f53f27b0ed0c653eaa3a1de3732b69364e28b1b36fd1e'
+            '31124d7053454eb082a815b8d15249621dfb92aff50400090854d1f47b174f25'
+            'b66d33a35942c4d4575d169974f91f3e525f6de4fb82e61dc70723e0a43123d6')
+
+prepare() {
+  cd "${srcdir}/${pkgbase}-${pkgver}"
+
+  patch -p1 -i ${srcdir}/0002-Remove-version-in-file-name-of-dynamic-library-guile.patch
+  
+  patch -p1 -i ${srcdir}/0101-In-tests-add-dynamic-link-to-msys-2.0-for-host-type-msys.patch
+  patch -p1 -i ${srcdir}/0102-Skip-tests-using-setrlimit-for-MSYS-as-done-for-Cygwin.patch
+  patch -p1 -i ${srcdir}/0103-Activate-test-pthread-create-secondary-for-CYGWIN-MSYS.patch
+
+  autoreconf -fi
+}
+
+build() {
+  cd "${srcdir}/${pkgbase}-${pkgver}"
+  ./configure \
+    --build=${CHOST} \
+    --prefix=/usr \
+    --disable-debug-malloc \
+    --disable-guile-debug \
+    --disable-error-on-warning \
+    --disable-rpath \
+    --enable-deprecated \
+    --enable-networking \
+    --enable-nls \
+    --enable-posix \
+    --enable-regex \
+    --with-threads \
+    --with-modules \
+    --disable-static
+  make
+  make DESTDIR="${srcdir}/dest" install
+}
+
+package_guile() {
+  depends=("lib${pkgbase}${guilever}=${pkgver}" 'info')
+  install=${pkgbase}.install
+
+  mkdir -p ${pkgdir}/usr/bin
+  cp -rf ${srcdir}/dest/usr/bin ${pkgdir}/usr/
+  rm -f ${pkgdir}/usr/bin/*.dll
+  rm -f ${pkgdir}/usr/bin/*-config
+
+  mkdir -p ${pkgdir}/usr/share
+  cp -rf ${srcdir}/dest/usr/share/info ${pkgdir}/usr/share/
+  cp -rf ${srcdir}/dest/usr/share/man ${pkgdir}/usr/share/
+}
+
+# libguile name with version to allow for different parallel installations
+package_libguile3.0() {
+  depends=('gmp' 'libltdl' 'ncurses' 'libunistring' 'libgc' 'libffi' 'libreadline>=7.0.0')
+  groups=('libraries')
+
+  mkdir -p ${pkgdir}/usr/bin
+  install -Dm755 ${srcdir}/dest/usr/bin/*.dll ${pkgdir}/usr/bin/
+
+  mkdir -p ${pkgdir}/usr/share
+  cp -rf ${srcdir}/dest/usr/share/guile ${pkgdir}/usr/share/
+
+  mkdir -p ${pkgdir}/usr/lib
+  cp -rf ${srcdir}/dest/usr/lib/guile ${pkgdir}/usr/lib/
+}
+
+package_libguile-devel() {
+  depends=("lib${pkgbase}${guilever}=${pkgver}")
+  groups=('development')
+  options=('staticlibs')
+
+  mkdir -p ${pkgdir}/usr/bin
+  install -Dm755 ${srcdir}/dest/usr/bin/*-config ${pkgdir}/usr/bin/
+  cp -rf ${srcdir}/dest/usr/include ${pkgdir}/usr/
+  mkdir -p ${pkgdir}/usr/lib
+  cp -rf ${srcdir}/dest/usr/lib/*.a ${pkgdir}/usr/lib/
+  cp -rf ${srcdir}/dest/usr/lib/pkgconfig ${pkgdir}/usr/lib/
+  mkdir -p ${pkgdir}/usr/share
+  cp -rf ${srcdir}/dest/usr/share/aclocal ${pkgdir}/usr/share/
+}

--- a/guile3/guile.install
+++ b/guile3/guile.install
@@ -1,0 +1,32 @@
+infodir=/usr/share/info
+filelist="guile.info
+          guile.info-1
+          guile.info-2
+          guile.info-3
+          guile.info-4
+          guile.info-5
+          guile.info-6
+          guile.info-7
+          guile.info-8
+          guile.info-9
+          guile.info-10
+          guile.info-11
+          r5rs.info"
+
+post_install() {
+  [ -x usr/bin/install-info ] || return 0
+  for file in ${filelist}; do
+    install-info $infodir/$file.gz $infodir/dir 2> /dev/null
+  done
+}
+
+post_upgrade() {
+  post_install $1
+}
+
+pre_remove() {
+  [ -x usr/bin/install-info ] || return 0
+  for file in ${filelist}; do
+    install-info --delete $infodir/$file.gz $infodir/dir 2> /dev/null
+  done
+}


### PR DESCRIPTION
This allows parallel installation of libguile and does not break existing
dependencies to libguile 2.2. Therefore the libguile package name includes
the version 3.0, i.e. libguile3.0-3.0.4-1-i686.pkg.tar.zst