### PR TITLE
mingw-w64-cross-clang arm and aarch64 targets

### DIFF
--- a/mingw-w64-cross-clang-crt/PKGBUILD
+++ b/mingw-w64-cross-clang-crt/PKGBUILD
@@ -5,7 +5,7 @@ _mingw_suff=mingw-w64-cross-clang
 pkgname=("${_mingw_suff}-${_realname}")
 conflicts=("${_mingw_suff%-*}-${_realname}")
 pkgver=9.0.0.6158.1c773877
-pkgrel=1
+pkgrel=2
 pkgdesc='MinGW-w64 CRT for cross-compiler'
 arch=('i686' 'x86_64')
 url='https://mingw-w64.sourceforge.io/'
@@ -18,7 +18,7 @@ _commit='1c773877f4a13c8bd7bfb8da80e1e8761a889f51'
 source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit")
 sha256sums=('SKIP')
 
-_targets="x86_64-w64-mingw32 i686-w64-mingw32" #armv7-w64-mingw32
+_targets="x86_64-w64-mingw32 i686-w64-mingw32 armv7-w64-mingw32 aarch64-w64-mingw32"
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
@@ -44,6 +44,9 @@ build() {
     ;;
     armv7*)
       _crt_configure_args="--disable-lib32 --disable-lib64 --enable-libarm32"
+    ;;
+    aarch64*)
+      _crt_configure_args="--disable-lib32 --disable-lib64 --disable-libarm32 --enable-libarm64"
     ;;
   esac
     mkdir -p ${srcdir}/crt-${_target} && cd ${srcdir}/crt-${_target}

--- a/mingw-w64-cross-clang-headers/PKGBUILD
+++ b/mingw-w64-cross-clang-headers/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${_mingw_suff}-${_realname}")
 conflicts=("${_mingw_suff%-*}-${_realname}")
 pkgdesc="MinGW-w64 headers for cross-compiler"
 pkgver=9.0.0.6158.1c773877
-pkgrel=1
+pkgrel=2
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
 license=('custom')
@@ -17,7 +17,7 @@ _commit='1c773877f4a13c8bd7bfb8da80e1e8761a889f51'
 source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit")
 sha256sums=('SKIP')
 
-_targets="i686-w64-mingw32 x86_64-w64-mingw32 armv7-w64-mingw32"
+_targets="i686-w64-mingw32 x86_64-w64-mingw32 armv7-w64-mingw32 aarch64-w64-mingw32"
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
@@ -36,13 +36,24 @@ build() {
     msg "Configuring ${_target} headers"
     mkdir -p ${srcdir}/headers-${_target} && cd ${srcdir}/headers-${_target}
 
+    local _default_win32_winnt
+    case "${_target%%-*}" in
+      i686|x86_64)
+        _default_win32_winnt=0x601
+        ;;
+      *)
+        # assume any new arches added will be at least Win10
+        _default_win32_winnt=0xA00
+        ;;
+    esac
+
     ${srcdir}/mingw-w64/mingw-w64-headers/configure \
     --build=${CHOST} \
     --host=${_target} \
     --prefix=/opt/${_target} \
     --enable-sdk=all \
     --enable-secure-api \
-    --with-default-win32-winnt=0x601 \
+    --with-default-win32-winnt=${_default_win32_winnt} \
     --with-default-msvcrt=ucrt
   done
 }

--- a/mingw-w64-cross-clang/PKGBUILD
+++ b/mingw-w64-cross-clang/PKGBUILD
@@ -46,7 +46,7 @@ prepare() {
 
 build() {
   for _target in ${_targets}; do
-    export CC="clang" CXX="clang++" AS="clang" AR="llvm-ar" RANLIB="llvm-ranlib" DLLTOOL="llvm-dlltool" LD="clang"
+    export CC="clang" CXX="clang++" ASM="clang" AR="llvm-ar" RANLIB="llvm-ranlib" DLLTOOL="llvm-dlltool" LD="clang"
 
     CFLAGS+=" -target ${_target} --sysroot=/opt/${_target} -rtlib=compiler-rt"
     CPPFLAGS+=" -target ${_target} --sysroot=/opt/${_target}"
@@ -56,6 +56,11 @@ build() {
     # Force win32 threads for libc++abi
     export CXXFLAGS+=" -D_LIBCPP_HAS_THREAD_API_WIN32"
     COMMON_CMAKE_ARGS=(-G'Unix Makefiles'
+      -DCMAKE_AR="$(which llvm-ar)"
+      -DCMAKE_ASM_COMPILER="clang"
+      -DCMAKE_C_COMPILER="clang"
+      -DCMAKE_CXX_COMPILER="clang++"
+      -DCMAKE_RANLIB="$(which llvm-ranlib)"
       -DCMAKE_BUILD_TYPE=Release
       -DCMAKE_C_COMPILER_WORKS=ON
       -DCMAKE_CROSSCOMPILING=ON

--- a/mingw-w64-cross-clang/PKGBUILD
+++ b/mingw-w64-cross-clang/PKGBUILD
@@ -4,7 +4,7 @@ _realname=clang
 _mingw_suff=mingw-w64-cross
 pkgname=("${_mingw_suff}-${_realname}")
 pkgver=11.0.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Cross Clang for the MinGW-w64"
 groups=("${_mingw_suff}-${_realname}-toolchain")
 arch=('i686' 'x86_64')
@@ -30,7 +30,7 @@ validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Googl
               '474E22316ABF4785A88C6E8EA2C794A986419D8A') # Tom Stellard
 noextract=(libcxx-${pkgver}.src.tar.xz)
 
-_targets="x86_64-w64-mingw32 i686-w64-mingw32"
+_targets="x86_64-w64-mingw32 i686-w64-mingw32 armv7-w64-mingw32 aarch64-w64-mingw32"
 
 prepare() {
   plain "Extracting libcxx-${pkgver}.src.tar.xz due to symlink(s) without pre-existing target(s)"

--- a/mingw-w64-cross-compiler-rt/PKGBUILD
+++ b/mingw-w64-cross-compiler-rt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=compiler-rt
 _mingw_suff=mingw-w64-cross
 pkgname=("${_mingw_suff}-${_realname}")
 pkgver=11.0.0
-pkgrel=5
+pkgrel=6
 pkgdesc="Compiler runtime libraries for cross clang"
 arch=('i686' 'x86_64')
 url="https://llvm.org"
@@ -19,7 +19,7 @@ sha256sums=('374aff82ff573a449f9aabbd330a5d0a441181c535a3599996127378112db234'
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A') # Tom Stellard
 
-_targets="x86_64-w64-mingw32 i686-w64-mingw32"
+_targets="x86_64-w64-mingw32 i686-w64-mingw32 armv7-w64-mingw32 aarch64-w64-mingw32"
 
 prepare() {
   cd ${srcdir}
@@ -28,14 +28,20 @@ prepare() {
 build() {
   for _target in ${_targets}; do
     cd "${srcdir}"
+    _llvmtarget=${_target%%-*}
     case "${_target}" in
       x86_64*)
         _sizeof_void_p=8
-        _llvmtarget=x86_64
         ;;
-      i686*)
+      i?86*)
         _sizeof_void_p=4
         _llvmtarget=i386
+        ;;
+      aarch64*)
+        _sizeof_void_p=8
+        ;;
+      armv7*)
+        _sizeof_void_p=4
         ;;
     esac
 
@@ -83,6 +89,10 @@ package() {
     fi
     cd $srcdir/build-${_target}
     mkdir -p "${pkgdir}/usr/lib/clang/${pkgver}/lib/windows"
-    cp "lib/windows/libclang_rt.builtins-${_llvmtarget}.a" "${pkgdir}/usr/lib/clang/${pkgver}/lib/windows"
+    if [[ ${_llvmtarget} == armv7 ]]; then
+      cp "lib/windows/libclang_rt.builtins-${_llvmtarget}.a" "${pkgdir}/usr/lib/clang/${pkgver}/lib/windows/libclang_rt.builtins-arm.a"
+    else
+      cp "lib/windows/libclang_rt.builtins-${_llvmtarget}.a" "${pkgdir}/usr/lib/clang/${pkgver}/lib/windows"
+    fi
   done
 }

--- a/mingw-w64-cross-compiler-rt/PKGBUILD
+++ b/mingw-w64-cross-compiler-rt/PKGBUILD
@@ -48,7 +48,7 @@ build() {
     [[ -d build-${_target} ]] && rm -rf build-${_target}
     mkdir build-${_target} && cd build-${_target}
 
-    export CC="clang" CXX="clang++" AS="clang" AR="llvm-ar" RANLIB="llvm-ranlib" DLLTOOL="llvm-dlltool" LD="clang"
+    export CC="clang" CXX="clang++" ASM="clang" AR="llvm-ar" RANLIB="llvm-ranlib" DLLTOOL="llvm-dlltool" LD="clang"
     export ASMFLAGS
 
     ASMFLAGS+=" -target ${_target} --sysroot=/opt/${_target}"
@@ -59,6 +59,11 @@ build() {
 
     cmake \
       -G'Ninja' \
+      -DCMAKE_AR="$(which llvm-ar)" \
+      -DCMAKE_ASM_COMPILER="clang" \
+      -DCMAKE_C_COMPILER="clang" \
+      -DCMAKE_CXX_COMPILER="clang++" \
+      -DCMAKE_RANLIB="$(which llvm-ranlib)" \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_C_COMPILER_TARGET=${_llvmtarget}-windows-gnu \
       -DCMAKE_C_COMPILER_WORKS=ON \


### PR DESCRIPTION
This PR adds armv7-w64-mingw32 and aarch64-w64-mingw32 targets for mingw-w64-cross-clang{,-headers,-crt} and mingw-w64-cross-compiler-rt.