### PR TITLE
clang: package clang-tblgen.exe

### DIFF
--- a/clang/PKGBUILD
+++ b/clang/PKGBUILD
@@ -12,10 +12,10 @@ else
 fi
 
 _realname=clang
-pkgbase=mingw-w64-${_realname}
+pkgbase=${_realname}
 pkgname=("${_realname}" "lld" "llvm")
 pkgver=11.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM"
 arch=('i686' 'x86_64')
 url="https://llvm.org/"
@@ -120,7 +120,7 @@ prepare() {
       "0305-Msysize.patch"
 
   cd "${srcdir}"
-  rm -rf clang lldb | true
+  rm -rf clang lld | true
   mv "${srcdir}/clang-${pkgver}.src"             clang
   mv "${srcdir}/lld-${pkgver}.src"               lld
 }
@@ -183,6 +183,8 @@ package_clang() {
   # Install static libraries
   install -Dm644 ../build-${CARCH}/lib/libclang.a ${pkgdir}/usr/lib/libclang.a
   install -Dm644 ../build-${CARCH}/lib/libclang.a ${pkgdir}/usr/lib/libclang_static.a
+  # clang-tblgen is needed to cross-compile clang.
+  install -Dm755 "${srcdir}"/build-${CARCH}/bin/clang-tblgen.exe "${pkgdir}/usr/bin/clang-tblgen.exe"
 }
 
 package_lld() {


### PR DESCRIPTION
Needed for cross-compiling clang.  `llvm-tblgen` was already installed, but `clang-tblgen` was not.

Also fixed pkgbase, and a reference to lldb where it meant lld.

With this, #2294, and some hacks not yet ready for light of day, was able to use [msys2/CLANG-packages' mingw-w64-clang PKGBUILD](https://github.com/msys2/CLANG-packages/tree/bootstrap/mingw-w64-clang) to cross-compile clang for aarch64-w64-mingw32.

I haven't tested it yet, my raspberry pi is still trying to build the same 'native' and probably won't finish any time soon 😉 