### PR TITLE
zsh: make zpty module work

### DIFF
--- a/zsh/PKGBUILD
+++ b/zsh/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=zsh
 pkgname=('zsh' 'zsh-doc')
 pkgver=5.8
-pkgrel=3
+pkgrel=4
 arch=('i686' 'x86_64')
 url='https://www.zsh.org/'
 license=('custom')
@@ -18,20 +18,22 @@ source=("https://www.zsh.org/pub/zsh-${pkgver}.tar.xz"{,.asc}
         add-pwd-W-option.patch
         msysize.patch
         zsh-5.0.6-1.patch
-        msys-symlink-hack.patch)
+        msys-symlink-hack.patch
+        fix-zpty-module.patch)
 sha256sums=('dcc4b54cc5565670a65581760261c163d720991f0d06486da61f8d839b52de27'
             'SKIP'
             '9b4e939593cb5a76564d2be2e2bfbb6242509c0c56fd9ba52f5dba6cf06fdcc4'
             'SKIP'
-            'c081ced2d645e3b107fbf864529cc0e5954399a09b87a4f1d300470854b6dea4'
-            'f08fe8f207c0fa6d722312774c28365024682333f5547c8192d0547957b000af'
+            'a41df3c465f3704faf331f052c4c3975f656436902d1778e81e16b5b511fb5ed'
+            'd15bed73e5596867e584b20fc21b1c5a1a84203b25f50fddd543b77a3e8d1876'
             '230832038c3b8f67fdb1b284ac5f68d709cdb7f1bc752b0e60657b9b9d091045'
             '06c05faa800cb7385b606fd2b3c9aa24cfac07d1dde7f0d2f017c11ede9b2ac8'
             '971e48433ec40e0c2fb64584b5555367b4f997156aa9acbd06c67d7bdacd6c59'
             'b3f74a10a27eff498124adc96bc8c5cced7bb15e18c2603d7c3490a81e3c2e48'
             'b879d33cc60fc0c44361189eef1ee95a3bd0b8f9e8b32c81e439950483c151aa'
             '336a8e6e93b778e7aec27348619b7200e0a75e5cf14dce720afd9dd6f836ea2c'
-            'de515b0d86c13c29a663b4ba0fdb338dea83f82f145cf8c4da78d30369f963e4')
+            'de515b0d86c13c29a663b4ba0fdb338dea83f82f145cf8c4da78d30369f963e4'
+            '3aa6a7c2e67bcd51c5bf1890c26b221171e9baae3adfc661e2a2882c302f562a')
 validpgpkeys=('F7B2754C7DE2830914661F0EA71D9A9D4BDB27B3'
               'E96646BE08C0AF0AA0F90788A5FEEE3AC7937444'
               '7CA7ECAAF06216B90F894146ACF8146CAE8CBBC4')
@@ -43,6 +45,8 @@ prepare() {
   patch -p1 -i "${srcdir}/msysize.patch"
   patch -p1 -i "${srcdir}/zsh-5.0.6-1.patch"
   patch -p1 -i "${srcdir}/msys-symlink-hack.patch"
+  # https://cygwin.com/pipermail/cygwin-developers/2021-January/012030.html
+  patch -p1 -i "${srcdir}/fix-zpty-module.patch"
 
   autoreconf -fiv
 

--- a/zsh/fix-zpty-module.patch
+++ b/zsh/fix-zpty-module.patch
@@ -1,0 +1,33 @@
+diff --git a/Src/Modules/zpty.c b/Src/Modules/zpty.c
+index 45fd15ee0..eadb7ceac 100644
+--- a/Src/Modules/zpty.c
++++ b/Src/Modules/zpty.c
+@@ -428,6 +428,7 @@ newptycmd(char *nam, char *pname, char **args, int echo, int nblock)
+ 	mypid = 0; /* trick to ensure we _exit() */
+ 	zexit(lastval, ZEXIT_NORMAL);
+     }
++#ifndef __CYGWIN__
+     master = movefd(master);
+     if (master == -1) {
+ 	zerrnam(nam, "cannot duplicate fd %d: %e", master, errno);
+@@ -435,6 +436,7 @@ newptycmd(char *nam, char *pname, char **args, int echo, int nblock)
+ 	ineval = oineval;
+ 	return 1;
+     }
++#endif
+ 
+     p = (Ptycmd) zalloc(sizeof(*p));
+ 
+diff --git a/configure.ac b/configure.ac
+index bd1b40225..3b0cc1f53 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2504,7 +2504,7 @@ if test x$ac_cv_have_dev_ptmx = xyes -o x$ac_cv_func_posix_openpt = xyes && \
+    test x$ac_cv_func_ptsname = xyes; then
+    AC_CACHE_CHECK([if /dev/ptmx is usable],
+    ac_cv_use_dev_ptmx,
+-   [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#ifdef __linux
++   [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#if defined(__linux) || defined(__CYGWIN__)
+ #define _GNU_SOURCE 1
+ #endif
+ #include <stdlib.h>


### PR DESCRIPTION
make zsh/zpty work with msys2, and can pass most mafredri/zsh-async#26 test.

```c
    master = movefd(master);
    if (master == -1) {
	zerrnam(nam, "cannot duplicate fd %d: %e", master, errno);
	scriptname = oscriptname;
	ineval = oineval;
	return 1;
    }
```

Since cygwin uses two threads to process the pseudoterminal master device, zpty calls the `movefd` method to move the file description of the master device, and cygwin disposed the original `fhandler_pty_master` object, which causes the process thread to run incorrectly. here simply disable the zpty move the master device file descriptor untill cygwin upstream fix this issue.

-  zpty error strace

```
   30 27794711 [main] zsh 1918 fhandler_pty_master::cleanup: /dev/ptmx closing master, usecount 0
   43 27794754 [main] zsh 1918 fhandler_pty_master::close: closing from_master(0x310)/from_master_cyg(0x310)/to_master(0x264)/to_master_cyg(0x31C) since we own them(0)
   38 27794792 [main] zsh 1918 fhandler_pty_master::close: (2420): pty output_mutex (0x1F8): waiting -1 ms
   37 27794829 [main] zsh 1918 fhandler_pty_master::close: (2420): pty output_mutex: acquired
   71 27794900 [ptym] zsh 1918 fhandler_pty_master::pty_master_thread: ReadFile, Win32 error 6
   34 27794934 [ptym] zsh 1918 fhandler_pty_master::pty_master_thread: Reply: from 0x0, to 0x0, error 6
   37 27794971 [ptym] zsh 1918 fhandler_pty_master::pty_master_thread: WriteFile, Win32 error 6
   37 27795008 [ptym] zsh 1918 fhandler_pty_master::pty_master_thread: DisconnectNamedPipe, Win32 error 6
   39 27795047 [ptym] zsh 1918 fhandler_pty_master::pty_master_thread: Leaving
```

-  zsh-async test log

```
=== RUN   test__async_job_multiple_commands
--- PASS: test__async_job_multiple_commands (0.08s)
=== RUN   test__async_job_print_hi
--- PASS: test__async_job_print_hi (0.07s)
=== RUN   test__async_job_stderr
--- PASS: test__async_job_stderr (0.07s)
=== RUN   test__async_job_wait_for_token
--- PASS: test__async_job_wait_for_token (0.19s)
=== RUN   test_all_options
--- FAIL: test_all_options (15.05s)
        ./async_test.zsh:517: timed out
=== RUN   test_async_flush_jobs
--- PASS: test_async_flush_jobs (0.63s)
=== RUN   test_async_job_error_and_nonzero_exit
--- PASS: test_async_job_error_and_nonzero_exit (0.24s)
=== RUN   test_async_job_git_status
--- PASS: test_async_job_git_status (0.43s)
=== RUN   test_async_job_keeps_nulls
--- PASS: test_async_job_keeps_nulls (0.21s)
=== RUN   test_async_job_multiple_arguments_and_spaces
--- PASS: test_async_job_multiple_arguments_and_spaces (0.27s)
=== RUN   test_async_job_multiple_commands_in_multiline_string
--- PASS: test_async_job_multiple_commands_in_multiline_string (0.22s)
=== RUN   test_async_job_print_matches_input_exactly
--- PASS: test_async_job_print_matches_input_exactly (0.21s)
=== RUN   test_async_job_unique_worker
--- PASS: test_async_job_unique_worker (0.49s)
=== RUN   test_async_job_with_rc_expand_param
--- PASS: test_async_job_with_rc_expand_param (0.19s)
=== RUN   test_async_process_results
--- PASS: test_async_process_results (0.25s)
=== RUN   test_async_process_results_stress
--- FAIL: test_async_process_results_stress (9.13s)
        ./async_test.zsh:182: timed out after 5s
        ./async_test.zsh:183: wanted 20 results, got 14
=== RUN   test_async_start_stop_worker
--- PASS: test_async_start_stop_worker (0.06s)
=== RUN   test_async_worker_notify_sigwinch
--- PASS: test_async_worker_notify_sigwinch (2.44s)
=== RUN   test_async_worker_survives_termination_of_other_worker
--- PASS: test_async_worker_survives_termination_of_other_worker (0.15s)
=== RUN   test_async_worker_update_pwd
--- PASS: test_async_worker_update_pwd (0.33s)
=== RUN   test_async_worker_update_pwd_and_env
--- PASS: test_async_worker_update_pwd_and_env (0.36s)
=== RUN   test_zle_watcher
--- SKIP: test_zle_watcher (0.01s)
        ./async_test.zsh:596: Test is not reliable on zsh 5.0.X
FAIL
exit code 1
FAIL    ./async_test.zsh        31.139s
```