### PR TITLE
glib2: for glib2-devel add dependency to gettext-devel

### DIFF
--- a/glib2/PKGBUILD
+++ b/glib2/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=glib2
 pkgname=(glib2 glib2-devel glib2-docs)
 pkgver=2.66.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Common C routines used by GTK+ and other libs"
 license=(LGPL2)
 url="https://www.gtk.org/"
@@ -33,7 +33,7 @@ prepare() {
   # https://gitlab.gnome.org/GNOME/glib/-/merge_requests/756
   patch -p2 -i ${srcdir}/2.38.2-gconvert-cygwin.patch
 
-  # Unclear what this is about and why it's not upstrean..
+  # Unclear what this is about and why it's not upstream..
   # Rebased from cygwin 2.50-gmodule-cygwin.patch
   patch -p1 -i ${srcdir}/2.64-gmodule-cygwin-rebased.patch
 }
@@ -102,7 +102,7 @@ package_glib2() {
 package_glib2-devel() {
   pkgdesc="glib2 headers and libraries"
   groups=('development')
-  depends=("glib2=${pkgver}" 'pcre-devel' 'libffi-devel' 'libiconv-devel' 'zlib-devel')
+  depends=("glib2=${pkgver}" 'gettext-devel' 'libffi-devel' 'libiconv-devel' 'pcre-devel' 'zlib-devel')
   options=('emptydirs')
 
   mkdir -p ${pkgdir}/usr/{bin,lib,share}


### PR DESCRIPTION
Since 'pkg-config glib-2.0 --libs' adds also '-lintl' the related
library should be also available