### PR TITLE
Perl updates

### DIFF
--- a/perl-Algorithm-Diff/PKGBUILD
+++ b/perl-Algorithm-Diff/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=Algorithm-Diff
 pkgname=perl-${_realname}
-pkgver=1.1903
+pkgver=1.201
 pkgrel=1
 pkgdesc="Compute 'intelligent' differences between two files / lists"
 arch=('any')
@@ -10,8 +10,8 @@ url="https://metacpan.org/author/TYEMQ${_realname}-${pkgver}"
 groups=('perl-modules')
 depends=('perl')
 license=('GPL' 'PerlArtistic')
-source=("https://www.cpan.org/authors/id/T/TY/TYEMQ/${_realname}-${pkgver}.tar.gz")
-sha256sums=('30e84ac4b31d40b66293f7b1221331c5a50561a39d580d85004d9c1fff991751')
+source=("https://cpan.metacpan.org/authors/id/R/RJ/RJBS/${_realname}-${pkgver}.tar.gz")
+sha256sums=('0022da5982645d9ef0207f3eb9ef63e70e9713ed2340ed7b3850779b0d842a7d')
 
 build() {
   cd ${_realname}-${pkgver}

--- a/perl-Alien-Build/PKGBUILD
+++ b/perl-Alien-Build/PKGBUILD
@@ -2,8 +2,8 @@
 
 _realname=Alien-Build
 pkgname=perl-${_realname}
-pkgver=2.26
-pkgrel=3
+pkgver=2.38
+pkgrel=1
 pkgdesc="Build external dependencies for use in CPAN"
 arch=('any')
 license=('PerlArtistic')
@@ -17,7 +17,7 @@ options=(!emptydirs)
 source=("https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/${_realname}-${pkgver}.tar.gz"
         01-msysize.patch)
 options=(!emptydirs)
-sha256sums=('b104566f2c82e12913a276f1485270bb5f5b6bcb6ff9dbe3d098e99d8d74cf71'
+sha256sums=('6bbd4116d1a08f95df669fcba16acd6a7e94329843abc8cb7c4b038d1778bded'
             '483769e64ca04e7005fb743e3500561ab8fd49ca9ee239fd5dd96045dc9677a2')
 
 prepare() {

--- a/perl-Alien-Build/PKGBUILD
+++ b/perl-Alien-Build/PKGBUILD
@@ -9,7 +9,7 @@ arch=('any')
 license=('PerlArtistic')
 url="https://metacpan.org/release/Alien-Build"
 groups=('perl-modules')
-depends=('perl-Capture-Tiny' 'perl-FFI-CheckLib' 'perl-File-chdir' 'perl-File-Which')
+depends=('perl-Capture-Tiny' 'perl-FFI-CheckLib' 'perl-File-chdir' 'perl-File-Which' 'perl-Path-Tiny')
 makedepends=('perl-Test2-Suite' 'perl-devel')
 #checkdepends=('perl-Alien-Base-ModuleBuild' 'perl-Alien-cmake3' 'perl-Env-ShellWords'
 #              'perl-PkgConfig' 'perl-PkgConfig-LibPkgConf' 'perl-Readonly' 'perl-Sort-Versions')

--- a/perl-Alien-Libxml2/PKGBUILD
+++ b/perl-Alien-Libxml2/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=Alien-Libxml2
 pkgname=perl-${_realname}
-pkgver=0.16
+pkgver=0.17
 pkgrel=1
 pkgdesc="Install the C libxml2 library on your system"
 arch=('any')
@@ -14,7 +14,7 @@ makedepends=('perl-HTML-Parser' 'perl-Sort-Versions' 'perl-Test2-Suite' 'perl-UR
 options=(!emptydirs)
 source=("https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/${_realname}-${pkgver}.tar.gz")
 options=(!emptydirs)
-sha256sums=('56f06a58054f788dcef8d3b6669fb47d172e9ca0b7a12d0241d9cf7835a53b97')
+sha256sums=('73b45244f0b5c36e5332c33569b82a1ab2c33e263f1d00785d2003bcaec68db3')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}

--- a/perl-Alien-Libxml2/PKGBUILD
+++ b/perl-Alien-Libxml2/PKGBUILD
@@ -9,7 +9,7 @@ arch=('any')
 license=('PerlArtistic')
 url="https://metacpan.org/release/Alien-Libxml2"
 groups=('perl-modules')
-depends=('libxml2' 'perl-Alien-Build')
+depends=('libxml2' 'perl-Alien-Build>=2.37')
 makedepends=('perl-HTML-Parser' 'perl-Sort-Versions' 'perl-Test2-Suite' 'perl-URI' 'libxml2-devel')
 options=(!emptydirs)
 source=("https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/${_realname}-${pkgver}.tar.gz")

--- a/perl-ExtUtils-MakeMaker/PKGBUILD
+++ b/perl-ExtUtils-MakeMaker/PKGBUILD
@@ -2,18 +2,19 @@
 
 _realname=ExtUtils-MakeMaker
 pkgname=perl-${_realname}
-pkgver=7.46
+pkgver=7.58
 pkgrel=1
 pkgdesc="ExtUtils::MakeMaker - Create a module Makefile"
 arch=('any')
 license=('GPL' 'PerlArtistic')
 url="https://metacpan.org/release/ExtUtils-MakeMaker"
 depends=('perl')
+makedepends=('libcrypt-devel')
 groups=('perl-modules')
 options=('!emptydirs')
 source=(https://www.cpan.org/authors/id/B/BI/BINGOS/${_realname}-${pkgver}.tar.gz
         001-msysize.patch)
-sha256sums=('8f4a107565392d0f36c99c849a3bfe7126ba58148a4dca334c139add0dd0d328'
+sha256sums=('aa73736cd926536c0f393f441d1b8742453573ad6efa2d855471e772f84c1eee'
             '2e460d107c65b3fe4abce518327d59bfb70adcca8ae27404f5b0f68359af30a3')
 
 prepare() {

--- a/perl-HTTP-Cookies/PKGBUILD
+++ b/perl-HTTP-Cookies/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=HTTP-Cookies
 pkgname=perl-${_realname}
-pkgver=6.09
+pkgver=6.10
 pkgrel=1
 pkgdesc="HTTP cookie jars"
 arch=('any')
@@ -15,7 +15,7 @@ checkdepends=()
 conflicts=('perl-libwww<6')
 url="https://metacpan.org/release/HTTP-Cookies"
 source=(https://www.cpan.org/authors/id/O/OA/OALDERS/${_realname}-${pkgver}.tar.gz)
-sha256sums=('903f017afaa5b78599cc90efc14ecccc8cc2ebfb636eb8c02f8f16ba861d1fe0')
+sha256sums=('e36f36633c5ce6b5e4b876ffcf74787cc5efe0736dd7f487bdd73c14f0bd7007')
 
 build() {
   ( export PERL_MM_USE_DEFAULT=1 PERL5LIB=""                 \

--- a/perl-HTTP-Message/PKGBUILD
+++ b/perl-HTTP-Message/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=HTTP-Message
 pkgname=perl-${_realname}
-pkgver=6.26
+pkgver=6.27
 pkgrel=1
 pkgdesc="HTTP style messages"
 arch=(any)
@@ -15,7 +15,7 @@ depends=('perl>=5.8.8' 'perl-Clone' 'perl-Encode-Locale>=1'
          'perl-LWP-MediaTypes>=6' 'perl-URI>=1.10')
 conflicts=('perl-libwww<6')
 source=("https://search.cpan.org/CPAN/authors/id/O/OA/OALDERS/${_realname}-${pkgver}.tar.gz")
-sha256sums=('6ce6c359de75c3bb86696a390189b485ec93e3ffc55326b6d044fa900f1725e1')
+sha256sums=('0be0f720fbbbdbae8711f6eec9b2f0d34bd5ed5046fc66b80dc3b42017c1e699')
 
 build() {
   ( export PERL_MM_USE_DEFAULT=1 PERL5LIB=""                 \

--- a/perl-IO-Socket-IP/PKGBUILD
+++ b/perl-IO-Socket-IP/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=IO-Socket-IP
 pkgname="perl-${_realname}"
-pkgver=0.39
+pkgver=0.41
 pkgrel=1
 pkgdesc="Family-neutral IP socket supporting both IPv4 and IPv6"
 arch=('any')
@@ -13,21 +13,26 @@ makedepends=()
 url='https://metacpan.org/release/IO-Socket-IP'
 groups=('perl-modules')
 source=("https://www.cpan.org/authors/id/P/PE/PEVANS/${_realname}-${pkgver}.tar.gz")
-sha256sums=('11950da7636cb786efd3bfb5891da4c820975276bce43175214391e5c32b7b96')
+sha256sums=('849a45a238f8392588b97722c850382c4e6d157cd08a822ddcb9073c73bf1446')
 
 build() {
   cd "${_realname}-${pkgver}"
-  /usr/bin/perl Makefile.PL INSTALLDIRS=vendor
-  make
+  /usr/bin/perl Build.PL INSTALLDIRS=vendor
+  ./Build
 }
 
 check() {
   cd "${_realname}-${pkgver}"
-  make test
+  ./Build test
 }
 
 package() {
   cd "${_realname}-${pkgver}"
-  make DESTDIR="$pkgdir" install
+  #./Build DESTDIR="$pkgdir" install
+  ( export PERL_AUTOINSTALL=--skipdeps                       \
+      PERL_MM_OPT="INSTALLDIRS=vendor DESTDIR='$pkgdir'"     \
+      PERL_MB_OPT="--installdirs vendor --destdir '$pkgdir'"
+    ./Build install
+  )
   find "$pkgdir" -name .packlist -o -name perllocal.pod -delete
 }

--- a/perl-IO-Socket-SSL/PKGBUILD
+++ b/perl-IO-Socket-SSL/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=IO-Socket-SSL
 pkgname=perl-${_realname}
-pkgver=2.068
+pkgver=2.069
 pkgrel=1
 pkgdesc="Nearly transparent SSL encapsulation for IO::Socket::INET"
 arch=('any')
@@ -13,7 +13,7 @@ depends=('perl-Net-SSLeay' 'perl' 'perl-URI')
 checkdepends=('perl-IO-Socket-INET6')
 options=('!emptydirs')
 source=(https://www.cpan.org/authors/id/S/SU/SULLR/${_realname}-${pkgver}.tar.gz)
-sha256sums=('4420fc0056f1827b4dd1245eacca0da56e2182b4ef6fc078f107dc43c3fb8ff9')
+sha256sums=('d83c2cae5e8a22ab49c9f2d964726625e9efe56490d756a48a7b149a3d6e278d')
 
 build() {
   cd ${_realname}-${pkgver}

--- a/perl-Importer/PKGBUILD
+++ b/perl-Importer/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=Importer
 pkgname=perl-${_realname}
-pkgver=0.025
+pkgver=0.026
 pkgrel=1
 pkgdesc="Alternative but compatible interface to modules that export symbols"
 arch=('any')
@@ -12,7 +12,7 @@ license=('PerlArtistic')
 depends=('perl')
 options=('!emptydirs')
 source=("https://cpan.metacpan.org/authors/id/E/EX/EXODIST/${_realname}-${pkgver}.tar.gz")
-sha256sums=('0745138c487d74033d0cbeb36f06595036dc7e688f1a5dbec9cc2fa799e13946')
+sha256sums=('e08fa84e13cb998b7a897fc8ec9c3459fcc1716aff25cc343e36ef875891b0ef')
 
 build() {
   cd  "${srcdir}/${_realname}-${pkgver}"

--- a/perl-JSON/PKGBUILD
+++ b/perl-JSON/PKGBUILD
@@ -2,7 +2,7 @@
 
 _perlmod='JSON'
 pkgname="perl-${_perlmod}"
-pkgver=4.02
+pkgver=4.03
 pkgrel=1
 pkgdesc="JSON (JavaScript Object Notation) encoder/decoder"
 arch=('any')
@@ -12,12 +12,17 @@ groups=('perl-modules')
 depends=('perl>=5.10.0')
 options=('!emptydirs')
 source=(http://search.cpan.org/CPAN/authors/id/I/IS/ISHIGAKI/JSON-${pkgver}.tar.gz)
-sha256sums=('444a88755a89ffa2a5424ab4ed1d11dca61808ebef57e81243424619a9e8627c')
+sha256sums=('e41f8761a5e7b9b27af26fe5780d44550d7a6a66bf3078e337d676d07a699941')
 
 build() {
   cd  "${srcdir}"/JSON-${pkgver}
   PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
   make
+}
+
+check() {
+  cd "${srcdir}"/JSON-${pkgver}
+  make test
 }
 
 package() {

--- a/perl-List-MoreUtils-XS/PKGBUILD
+++ b/perl-List-MoreUtils-XS/PKGBUILD
@@ -2,8 +2,8 @@
 
 _realname=List-MoreUtils-XS
 pkgname=perl-${_realname}
-pkgver=0.428
-pkgrel=6
+pkgver=0.430
+pkgrel=1
 pkgdesc="Provide the stuff missing in List::Util"
 arch=('i686' 'x86_64')
 license=('GPL' 'PerlArtistic')
@@ -13,7 +13,7 @@ makedepends=('perl-devel')
 groups=('perl-modules')
 options=('!emptydirs')
 source=(https://www.cpan.org/authors/id/R/RE/REHSACK/${_realname}-${pkgver}.tar.gz)
-sha256sums=('9d9fe621429dfe7cf2eb1299c192699ddebf060953e5ebdc1b4e293c6d6dd62d')
+sha256sums=('e8ce46d57c179eecd8758293e9400ff300aaf20fefe0a9d15b9fe2302b9cb242')
 
 build() {
   cd ${_realname}-${pkgver}

--- a/perl-List-MoreUtils/PKGBUILD
+++ b/perl-List-MoreUtils/PKGBUILD
@@ -9,6 +9,7 @@ arch=('any')
 license=('GPL' 'PerlArtistic')
 url="https://metacpan.org/release/List-MoreUtils"
 depends=('perl' 'perl-Exporter-Tiny' 'perl-List-MoreUtils-XS')
+makedepends=('perl-devel')
 groups=('perl-modules')
 options=('!emptydirs')
 source=(https://www.cpan.org/authors/id/R/RE/REHSACK/${_realname}-${pkgver}.tar.gz)

--- a/perl-List-MoreUtils/PKGBUILD
+++ b/perl-List-MoreUtils/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=List-MoreUtils
 pkgname=perl-${_realname}
-pkgver=0.428
+pkgver=0.430
 pkgrel=1
 pkgdesc="List::MoreUtils provides some trivial but commonly needed functionality on lists which is not going to go into List::Util"
 arch=('any')
@@ -12,7 +12,7 @@ depends=('perl' 'perl-Exporter-Tiny' 'perl-List-MoreUtils-XS')
 groups=('perl-modules')
 options=('!emptydirs')
 source=(https://www.cpan.org/authors/id/R/RE/REHSACK/${_realname}-${pkgver}.tar.gz)
-sha256sums=('713e0945d5f16e62d81d5f3da2b6a7b14a4ce439f6d3a7de74df1fd166476cc2')
+sha256sums=('63b1f7842cd42d9b538d1e34e0330de5ff1559e4c2737342506418276f646527')
 
 build() {
   cd ${_realname}-${pkgver}

--- a/perl-Net-HTTP/PKGBUILD
+++ b/perl-Net-HTTP/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=Net-HTTP
 pkgname=perl-${_realname}
-pkgver=6.19
+pkgver=6.20
 pkgrel=1
 pkgdesc="Low-level HTTP connection (client)"
 arch=('any')
@@ -13,7 +13,7 @@ options=('!emptydirs')
 depends=('perl>=5.6.2')
 conflicts=('perl-libwww<6')
 source=("https://www.cpan.org/authors/id/O/OA/OALDERS/${_realname}-${pkgver}.tar.gz")
-sha256sums=('52b76ec13959522cae64d965f15da3d99dcb445eddd85d2ce4e4f4df385b2fc4')
+sha256sums=('92527b2a24512961b8e3637c6216a057751e39b6fa751422ed181ff599779f1e')
 
 build() {
   export PERL_MM_USE_DEFAULT=1 PERL5LIB=""                 \

--- a/perl-Net-SSLeay/Net-SSLeay-1.55.patch
+++ b/perl-Net-SSLeay/Net-SSLeay-1.55.patch
@@ -1,24 +1,24 @@
 diff -Naur Net-SSLeay-1.55/t/local/61_threads-cb-crash.t Net-SSLeay-1.55-patched/t/local/61_threads-cb-crash.t
 --- Net-SSLeay-1.55/t/local/61_threads-cb-crash.t	2012-04-06 01:29:23.000000000 +0400
 +++ Net-SSLeay-1.55-patched/t/local/61_threads-cb-crash.t	2013-11-14 13:22:49.414800000 +0400
-@@ -9,7 +9,7 @@
- };
+@@ -7,7 +7,7 @@
  
- #XXX-TODO perhaps perl+ithreads related issue (needs more investigation)
--plan skip_all => "this test sometimes crashes on cygwin" if $^O eq 'cygwin';
-+plan skip_all => "this test sometimes crashes on cygwin" if $^O eq 'cygwin' or $^O eq 'msys';
- 
- # NOTE: expect warnings about threads still running under perl 5.8 and threads 1.71
- plan tests => 1;
+ if (not can_thread()) {
+     plan skip_all => "Threads not supported on this system";
+-} elsif ($^O eq 'cygwin') {
++} elsif ($^O eq 'cygwin' or $^O eq 'msys') {
+     # XXX-TODO perhaps perl+ithreads related issue (needs more investigation)
+     plan skip_all => "this test sometimes crashes on Cygwin";
+ } else {
 diff -Naur Net-SSLeay-1.55/t/local/62_threads-ctx_new-deadlock.t Net-SSLeay-1.55-patched/t/local/62_threads-ctx_new-deadlock.t
 --- Net-SSLeay-1.55/t/local/62_threads-ctx_new-deadlock.t	2012-04-06 01:29:23.000000000 +0400
 +++ Net-SSLeay-1.55-patched/t/local/62_threads-ctx_new-deadlock.t	2013-11-14 13:23:01.177200000 +0400
-@@ -9,7 +9,7 @@
- };
+@@ -7,7 +7,7 @@
  
- #XXX-TODO perhaps perl+ithreads related issue (needs more investigation)
--plan skip_all => "this test sometimes crashes on cygwin" if $^O eq 'cygwin';
-+plan skip_all => "this test sometimes crashes on cygwin" if $^O eq 'cygwin' or $^O eq 'msys';
- 
- plan tests => 1;
- 
+ if (not can_thread()) {
+     plan skip_all => "Threads not supported on this system";
+-} elsif ($^O eq 'cygwin') {
++} elsif ($^O eq 'cygwin' or $^O eq 'msys') {
+     #XXX-TODO perhaps perl+ithreads related issue (needs more investigation)
+     plan skip_all => "this test sometimes crashes on Cygwin";
+ } else {

--- a/perl-Net-SSLeay/PKGBUILD
+++ b/perl-Net-SSLeay/PKGBUILD
@@ -2,8 +2,8 @@
 
 _realname=Net-SSLeay
 pkgname=perl-${_realname}
-pkgver=1.89_01
-pkgrel=3
+pkgver=1.90
+pkgrel=1
 pkgdesc="Perl extension for using OpenSSL"
 arch=('i686' 'x86_64')
 license=('custom:BSD')
@@ -16,8 +16,8 @@ replaces=('net-ssleay')
 provides=('net-ssleay')
 source=("https://cpan.metacpan.org/authors/id/C/CH/CHRISN/${_realname}-${pkgver}.tar.gz"
         'Net-SSLeay-1.55.patch')
-sha256sums=('9fa58a740565bf6032188fee57bec38f441c1b359f8927834ab4ea860767581e'
-            'a81e528372aeae3d47585260e317f40f80d786fe56d295a1b0c63e90275159d3')
+sha256sums=('f8696cfaca98234679efeedc288a9398fcf77176f1f515dbc589ada7c650dc93'
+            'a38e04f08fd71bbafad3c56cdbee73240d0645e231baf13f033723a837022166')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}

--- a/perl-Params-Util/PKGBUILD
+++ b/perl-Params-Util/PKGBUILD
@@ -9,6 +9,7 @@ arch=('i686' 'x86_64')
 url="https://metacpan.org/release/Params-Util"
 groups=('perl-modules')
 depends=('perl')
+makedepends=('perl-devel')
 license=('GPL' 'PerlArtistic')
 source=("https://cpan.metacpan.org/authors/id/R/RE/REHSACK/Params-Util-${pkgver}.tar.gz"
         01-msysize.patch)

--- a/perl-Params-Util/PKGBUILD
+++ b/perl-Params-Util/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=Params-Util
 pkgname=perl-${_realname}
-pkgver=1.07
+pkgver=1.102
 pkgrel=1
 pkgdesc="Simple, compact and correct param-checking functions"
 arch=('i686' 'x86_64')
@@ -10,14 +10,14 @@ url="https://metacpan.org/release/Params-Util"
 groups=('perl-modules')
 depends=('perl')
 license=('GPL' 'PerlArtistic')
-source=("https://search.cpan.org/CPAN/authors/id/A/AD/ADAMK/Params-Util-${pkgver}.tar.gz"
+source=("https://cpan.metacpan.org/authors/id/R/RE/REHSACK/Params-Util-${pkgver}.tar.gz"
         01-msysize.patch)
-sha256sums=('30f1ec3f2cf9ff66ae96f973333f23c5f558915bb6266881eac7423f52d7c76c'
+sha256sums=('499bb1b482db24fda277a51525596ad092c2bd51dd508fa8fec2e9f849097402'
             '0cf95e252716dbaddb96916a945a82e5c10fe5bb0ff4451fe8299b15d5cbe017')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  patch -p1 -i ${srcdir}/01-msysize.patch
+  #patch -p1 -i ${srcdir}/01-msysize.patch
 }
 
 build() {
@@ -26,6 +26,11 @@ build() {
   PERL_MM_USE_DEFAULT=1 PERL_AUTOINSTALL=--skipdeps \
   perl Makefile.PL INSTALLDIRS=vendor
   make
+}
+
+check() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  make test
 }
 
 package() {

--- a/perl-Path-Tiny/PKGBUILD
+++ b/perl-Path-Tiny/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=Path-Tiny
 pkgname=perl-${_realname}
-pkgver=0.114
+pkgver=0.116
 pkgrel=1
 pkgdesc="File path utility"
 arch=('any')
@@ -12,7 +12,7 @@ groups=('perl-modules')
 depends=('perl>=5.8.1')
 options=(!emptydirs)
 source=(https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/${_realname}-${pkgver}.tar.gz)
-sha256sums=('cd0f88f37a58fc3667ec065767fe01e73ee6efa18a112bfd3508cf6579ca00e1')
+sha256sums=('0379108b2aee556f877760711e03ce8775a98859cdd03cb94aaf4738a37a62d3')
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/perl-Role-Tiny/PKGBUILD
+++ b/perl-Role-Tiny/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=Role-Tiny
 pkgname=perl-${_realname}
-pkgver=2.001004
+pkgver=2.002004
 pkgrel=1
 pkgdesc="Roles. Like a nouvelle cuisine portion size slice of Moose."
 arch=('any')
@@ -12,7 +12,7 @@ depends=('perl')
 checkdepends=('perl-Test-Fatal>=0.003')
 options=('!emptydirs')
 source=(https://search.cpan.org/CPAN/authors/id/H/HA/HAARG/Role-Tiny-${pkgver}.tar.gz)
-sha512sums=('818373746cc4d86f87f9f88adf7f108de396f135e5dd1e380bf7722503675cacd9ee1d0d1f1eb2cd7851e50121504f94db02b3b67512d4069d7fdec94e441130')
+sha512sums=('f66a799a0cd4e989adc173f6d913967df7aa6b9ffda934c2a80c0a91dcfe4edce606bd27cf1b4d857d52d0aa770224315ae4e915e4e735c6a9483a6cf5ce02f1')
 
 prepare() {
   cd ${_realname}-${pkgver}
@@ -29,6 +29,11 @@ build() {
   perl Makefile.PL
   make
 }
+
+check() (
+  cd ${_realname}-${pkgver}
+  make test
+)
 
 package() {
   cd ${_realname}-${pkgver}

--- a/perl-Test-Fatal/PKGBUILD
+++ b/perl-Test-Fatal/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=Test-Fatal
 pkgname=perl-${_realname}
-pkgver=0.014
+pkgver=0.016
 pkgrel=1
 pkgdesc="Incredibly simple helpers for testing code with exceptions"
 arch=('any')
@@ -11,7 +11,7 @@ groups=('perl-modules')
 depends=('perl' 'perl-Try-Tiny')
 license=('GPL' 'PerlArtistic')
 source=("http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Test-Fatal-${pkgver}.tar.gz")
-sha256sums=('bcdcef5c7b2790a187ebca810b0a08221a63256062cfab3c3b98685d91d1cbb0')
+sha256sums=('7283d430f2ba2030b8cd979ae3039d3f1b2ec3dde1a11ca6ae09f992a66f788f')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -22,6 +22,11 @@ build() {
   PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
   make
 }
+
+check() (
+  cd "${srcdir}/${_realname}-${pkgver}"
+  make test
+)
 
 package() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/perl-Test-Simple/PKGBUILD
+++ b/perl-Test-Simple/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=Test-Simple
 pkgname=perl-${_realname}
-pkgver=1.302175
+pkgver=1.302183
 pkgrel=1
 pkgdesc="Basic utilities for writing tests"
 arch=('any')
@@ -11,10 +11,15 @@ groups=('perl-modules')
 depends=('perl')
 license=('GPL' 'PerlArtistic')
 source=("https://www.cpan.org/authors/id/E/EX/EXODIST/${_realname}-${pkgver}.tar.gz")
-sha256sums=('c8c8f5c51ad6d7a858c3b61b8b658d8e789d3da5d300065df0633875b0075e49')
+sha256sums=('9a03bda5ec420aea9692b650437f4d5b574fa505fdd7ff60cdb5f3ec034106ff')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+}
+
+check() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  make test
 }
 
 build() {

--- a/perl-Test2-Suite/PKGBUILD
+++ b/perl-Test2-Suite/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=Test2-Suite
 pkgname=perl-${_realname}
-pkgver=0.000130
+pkgver=0.000139
 pkgrel=1
 pkgdesc="Distribution with a rich set of tools built upon the Test2 framework"
 arch=('any')
@@ -12,7 +12,7 @@ depends=('perl-Module-Pluggable' 'perl-Importer' 'perl-Scope-Guard' 'perl-Sub-In
          'perl-Term-Table' 'perl-Test-Simple>=1.302158')
 license=('PerlArtistic')
 source=("https://cpan.metacpan.org/authors/id/E/EX/EXODIST/${_realname}-${pkgver}.tar.gz")
-sha256sums=('d462cb95024c0735fc0fdb22f92fda4f852bf85d92d89bd95e4fa212730d534a')
+sha256sums=('559b474012ec34cb88d717240f6cfb7a86c49ce124c9941ccc60318b11079743')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/perl-URI/PKGBUILD
+++ b/perl-URI/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=URI
 pkgname=perl-${_realname}
-pkgver=5.05
+pkgver=5.07
 pkgrel=1
 pkgdesc="Uniform Resource Identifiers (absolute and relative)"
 arch=('any')
@@ -14,7 +14,7 @@ checkdepends=('perl-Test-Needs')
 provides=('perl-URI-Escape=3.30')
 options=('!emptydirs')
 source=("https://cpan.metacpan.org/authors/id/O/OA/OALDERS/${_realname}-${pkgver}.tar.gz")
-sha256sums=('a5c113d2d02706d9fbdca6a86f290c5b05b2f86836d4e7fe1447f063261b79ec')
+sha256sums=('eeb6ed2ae212434e2021e29f7556f4024169421a5d8b001a89e65982944131ea')
 
 build() {
   cd "${srcdir}/${_realname}-$pkgver"

--- a/perl-XML-LibXML/PKGBUILD
+++ b/perl-XML-LibXML/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=XML-LibXML
 pkgname=perl-${_realname}
 pkgver=2.0206
-pkgrel=3
+pkgrel=1
 pkgdesc="Interface to the libxml library"
 arch=('i686' 'x86_64')
 license=('GPL' 'PerlArtistic')

--- a/perl-XML-LibXML/PKGBUILD
+++ b/perl-XML-LibXML/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=XML-LibXML
 pkgname=perl-${_realname}
-pkgver=2.0205
+pkgver=2.0206
 pkgrel=3
 pkgdesc="Interface to the libxml library"
 arch=('i686' 'x86_64')
@@ -18,7 +18,7 @@ install=perl-xml-libxml.install
 options=('!emptydirs')
 source=("https://www.cpan.org/authors/id/S/SH/SHLOMIF/${_realname}-${pkgver}.tar.gz"
         'XML-LibXML-2.0200.patch')
-sha256sums=('3a25002714b13f192d0baef5dc25ad2fbf09f8ec4ad1f793dec8fe6e2f5b2278'
+sha256sums=('010ba395c38711f9c233ee23d0b0b18b761e6d99a762125f7e6180d068851619'
             'ea1e1f58f33681dc0206c4fa868cc191efeb91facaa88631bc79c73e910cf745')
 
 prepare() {

--- a/perl-YAML-Syck/PKGBUILD
+++ b/perl-YAML-Syck/PKGBUILD
@@ -2,8 +2,8 @@
 
 _realname=YAML-Syck
 pkgname=perl-YAML-Syck
-pkgver=1.32
-pkgrel=4
+pkgver=1.34
+pkgrel=1
 pkgdesc="Fast, lightweight YAML loader and dumper"
 arch=('i686' 'x86_64')
 url="https://metacpan.org/release/YAML-Syck"
@@ -14,7 +14,7 @@ groups=('perl-modules')
 options=('!emptydirs')
 source=(https://www.cpan.org/authors/id/T/TO/TODDR/YAML-Syck-${pkgver}.tar.gz
         'msysize.patch')
-sha256sums=('db1d90ec03e0466e134e6032d03eaf73a7305631bcdbbfd8fe5356bd77cae9bb'
+sha256sums=('cc9156ccaebda798ebfe2f31b619e806577f860ed1704262f17ffad3c6e34159'
             'db21cdfc97ccbc346af5cc266ad6f5b971efa3cfb420099d2760b7471a89057a')
 
 prepare() {

--- a/perl-libwww/PKGBUILD
+++ b/perl-libwww/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=perl-libwww
-pkgver=6.50
+pkgver=6.52
 pkgrel=1
 pkgdesc="The World-Wide Web library for Perl"
 arch=('any')
@@ -17,7 +17,7 @@ depends=('perl' 'perl-Encode-Locale' 'perl-File-Listing'
 optdepends=('perl-LWP-Protocol-https: for https:// url schemes')
 checkdepends=('perl-Test-Fatal' 'perl-Test-Requiresinternet')
 source=(https://cpan.metacpan.org/authors/id/O/OA/OALDERS/libwww-perl-${pkgver}.tar.gz)
-sha256sums=('f07dea0be3d916ab3c3942f1392f7c45484b1499a66b04ba86b4e2e817aed850')
+sha256sums=('b63f67647b7cfb0bace19ada32e4feb2c2e8e0f4204546c62ce6247fa59d778d')
 
 build() {
   cd libwww-perl-${pkgver}


### PR DESCRIPTION
perl-Algorithm-Diff: Update to 1.201
perl-ExtUtils-MakeMaker: Update to 7.58
perl-JSON: Update to 4.03
perl-IO-Socket-IP: Update to 0.41
perl-IO-Socket-SSL: Update to 2.069
perl-Net-SSLeay: Update to 1.90
perl-Path-Tiny: Update to 0.116
perl-Role-Tiny: Update to 2.002004
perl-Test-Fatal: Update to 0.016
perl-Importer: Update to 0.026
perl-XML-LibXML: Update to 2.0206
perl-List-MoreUtils: Update to 0.430
perl-Test-Simple: Update to 1.302183
perl-YAML-Syck: Update to 1.34
perl-Alien-Build: Update to 2.38
perl-Alien-Libxml2: Update to 0.17
perl-Params-Util: Update to 1.102
perl-Test2-Suite: Update to 0.000139
perl-HTTP-Message: Update to 6.27
perl-perl-HTTP-Cookies: Update to 6.10
perl-libwww: Update to 6.52
perl-Net-HTTP: Update to 6.20
perl-URI: Update to 5.07