### PR TITLE
filesystem: Avoid trying to chmod /dev/{shm,mqueue}

### DIFF
--- a/filesystem/01-devices.post
+++ b/filesystem/01-devices.post
@@ -52,8 +52,6 @@ maybe_create_devs ()
       echo "POSIX semaphores and POSIX shared memory will not work"
       echo
     fi
-  else
-    chmod 1777 "${DEVDIR}/shm"
   fi
 
   # Check for ${DEVDIR}/mqueue directory (for POSIX message queues)
@@ -81,8 +79,6 @@ maybe_create_devs ()
       echo "POSIX message queues will not work"
       echo
     fi
-  else
-    chmod 1777 "${DEVDIR}/mqueue"
   fi
   
   # Install /dev/fd, /dev/std{in,out,err}.  The bash builtin test was compiled

--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Alethea Rose <alethea@alethearose.com>
 
 pkgname=filesystem
-pkgver=2021.01
+pkgver=2021.02
 pkgrel=1
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
@@ -72,7 +72,7 @@ sha256sums=('742a7d66b7a5ebd2b8461728c5b44a46b2305fd2116208eecae5f45828938ea0'
             '2087410bf7ead6fa586628ea7fc97c53f5ea3ce16d1ee91ecc15ccc18ab53094'
             'f63241cc56aa7b7ec6962d19991d211b4e1641b78ba5226835118ab493830a8b'
             'e96c1f54ffff792e738aa032815c82c30821b0683806e5ed0ba2a759db2fd494'
-            '95105051d31ecbe4ace262a4496ec1055bdd14d61b7d475a771b56fe15f8ccd9'
+            'a5b9c91241d5e1f0bb461119b3e36f5f661ff6f0758e63e756275fa5cb31a410'
             'd7b7eb4cd9e1f9bc227b009cdcacf700f5523ccc109fbd3c1c0331726d314c9e'
             '9c126262051a047450ed97397ee89a7148098c03ae00a1cd67c3f3425d8e4b12'
             'fedaf4d9ae282f6c1698d04d280dd48c8d3247321a5cb5e309e61e2c655102c6'


### PR DESCRIPTION
Although the default and most used way to install MSYS2 is to have it
user-writable, some users prefer to have the root writable only to
admins.  In that case, the 01-devices.post script would always print out
two failures on "login" when trying to chmod /dev/{shm,mqueue}.  Since
the only supported configuration for MSYS2 is to mount `/` with noacl
where chmod() is a no-op, the failure is purely cosmetic, as is the
chmod invocation itself.  For these reasons, let's not chmod at all.

I'm aware the non-user-writable root configuration itself is not
officially supported either, but I've been using it like that for years
now and this is the only issue I know of, so I think it's reasonable to
resolve this.