### PR TITLE
binutils: update to 2.36.1

### DIFF
--- a/binutils/0100-binutils-2.36-msys2.patch
+++ b/binutils/0100-binutils-2.36-msys2.patch
@@ -1,6 +1,6 @@
-diff -Naur binutils-2.30.orig/bfd/acinclude.m4 binutils-2.30/bfd/acinclude.m4
---- binutils-2.30.orig/bfd/acinclude.m4	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/bfd/acinclude.m4	2018-06-13 08:19:13.199163100 +0300
+diff -Nbadur binutils-2.36.1.orig/bfd/acinclude.m4 binutils-2.36.1/bfd/acinclude.m4
+--- binutils-2.36.1.orig/bfd/acinclude.m4	2021-01-09 18:47:33.000000000 +0800
++++ binutils-2.36.1/bfd/acinclude.m4	2021-02-18 17:57:15.468229900 +0800
 @@ -21,7 +21,7 @@
  [AC_REQUIRE([AC_CANONICAL_TARGET])
  case "${host}" in
@@ -10,40 +10,31 @@ diff -Naur binutils-2.30.orig/bfd/acinclude.m4 binutils-2.30/bfd/acinclude.m4
  changequote([,])dnl
    AC_DEFINE(USE_BINARY_FOPEN, 1, [Use b modifier when opening binary files?]) ;;
  esac])dnl
-diff -Naur binutils-2.30.orig/bfd/config.bfd binutils-2.30/bfd/config.bfd
---- binutils-2.30.orig/bfd/config.bfd	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/bfd/config.bfd	2018-06-13 08:19:13.199163100 +0300
-@@ -804,7 +804,7 @@
-     targ_archs="$targ_archs bfd_arm_arch"
+diff -Nbadur binutils-2.36.1.orig/bfd/config.bfd binutils-2.36.1/bfd/config.bfd
+--- binutils-2.36.1.orig/bfd/config.bfd	2021-01-09 18:47:33.000000000 +0800
++++ binutils-2.36.1/bfd/config.bfd	2021-02-18 17:57:15.468229900 +0800
+@@ -684,7 +684,7 @@
+     targ_selvecs="i386_elf32_vec iamcu_elf32_vec x86_64_elf32_vec i386_pei_vec x86_64_pe_vec x86_64_pei_vec l1om_elf64_vec k1om_elf64_vec"
      want64=true
      ;;
 -  x86_64-*-mingw* | x86_64-*-pe | x86_64-*-pep | x86_64-*-cygwin)
 +  x86_64-*-mingw* | x86_64-*-pe | x86_64-*-pep | x86_64-*-cygwin | x86_64-*-msys*)
      targ_defvec=x86_64_pe_vec
-     targ_selvecs="x86_64_pe_vec x86_64_pei_vec x86_64_pe_be_vec x86_64_elf64_vec l1om_elf64_vec k1om_elf64_vec i386_pe_vec i386_pei_vec i386_elf32_vec iamcu_elf32_vec"
+     targ_selvecs="x86_64_pe_vec x86_64_pei_vec x86_64_pe_big_vec x86_64_elf64_vec l1om_elf64_vec k1om_elf64_vec i386_pe_vec i386_pei_vec i386_elf32_vec iamcu_elf32_vec"
      want64=true
-@@ -862,7 +862,7 @@
+@@ -734,7 +734,7 @@
      targ_defvec=i386_elf32_vec
      targ_selvecs="iamcu_elf32_vec i386_coff_vec"
      ;;
 -  i[3-7]86-*-mingw32* | i[3-7]86-*-cygwin* | i[3-7]86-*-winnt | i[3-7]86-*-pe)
 +  i[3-7]86-*-mingw32* | i[3-7]86-*-cygwin* | i[3-7]86-*-msys* | i[3-7]86-*-winnt | i[3-7]86-*-pe)
      targ_defvec=i386_pe_vec
-     targ_selvecs="i386_pe_vec i386_pei_vec i386_elf32_vec iamcu_elf32_vec"
+     targ_selvecs="i386_pe_vec i386_pe_big_vec i386_pei_vec i386_elf32_vec iamcu_elf32_vec"
      targ_underscore=yes
-@@ -1438,7 +1438,7 @@
-     targ_selvecs="rs6000_xcoff_vec powerpc_elf32_vec powerpc_boot_vec"
-     targ64_selvecs="powerpc_elf64_vec powerpc_elf64_le_vec"
-     ;;
--  powerpcle-*-pe | powerpcle-*-winnt* | powerpcle-*-cygwin*)
-+  powerpcle-*-pe | powerpcle-*-winnt* | powerpcle-*-cygwin* | powerpcle-*-msys*)
-     targ_defvec=powerpc_pe_le_vec
-     targ_selvecs="powerpc_pei_le_vec powerpc_pei_vec powerpc_pe_le_vec powerpc_pe_vec"
-     ;;
-diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
---- binutils-2.30.orig/bfd/configure	2018-01-27 17:58:29.000000000 +0300
-+++ binutils-2.30/bfd/configure	2018-06-13 08:19:13.199163100 +0300
-@@ -5997,7 +5997,7 @@
+diff -Nbadur binutils-2.36.1.orig/bfd/configure binutils-2.36.1/bfd/configure
+--- binutils-2.36.1.orig/bfd/configure	2021-02-06 17:02:09.000000000 +0800
++++ binutils-2.36.1/bfd/configure	2021-02-18 17:57:15.483851200 +0800
+@@ -6298,7 +6298,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -52,7 +43,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -6339,7 +6339,7 @@
+@@ -6640,7 +6640,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -61,7 +52,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -6919,7 +6919,7 @@
+@@ -7220,7 +7220,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -70,7 +61,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -8503,7 +8503,7 @@
+@@ -8804,7 +8804,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -79,7 +70,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -8585,7 +8585,7 @@
+@@ -8886,7 +8886,7 @@
        fi
        ;;
  
@@ -88,7 +79,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -9047,7 +9047,7 @@
+@@ -9348,7 +9348,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -97,7 +88,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -9162,7 +9162,7 @@
+@@ -9463,7 +9463,7 @@
        fi
        ;;
  
@@ -106,7 +97,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec='-L$libdir'
-@@ -9593,7 +9593,7 @@
+@@ -9894,7 +9894,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -115,7 +106,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -10494,14 +10494,14 @@
+@@ -10795,14 +10795,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -132,7 +123,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -10525,6 +10525,12 @@
+@@ -10826,6 +10826,12 @@
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
@@ -145,7 +136,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -11161,7 +11167,7 @@
+@@ -11452,7 +11458,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -154,7 +145,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
-@@ -13855,7 +13861,7 @@
+@@ -14246,7 +14252,7 @@
  
  
  case "${host}" in
@@ -163,7 +154,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
  
  $as_echo "#define USE_BINARY_FOPEN 1" >>confdefs.h
   ;;
-@@ -14031,7 +14037,7 @@
+@@ -14458,7 +14464,7 @@
  
  LIBM=
  case $host in
@@ -172,37 +163,37 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
    # These system don't have libm, or don't need it
    ;;
  *-ncr-sysv4.3*)
-@@ -14181,6 +14187,11 @@
-     SHARED_LDFLAGS="-no-undefined"
+@@ -14609,6 +14615,11 @@
      SHARED_LIBADD="-L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lcygwin -lkernel32"
    ;;
-+
+ 
 +  *-*-msys*)
 +    SHARED_LDFLAGS="-no-undefined"
 +    SHARED_LIBADD="-L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lmsys-2.0 -lkernel32"
 +  ;;
- 
++
    # Use built-in libintl on macOS, since it is not provided by libc.
    *-*-darwin*)
-diff -Naur binutils-2.30.orig/bfd/configure.ac binutils-2.30/bfd/configure.ac
---- binutils-2.30.orig/bfd/configure.ac	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/bfd/configure.ac	2018-06-13 08:19:13.199163100 +0300
-@@ -299,6 +299,11 @@
-     SHARED_LDFLAGS="-no-undefined"
+     SHARED_LIBADD="-L`pwd`/../libiberty/pic -L`pwd`/../intl -liberty -lintl"
+diff -Nbadur binutils-2.36.1.orig/bfd/configure.ac binutils-2.36.1/bfd/configure.ac
+--- binutils-2.36.1.orig/bfd/configure.ac	2021-01-09 18:47:33.000000000 +0800
++++ binutils-2.36.1/bfd/configure.ac	2021-02-18 17:57:15.499474700 +0800
+@@ -325,6 +325,11 @@
      SHARED_LIBADD="-L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lcygwin -lkernel32"
    ;;
-+
+ 
 +  *-*-msys*)
 +    SHARED_LDFLAGS="-no-undefined"
 +    SHARED_LIBADD="-L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lmsys-2.0 -lkernel32"
 +  ;;
- 
++
    # Use built-in libintl on macOS, since it is not provided by libc.
    *-*-darwin*)
-diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configure
---- binutils-2.30.orig/binutils/configure	2018-01-27 18:02:51.000000000 +0300
-+++ binutils-2.30/binutils/configure	2018-06-13 08:19:13.214763200 +0300
-@@ -5764,7 +5764,7 @@
+     SHARED_LIBADD="-L`pwd`/../libiberty/pic -L`pwd`/../intl -liberty -lintl"
+diff -Nbadur binutils-2.36.1.orig/binutils/configure binutils-2.36.1/binutils/configure
+--- binutils-2.36.1.orig/binutils/configure	2021-02-06 17:03:12.000000000 +0800
++++ binutils-2.36.1/binutils/configure	2021-02-18 17:57:15.593262500 +0800
+@@ -6094,7 +6094,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -211,7 +202,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -6106,7 +6106,7 @@
+@@ -6436,7 +6436,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -220,7 +211,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -6686,7 +6686,7 @@
+@@ -7016,7 +7016,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -229,7 +220,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -8301,7 +8301,7 @@
+@@ -8631,7 +8631,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -238,7 +229,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -8383,7 +8383,7 @@
+@@ -8713,7 +8713,7 @@
        fi
        ;;
  
@@ -247,7 +238,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -8845,7 +8845,7 @@
+@@ -9175,7 +9175,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -256,7 +247,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -8960,7 +8960,7 @@
+@@ -9290,7 +9290,7 @@
        fi
        ;;
  
@@ -265,7 +256,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
        # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec='-L$libdir'
-@@ -9391,7 +9391,7 @@
+@@ -9721,7 +9721,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -274,7 +265,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -10292,14 +10292,14 @@
+@@ -10622,14 +10622,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -291,7 +282,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -10323,6 +10323,12 @@
+@@ -10653,6 +10653,12 @@
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
@@ -304,7 +295,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -10959,7 +10965,7 @@
+@@ -11279,7 +11285,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -313,7 +304,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
-@@ -13653,7 +13659,7 @@
+@@ -14520,7 +14526,7 @@
  
  
  case "${host}" in
@@ -322,7 +313,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
  
  $as_echo "#define USE_BINARY_FOPEN 1" >>confdefs.h
   ;;
-@@ -14505,7 +14511,7 @@
+@@ -15355,7 +15361,7 @@
  	  BUILD_WINDRES='$(WINDRES_PROG)$(EXEEXT)'
  	  BUILD_WINDMC='$(WINDMC_PROG)$(EXEEXT)'
  	  ;;
@@ -331,7 +322,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
    	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
  	  if test -z "$DLLTOOL_DEFAULT"; then
  	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_MX86_64"
-@@ -14515,7 +14521,7 @@
+@@ -15365,7 +15371,7 @@
  	  BUILD_WINDMC='$(WINDMC_PROG)$(EXEEXT)'
  	  BUILD_DLLWRAP='$(DLLWRAP_PROG)$(EXEEXT)'
  	  ;;
@@ -340,19 +331,10 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
    	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
  	  if test -z "$DLLTOOL_DEFAULT"; then
  	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_I386"
-@@ -14537,7 +14543,7 @@
- 	powerpc*-aix[5-9].*)
- 	  OBJDUMP_DEFS="-DAIX_WEAK_SUPPORT"
- 	  ;;
--	powerpc*-*-pe* | powerpc*-*-cygwin*)
-+	powerpc*-*-pe* | powerpc*-*-cygwin* | powerpc*-*-msys*)
-   	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
- 	  if test -z "$DLLTOOL_DEFAULT"; then
- 	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_PPC"
-diff -Naur binutils-2.30.orig/binutils/configure.ac binutils-2.30/binutils/configure.ac
---- binutils-2.30.orig/binutils/configure.ac	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/configure.ac	2018-06-13 08:19:13.214763200 +0300
-@@ -315,7 +315,7 @@
+diff -Nbadur binutils-2.36.1.orig/binutils/configure.ac binutils-2.36.1/binutils/configure.ac
+--- binutils-2.36.1.orig/binutils/configure.ac	2021-01-09 18:47:33.000000000 +0800
++++ binutils-2.36.1/binutils/configure.ac	2021-02-18 17:57:15.624477400 +0800
+@@ -305,7 +305,7 @@
  	  BUILD_WINDRES='$(WINDRES_PROG)$(EXEEXT)'
  	  BUILD_WINDMC='$(WINDMC_PROG)$(EXEEXT)'
  	  ;;
@@ -361,7 +343,7 @@ diff -Naur binutils-2.30.orig/binutils/configure.ac binutils-2.30/binutils/confi
    	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
  	  if test -z "$DLLTOOL_DEFAULT"; then
  	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_MX86_64"
-@@ -326,7 +326,7 @@
+@@ -316,7 +316,7 @@
  	  BUILD_DLLWRAP='$(DLLWRAP_PROG)$(EXEEXT)'
  	  ;;
  changequote(,)dnl
@@ -370,18 +352,9 @@ diff -Naur binutils-2.30.orig/binutils/configure.ac binutils-2.30/binutils/confi
  changequote([,])dnl
    	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
  	  if test -z "$DLLTOOL_DEFAULT"; then
-@@ -355,7 +355,7 @@
- changequote([,])dnl
- 	  OBJDUMP_DEFS="-DAIX_WEAK_SUPPORT"
- 	  ;;
--	powerpc*-*-pe* | powerpc*-*-cygwin*)
-+	powerpc*-*-pe* | powerpc*-*-cygwin* | powerpc*-*-msys*)
-   	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
- 	  if test -z "$DLLTOOL_DEFAULT"; then
- 	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_PPC"
-diff -Naur binutils-2.30.orig/binutils/dllwrap.c binutils-2.30/binutils/dllwrap.c
---- binutils-2.30.orig/binutils/dllwrap.c	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/dllwrap.c	2018-06-13 08:19:13.214763200 +0300
+diff -Nbadur binutils-2.36.1.orig/binutils/dllwrap.c binutils-2.36.1/binutils/dllwrap.c
+--- binutils-2.36.1.orig/binutils/dllwrap.c	2021-01-09 18:47:33.000000000 +0800
++++ binutils-2.36.1/binutils/dllwrap.c	2021-02-18 17:57:15.640098700 +0800
 @@ -78,6 +78,7 @@
  typedef enum {
    UNKNOWN_TARGET,
@@ -390,7 +363,7 @@ diff -Naur binutils-2.30.orig/binutils/dllwrap.c binutils-2.30/binutils/dllwrap.
    MINGW_TARGET
  }
  target_type;
-@@ -832,6 +833,8 @@
+@@ -835,6 +836,8 @@
    /* Set the target platform.  */
    if (strstr (target, "cygwin"))
      which_target = CYGWIN_TARGET;
@@ -399,7 +372,7 @@ diff -Naur binutils-2.30.orig/binutils/dllwrap.c binutils-2.30/binutils/dllwrap.
    else if (strstr (target, "mingw"))
      which_target = MINGW_TARGET;
    else
-@@ -883,6 +886,10 @@
+@@ -886,6 +889,10 @@
  	  driver_flags = cygwin_driver_flags;
  	  break;
  
@@ -410,7 +383,7 @@ diff -Naur binutils-2.30.orig/binutils/dllwrap.c binutils-2.30/binutils/dllwrap.
  	case MINGW_TARGET:
  	  driver_flags = mingw32_driver_flags;
  	  break;
-@@ -916,6 +923,10 @@
+@@ -919,6 +926,10 @@
  	  name_entry = "_cygwin_dll_entry";
  	  break;
  
@@ -421,7 +394,7 @@ diff -Naur binutils-2.30.orig/binutils/dllwrap.c binutils-2.30/binutils/dllwrap.
  	case MINGW_TARGET:
  	  name_entry = "DllMainCRTStartup";
  	  break;
-@@ -979,7 +990,7 @@
+@@ -982,7 +993,7 @@
  	{
  	  dyn_string_append_cstr (step_pre1, " --export-all --exclude-symbol=");
  	  dyn_string_append_cstr (step_pre1,
@@ -430,87 +403,9 @@ diff -Naur binutils-2.30.orig/binutils/dllwrap.c binutils-2.30/binutils/dllwrap.
  	}
        dyn_string_append_cstr (step_pre1, " --output-def ");
        dyn_string_append_cstr (step_pre1, def_file_name);
-diff -Naur binutils-2.30.orig/binutils/testsuite/binutils-all/copy-3.d binutils-2.30/binutils/testsuite/binutils-all/copy-3.d
---- binutils-2.30.orig/binutils/testsuite/binutils-all/copy-3.d	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/testsuite/binutils-all/copy-3.d	2018-06-13 08:19:13.214763200 +0300
-@@ -3,7 +3,7 @@
- #objcopy: --set-section-flags .text=alloc,data
- #name: copy with setting section flags 3
- #source: bintest.s
--#notarget: *-*-*aout *-*-*coff *-*-cygwin* *-*-darwin *-*-mingw* *-*-go32 *-*-*pe hppa*-*-hpux* ns32k-*-* powerpc-*-aix* rs6000-*-* rx-*-*
-+#notarget: *-*-*aout *-*-*coff *-*-cygwin* *-*-msys* *-*-darwin *-*-mingw* *-*-go32 *-*-*pe hppa*-*-hpux* ns32k-*-* powerpc-*-aix* rs6000-*-* rx-*-*
- # The .text # section in PE/COFF has a fixed set of flags and these
- # cannot be changed.  We skip it for them.
- 
-diff -Naur binutils-2.30.orig/binutils/testsuite/binutils-all/dlltool.exp binutils-2.30/binutils/testsuite/binutils-all/dlltool.exp
---- binutils-2.30.orig/binutils/testsuite/binutils-all/dlltool.exp	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/testsuite/binutils-all/dlltool.exp	2018-06-13 08:19:13.214763200 +0300
-@@ -22,6 +22,7 @@
- 
- if {![istarget "i*86-*-*pe*"] \
-     && ![istarget "i*86-*-cygwin*"] \
-+    && ![istarget "i*86-*-msys*"] \
-     && ![istarget "i*86-*-mingw32*"] \
-     && ![istarget "arm-*-pe*"] \
-     && ![istarget "x86_64-*-mingw*"] } {
-diff -Naur binutils-2.30.orig/binutils/testsuite/binutils-all/objcopy.exp binutils-2.30/binutils/testsuite/binutils-all/objcopy.exp
---- binutils-2.30.orig/binutils/testsuite/binutils-all/objcopy.exp	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/testsuite/binutils-all/objcopy.exp	2018-06-13 08:19:13.214763200 +0300
-@@ -554,7 +554,7 @@
- 
- # Build a final executable.
- 
--if { [istarget *-*-cygwin] || [istarget *-*-mingw*] } {
-+if { [istarget *-*-cygwin] || [istarget *-*-mingw*] || [istarget *-*-msys*] } {
-     set test_prog "testprog.exe"
- } else {
-     set test_prog "testprog"
-@@ -661,6 +661,7 @@
- 	setup_xfail "arm*-*-pe"
- 	setup_xfail "*-*-mingw*"
- 	setup_xfail "*-*-cygwin*"
-+	setup_xfail "*-*-msys*"
- 
- 	fail $test1
-     }
-diff -Naur binutils-2.30.orig/binutils/testsuite/binutils-all/windres/windres.exp binutils-2.30/binutils/testsuite/binutils-all/windres/windres.exp
---- binutils-2.30.orig/binutils/testsuite/binutils-all/windres/windres.exp	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/testsuite/binutils-all/windres/windres.exp	2018-06-13 08:19:13.214763200 +0300
-@@ -19,7 +19,7 @@
- 
- # Written by DJ Delorie <dj@redhat.com>
- 
--if {![istarget "i*86-*-*"] && ![istarget "x86_64-*-mingw*"] && ![istarget "x86_64-*-cygwin"] } {
-+if {![istarget "i*86-*-*"] && ![istarget "x86_64-*-mingw*"] && ![istarget "x86_64-*-cygwin"] && ![istarget "x86_64-*-msys"] } {
-     verbose "Not a Cygwin/Mingw target" 1
-     return
- }
-diff -Naur binutils-2.30.orig/binutils/testsuite/lib/binutils-common.exp binutils-2.30/binutils/testsuite/lib/binutils-common.exp
---- binutils-2.30.orig/binutils/testsuite/lib/binutils-common.exp	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/testsuite/lib/binutils-common.exp	2018-06-13 08:19:13.230363200 +0300
-@@ -98,6 +98,7 @@
-     if { [istarget *-*-beospe*]
- 	 || [istarget *-*-cegcc*]
- 	 || [istarget *-*-cygwin*]
-+	 || [istarget *-*-msys*]
- 	 || [istarget *-*-interix*]
- 	 || [istarget *-*-mingw*]
- 	 || [istarget *-*-netbsdpe*]
-diff -Naur binutils-2.30.orig/binutils/testsuite/lib/utils-lib.exp binutils-2.30/binutils/testsuite/lib/utils-lib.exp
---- binutils-2.30.orig/binutils/testsuite/lib/utils-lib.exp	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/testsuite/lib/utils-lib.exp	2018-06-13 08:19:13.230363200 +0300
-@@ -136,7 +136,7 @@
- #	Returns target executable extension, if any.
- #
- proc exe_ext {} {
--    if { [istarget *-*-mingw*] || [istarget *-*-cygwin*] } {
-+    if { [istarget *-*-mingw*] || [istarget *-*-cygwin*] || [istarget *-*-msys*] } {
-         return ".exe"
-     } else {
-         return ""
-diff -Naur binutils-2.30.orig/compile binutils-2.30/compile
---- binutils-2.30.orig/compile	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/compile	2018-06-13 08:19:13.230363200 +0300
+diff -Nbadur binutils-2.36.1.orig/compile binutils-2.36.1/compile
+--- binutils-2.36.1.orig/compile	2021-01-09 18:47:33.000000000 +0800
++++ binutils-2.36.1/compile	2021-02-18 17:57:15.655724600 +0800
 @@ -53,7 +53,7 @@
  	  MINGW*)
  	    file_conv=mingw
@@ -529,12 +424,12 @@ diff -Naur binutils-2.30.orig/compile binutils-2.30/compile
  	  file=`cygpath -m "$file" || echo "$file"`
  	  ;;
  	wine/*)
-diff -Naur binutils-2.30.orig/config/dfp.m4 binutils-2.30/config/dfp.m4
---- binutils-2.30.orig/config/dfp.m4	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config/dfp.m4	2018-06-13 08:19:13.230363200 +0300
+diff -Nbadur binutils-2.36.1.orig/config/dfp.m4 binutils-2.36.1/config/dfp.m4
+--- binutils-2.36.1.orig/config/dfp.m4	2021-01-09 18:47:33.000000000 +0800
++++ binutils-2.36.1/config/dfp.m4	2021-02-18 17:57:15.671352700 +0800
 @@ -23,7 +23,8 @@
      powerpc*-*-linux* | i?86*-*-linux* | x86_64*-*-linux* | s390*-*-linux* | \
-     i?86*-*-elfiamcu | i?86*-*-gnu* | \
+     i?86*-*-elfiamcu | i?86*-*-gnu* | x86_64*-*-gnu* | \
      i?86*-*-mingw* | x86_64*-*-mingw* | \
 -    i?86*-*-cygwin* | x86_64*-*-cygwin*)
 +    i?86*-*-cygwin* | x86_64*-*-cygwin* | \
@@ -542,9 +437,9 @@ diff -Naur binutils-2.30.orig/config/dfp.m4 binutils-2.30/config/dfp.m4
        enable_decimal_float=yes
        ;;
      *)
-diff -Naur binutils-2.30.orig/config/elf.m4 binutils-2.30/config/elf.m4
---- binutils-2.30.orig/config/elf.m4	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config/elf.m4	2018-06-13 08:19:13.230363200 +0300
+diff -Nbadur binutils-2.36.1.orig/config/elf.m4 binutils-2.36.1/config/elf.m4
+--- binutils-2.36.1.orig/config/elf.m4	2021-01-09 18:47:33.000000000 +0800
++++ binutils-2.36.1/config/elf.m4	2021-02-18 17:57:15.671352700 +0800
 @@ -15,7 +15,7 @@
  
  target_elf=no
@@ -554,9 +449,9 @@ diff -Naur binutils-2.30.orig/config/elf.m4 binutils-2.30/config/elf.m4
    *-msdosdjgpp* | *-vms* | *-wince* | *-*-pe* | \
    alpha*-dec-osf* | *-interix* | hppa[[12]]*-*-hpux* | \
    nvptx-*-none)
-diff -Naur binutils-2.30.orig/config/lthostflags.m4 binutils-2.30/config/lthostflags.m4
---- binutils-2.30.orig/config/lthostflags.m4	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config/lthostflags.m4	2018-06-13 08:19:13.230363200 +0300
+diff -Nbadur binutils-2.36.1.orig/config/lthostflags.m4 binutils-2.36.1/config/lthostflags.m4
+--- binutils-2.36.1.orig/config/lthostflags.m4	2021-01-09 18:47:33.000000000 +0800
++++ binutils-2.36.1/config/lthostflags.m4	2021-02-18 17:57:15.686980000 +0800
 @@ -13,7 +13,7 @@
  AC_REQUIRE([AC_CANONICAL_SYSTEM])
  
@@ -566,9 +461,9 @@ diff -Naur binutils-2.30.orig/config/lthostflags.m4 binutils-2.30/config/lthostf
      # 'host' will be top-level target in the case of a target lib,
      # we must compare to with_cross_host to decide if this is a native
      # or cross-compiler and select where to install dlls appropriately.
-diff -Naur binutils-2.30.orig/config/mmap.m4 binutils-2.30/config/mmap.m4
---- binutils-2.30.orig/config/mmap.m4	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config/mmap.m4	2018-06-13 08:19:13.230363200 +0300
+diff -Nbadur binutils-2.36.1.orig/config/mmap.m4 binutils-2.36.1/config/mmap.m4
+--- binutils-2.36.1.orig/config/mmap.m4	2021-01-09 18:47:33.000000000 +0800
++++ binutils-2.36.1/config/mmap.m4	2021-02-18 17:57:15.702597300 +0800
 @@ -42,7 +42,7 @@
     # Systems known to be in this category are Windows (all variants),
     # VMS, and Darwin.
@@ -587,9 +482,9 @@ diff -Naur binutils-2.30.orig/config/mmap.m4 binutils-2.30/config/mmap.m4
          gcc_cv_func_mmap_anon=no ;;
       *)
          gcc_cv_func_mmap_anon=yes;;
-diff -Naur binutils-2.30.orig/config/picflag.m4 binutils-2.30/config/picflag.m4
---- binutils-2.30.orig/config/picflag.m4	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config/picflag.m4	2018-06-13 08:19:13.230363200 +0300
+diff -Nbadur binutils-2.36.1.orig/config/picflag.m4 binutils-2.36.1/config/picflag.m4
+--- binutils-2.36.1.orig/config/picflag.m4	2021-01-09 18:47:33.000000000 +0800
++++ binutils-2.36.1/config/picflag.m4	2021-02-18 17:57:15.702597300 +0800
 @@ -25,6 +25,8 @@
  	;;
      i[[34567]]86-*-cygwin* | x86_64-*-cygwin*)
@@ -599,9 +494,9 @@ diff -Naur binutils-2.30.orig/config/picflag.m4 binutils-2.30/config/picflag.m4
      i[[34567]]86-*-mingw* | x86_64-*-mingw*)
  	;;
      i[[34567]]86-*-interix[[3-9]]*)
-diff -Naur binutils-2.30.orig/config/tcl.m4 binutils-2.30/config/tcl.m4
---- binutils-2.30.orig/config/tcl.m4	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config/tcl.m4	2018-06-13 08:19:13.230363200 +0300
+diff -Nbadur binutils-2.36.1.orig/config/tcl.m4 binutils-2.36.1/config/tcl.m4
+--- binutils-2.36.1.orig/config/tcl.m4	2021-01-09 18:47:33.000000000 +0800
++++ binutils-2.36.1/config/tcl.m4	2021-02-18 17:57:15.718227900 +0800
 @@ -33,7 +33,7 @@
  
  	    # First check to see if --with-tcl was specified.
@@ -620,22 +515,22 @@ diff -Naur binutils-2.30.orig/config/tcl.m4 binutils-2.30/config/tcl.m4
  		*) platDir="unix" ;;
  	    esac
  	    if test x"${ac_cv_c_tkconfig}" = x ; then
-diff -Naur binutils-2.30.orig/config.guess binutils-2.30/config.guess
---- binutils-2.30.orig/config.guess	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config.guess	2018-06-13 08:22:46.858542000 +0300
-@@ -876,6 +876,9 @@
+diff -Nbadur binutils-2.36.1.orig/config.guess binutils-2.36.1/config.guess
+--- binutils-2.36.1.orig/config.guess	2021-01-09 18:47:33.000000000 +0800
++++ binutils-2.36.1/config.guess	2021-02-18 17:57:15.718227900 +0800
+@@ -915,6 +915,9 @@
      amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
- 	echo x86_64-unknown-cygwin
+ 	echo x86_64-pc-cygwin
  	exit ;;
 +    amd64:MSYS*:*:* | x86_64:MSYS*:*:*)
 +	echo x86_64-unknown-msys
 +	exit ;;
      prep*:SunOS:5.*:*)
- 	echo powerpcle-unknown-solaris2`echo ${UNAME_RELEASE}|sed -e 's/[^.]*//'`
+ 	echo powerpcle-unknown-solaris2"$(echo "$UNAME_RELEASE"|sed -e 's/[^.]*//')"
  	exit ;;
-diff -Naur binutils-2.30.orig/config.rpath binutils-2.30/config.rpath
---- binutils-2.30.orig/config.rpath	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config.rpath	2018-06-13 08:19:13.245963200 +0300
+diff -Nbadur binutils-2.36.1.orig/config.rpath binutils-2.36.1/config.rpath
+--- binutils-2.36.1.orig/config.rpath	2021-01-09 18:47:33.000000000 +0800
++++ binutils-2.36.1/config.rpath	2021-02-18 17:57:15.733855200 +0800
 @@ -109,7 +109,7 @@
  hardcode_minus_L=no
  
@@ -672,10 +567,10 @@ diff -Naur binutils-2.30.orig/config.rpath binutils-2.30/config.rpath
      shrext=.dll
      ;;
    darwin* | rhapsody*)
-diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
---- binutils-2.30.orig/configure	2018-01-13 16:43:23.000000000 +0300
-+++ binutils-2.30/configure	2018-06-13 08:24:38.459138200 +0300
-@@ -3037,7 +3037,7 @@
+diff -Nbadur binutils-2.36.1.orig/configure binutils-2.36.1/configure
+--- binutils-2.36.1.orig/configure	2021-01-24 18:41:35.000000000 +0800
++++ binutils-2.36.1/configure	2021-02-18 17:57:15.749494000 +0800
+@@ -3082,7 +3082,7 @@
  # Configure extra directories which are host specific
  
  case "${host}" in
@@ -684,7 +579,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
      configdirs="$configdirs libtermcap" ;;
  esac
  
-@@ -3457,7 +3457,7 @@
+@@ -3483,7 +3483,7 @@
  # Disable the go frontend on systems where it is known to not work. Please keep
  # this in sync with contrib/config-list.mk.
  case "${target}" in
@@ -693,7 +588,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
      unsupported_languages="$unsupported_languages go"
      ;;
  esac
-@@ -3470,7 +3470,7 @@
+@@ -3515,7 +3515,7 @@
  	# PR 46986
  	noconfigdirs="$noconfigdirs target-libgo"
  	;;
@@ -702,7 +597,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
  	noconfigdirs="$noconfigdirs target-libgo"
  	;;
      esac
-@@ -3738,7 +3738,7 @@
+@@ -3783,7 +3783,7 @@
    i[3456789]86-*-mingw*)
      target_configdirs="$target_configdirs target-winsup"
      ;;
@@ -711,7 +606,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
      target_configdirs="$target_configdirs target-libtermcap target-winsup"
      noconfigdirs="$noconfigdirs target-libgloss"
      # always build newlib if winsup directory is present.
-@@ -3876,7 +3876,7 @@
+@@ -3931,7 +3931,7 @@
    i[3456789]86-*-msdosdjgpp*)
      host_makefile_frag="config/mh-djgpp"
      ;;
@@ -720,7 +615,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
  
  { $as_echo "$as_me:${as_lineno-$LINENO}: checking to see if cat works as expected" >&5
  $as_echo_n "checking to see if cat works as expected... " >&6; }
-@@ -5994,7 +5994,7 @@
+@@ -6091,7 +6091,7 @@
  
  target_elf=no
  case $target in
@@ -729,7 +624,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
    *-msdosdjgpp* | *-vms* | *-wince* | *-*-pe* | \
    alpha*-dec-osf* | *-interix* | hppa[12]*-*-hpux* | \
    nvptx-*-none)
-@@ -6012,7 +6012,7 @@
+@@ -6109,7 +6109,7 @@
  else
    if test x"$default_enable_lto" = x"yes" ; then
      case $target in
@@ -738,16 +633,16 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
        # On other non-ELF platforms, LTO has yet to be validated.
        *) enable_lto=no ;;
      esac
-@@ -6023,7 +6023,7 @@
+@@ -6120,7 +6120,7 @@
    # warn during gcc/ subconfigure; unless you're bootstrapping with
    # -flto it won't be needed until after installation anyway.
      case $target in
 -      *-cygwin* | *-mingw* | *-apple-darwin* | *djgpp*) ;;
 +      *-cygwin* | *-msys* | *-mingw* | *-apple-darwin* | *djgpp*) ;;
        *) if test x"$enable_lto" = x"yes"; then
- 	as_fn_error "LTO support is not enabled for this target." "$LINENO" 5
+ 	as_fn_error $? "LTO support is not enabled for this target." "$LINENO" 5
          fi
-@@ -6033,7 +6033,7 @@
+@@ -6130,7 +6130,7 @@
    # Among non-ELF, only Windows platforms support the lto-plugin so far.
    # Build it unless LTO was explicitly disabled.
    case $target in
@@ -756,7 +651,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
      *) ;;
    esac
  
-@@ -6997,7 +6997,7 @@
+@@ -7094,7 +7094,7 @@
  case "${host}" in
    *-*-hpux*) RPATH_ENVVAR=SHLIB_PATH ;;
    *-*-darwin*) RPATH_ENVVAR=DYLD_LIBRARY_PATH ;;
@@ -765,7 +660,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
    *) RPATH_ENVVAR=LD_LIBRARY_PATH ;;
  esac
  
-@@ -7510,7 +7510,7 @@
+@@ -7619,7 +7619,7 @@
    case " $target_configargs " in
    *" --with-newlib "*)
     case "$target" in
@@ -774,10 +669,10 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
        FLAGS_FOR_TARGET=$FLAGS_FOR_TARGET' -L$$r/$(TARGET_SUBDIR)/winsup/cygwin -isystem $$s/winsup/cygwin/include'
        ;;
     esac
-diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
---- binutils-2.30.orig/configure.ac	2018-01-27 18:13:40.000000000 +0300
-+++ binutils-2.30/configure.ac	2018-06-13 08:24:00.301471200 +0300
-@@ -403,7 +403,7 @@
+diff -Nbadur binutils-2.36.1.orig/configure.ac binutils-2.36.1/configure.ac
+--- binutils-2.36.1.orig/configure.ac	2021-02-06 17:25:05.000000000 +0800
++++ binutils-2.36.1/configure.ac	2021-02-18 17:57:15.811974100 +0800
+@@ -407,7 +407,7 @@
  # Configure extra directories which are host specific
  
  case "${host}" in
@@ -786,7 +681,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
      configdirs="$configdirs libtermcap" ;;
  esac
  
-@@ -788,7 +788,7 @@
+@@ -776,7 +776,7 @@
  # Disable the go frontend on systems where it is known to not work. Please keep
  # this in sync with contrib/config-list.mk.
  case "${target}" in
@@ -795,7 +690,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
      unsupported_languages="$unsupported_languages go"
      ;;
  esac
-@@ -801,7 +801,7 @@
+@@ -805,7 +805,7 @@
  	# PR 46986
  	noconfigdirs="$noconfigdirs target-libgo"
  	;;
@@ -804,7 +699,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
  	noconfigdirs="$noconfigdirs target-libgo"
  	;;
      esac
-@@ -1069,7 +1069,7 @@
+@@ -1073,7 +1073,7 @@
    i[[3456789]]86-*-mingw*)
      target_configdirs="$target_configdirs target-winsup"
      ;;
@@ -813,7 +708,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
      target_configdirs="$target_configdirs target-libtermcap target-winsup"
      noconfigdirs="$noconfigdirs target-libgloss"
      # always build newlib if winsup directory is present.
-@@ -1207,7 +1207,7 @@
+@@ -1221,7 +1221,7 @@
    i[[3456789]]86-*-msdosdjgpp*)
      host_makefile_frag="config/mh-djgpp"
      ;;
@@ -822,7 +717,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
      ACX_CHECK_CYGWIN_CAT_WORKS
      host_makefile_frag="config/mh-cygwin"
      ;;
-@@ -1697,7 +1697,7 @@
+@@ -1725,7 +1725,7 @@
    build_lto_plugin=yes
  ],[if test x"$default_enable_lto" = x"yes" ; then
      case $target in
@@ -831,7 +726,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
        # On other non-ELF platforms, LTO has yet to be validated.
        *) enable_lto=no ;;
      esac
-@@ -1708,7 +1708,7 @@
+@@ -1736,7 +1736,7 @@
    # warn during gcc/ subconfigure; unless you're bootstrapping with
    # -flto it won't be needed until after installation anyway.
      case $target in
@@ -840,7 +735,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
        *) if test x"$enable_lto" = x"yes"; then
  	AC_MSG_ERROR([LTO support is not enabled for this target.])
          fi
-@@ -1718,7 +1718,7 @@
+@@ -1746,7 +1746,7 @@
    # Among non-ELF, only Windows platforms support the lto-plugin so far.
    # Build it unless LTO was explicitly disabled.
    case $target in
@@ -849,7 +744,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
      *) ;;
    esac
  ])
-@@ -2591,7 +2591,7 @@
+@@ -2619,7 +2619,7 @@
  case "${host}" in
    *-*-hpux*) RPATH_ENVVAR=SHLIB_PATH ;;
    *-*-darwin*) RPATH_ENVVAR=DYLD_LIBRARY_PATH ;;
@@ -858,7 +753,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
    *) RPATH_ENVVAR=LD_LIBRARY_PATH ;;
  esac
  
-@@ -3099,7 +3099,7 @@
+@@ -3139,7 +3139,7 @@
    case " $target_configargs " in
    *" --with-newlib "*)
     case "$target" in
@@ -867,10 +762,10 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
        FLAGS_FOR_TARGET=$FLAGS_FOR_TARGET' -L$$r/$(TARGET_SUBDIR)/winsup/cygwin -isystem $$s/winsup/cygwin/include'
        ;;
     esac
-diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
---- binutils-2.30.orig/gas/configure	2018-01-27 17:59:06.000000000 +0300
-+++ binutils-2.30/gas/configure	2018-06-13 08:19:13.277163300 +0300
-@@ -5525,7 +5525,7 @@
+diff -Nbadur binutils-2.36.1.orig/gas/configure binutils-2.36.1/gas/configure
+--- binutils-2.36.1.orig/gas/configure	2021-02-06 17:02:48.000000000 +0800
++++ binutils-2.36.1/gas/configure	2021-02-18 17:57:15.843223200 +0800
+@@ -5882,7 +5882,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -879,7 +774,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -5867,7 +5867,7 @@
+@@ -6224,7 +6224,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -888,7 +783,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -6447,7 +6447,7 @@
+@@ -6804,7 +6804,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -897,7 +792,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -8062,7 +8062,7 @@
+@@ -8419,7 +8419,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -906,7 +801,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -8144,7 +8144,7 @@
+@@ -8501,7 +8501,7 @@
        fi
        ;;
  
@@ -915,7 +810,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -8606,7 +8606,7 @@
+@@ -8963,7 +8963,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -924,7 +819,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -8721,7 +8721,7 @@
+@@ -9078,7 +9078,7 @@
        fi
        ;;
  
@@ -933,7 +828,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec='-L$libdir'
-@@ -9152,7 +9152,7 @@
+@@ -9509,7 +9509,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -942,7 +837,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -10053,14 +10053,14 @@
+@@ -10410,14 +10410,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -959,7 +854,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -10084,6 +10084,12 @@
+@@ -10441,6 +10441,12 @@
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
@@ -972,7 +867,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -10720,7 +10726,7 @@
+@@ -11067,7 +11073,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -981,7 +876,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
-@@ -13951,7 +13957,7 @@
+@@ -14512,7 +14518,7 @@
  yes)
    LIBM=
  case $host in
@@ -990,7 +885,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
    # These system don't have libm, or don't need it
    ;;
  *-ncr-sysv4.3*)
-@@ -14543,7 +14549,7 @@
+@@ -15104,7 +15110,7 @@
  
  
  case "${host}" in
@@ -999,10 +894,10 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
  
  $as_echo "#define USE_BINARY_FOPEN 1" >>confdefs.h
   ;;
-diff -Naur binutils-2.30.orig/gas/configure.tgt binutils-2.30/gas/configure.tgt
---- binutils-2.30.orig/gas/configure.tgt	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/gas/configure.tgt	2018-06-13 08:19:13.277163300 +0300
-@@ -275,7 +275,7 @@
+diff -Nbadur binutils-2.36.1.orig/gas/configure.tgt binutils-2.36.1/gas/configure.tgt
+--- binutils-2.36.1.orig/gas/configure.tgt	2021-01-09 18:47:33.000000000 +0800
++++ binutils-2.36.1/gas/configure.tgt	2021-02-18 17:57:15.905734600 +0800
+@@ -243,7 +243,7 @@
    i386-*-msdos*)			fmt=aout ;;
    i386-*-moss*)				fmt=elf ;;
    i386-*-pe)				fmt=coff em=pe ;;
@@ -1011,61 +906,10 @@ diff -Naur binutils-2.30.orig/gas/configure.tgt binutils-2.30/gas/configure.tgt
     case ${cpu} in
       x86_64*)				fmt=coff em=pep ;;
       i*)				fmt=coff em=pe ;;
-diff -Naur binutils-2.30.orig/gas/testsuite/gas/all/gas.exp binutils-2.30/gas/testsuite/gas/all/gas.exp
---- binutils-2.30.orig/gas/testsuite/gas/all/gas.exp	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/gas/testsuite/gas/all/gas.exp	2018-06-13 08:19:13.277163300 +0300
-@@ -177,8 +177,8 @@
- 	# failures.
- 	setup_xfail "bfin-*-*" "i\[3-7\]86-*-*coff" \
- 	    "i\[3-7\]86-*-*pe" "i\[3-7\]86-*-go32*" \
--	    "i\[3-7\]86-*-cygwin*" "i\[3-7\]86-*-mingw*" \
--	    "x86_64-*-cygwin*" "x86_64-*-mingw*"
-+	    "i\[3-7\]86-*-cygwin*" "i\[3-7\]86-*-msys*" "i\[3-7\]86-*-mingw*" \
-+	    "x86_64-*-cygwin*" "x86_64-*-msys*" "x86_64-*-mingw*"
- 	run_dump_test redef3
- 	gas_test_error "redef4.s" "" ".set for symbol already used as label"
- 	gas_test_error "redef5.s" "" ".set for symbol already defined through .comm"
-@@ -333,6 +333,7 @@
-      || [istarget i*86-*-isc*] \
-      || [istarget i*86-*-go32*] \
-      || [istarget i*86-*-cygwin*] \
-+     || [istarget i*86-*-msys*] \
-      || [istarget x86_64-*-mingw*] \
-      || [istarget i*86-*-*nt] \
-      || [istarget i*86-*-interix*] \
-@@ -381,6 +382,7 @@
- 
- if {  ([istarget "i*86-*-*pe*"] && ![istarget "i*86-*-openbsd*"]) \
-     || [istarget "i*86-*-cygwin*"] \
-+    || [istarget "i*86-*-msys*"] \
-     || [istarget "i*86-*-mingw32*"] } {
-   gas_test "fastcall.s" ""   "" "fastcall labels"
- }
-diff -Naur binutils-2.30.orig/gas/testsuite/gas/i386/i386.exp binutils-2.30/gas/testsuite/gas/i386/i386.exp
---- binutils-2.30.orig/gas/testsuite/gas/i386/i386.exp	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/gas/testsuite/gas/i386/i386.exp	2018-06-13 08:19:13.277163300 +0300
-@@ -510,7 +510,7 @@
- 
-     # This is a PE specific test.
-     if { [istarget "*-*-cygwin*"] || [istarget "*-*-pe"]
--	 || [istarget "*-*-mingw*"]
-+	 || [istarget "*-*-mingw*"] || [istarget "*-*-msys*"]
-     } then {
- 	run_dump_test "secrel"
-     }
-@@ -667,7 +667,7 @@
-     run_dump_test "x86-64-addr32-intel"
-     run_dump_test "x86-64-opcode"
-     run_dump_test "x86-64-intel64"
--    if { ! [istarget "*-*-*cygwin*"] && ![istarget "*-*-mingw*"] } then {
-+    if { ! [istarget "*-*-*cygwin*"] && ![istarget "*-*-mingw*"] && ![istarget "*-*-msys*"] } then {
-       run_dump_test "x86-64-pcrel"
-       run_dump_test "x86-64-disassem"
-     } else {
-diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
---- binutils-2.30.orig/gprof/configure	2018-01-27 18:02:44.000000000 +0300
-+++ binutils-2.30/gprof/configure	2018-06-13 08:19:13.292763300 +0300
-@@ -5440,7 +5440,7 @@
+diff -Nbadur binutils-2.36.1.orig/gprof/configure binutils-2.36.1/gprof/configure
+--- binutils-2.36.1.orig/gprof/configure	2021-02-06 17:03:47.000000000 +0800
++++ binutils-2.36.1/gprof/configure	2021-02-18 17:57:15.921358800 +0800
+@@ -5729,7 +5729,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -1074,7 +918,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -5782,7 +5782,7 @@
+@@ -6071,7 +6071,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -1083,7 +927,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -6362,7 +6362,7 @@
+@@ -6651,7 +6651,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -1092,7 +936,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -7977,7 +7977,7 @@
+@@ -8266,7 +8266,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -1101,7 +945,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -8059,7 +8059,7 @@
+@@ -8348,7 +8348,7 @@
        fi
        ;;
  
@@ -1110,7 +954,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -8521,7 +8521,7 @@
+@@ -8810,7 +8810,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -1119,7 +963,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -8636,7 +8636,7 @@
+@@ -8925,7 +8925,7 @@
        fi
        ;;
  
@@ -1128,7 +972,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec='-L$libdir'
-@@ -9067,7 +9067,7 @@
+@@ -9356,7 +9356,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -1137,7 +981,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -9968,14 +9968,14 @@
+@@ -10257,14 +10257,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -1154,7 +998,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -9999,6 +9999,12 @@
+@@ -10288,6 +10288,12 @@
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
@@ -1167,7 +1011,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -10635,7 +10641,7 @@
+@@ -10914,7 +10920,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -1176,10 +1020,10 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
-diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
---- binutils-2.30.orig/ld/configure	2018-01-27 18:03:10.000000000 +0300
-+++ binutils-2.30/ld/configure	2018-06-13 08:19:13.292763300 +0300
-@@ -6262,7 +6262,7 @@
+diff -Nbadur binutils-2.36.1.orig/ld/configure binutils-2.36.1/ld/configure
+--- binutils-2.36.1.orig/ld/configure	2021-02-06 17:03:33.000000000 +0800
++++ binutils-2.36.1/ld/configure	2021-02-18 17:57:15.952602400 +0800
+@@ -6580,7 +6580,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -1188,7 +1032,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -6604,7 +6604,7 @@
+@@ -6922,7 +6922,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -1197,7 +1041,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -7184,7 +7184,7 @@
+@@ -7502,7 +7502,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -1206,7 +1050,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -8800,7 +8800,7 @@
+@@ -9118,7 +9118,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -1215,7 +1059,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -8882,7 +8882,7 @@
+@@ -9200,7 +9200,7 @@
        fi
        ;;
  
@@ -1224,7 +1068,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -9344,7 +9344,7 @@
+@@ -9662,7 +9662,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -1233,7 +1077,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -9459,7 +9459,7 @@
+@@ -9777,7 +9777,7 @@
        fi
        ;;
  
@@ -1242,7 +1086,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec='-L$libdir'
-@@ -9890,7 +9890,7 @@
+@@ -10208,7 +10208,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -1251,7 +1095,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -10791,14 +10791,14 @@
+@@ -11109,14 +11109,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -1268,7 +1112,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -10822,6 +10822,12 @@
+@@ -11140,6 +11140,12 @@
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
@@ -1281,7 +1125,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -11458,7 +11464,7 @@
+@@ -11766,7 +11772,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -1290,7 +1134,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
-@@ -12680,7 +12686,7 @@
+@@ -12988,7 +12994,7 @@
          esac
          ;;
  
@@ -1299,7 +1143,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
          # _LT_TAGVAR(hardcode_libdir_flag_spec, CXX) is actually meaningless,
          # as there is no search path for DLLs.
          hardcode_libdir_flag_spec_CXX='-L$libdir'
-@@ -13649,7 +13655,7 @@
+@@ -13957,7 +13963,7 @@
      beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
        # PIC is the default for these OSes.
        ;;
@@ -1308,7 +1152,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -14189,7 +14195,7 @@
+@@ -14497,7 +14503,7 @@
    pw32*)
      export_symbols_cmds_CXX="$ltdll_cmds"
    ;;
@@ -1317,7 +1161,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
      export_symbols_cmds_CXX='$NM $libobjs $convenience | $global_symbol_pipe | $SED -e '\''/^[BCDGRS][ ]/s/.*[ ]\([^ ]*\)/\1 DATA/;/^.*[ ]__nm__/s/^.*[ ]__nm__\([^ ]*\)[ ][^ ]*/\1 DATA/;/^I[ ]/d;/^[AITW][ ]/s/.* //'\'' | sort | uniq > $export_symbols'
    ;;
    *)
-@@ -14453,14 +14459,14 @@
+@@ -14761,14 +14767,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -1334,7 +1178,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -14483,6 +14489,11 @@
+@@ -14791,6 +14797,11 @@
        soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
  
        ;;
@@ -1346,7 +1190,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -16995,7 +17006,7 @@
+@@ -17405,7 +17416,7 @@
  
  
  case "${host}" in
@@ -1355,10 +1199,10 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
  
  $as_echo "#define USE_BINARY_FOPEN 1" >>confdefs.h
   ;;
-diff -Naur binutils-2.30.orig/ld/configure.tgt binutils-2.30/ld/configure.tgt
---- binutils-2.30.orig/ld/configure.tgt	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/configure.tgt	2018-06-13 08:19:13.308363300 +0300
-@@ -388,7 +388,7 @@
+diff -Nbadur binutils-2.36.1.orig/ld/configure.tgt binutils-2.36.1/ld/configure.tgt
+--- binutils-2.36.1.orig/ld/configure.tgt	2021-01-09 18:47:34.000000000 +0800
++++ binutils-2.36.1/ld/configure.tgt	2021-02-18 17:57:16.015107200 +0800
+@@ -381,7 +381,7 @@
  i[3-7]86-*-pe)		targ_emul=i386pe ;
  			targ_extra_ofiles="deffilep.o pe-dll.o"
  			;;
@@ -1367,16 +1211,7 @@ diff -Naur binutils-2.30.orig/ld/configure.tgt binutils-2.30/ld/configure.tgt
  			targ_extra_ofiles="deffilep.o pe-dll.o" ;
  			test "$targ" != "$host" && LIB_PATH='${tooldir}/lib/w32api'
  			;;
-@@ -731,7 +731,7 @@
- powerpc-*-macos*)	targ_emul=ppcmacos
- 			targ_extra_ofiles=
- 			;;
--powerpcle-*-pe | powerpcle-*-winnt* | powerpcle-*-cygwin*)
-+powerpcle-*-pe | powerpcle-*-winnt* | powerpcle-*-cygwin* | powerpcle-*-msys*)
- 			targ_emul=ppcpe
- 			targ_extra_ofiles="deffilep.o pe-dll.o"
- 			;;
-@@ -988,7 +988,7 @@
+@@ -993,7 +993,7 @@
  			targ_extra_emuls=i386pe ;
  			targ_extra_ofiles="deffilep.o pep-dll.o pe-dll.o"
  			;;
@@ -1385,21 +1220,21 @@ diff -Naur binutils-2.30.orig/ld/configure.tgt binutils-2.30/ld/configure.tgt
  			targ_extra_emuls=i386pe
  			targ_extra_ofiles="deffilep.o pep-dll.o pe-dll.o"
  			test "$targ" != "$host" && LIB_PATH='${tooldir}/lib/w32api'
-@@ -1075,6 +1075,10 @@
- i[03-9x]86-*-cygwin* | x86_64-*-cygwin*)
+@@ -1076,6 +1076,10 @@
    NATIVE_LIB_DIRS='/usr/lib /usr/lib/w32api'
    ;;
-+
+ 
 +i[03-9x]86-*-msys* | x86_64-*-msys*)
 +  NATIVE_LIB_DIRS='/usr/lib /usr/lib/w32api'
 +  ;;
- 
++
  *-*-linux*)
    ;;
-diff -Naur binutils-2.30.orig/ld/emultempl/pe.em binutils-2.30/ld/emultempl/pe.em
---- binutils-2.30.orig/ld/emultempl/pe.em	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/emultempl/pe.em	2018-06-13 08:19:13.308363300 +0300
-@@ -176,7 +176,7 @@
+ 
+diff -Nbadur binutils-2.36.1.orig/ld/emultempl/pe.em binutils-2.36.1/ld/emultempl/pe.em
+--- binutils-2.36.1.orig/ld/emultempl/pe.em	2021-01-09 18:47:34.000000000 +0800
++++ binutils-2.36.1/ld/emultempl/pe.em	2021-02-18 17:57:16.015107200 +0800
+@@ -177,7 +177,7 @@
  # merge_rdata defaults to 0 for cygwin:
  #  http://cygwin.com/ml/cygwin-apps/2013-04/msg00187.html
  case ${target} in
@@ -1408,9 +1243,9 @@ diff -Naur binutils-2.30.orig/ld/emultempl/pe.em binutils-2.30/ld/emultempl/pe.e
      default_auto_import=1
      default_merge_rdata=0
      ;;
-diff -Naur binutils-2.30.orig/ld/emultempl/pep.em binutils-2.30/ld/emultempl/pep.em
---- binutils-2.30.orig/ld/emultempl/pep.em	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/emultempl/pep.em	2018-06-13 08:19:13.308363300 +0300
+diff -Nbadur binutils-2.36.1.orig/ld/emultempl/pep.em binutils-2.36.1/ld/emultempl/pep.em
+--- binutils-2.36.1.orig/ld/emultempl/pep.em	2021-01-09 18:47:34.000000000 +0800
++++ binutils-2.36.1/ld/emultempl/pep.em	2021-02-18 17:57:16.030726200 +0800
 @@ -7,7 +7,7 @@
  fi
  
@@ -1420,10 +1255,10 @@ diff -Naur binutils-2.30.orig/ld/emultempl/pep.em binutils-2.30/ld/emultempl/pep
      move_default_addr_high=1
      ;;
    *)
-diff -Naur binutils-2.30.orig/ld/pe-dll.c binutils-2.30/ld/pe-dll.c
---- binutils-2.30.orig/ld/pe-dll.c	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/pe-dll.c	2018-06-13 08:19:13.308363300 +0300
-@@ -207,6 +207,7 @@
+diff -Nbadur binutils-2.36.1.orig/ld/pe-dll.c binutils-2.36.1/ld/pe-dll.c
+--- binutils-2.36.1.orig/ld/pe-dll.c	2021-01-09 18:47:34.000000000 +0800
++++ binutils-2.36.1/ld/pe-dll.c	2021-02-18 17:57:16.046349100 +0800
+@@ -209,6 +209,7 @@
    { STRING_COMMA_LEN ("_NULL_IMPORT_DESCRIPTOR") },
    /* Entry point symbols, and entry hooks.  */
    { STRING_COMMA_LEN ("cygwin_crt0") },
@@ -1431,7 +1266,7 @@ diff -Naur binutils-2.30.orig/ld/pe-dll.c binutils-2.30/ld/pe-dll.c
  #ifdef pe_use_x86_64
    { STRING_COMMA_LEN ("DllMain") },
    { STRING_COMMA_LEN ("DllEntryPoint") },
-@@ -214,6 +215,9 @@
+@@ -216,6 +217,9 @@
    { STRING_COMMA_LEN ("_cygwin_dll_entry") },
    { STRING_COMMA_LEN ("_cygwin_crt0_common") },
    { STRING_COMMA_LEN ("_cygwin_noncygwin_dll_entry") },
@@ -1441,7 +1276,7 @@ diff -Naur binutils-2.30.orig/ld/pe-dll.c binutils-2.30/ld/pe-dll.c
  #else
    { STRING_COMMA_LEN ("DllMain@12") },
    { STRING_COMMA_LEN ("DllEntryPoint@0") },
-@@ -222,6 +226,10 @@
+@@ -224,6 +228,10 @@
    { STRING_COMMA_LEN ("_cygwin_crt0_common@8") },
    { STRING_COMMA_LEN ("_cygwin_noncygwin_dll_entry@12") },
    { STRING_COMMA_LEN ("cygwin_attach_dll") },
@@ -1452,7 +1287,7 @@ diff -Naur binutils-2.30.orig/ld/pe-dll.c binutils-2.30/ld/pe-dll.c
  #endif
    { STRING_COMMA_LEN ("cygwin_premain0") },
    { STRING_COMMA_LEN ("cygwin_premain1") },
-@@ -335,6 +343,7 @@
+@@ -337,6 +345,7 @@
  {
    { STRING_COMMA_LEN ("libcegcc") },
    { STRING_COMMA_LEN ("libcygwin") },
@@ -1460,270 +1295,149 @@ diff -Naur binutils-2.30.orig/ld/pe-dll.c binutils-2.30/ld/pe-dll.c
    { STRING_COMMA_LEN ("libgcc") },
    { STRING_COMMA_LEN ("libgcc_s") },
    { STRING_COMMA_LEN ("libstdc++") },
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-auto-import/auto-import.exp binutils-2.30/ld/testsuite/ld-auto-import/auto-import.exp
---- binutils-2.30.orig/ld/testsuite/ld-auto-import/auto-import.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-auto-import/auto-import.exp	2018-06-13 08:19:13.323963400 +0300
-@@ -56,7 +56,8 @@
+diff -Nbadur binutils-2.36.1.orig/libctf/configure binutils-2.36.1/libctf/configure
+--- binutils-2.36.1.orig/libctf/configure	2021-01-09 18:56:31.000000000 +0800
++++ binutils-2.36.1/libctf/configure	2021-02-18 17:59:22.149494600 +0800
+@@ -6086,7 +6086,7 @@
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
  
- # This test can only be run on a couple of platforms.
- # Square bracket expressions seem to confuse istarget.
--if { ![istarget *-pc-cygwin]    
-+if { ![istarget *-pc-cygwin]   
-+     && ![istarget *-pc-msys]
-      && ![istarget *-pc-mingw*] } {
-     return
- }
-@@ -113,17 +114,26 @@
- set tmpdir tmpdir
- set SHCFLAG ""
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6428,7 +6428,7 @@
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
  
--if [istarget *-pc-cygwin] {
-+if [istarget *-pc-cygwin || istarget *-pc-msys] {
-     # Set some libs needed for cygwin.
-+    if [istarget *-pc-cygwin] {
-     set MYLIBS "-L/usr/lib -lcygwin -L/usr/lib/w32api -lkernel32"
--    
-+	} else {
-+    set MYLIBS "-L/usr/lib -lmsys-2.0 -L/usr/lib/w32api -lkernel32"
-+	}
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -7008,7 +7008,7 @@
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8593,7 +8593,7 @@
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8675,7 +8675,7 @@
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9137,7 +9137,7 @@
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9252,7 +9252,7 @@
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9683,7 +9683,7 @@
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10584,14 +10584,14 @@
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10615,6 +10615,12 @@
+ 
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
++    msys*)
++      # MSYS DLLs use 'cyg' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
 +
-     # Compile the dll.
-     if ![ld_compile "$CC $CFLAGS $SHCFLAG" $srcdir/$subdir/dll.c $tmpdir/dll.o] {
- 	fail "compiling shared lib"
-     }
-+    if [istarget *-pc-cygwin] {
-     if ![ld_special_link "$ld -shared --enable-auto-import -e __cygwin_dll_entry@12 --out-implib=$tmpdir/libstandard.dll.a" $tmpdir/dll.dll "$tmpdir/dll.o $MYLIBS"] {
- 	fail "linking shared lib"
-     }
-+    } else {
-+    if ![ld_special_link "$ld -shared --enable-auto-import -e __msys_dll_entry@12 --out-implib=$tmpdir/libstandard.dll.a" $tmpdir/dll.dll "$tmpdir/dll.o $MYLIBS"] {
-+	fail "linking shared lib	
-+	}
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
+     mingw* | cegcc*)
+       # MinGW DLLs use traditional 'lib' prefix
+       soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+@@ -11241,7 +11247,7 @@
+     lt_cv_dlopen_libs=
+     ;;
  
-     # Create symbolic link.
-     catch "exec ln -fs dll.dll $tmpdir/libsymlinked_dll.dll.a" ln_catch
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-bootstrap/bootstrap.exp binutils-2.30/ld/testsuite/ld-bootstrap/bootstrap.exp
---- binutils-2.30.orig/ld/testsuite/ld-bootstrap/bootstrap.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-bootstrap/bootstrap.exp	2018-06-13 08:19:13.323963400 +0300
-@@ -126,7 +126,7 @@
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+@@ -13350,6 +13356,10 @@
+       SHARED_LDFLAGS="-no-undefined"
+       CTF_LIBADD="$CTF_LIBADD -L`pwd`/../intl -lintl -lcygwin"
+       ;;
++    *-*-cygwin*)
++      SHARED_LDFLAGS="-no-undefined"
++      CTF_LIBADD="$CTF_LIBADD -L`pwd`/../intl -lintl -lmsys-2.0"
++      ;;
+   esac
+ fi
  
-     # On Cygwin, -lintl may require -liconv when linking statically.
-     set extralibs ""
--    if { [istarget "*-*-cygwin*"]} {
-+    if { [istarget "*-*-cygwin*"] || [istarget "*-*-msys*"] } {
- 	if {"$flags" == "--static"} {
- 	    set extralibs "-liconv"
- 	}
-@@ -194,6 +194,7 @@
-     if {[istarget "*-*-pe"]
- 	|| [istarget "*-*-wince"]
- 	|| [istarget "*-*-cygwin*"]
-+	|| [istarget "*-*-msys*"]
- 	|| [istarget "*-*-winnt*"]
- 	|| [istarget "*-*-mingw*"]
- 	|| [istarget "*-*-interix*"]
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-cygwin/exe-export.exp binutils-2.30/ld/testsuite/ld-cygwin/exe-export.exp
---- binutils-2.30.orig/ld/testsuite/ld-cygwin/exe-export.exp	2018-06-13 08:38:48.028433800 +0300
-+++ binutils-2.30/ld/testsuite/ld-cygwin/exe-export.exp	2018-06-13 08:19:13.323963400 +0300
-@@ -23,7 +23,7 @@
- #
-  
- # This test can only be run on a cygwin platforms.
--if {![istarget *-pc-cygwin]} {
-+if {![istarget *-*-cygwin]} && ![istarget *-*-msys*]} {
-     verbose "Not a cygwin target."
-     return
- }
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-fastcall/fastcall.exp binutils-2.30/ld/testsuite/ld-fastcall/fastcall.exp
---- binutils-2.30.orig/ld/testsuite/ld-fastcall/fastcall.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-fastcall/fastcall.exp	2018-06-13 08:19:13.339563400 +0300
-@@ -26,6 +26,7 @@
- 
- if {  !([istarget "i*86-*-*pe*"] && ![istarget "i*86-*-opensd*"]) \
-     && ![istarget "i*86-*-cygwin*"] \
-+    && ![istarget "i*86-*-msys*"] \
-     && ![istarget "x86_64-*-mingw*"] \
-     && ![istarget "i*86-*-mingw*"] } {
-     return
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-pe/export_dynamic_warning.d binutils-2.30/ld/testsuite/ld-pe/export_dynamic_warning.d
---- binutils-2.30.orig/ld/testsuite/ld-pe/export_dynamic_warning.d	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-pe/export_dynamic_warning.d	2018-06-13 08:19:13.339563400 +0300
-@@ -1,5 +1,5 @@
- #name: PE-COFF --export-dynamic warning
--#target: *-*-mingw32 *-*-cygwin *-*-pe
-+#target: *-*-mingw32 *-*-cygwin *-*-msys *-*-pe
- #ld: --export-dynamic
- #warning: warning: --export-dynamic is not supported for PE\+? targets, did you mean --export-all-symbols\?
- 
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-pe/image_size.d binutils-2.30/ld/testsuite/ld-pe/image_size.d
---- binutils-2.30.orig/ld/testsuite/ld-pe/image_size.d	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-pe/image_size.d	2018-06-13 08:19:13.339563400 +0300
-@@ -1,7 +1,7 @@
- #name: PE-COFF SizeOfImage
- #ld: -T image_size.t
- #objdump: -p
--#target: *-*-mingw32 *-*-cygwin
-+#target: *-*-mingw32 *-*-cygwin *-*-msys
- 
- .*:     file format .*
- #...
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-pe/pe.exp binutils-2.30/ld/testsuite/ld-pe/pe.exp
---- binutils-2.30.orig/ld/testsuite/ld-pe/pe.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-pe/pe.exp	2018-06-13 08:19:13.339563400 +0300
-@@ -26,6 +26,7 @@
- 
- # This test can only be run on PE/COFF platforms that support .secrel32.
- if {[istarget i*86-*-cygwin*]
-+	|| [istarget i*86-*-msys*]
-     || [istarget i*86-*-pe]
-     || [istarget i*86-*-mingw*]
-     || [istarget x86_64-*-mingw*]
-@@ -40,7 +41,7 @@
- 	{"TLS directory entry" "" "" "" "tlssec.s"
- 	 {{objdump -p tlssec64.d}} "tlssec.dll"}
-       }
--    } elseif {[istarget i*86-*-cygwin*] } {
-+    } elseif {[istarget i*86-*-cygwin*] || [istarget i*86-*-msys*] } {
-       set pe_tests {
- 	{".secrel32" "--disable-auto-import" "" "" {secrel1.s secrel2.s}
- 	 {{objdump -s secrel.d}} "secrel.x"}
-@@ -94,7 +95,7 @@
- 
- if {[istarget x86_64-*-mingw*] } {
- 	run_dump_test "cfi"
--} elseif {[istarget i*86-*-cygwin*] || [istarget i*86-*-mingw*] } {
-+} elseif {[istarget i*86-*-cygwin*] || [istarget i*86-*-msys*] || [istarget i*86-*-mingw*] } {
- 	run_dump_test "cfi32"
- }
- 
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-pe/pe-compile.exp binutils-2.30/ld/testsuite/ld-pe/pe-compile.exp
---- binutils-2.30.orig/ld/testsuite/ld-pe/pe-compile.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-pe/pe-compile.exp	2018-06-13 08:19:13.339563400 +0300
-@@ -118,6 +118,7 @@
- run_ver_script_test "vers-script-4"
- 
- if {[istarget i*86-*-cygwin*]
-+    || [istarget i*86-*-msys*]
-     || [istarget i*86-*-pe]
-     || [istarget i*86-*-mingw*]
-     || [istarget x86_64-*-mingw*] } {
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-pe/weakdef-1.d binutils-2.30/ld/testsuite/ld-pe/weakdef-1.d
---- binutils-2.30.orig/ld/testsuite/ld-pe/weakdef-1.d	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-pe/weakdef-1.d	2018-06-13 08:19:13.339563400 +0300
-@@ -1,5 +1,5 @@
- #source: weakdef-1.s
--#target: i*86-*-cygwin* i*86-*-pe i*86-*-mingw*
-+#target: i*86-*-cygwin* i*86-*-msys* i*86-*-pe i*86-*-mingw*
- #ld: -e _start --gc-sections
- #objdump: -d
- 
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-scripts/fill.d binutils-2.30/ld/testsuite/ld-scripts/fill.d
---- binutils-2.30.orig/ld/testsuite/ld-scripts/fill.d	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-scripts/fill.d	2018-06-13 08:19:13.339563400 +0300
-@@ -5,7 +5,7 @@
- #objdump: -s -j .text
- #skip: ia64-*-* mips*-*-freebsd* mips*-*-gnu* mips*-*-irix* mips*-*-kfreebsd*
- #skip: mips*-*-linux* mips*-*-netbsd* mips*-*-openbsd* mips*-*-sysv4*
--#skip: tilegx*-*-* tilepro-*-* x86_64-*-cygwin x86_64-*-mingw* x86_64-*-pe*
-+#skip: tilegx*-*-* tilepro-*-* x86_64-*-cygwin x86_64-*-msys x86_64-*-mingw* x86_64-*-pe*
- #xfail: alpha*-*-*ecoff sh-*-pe sparc*-*-coff
- #xfail: tic30-*-coff tic4x-*-* tic54x-*-* z8k-*-*
- #
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-scripts/pr20302.d binutils-2.30/ld/testsuite/ld-scripts/pr20302.d
---- binutils-2.30.orig/ld/testsuite/ld-scripts/pr20302.d	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-scripts/pr20302.d	2018-06-13 08:19:13.339563400 +0300
-@@ -1,7 +1,7 @@
- #ld: -Tdata=0x1000 -Tdata=0x2000 -Tcross2.t
- #source: align2a.s
- #objdump: -h
--#notarget: *-*-*aout *-*-netbsd *-*-vms ns32k-*-* rx-*-* x86_64-*-cygwin
-+#notarget: *-*-*aout *-*-netbsd *-*-vms ns32k-*-* rx-*-* x86_64-*-cygwin x86_64-*-msys
- # AOUT and NETBSD (ns32k is aout) have fixed address for the data section.
- # VMS targets need extra libraries.
- # RX uses non standard section names.
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-scripts/provide-6.d binutils-2.30/ld/testsuite/ld-scripts/provide-6.d
---- binutils-2.30.orig/ld/testsuite/ld-scripts/provide-6.d	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-scripts/provide-6.d	2018-06-13 08:19:13.339563400 +0300
-@@ -1,7 +1,7 @@
- #source: provide-5.s
- #ld: -T provide-6.t
- #nm: -B
--#xfail: x86_64-*-cygwin
-+#xfail: x86_64-*-cygwin x86_64-*-msys
- 
- #...
- 0+1000 D foo
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-scripts/provide-8.d binutils-2.30/ld/testsuite/ld-scripts/provide-8.d
---- binutils-2.30.orig/ld/testsuite/ld-scripts/provide-8.d	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-scripts/provide-8.d	2018-06-13 08:19:13.339563400 +0300
-@@ -1,7 +1,7 @@
- #source: provide-5.s
- #ld: -T provide-8.t
- #nm: -B
--#xfail: x86_64-*-cygwin mmix-*-* sh-*-pe spu-*-*
-+#xfail: x86_64-*-cygwin x86_64-*-msys mmix-*-* sh-*-pe spu-*-*
- 
- #...
- 0+4000 D __FOO
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-scripts/script.exp binutils-2.30/ld/testsuite/ld-scripts/script.exp
---- binutils-2.30.orig/ld/testsuite/ld-scripts/script.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-scripts/script.exp	2018-06-13 08:19:13.339563400 +0300
-@@ -163,6 +163,10 @@
- 	    pass $testname
- 	    return
- 	}
-+	[a-z]*-*-msys$ {
-+	    pass $testname
-+	    return
-+	}
-     }
- 
-     set extract_syms [run_host_cmd $nm $copyfile]
-@@ -185,6 +189,7 @@
- set flags ""
- if {[istarget "*-*-pe*"] \
-     || [istarget "*-*-cygwin*"] \
-+    || [istarget "*-*-msys*"] \
-     || [istarget "*-*-mingw*"] \
-     || [istarget "*-*-winnt*"] \
-     || [istarget "*-*-nt"] \
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-srec/srec.exp binutils-2.30/ld/testsuite/ld-srec/srec.exp
---- binutils-2.30.orig/ld/testsuite/ld-srec/srec.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-srec/srec.exp	2018-06-13 08:19:13.339563400 +0300
-@@ -407,7 +407,7 @@
- # The S-record linker doesn't support the special PE headers - the PE
- # emulation tries to write pe-specific information to the PE headers
- # in the output bfd, but it's not a PE bfd (it's an srec bfd)
--setup_xfail "*-*-cygwin*" "*-*-mingw*" "*-*-pe*" "*-*-winnt*"
-+setup_xfail "*-*-cygwin*" "*-*-msys*" "*-*-mingw*" "*-*-pe*" "*-*-winnt*"
- setup_xfail "score-*-*"
- 
- # The S-record linker doesn't support Blackfin ELF FDPIC ABI.
-@@ -451,7 +451,7 @@
- setup_xfail "alpha*-*-netbsd*"
- setup_xfail "hppa*-*-*" "mep-*-*"
- setup_xfail "ia64-*-*"
--setup_xfail "*-*-cygwin*" "*-*-mingw*" "*-*-pe*" "*-*-winnt*"
-+setup_xfail "*-*-cygwin*" "*-*-msys*" "*-*-mingw*" "*-*-pe*" "*-*-winnt*"
- setup_xfail "score-*-*"
- setup_xfail "bfin-*-linux-uclibc"
- setup_xfail "tile*-*-*"
-diff -Naur binutils-2.30.orig/ld/testsuite/lib/ld-lib.exp binutils-2.30/ld/testsuite/lib/ld-lib.exp
---- binutils-2.30.orig/ld/testsuite/lib/ld-lib.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/lib/ld-lib.exp	2018-06-13 08:19:13.339563400 +0300
-@@ -392,7 +392,7 @@
-     }
- 
-     # Windows targets need __main, some prefixed with underscore.
--    if {[istarget *-*-cygwin* ] || [istarget *-*-mingw*]} {
-+    if {[istarget *-*-cygwin* ] || [istarget *-*-mingw*] || [istarget *-*-msys*]} {
-         append flags " --defsym __main=0 --defsym ___main=0"
-     }
- 
-diff -Naur binutils-2.30.orig/libiberty/configure binutils-2.30/libiberty/configure
---- binutils-2.30.orig/libiberty/configure	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/libiberty/configure	2018-06-13 08:19:13.339563400 +0300
-@@ -5110,6 +5110,8 @@
+diff -Nbadur binutils-2.36.1.orig/libctf/configure.ac binutils-2.36.1/libctf/configure.ac
+--- binutils-2.36.1.orig/libctf/configure.ac	2021-01-09 18:47:34.000000000 +0800
++++ binutils-2.36.1/libctf/configure.ac	2021-02-18 17:58:55.585162500 +0800
+@@ -195,6 +195,10 @@
+       SHARED_LDFLAGS="-no-undefined"
+       CTF_LIBADD="$CTF_LIBADD -L`pwd`/../intl -lintl -lcygwin"
+       ;;
++    *-*-msys*)
++      SHARED_LDFLAGS="-no-undefined"
++      CTF_LIBADD="$CTF_LIBADD -L`pwd`/../intl -lintl -lmsys-2.0"
++      ;;
+   esac
+ fi
+ AC_SUBST(SHARED_LDFLAGS)
+diff -Nbadur binutils-2.36.1.orig/libiberty/configure binutils-2.36.1/libiberty/configure
+--- binutils-2.36.1.orig/libiberty/configure	2021-01-09 18:47:34.000000000 +0800
++++ binutils-2.36.1/libiberty/configure	2021-02-18 17:57:16.061972100 +0800
+@@ -5186,6 +5186,8 @@
  	;;
      i[34567]86-*-cygwin* | x86_64-*-cygwin*)
  	;;
@@ -1732,7 +1446,7 @@ diff -Naur binutils-2.30.orig/libiberty/configure binutils-2.30/libiberty/config
      i[34567]86-*-mingw* | x86_64-*-mingw*)
  	;;
      i[34567]86-*-interix[3-9]*)
-@@ -6185,7 +6187,7 @@
+@@ -6448,7 +6450,7 @@
  
  
  case "${host}" in
@@ -1741,10 +1455,10 @@ diff -Naur binutils-2.30.orig/libiberty/configure binutils-2.30/libiberty/config
      $as_echo "#define HAVE_SYS_ERRLIST 1" >>confdefs.h
  
      $as_echo "#define HAVE_SYS_NERR 1" >>confdefs.h
-diff -Naur binutils-2.30.orig/libiberty/configure.ac binutils-2.30/libiberty/configure.ac
---- binutils-2.30.orig/libiberty/configure.ac	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/libiberty/configure.ac	2018-06-13 08:19:13.355163400 +0300
-@@ -550,7 +550,7 @@
+diff -Nbadur binutils-2.36.1.orig/libiberty/configure.ac binutils-2.36.1/libiberty/configure.ac
+--- binutils-2.36.1.orig/libiberty/configure.ac	2021-01-09 18:47:34.000000000 +0800
++++ binutils-2.36.1/libiberty/configure.ac	2021-02-18 17:57:16.077598700 +0800
+@@ -553,7 +553,7 @@
  AC_SUBST(target_header_dir)
  
  case "${host}" in
@@ -1753,9 +1467,9 @@ diff -Naur binutils-2.30.orig/libiberty/configure.ac binutils-2.30/libiberty/con
      AC_DEFINE(HAVE_SYS_ERRLIST)
      AC_DEFINE(HAVE_SYS_NERR)
      ;;
-diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
---- binutils-2.30.orig/libtool.m4	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/libtool.m4	2018-06-13 08:19:13.355163400 +0300
+diff -Nbadur binutils-2.36.1.orig/libtool.m4 binutils-2.36.1/libtool.m4
+--- binutils-2.36.1.orig/libtool.m4	2021-01-09 18:47:34.000000000 +0800
++++ binutils-2.36.1/libtool.m4	2021-02-18 17:57:16.093227400 +0800
 @@ -1491,7 +1491,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
@@ -1804,7 +1518,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[[.]]/-/g'`${versuffix}${shared_ext}'
-@@ -3001,7 +3007,7 @@
+@@ -2991,7 +2997,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -1813,7 +1527,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -3285,7 +3291,7 @@
+@@ -3275,7 +3281,7 @@
  [AC_REQUIRE([AC_CANONICAL_HOST])dnl
  LIBM=
  case $host in
@@ -1822,7 +1536,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
    # These system don't have libm, or don't need it
    ;;
  *-ncr-sysv4.3*)
-@@ -3360,7 +3366,7 @@
+@@ -3350,7 +3356,7 @@
  aix*)
    symcode='[[BCDT]]'
    ;;
@@ -1831,7 +1545,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
    symcode='[[ABCDGISTW]]'
    ;;
  hpux*)
-@@ -3607,7 +3613,7 @@
+@@ -3597,7 +3603,7 @@
      beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
        # PIC is the default for these OSes.
        ;;
@@ -1840,7 +1554,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -3920,7 +3926,7 @@
+@@ -3910,7 +3916,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -1849,7 +1563,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -4003,7 +4009,7 @@
+@@ -3993,7 +3999,7 @@
        fi
        ;;
  
@@ -1858,7 +1572,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        m4_if([$1], [GCJ], [],
-@@ -4236,7 +4242,7 @@
+@@ -4226,7 +4232,7 @@
    pw32*)
      _LT_TAGVAR(export_symbols_cmds, $1)="$ltdll_cmds"
    ;;
@@ -1867,7 +1581,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
      _LT_TAGVAR(export_symbols_cmds, $1)='$NM $libobjs $convenience | $global_symbol_pipe | $SED -e '\''/^[[BCDGRS]][[ ]]/s/.*[[ ]]\([[^ ]]*\)/\1 DATA/;/^.*[[ ]]__nm__/s/^.*[[ ]]__nm__\([[^ ]]*\)[[ ]][[^ ]]*/\1 DATA/;/^I[[ ]]/d;/^[[AITW]][[ ]]/s/.* //'\'' | sort | uniq > $export_symbols'
    ;;
    *)
-@@ -4288,7 +4294,7 @@
+@@ -4278,7 +4284,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -1876,7 +1590,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -4403,7 +4409,7 @@
+@@ -4393,7 +4399,7 @@
        fi
        ;;
  
@@ -1885,7 +1599,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
        # _LT_TAGVAR(hardcode_libdir_flag_spec, $1) is actually meaningless,
        # as there is no search path for DLLs.
        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
-@@ -4776,7 +4782,7 @@
+@@ -4766,7 +4772,7 @@
        _LT_TAGVAR(export_dynamic_flag_spec, $1)=-rdynamic
        ;;
  
@@ -1894,7 +1608,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -5720,7 +5726,7 @@
+@@ -5710,7 +5716,7 @@
          esac
          ;;
  
@@ -1903,9 +1617,9 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
          # _LT_TAGVAR(hardcode_libdir_flag_spec, $1) is actually meaningless,
          # as there is no search path for DLLs.
          _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
-diff -Naur binutils-2.30.orig/ltmain.sh binutils-2.30/ltmain.sh
---- binutils-2.30.orig/ltmain.sh	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ltmain.sh	2018-06-13 08:19:13.355163400 +0300
+diff -Nbadur binutils-2.36.1.orig/ltmain.sh binutils-2.36.1/ltmain.sh
+--- binutils-2.36.1.orig/ltmain.sh	2021-01-09 18:47:34.000000000 +0800
++++ binutils-2.36.1/ltmain.sh	2021-02-18 17:57:16.108852100 +0800
 @@ -976,7 +976,7 @@
  
  
@@ -2139,9 +1853,9 @@ diff -Naur binutils-2.30.orig/ltmain.sh binutils-2.30/ltmain.sh
  	      # If a -bindir argument was supplied, place the dll there.
  	      if test "x$bindir" != x ;
  	      then
-diff -Naur binutils-2.30.orig/ltoptions.m4 binutils-2.30/ltoptions.m4
---- binutils-2.30.orig/ltoptions.m4	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ltoptions.m4	2018-06-13 08:19:13.355163400 +0300
+diff -Nbadur binutils-2.36.1.orig/ltoptions.m4 binutils-2.36.1/ltoptions.m4
+--- binutils-2.36.1.orig/ltoptions.m4	2021-01-09 18:47:34.000000000 +0800
++++ binutils-2.36.1/ltoptions.m4	2021-02-18 17:57:16.124481200 +0800
 @@ -126,7 +126,7 @@
  [enable_win32_dll=yes
  
@@ -2151,10 +1865,10 @@ diff -Naur binutils-2.30.orig/ltoptions.m4 binutils-2.30/ltoptions.m4
    AC_CHECK_TOOL(AS, as, false)
    AC_CHECK_TOOL(DLLTOOL, dlltool, false)
    AC_CHECK_TOOL(OBJDUMP, objdump, false)
-diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
---- binutils-2.30.orig/opcodes/configure	2018-01-27 17:58:57.000000000 +0300
-+++ binutils-2.30/opcodes/configure	2018-06-13 08:19:13.355163400 +0300
-@@ -5719,7 +5719,7 @@
+diff -Nbadur binutils-2.36.1.orig/opcodes/configure binutils-2.36.1/opcodes/configure
+--- binutils-2.36.1.orig/opcodes/configure	2021-02-06 17:02:39.000000000 +0800
++++ binutils-2.36.1/opcodes/configure	2021-02-18 17:57:16.140098300 +0800
+@@ -6007,7 +6007,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -2163,7 +1877,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -6061,7 +6061,7 @@
+@@ -6349,7 +6349,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -2172,7 +1886,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -6641,7 +6641,7 @@
+@@ -6929,7 +6929,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -2181,7 +1895,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -8226,7 +8226,7 @@
+@@ -8514,7 +8514,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -2190,7 +1904,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -8308,7 +8308,7 @@
+@@ -8596,7 +8596,7 @@
        fi
        ;;
  
@@ -2199,7 +1913,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -8770,7 +8770,7 @@
+@@ -9058,7 +9058,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -2208,7 +1922,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -8885,7 +8885,7 @@
+@@ -9173,7 +9173,7 @@
        fi
        ;;
  
@@ -2217,7 +1931,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec='-L$libdir'
-@@ -9316,7 +9316,7 @@
+@@ -9604,7 +9604,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -2226,7 +1940,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -10217,14 +10217,14 @@
+@@ -10505,14 +10505,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -2243,7 +1957,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -10248,6 +10248,12 @@
+@@ -10536,6 +10536,12 @@
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
@@ -2256,7 +1970,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -10884,7 +10890,7 @@
+@@ -11162,7 +11168,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -2265,7 +1979,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
-@@ -12381,7 +12387,7 @@
+@@ -12607,7 +12613,7 @@
  
  LIBM=
  case $host in
@@ -2274,7 +1988,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
    # These system don't have libm, or don't need it
    ;;
  *-ncr-sysv4.3*)
-@@ -12551,6 +12557,10 @@
+@@ -12777,6 +12783,10 @@
        SHARED_LDFLAGS="-no-undefined"
        SHARED_LIBADD="-L`pwd`/../bfd -lbfd -L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lcygwin"
        ;;
@@ -2285,10 +1999,10 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
     *-*-darwin*)
       SHARED_LIBADD="-Wl,`pwd`/../bfd/.libs/libbfd.dylib ${SHARED_LIBADD}"
       SHARED_DEPENDENCIES="../bfd/libbfd.la"
-diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
---- binutils-2.30.orig/zlib/configure	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/zlib/configure	2018-06-13 08:19:13.370763400 +0300
-@@ -4644,7 +4644,7 @@
+diff -Nbadur binutils-2.36.1.orig/zlib/configure binutils-2.36.1/zlib/configure
+--- binutils-2.36.1.orig/zlib/configure	2021-01-09 18:47:35.000000000 +0800
++++ binutils-2.36.1/zlib/configure	2021-02-18 17:57:16.171352700 +0800
+@@ -4881,7 +4881,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -2297,7 +2011,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -4986,7 +4986,7 @@
+@@ -5223,7 +5223,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -2306,7 +2020,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -5566,7 +5566,7 @@
+@@ -5803,7 +5803,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -2315,7 +2029,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -7456,7 +7456,7 @@
+@@ -7692,7 +7692,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -2324,7 +2038,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -7538,7 +7538,7 @@
+@@ -7774,7 +7774,7 @@
        fi
        ;;
  
@@ -2333,7 +2047,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -8000,7 +8000,7 @@
+@@ -8236,7 +8236,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -2342,7 +2056,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -8115,7 +8115,7 @@
+@@ -8351,7 +8351,7 @@
        fi
        ;;
  
@@ -2351,7 +2065,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec='-L$libdir'
-@@ -8552,7 +8552,7 @@
+@@ -8788,7 +8788,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -2360,7 +2074,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -9456,14 +9456,14 @@
+@@ -9692,14 +9692,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -2377,7 +2091,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -9487,6 +9487,12 @@
+@@ -9723,6 +9723,12 @@
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
@@ -2390,7 +2104,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -10126,7 +10132,7 @@
+@@ -10352,7 +10358,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -2399,144 +2113,3 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
---- binutils-2.34/libctf/configure.orig	2020-01-18 17:02:31.000000000 +0300
-+++ binutils-2.34/libctf/configure	2020-03-19 20:36:45.535998000 +0300
-@@ -5999,7 +5999,7 @@
-     lt_cv_sys_max_cmd_len=-1;
-     ;;
- 
--  cygwin* | mingw* | cegcc*)
-+  cygwin* | msys* | mingw* | cegcc*)
-     # On Win9x/ME, this test blows up -- it succeeds, but takes
-     # about 5 minutes as the teststring grows exponentially.
-     # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -6341,7 +6341,7 @@
-   lt_cv_file_magic_test_file=/shlib/libc.so
-   ;;
- 
--cygwin*)
-+cygwin* | msys*)
-   # func_win32_libid is a shell function defined in ltmain.sh
-   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
-   lt_cv_file_magic_cmd='func_win32_libid'
-@@ -6921,7 +6921,7 @@
- aix*)
-   symcode='[BCDT]'
-   ;;
--cygwin* | mingw* | pw32* | cegcc*)
-+cygwin* | msys* | mingw* | pw32* | cegcc*)
-   symcode='[ABCDGISTW]'
-   ;;
- hpux*)
-@@ -8506,7 +8506,7 @@
-       # PIC is the default for these OSes.
-       ;;
- 
--    mingw* | cygwin* | pw32* | os2* | cegcc*)
-+    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
-       # This hack is so that the source file can tell whether it is being
-       # built for inclusion in a dll (and should export symbols for example).
-       # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -8588,7 +8588,7 @@
-       fi
-       ;;
- 
--    mingw* | cygwin* | pw32* | os2* | cegcc*)
-+    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
-       # This hack is so that the source file can tell whether it is being
-       # built for inclusion in a dll (and should export symbols for example).
-       lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -9050,7 +9050,7 @@
-   extract_expsyms_cmds=
- 
-   case $host_os in
--  cygwin* | mingw* | pw32* | cegcc*)
-+  cygwin* | msys* | mingw* | pw32* | cegcc*)
-     # FIXME: the MSVC++ port hasn't been tested in a loooong time
-     # When not using gcc, we currently assume that we are using
-     # Microsoft Visual C++.
-@@ -9165,7 +9165,7 @@
-       fi
-       ;;
- 
--    cygwin* | mingw* | pw32* | cegcc*)
-+    cygwin* | msys* | mingw* | pw32* | cegcc*)
-       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
-       # as there is no search path for DLLs.
-       hardcode_libdir_flag_spec='-L$libdir'
-@@ -9596,7 +9596,7 @@
-       export_dynamic_flag_spec=-rdynamic
-       ;;
- 
--    cygwin* | mingw* | pw32* | cegcc*)
-+    cygwin* | msys* | mingw* | pw32* | cegcc*)
-       # When not using gcc, we currently assume that we are using
-       # Microsoft Visual C++.
-       # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -10497,14 +10497,14 @@
-   # libtool to hard-code these into programs
-   ;;
- 
--cygwin* | mingw* | pw32* | cegcc*)
-+cygwin* | msys* | mingw* | pw32* | cegcc*)
-   version_type=windows
-   shrext_cmds=".dll"
-   need_version=no
-   need_lib_prefix=no
- 
-   case $GCC,$host_os in
--  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
-+  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
-     library_names_spec='$libname.dll.a'
-     # DLL is installed to $(libdir)/../bin by postinstall_cmds
-     postinstall_cmds='base_file=`basename \${file}`~
-@@ -10528,6 +10528,12 @@
- 
-       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
-       ;;
-+    msys*)
-+      # MSYS DLLs use 'cyg' prefix rather than 'lib'
-+      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-+
-+      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
-+      ;;
-     mingw* | cegcc*)
-       # MinGW DLLs use traditional 'lib' prefix
-       soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -11164,7 +11170,7 @@
-     lt_cv_dlopen_libs=
-     ;;
- 
--  cygwin*)
-+  cygwin* | msys*)
-     lt_cv_dlopen="dlopen"
-     lt_cv_dlopen_libs=
-     ;;
-@@ -13195,6 +13201,12 @@
-       BFD_LIBADD="-L`pwd`/../bfd -lbfd"
-       ;;
- 
-+    *-*-msys*)
-+      SHARED_LDFLAGS="-no-undefined"
-+      SHARED_LIBADD="-L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lmsys-2.0"
-+      BFD_LIBADD="-L`pwd`/../bfd -lbfd"
-+      ;;
-+
-     *-*-darwin*)
-       BFD_LIBADD="-Wl,`pwd`/../bfd/.libs/libbfd.dylib"
-       BFD_DEPENDENCIES="../bfd/libbfd.la"
---- binutils-2.34/libctf/configure.ac.orig	2020-03-19 20:39:09.663478400 +0300
-+++ binutils-2.34/libctf/configure.ac	2020-03-19 20:39:41.375811400 +0300
-@@ -188,6 +188,12 @@
-       BFD_LIBADD="-L`pwd`/../bfd -lbfd"
-       ;;
- 
-+    *-*-msys*)
-+      SHARED_LDFLAGS="-no-undefined"
-+      SHARED_LIBADD="-L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lmsys-2.0"
-+      BFD_LIBADD="-L`pwd`/../bfd -lbfd"
-+      ;;
-+
-     *-*-darwin*)
-       BFD_LIBADD="-Wl,`pwd`/../bfd/.libs/libbfd.dylib"
-       BFD_DEPENDENCIES="../bfd/libbfd.la"

--- a/binutils/PKGBUILD
+++ b/binutils/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=binutils
-pkgver=2.35.1
+pkgver=2.36.1
 pkgrel=1
 pkgdesc="A set of programs to assemble and manipulate binary and object files"
 arch=('i686' 'x86_64')
@@ -14,18 +14,18 @@ makedepends=('libiconv-devel' 'gettext-devel' 'zlib-devel')
 options=('staticlibs' '!distcc' '!ccache')
 source=(https://ftp.gnu.org/gnu/binutils/binutils-${pkgver}.tar.xz{,.sig}
         0050-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
-        0100-binutils-2.30-msys2.patch)
-sha256sums=('3ced91db9bf01182b7e420eab68039f2083aed0a214c0424e257eae3ddee8607'
+        0100-binutils-2.36-msys2.patch)
+sha256sums=('e81d9edf373f193af428a0f256674aea62a9d74dfe93f65192d4eae030b0f3b0'
             'SKIP'
             '604e76e0f702ced493ee22aa3c1768b4776b2008a7d70ae0dd35fe5be3522141'
-            '21a5f835d8e9c1d7daba1ffb8369fce8e38be05949997c4039b5cb10d8589082')
+            'fd67c34cbe827bd1a720de3e5ee2029c5788a02fe76f63221b6d20507be90a85')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
 
 prepare() {
   cd "${srcdir}"/binutils-${pkgver}
   patch -p1 -i "${srcdir}"/0050-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
-  patch -p1 -i "${srcdir}"/0100-binutils-2.30-msys2.patch
+  patch -p1 -i "${srcdir}"/0100-binutils-2.36-msys2.patch
 
   # hack! - libiberty configure tests for header files using "$CPP $CPPFLAGS"
   sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure


### PR DESCRIPTION
Remove testsuite patches to reduce maintenance effort. 

I guess they are not needed since we didn't run the testsuite.
