### PR TITLE
fish: Fix msystem variables to be exported

### DIFF
--- a/fish/PKGBUILD
+++ b/fish/PKGBUILD
@@ -14,11 +14,13 @@ install=fish.install
 source=("https://github.com/fish-shell/fish-shell/releases/download/${pkgver}/${pkgname}-${pkgver}.tar.gz"{,.asc}
         config.fish
         msys2.fish
+        msystem.fish
         perlbin.fish)
 sha256sums=('d5b927203b5ca95da16f514969e2a91a537b2f75bec9b21a584c4cd1c7aa74ed'
             'SKIP'
             '983c3273e0249957ed6c40785e005739da30f31d4f029383f257f9990d38811a'
-            '0c01d550c50633bd120f1a91a422f1193dca835258200e6f892daf613867f87b'
+            '2a66474cc0aa632c173ec7d5f33a6b9166d09cb58e3bccc1996bff9ee24e75bc'
+            '6c1477bc62facee8353da85e8e7c967c5be33cffe2cd068bdffad381fbc17b48'
             'b136a9fa94abf53e302f7a1cc28def03b58dd2326990c5f02ceb4988341a5ac6')
 validpgpkeys=('003837986104878835FA516D7A67D962D88A709A')
 
@@ -41,5 +43,6 @@ package() {
   make DESTDIR="${pkgdir}" install
   install -D -m644 "${srcdir}/config.fish" "${pkgdir}/etc/fish/config.fish"
   install -D -m644 "${srcdir}/msys2.fish" "${pkgdir}/etc/fish/msys2.fish"
+  install -D -m644 "${srcdir}/msystem.fish" "${pkgdir}/etc/fish/msystem.fish"
   install -D -m644 "${srcdir}/perlbin.fish" "${pkgdir}/etc/fish/perlbin.fish"
 }

--- a/fish/PKGBUILD
+++ b/fish/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=fish
 pkgver=3.1.2
-pkgrel=1
+pkgrel=2
 epoch=
 pkgdesc="a smart and user-friendly command line shell"
 arch=('i686' 'x86_64')

--- a/fish/msys2.fish
+++ b/fish/msys2.fish
@@ -42,7 +42,7 @@ case '*'
 end
 
 set -e MINGW_MOUNT_POINT
-/bin/sh '/etc/msystem'
+source '/etc/fish/msystem.fish'
 switch $MSYSTEM
 case MINGW32
   set MINGW_MOUNT_POINT $MINGW_PREFIX

--- a/fish/msystem.fish
+++ b/fish/msystem.fish
@@ -1,0 +1,55 @@
+# This is a direct port of /etc/msystem.
+
+if test -z $MSYSTEM
+  set -x MSYSTEM MSYS
+end
+
+set -e MSYSTEM_PREFIX
+set -e MSYSTEM_CARCH
+set -e MSYSTEM_CHOST
+
+set -e MINGW_CHOST
+set -e MINGW_PREFIX
+set -e MINGW_PACKAGE_PREFIX
+
+set -e CONFIG_SITE
+
+switch $MSYSTEM
+  case MINGW32
+    set -x MSYSTEM_PREFIX '/mingw32'
+    set -x MSYSTEM_CARCH 'i686'
+    set -x MSYSTEM_CHOST 'i686-w64-mingw32'
+    set -x MINGW_CHOST "$MSYSTEM_CHOST"
+    set -x MINGW_PREFIX "$MSYSTEM_PREFIX"
+    set -x MINGW_PACKAGE_PREFIX "mingw-w64-$MSYSTEM_CARCH"
+    set -x CONFIG_SITE "$MSYSTEM_PREFIX/etc/config.site"
+  case MINGW64
+    set -x MSYSTEM_PREFIX '/mingw64'
+    set -x MSYSTEM_CARCH 'x86_64'
+    set -x MSYSTEM_CHOST 'x86_64-w64-mingw32'
+    set -x MINGW_CHOST "$MSYSTEM_CHOST"
+    set -x MINGW_PREFIX "$MSYSTEM_PREFIX"
+    set -x MINGW_PACKAGE_PREFIX "mingw-w64-$MSYSTEM_CARCH"
+    set -x CONFIG_SITE "$MSYSTEM_PREFIX/etc/config.site"
+  case CLANG32
+    set -x MSYSTEM_PREFIX '/clang32'
+    set -x MSYSTEM_CARCH 'i686'
+    set -x MSYSTEM_CHOST 'i686-w64-mingw32'
+    set -x MINGW_CHOST "$MSYSTEM_CHOST"
+    set -x MINGW_PREFIX "$MSYSTEM_PREFIX"
+    set -x MINGW_PACKAGE_PREFIX "mingw-w64-clang-$MSYSTEM_CARCH"
+    set -x CONFIG_SITE "$MSYSTEM_PREFIX/etc/config.site"
+  case CLANG64
+    set -x MSYSTEM_PREFIX '/clang64'
+    set -x MSYSTEM_CARCH 'x86_64'
+    set -x MSYSTEM_CHOST 'x86_64-w64-mingw32'
+    set -x MINGW_CHOST "$MSYSTEM_CHOST"
+    set -x MINGW_PREFIX "$MSYSTEM_PREFIX"
+    set -x MINGW_PACKAGE_PREFIX "mingw-w64-clang-$MSYSTEM_CARCH"
+    set -x CONFIG_SITE "$MSYSTEM_PREFIX/etc/config.site"
+  case '*'
+    set -x MSYSTEM_PREFIX '/usr'
+    set -x MSYSTEM_CARCH (/usr/bin/uname -m)
+    set -x MSYSTEM_CHOST (/usr/bin/uname -m)"-pc-msys"
+    set -x CONFIG_SITE "/etc/config.site"
+end


### PR DESCRIPTION
I noticed fish doesn't get all of its supposed PATH when used as login shell, and I discovered /etc/msystem is not sourced correctly.

Unfortunately I couldn't find a way to source it nicely, I created msystem port for fish. I tested this on my machine.