### PR TITLE
pacman-mirrors: Enable the main repo again

### DIFF
--- a/pacman-mirrors/PKGBUILD
+++ b/pacman-mirrors/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Ray Donnelly <mingwandroid@gmail.com>
 
 pkgname=pacman-mirrors
-pkgver=20210127
+pkgver=20210227
 pkgrel=1
 pkgdesc="MSYS2 mirror list for use by pacman"
 arch=('any')
@@ -10,9 +10,9 @@ license=('GPL')
 source=(mirrorlist.msys
         mirrorlist.mingw32
         mirrorlist.mingw64)
-sha256sums=('5b8d7da4d21a2b6791da8ecb260e3ca4df4caf7d91594d17520d17d2c0c384d3'
-            '60ffd5c62b064a05f07af721d25883708f10e0b81a35cb01b933e7fd93f0f112'
-            '7b25740e177845b68a012dae49ab920086bc3c32c6cfe36717627757ec50b71e')
+sha256sums=('5f42bba7bbea81d5dbbbf88a29f76d49fee1ed4b9b009442e8752e54ce69c5e6'
+            '2a7ed47552193f464e0ee2759245388e9eded1dfef6e248e8f38655786dec962'
+            'b62d25ac09d4a44444201b62dce79d1537fcd92aa5e56acc1f991f2084e4ee1d')
 
 package() {
   mkdir -p ${pkgdir}/etc/pacman.d

--- a/pacman-mirrors/mirrorlist.mingw32
+++ b/pacman-mirrors/mirrorlist.mingw32
@@ -3,7 +3,8 @@
 ##
 
 ## Primary
-## msys2.org
+Server = https://repo.msys2.org/mingw/i686/
+## Mirrors
 Server = https://downloads.sourceforge.net/project/msys2/REPOS/MINGW/i686/
 Server = https://www2.futureware.at/~nickoe/msys2-mirror/mingw/i686/
 Server = https://mirror.yandex.ru/mirrors/msys2/mingw/i686/

--- a/pacman-mirrors/mirrorlist.mingw64
+++ b/pacman-mirrors/mirrorlist.mingw64
@@ -3,7 +3,8 @@
 ##
 
 ## Primary
-## msys2.org
+Server = https://repo.msys2.org/mingw/x86_64/
+## Mirrors
 Server = https://downloads.sourceforge.net/project/msys2/REPOS/MINGW/x86_64/
 Server = https://www2.futureware.at/~nickoe/msys2-mirror/mingw/x86_64/
 Server = https://mirror.yandex.ru/mirrors/msys2/mingw/x86_64/

--- a/pacman-mirrors/mirrorlist.msys
+++ b/pacman-mirrors/mirrorlist.msys
@@ -3,7 +3,8 @@
 ##
 
 ## Primary
-## msys2.org
+Server = https://repo.msys2.org/msys/$arch/
+## Mirrors
 Server = https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/$arch/
 Server = https://www2.futureware.at/~nickoe/msys2-mirror/msys/$arch/
 Server = https://mirror.yandex.ru/mirrors/msys2/msys/$arch/


### PR DESCRIPTION
We have migrated repo.msys2.org to a dedicated server, thanks to
~Appfleet.io~Appfleet.com.