### PR TITLE
binutils: change back the DLL characteristic defaults

### DIFF
--- a/binutils/2000-Temporarily-revert-default-dll-characteristics.patch
+++ b/binutils/2000-Temporarily-revert-default-dll-characteristics.patch
@@ -1,0 +1,82 @@
+From 7934b02b50b6948da3ef4ef6619412390e5e0dce Mon Sep 17 00:00:00 2001
+From: Jeremy Drake <github@jdrake.com>
+Date: Mon, 31 Aug 2020 10:26:19 -0700
+Subject: [PATCH] Temporarily revert default dll characteristics.
+
+Until more testing is done, this patch reverts the
+DEFAULT_DLL_CHARACTERISTICS to 0, but keeps the new --disable- options
+for the flags so that they can be overridden later on the command line.
+
+Note that this does NOT revert the default --enable-reloc-section.  This
+shouldn't hurt anything other than making the resulting executable
+larger.
+---
+ ld/emultempl/pe.em  | 3 +--
+ ld/emultempl/pep.em | 4 +---
+ ld/ld.texi          | 7 +++----
+ 3 files changed, 5 insertions(+), 9 deletions(-)
+
+diff --git a/ld/emultempl/pe.em b/ld/emultempl/pe.em
+index 59cb20241b..6c14af5e29 100644
+--- a/ld/emultempl/pe.em
++++ b/ld/emultempl/pe.em
+@@ -104,8 +104,7 @@ fragment <<EOF
+ #define DEFAULT_PSEUDO_RELOC_VERSION 1
+ #endif
+ 
+-#define DEFAULT_DLL_CHARACTERISTICS	(IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE \
+-					 | IMAGE_DLL_CHARACTERISTICS_NX_COMPAT)
++#define DEFAULT_DLL_CHARACTERISTICS	0
+ 
+ #if defined(TARGET_IS_i386pe) || ! defined(DLL_SUPPORT)
+ #define	PE_DEF_SUBSYSTEM		3
+diff --git a/ld/emultempl/pep.em b/ld/emultempl/pep.em
+index f3a0929b88..639a9e96cc 100644
+--- a/ld/emultempl/pep.em
++++ b/ld/emultempl/pep.em
+@@ -99,9 +99,7 @@ fragment <<EOF
+ #define DLL_SUPPORT
+ #endif
+ 
+-#define DEFAULT_DLL_CHARACTERISTICS	(IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE \
+-					 | IMAGE_DLL_CHARACTERISTICS_HIGH_ENTROPY_VA \
+-					 | IMAGE_DLL_CHARACTERISTICS_NX_COMPAT)
++#define DEFAULT_DLL_CHARACTERISTICS	0
+ 
+ #if defined(TARGET_IS_i386pep) || ! defined(DLL_SUPPORT)
+ #define	PE_DEF_SUBSYSTEM		3
+diff --git a/ld/ld.texi b/ld/ld.texi
+index 43658a2daa..3bc4d908a9 100644
+--- a/ld/ld.texi
++++ b/ld/ld.texi
+@@ -3099,7 +3099,7 @@ of the PE file header:
+ @item --high-entropy-va
+ @itemx --disable-high-entropy-va
+ Image is compatible with 64-bit address space layout randomization
+-(ASLR).  This option is enabled by default for 64-bit PE images.
++(ASLR).  This option is disabled by default.
+ 
+ This option also implies @option{--dynamicbase} and
+ @option{--enable-reloc-section}.
+@@ -3109,8 +3109,7 @@ This option also implies @option{--dynamicbase} and
+ @itemx --disable-dynamicbase
+ The image base address may be relocated using address space layout
+ randomization (ASLR).  This feature was introduced with MS Windows
+-Vista for i386 PE targets.  This option is enabled by default but
+-can be disabled via the @option{--disable-dynamicbase} option.
++Vista for i386 PE targets.  This option is disabled by default.
+ This option also implies @option{--enable-reloc-section}.
+ 
+ @kindex --forceinteg
+@@ -3124,7 +3123,7 @@ default.
+ @item --disable-nxcompat
+ The image is compatible with the Data Execution Prevention.
+ This feature was introduced with MS Windows XP SP2 for i386 PE
+-targets.  The option is enabled by default.
++targets.  The option is disabled by default.
+ 
+ @kindex --no-isolation
+ @item --no-isolation
+-- 
+2.28.0.windows.1
+

--- a/binutils/PKGBUILD
+++ b/binutils/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=binutils
 pkgver=2.36.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A set of programs to assemble and manipulate binary and object files"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/binutils/"
@@ -14,11 +14,13 @@ makedepends=('libiconv-devel' 'gettext-devel' 'zlib-devel')
 options=('staticlibs' '!distcc' '!ccache')
 source=(https://ftp.gnu.org/gnu/binutils/binutils-${pkgver}.tar.xz{,.sig}
         0050-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
-        0100-binutils-2.36-msys2.patch)
+        0100-binutils-2.36-msys2.patch
+        2000-Temporarily-revert-default-dll-characteristics.patch)
 sha256sums=('e81d9edf373f193af428a0f256674aea62a9d74dfe93f65192d4eae030b0f3b0'
             'SKIP'
             '604e76e0f702ced493ee22aa3c1768b4776b2008a7d70ae0dd35fe5be3522141'
-            'fd67c34cbe827bd1a720de3e5ee2029c5788a02fe76f63221b6d20507be90a85')
+            'fd67c34cbe827bd1a720de3e5ee2029c5788a02fe76f63221b6d20507be90a85'
+            '29c1aab1eb96bc188c1ad29422f611e7c946cca901aed29ee2d0b9e861c75a23')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
 
@@ -26,6 +28,9 @@ prepare() {
   cd "${srcdir}"/binutils-${pkgver}
   patch -p1 -i "${srcdir}"/0050-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
   patch -p1 -i "${srcdir}"/0100-binutils-2.36-msys2.patch
+
+  # Until we get a response here: https://cygwin.com/pipermail/cygwin/2021-February/247922.html
+  patch -p1 -i "${srcdir}"/2000-Temporarily-revert-default-dll-characteristics.patch
 
   # hack! - libiberty configure tests for header files using "$CPP $CPPFLAGS"
   sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure


### PR DESCRIPTION
To what they were in 2.35. We are not sure if they are compatible with
cygwin.

See https://github.com/msys2/MSYS2-packages/pull/2345 and
https://cygwin.com/pipermail/cygwin/2021-February/247922.html for context.