### PR TITLE
nano: Update to 5.6.1

### DIFF
--- a/nano/PKGBUILD
+++ b/nano/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=nano
-pkgver=5.4
+pkgver=5.6.1
 pkgrel=1
 pkgdesc="Pico editor clone with enhancements"
 arch=('i686' 'x86_64')
@@ -16,11 +16,11 @@ makedepends=('make'
              'gettext-devel')
 backup=('etc/nanorc')
 install=nano.install
-source=(https://www.nano-editor.org/dist/v${pkgver%.*}/${pkgname}-${pkgver}.tar.xz{,.asc}
+source=(https://www.nano-editor.org/dist/v5/${pkgname}-${pkgver}.tar.xz{,.asc}
         2.2.4-wchar.patch
         nano-2.3.4-fix-ncurses-location.patch
         nano-2.8.0-msys2.patch)
-sha256sums=('fe993408b22286355809ce48ebecc4444d19af8203ed4959d269969112ed86e9'
+sha256sums=('760d7059e0881ca0ee7e2a33b09d999ec456ff7204df86bee58eb6f523ee8b09'
             'SKIP'
             '021d6bba4d45068b6d24aefdaed5044675f05b01430b68d27721f90d5ea6f5d3'
             '62b0e50470254ed09e55c068b29b72fe784d0552f97fbc5a15b6ee791c9cbd72'
@@ -48,7 +48,6 @@ build() {
     --prefix=/usr \
     --sysconfdir=/etc \
     --enable-color \
-    --without-slang \
     --enable-nanorc \
     --enable-utf8 \
     CFLAGS="${CFLAGS} -I/usr/include/ncursesw" \


### PR DESCRIPTION
Remove '--without-slang' unused configure option.