### PR TITLE
makepkg-mingw: Rename MINGW_INSTALLS to MINGW_ARCH

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=5.2.2
-pkgrel=12
+pkgrel=13
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -72,7 +72,7 @@ sha256sums=('bb201a9f2fb53c28d011f661d50028efce6eef2c1d2a36728bdd0130189349a0'
             'c0091421bb949e4596cdffb7d3312f4dac222904185f809188ab40ce9a430fa1'
             '0e484f00a427f030c95f7ebcab3e0de1e637e55d01531438de9165d1f520cf81'
             'c26dba8f9ac285efa33708e58ca29b4ad0fd9a1d6f4e82cbe433782b180799ee'
-            '894cabd76d7bf22eb4304918772a96299ec863b3b9c1442cb0c60cb88b2f63e4'
+            '4fbfa58caa4c7dd020767e3751dd5ace23f5a1570daf5e31c430bbaa4acbd108'
             '2e2dde573b971011abad5340cb2cd5a4b9a0e8470a2ed94d7a969525e0bed0c1'
             '24ea2c8dca37847e04894ebfd05d1cf5df49dc0c8089f5581c99caa19b77a7ef'
             'abb81e2dc9507dc20dc860287b8ce1bf5e5cd7cec3dd386770dc568c39db6431'

--- a/pacman/makepkg-mingw
+++ b/pacman/makepkg-mingw
@@ -61,13 +61,20 @@ else
 fi
 
 readonly ALL_OFF BOLD BLUE GREEN RED YELLOW
-MINGW_INSTALLS="${MINGW_INSTALLS,,}"
-MINGW_INSTALLS="${MINGW_INSTALLS:-mingw64 mingw32}"
-MINGW_INSTALLS_ALLOWED=('mingw32' 'mingw64' 'clang32' 'clang64')
 
-for _mingw in ${MINGW_INSTALLS}; do
-  if [[ ! " ${MINGW_INSTALLS_ALLOWED[*]} " = *" ${_mingw} "* ]]; then
-    print_error "Requested mingw installation '${_mingw}' unknown, possible values: ${MINGW_INSTALLS_ALLOWED[*]}"
+# For backwards compatibility
+if [[ -z "${MINGW_ARCH}" ]] && [[ -n "${MINGW_INSTALLS}" ]]; then
+  plain "MINGW_INSTALLS is deprecated, use MINGW_ARCH instead"
+  MINGW_ARCH="${MINGW_INSTALLS}";
+fi
+
+MINGW_ARCH="${MINGW_ARCH,,}"
+MINGW_ARCH="${MINGW_ARCH:-mingw64 mingw32}"
+MINGW_ARCH_ALLOWED=('mingw32' 'mingw64' 'clang32' 'clang64')
+
+for _mingw in ${MINGW_ARCH}; do
+  if [[ ! " ${MINGW_ARCH_ALLOWED[*]} " = *" ${_mingw} "* ]]; then
+    print_error "MINGW_ARCH: '${_mingw}' unknown, possible values: ${MINGW_ARCH_ALLOWED[*]}"
     exit 1
   fi
 done
@@ -79,7 +86,7 @@ for _arg in "$@"; do
   fi
 done
 
-for _mingw in ${MINGW_INSTALLS}; do
+for _mingw in ${MINGW_ARCH}; do
   case ${_mingw} in
     mingw32)
       _msystem=MINGW32


### PR DESCRIPTION
In addition to this we want to add a `mingw_arch=(mingw32 mingw64)` for PKGBUILDs
in the future which tells us which type of builds a PKGBUILD supports.

The goal is to be more consistent and avoid confusion.

Other ideas welcome (we can change anything..)