### PR TITLE
Update to git 2.30.2, which fixes a security vulnerability

### DIFF
--- a/git/PKGBUILD
+++ b/git/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Ray Donnelly <mingw.android@gmail.com>
 
 pkgname=git
-pkgver=2.30.1
+pkgver=2.30.2
 pkgrel=1
 pkgdesc="The fast distributed version control system"
 arch=('i686' 'x86_64')
@@ -51,7 +51,7 @@ source=("${pkgname}-${pkgver}.tar.gz"::https://github.com/git/git/archive/v${pkg
         git-2.3.5-mingw-pwd.patch
         git-2.8.2-Cygwin-Allow-DOS-paths.patch
 	git-tcsh-completion-fixes.patch)
-sha256sums=('e0dd4e54518a4016a7349299bf6df882b4b3407c59cdc9f5a45efd82148451f6'
+sha256sums=('e637ff90a3465e519885c8c4b7a67657ab0b7b1820e9324d12e50ec2e38e4d0b'
             'c5e735d829e11f79e2d508b663d0924030498f48fc716881031fb975dbf187a5'
             '47f5ff7840fa00665702fa70e5cc744de23b63ce2d9d787e2f86d2c54d57cc7a'
             '340d289f8a9d82975b34bd635e8c734c0c8529d5ac1ad9bbc8a77ed752502b02'


### PR DESCRIPTION
https://github.com/git/git/security/advisories/GHSA-8prw-h3cq-mghm