### PR TITLE
sqlite: Update to 3.35.0

### DIFF
--- a/sqlite/PKGBUILD
+++ b/sqlite/PKGBUILD
@@ -6,9 +6,9 @@ pkgname=('sqlite' 'libsqlite' 'libsqlite-devel' 'sqlite-doc'
         'tcl-sqlite'
          'sqlite-extensions'
          'lemon')
-_sqlite_year=2020
-_amalgamationver=3340000
-pkgver=3.34.0
+_sqlite_year=2021
+_amalgamationver=3350000
+pkgver=3.35.0
 pkgrel=1
 pkgdesc="A C library that implements an SQL database engine"
 arch=('i686' 'x86_64')
@@ -24,8 +24,8 @@ source=(https://www.sqlite.org/${_sqlite_year}/sqlite-src-${_amalgamationver}.zi
         0002-sqlite3.32.3-Makefile.in-fix-rule-compiling-rbu.exe.patch
         0007-sqlite3.32.3-Makefile.in-fix-libtclsqlite-package-installation-bug.patch
         Makefile.ext.in README.md.in)
-sha256sums=('a5c2000ece56d2de13c474658b9cdba6b7f2608a4d711e245518ea02a2a2333e'
-            '1e86e24d3c1217b7ef10e67a9ff7f395d1e19a8beee732a46445b493c22979a8'
+sha256sums=('c72dea7b8148a4c1b00145c9aab52317cffbfb46b6179c476f6e41d4f87c6af2'
+            '27433ffad8f056c98616a2c3dd4d55a2a997e9bee068630c4f43b6ae75413602'
             '0b76663a90e034f3d7f2af5bfada4cedec5ebc275361899eccc5c18e6f01ff1f'
             'ee6bdd979a97205a1a2dd760e90c8588f45523cecb5256c0d927f24494f7fc9f'
             '589b7182343dba3dd8225c13ff1d7d275e5f714e7793bac1c88f7cfdd569d9e0'
@@ -93,6 +93,7 @@ build() {
     -DSQLITE_ENABLE_EXPLAIN_COMMENTS \
     -DSQLITE_ENABLE_STMTVTAB \
     -DSQLITE_HAVE_ZLIB \
+    -DSQLITE_ENABLE_MATH_FUNCTIONS \
 "
 
   mkdir -p build-${_amalgamationver}-${MSYSTEM_CHOST}
@@ -105,8 +106,7 @@ build() {
     --enable-shared \
     --enable-static \
     --enable-readline --disable-editline \
-    --enable-all \
-    --enable-rtree
+    --enable-all
 
   make -j all ${_sqlite_tools}
 
@@ -121,7 +121,7 @@ build() {
 check() {
   cd build-${_amalgamationver}-${MSYSTEM_CHOST}
   # This test run lasts very loooong ... despite the target name
-  # sqlite 3.34.0: 54 errors out of 302417 tests on fv-az15-18 MSYS_NT-10.0-17763 64-bit little-endian
+  # sqlite 3.35.0: 53 errors out of 303220 tests on MSYS_NT-10.0-19042 64-bit little-endian
   make quicktest || true
 }
 _install_license() {


### PR DESCRIPTION
* PKGBUILD:
  - increase version to 3.35.0 and year to 2021
  - remove redundant configure flag '--enable-rtree' (implied by flag
    '--enable-all')
  - add CFLAG 'SQLITE_ENABLE_MATH_FUNCTIONS' new since 3.35.0 to activate
    math functions