### PR TITLE
sqlite: Update to 3.35.1

### DIFF
--- a/sqlite/PKGBUILD
+++ b/sqlite/PKGBUILD
@@ -7,8 +7,8 @@ pkgname=('sqlite' 'libsqlite' 'libsqlite-devel' 'sqlite-doc'
          'sqlite-extensions'
          'lemon')
 _sqlite_year=2021
-_amalgamationver=3350000
-pkgver=3.35.0
+_amalgamationver=3350100
+pkgver=3.35.1
 pkgrel=1
 pkgdesc="A C library that implements an SQL database engine"
 arch=('i686' 'x86_64')
@@ -24,8 +24,8 @@ source=(https://www.sqlite.org/${_sqlite_year}/sqlite-src-${_amalgamationver}.zi
         0002-sqlite3.32.3-Makefile.in-fix-rule-compiling-rbu.exe.patch
         0007-sqlite3.32.3-Makefile.in-fix-libtclsqlite-package-installation-bug.patch
         Makefile.ext.in README.md.in)
-sha256sums=('c72dea7b8148a4c1b00145c9aab52317cffbfb46b6179c476f6e41d4f87c6af2'
-            '27433ffad8f056c98616a2c3dd4d55a2a997e9bee068630c4f43b6ae75413602'
+sha256sums=('8cb60d7cc55c410fcd6990fe92802fda02760efa4fe3569a677e3e8dcdf8b107'
+            '3bb955ea75606e735955aa0b680d72d91cde367b6d3e38ee14b88a588deb6a4f'
             '0b76663a90e034f3d7f2af5bfada4cedec5ebc275361899eccc5c18e6f01ff1f'
             'ee6bdd979a97205a1a2dd760e90c8588f45523cecb5256c0d927f24494f7fc9f'
             '589b7182343dba3dd8225c13ff1d7d275e5f714e7793bac1c88f7cfdd569d9e0'


### PR DESCRIPTION
The patch release `3.35.1` contains [bug](https://www.sqlite.org/src/info/1c24a659e6d7f3a1)  fix and documentation improvements.