### PR TITLE
btyacc: Update to 20210109

### DIFF
--- a/btyacc/PKGBUILD
+++ b/btyacc/PKGBUILD
@@ -1,7 +1,7 @@
 
 _realname=byacc
 pkgname=btyacc
-pkgver=20200910
+pkgver=20210109
 pkgrel=1
 pkgdesc="btyacc - an LALR(1) parser generator with support for backtracking"
 arch=('i686' 'x86_64')
@@ -9,17 +9,17 @@ url="https://invisible-island.net/byacc"
 license=('Public Domain')
 groups=('base-devel')
 
-source=(${_realname}-${pkgver}.tar.gz::https://invisible-mirror.net/archives/byacc/byacc-${pkgver}.tgz)
-sha256sums=('0a5906073aeaf23ddc20aaac0ea61cb5ccc18572870b113375dec4ffe85ecf30')
+source=(${_realname}-${pkgver}.tar.gz::https://github.com/ThomasDickey/byacc-snapshots/archive/t${pkgver}.tar.gz)
+sha256sums=('7cd3218438766c41dfb487b844e9ae213158c51934efd1b2746f33129e2ed5dc')
 
 
 prepare() {
-  cd ${_realname}-${pkgver}
+  cd ${_realname}-snapshots-t${pkgver}
   autoreconf -vfi
 }
 
 build() {
-  cd ${_realname}-${pkgver}
+  cd ${_realname}-snapshots-t${pkgver}
   mkdir -p build-${MSYSTEM_CHOST}
   pushd build-${MSYSTEM_CHOST}
   ../configure -C \
@@ -31,12 +31,12 @@ build() {
 }
 
 check() {
-  cd ${_realname}-${pkgver}/build-${MSYSTEM_CHOST}
+  cd ${_realname}-snapshots-t${pkgver}/build-${MSYSTEM_CHOST}
   make check
 }
 
 package() {
-  cd ${_realname}-${pkgver}
+  cd ${_realname}-snapshots-t${pkgver}
   mkdir -p "${pkgdir}/usr/share/licenses/${pkgname}"
   cp -pv package/debian/copyright "${pkgdir}/usr/share/licenses/${pkgname}"
   cd build-${MSYSTEM_CHOST}


### PR DESCRIPTION
* PKGBUILD:
  - change url to github repo since https://invisible-mirror.net appears
    to refuse download by CI.
  - change top src dir