### PR TITLE
msys2-runtime: make default Windows error reporting an opt-in

### DIFF
--- a/msys2-runtime/0029-Do-not-show-Error-dialogs-by-default.patch
+++ b/msys2-runtime/0029-Do-not-show-Error-dialogs-by-default.patch
@@ -1,0 +1,68 @@
+From c3de1fd2656cf2327d9cbee70dad14d1927077de Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 31 Mar 2021 11:38:41 +0200
+Subject: [PATCH 29/N] Do not show Error dialogs by default
+
+In https://github.com/msys2/msys2-runtime/pull/18, we discussed a change
+that would allow default Windows error handling of spawned processes to
+kick in (such as registered JIT debuggers). We even agreed that it would
+make sense to hide this functionality behind a flag, `winjitdebug`.
+
+However, when this got upstreamed as 21ec498d7f (cygwin: use
+CREATE_DEFAULT_ERROR_MODE in spawn, 2020-12-09), that flag was deemed
+unnecessary.
+
+But it would appear that it _is_ necessary: As reported in
+https://github.com/msys2/MSYS2-packages/pull/2414#issuecomment-810841296
+this new behavior is pretty disruptive e.g. in CI scenarios.
+
+So let's introduce that `winjitdebug` flag (settable via the environment
+variable `MSYS`) at long last.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/environ.cc | 1 +
+ winsup/cygwin/globals.cc | 1 +
+ winsup/cygwin/spawn.cc   | 2 +-
+ 3 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index 6a54ed4..e1dbba3 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -126,6 +126,7 @@ static struct parse_thing
+   {"winsymlinks", {func: set_winsymlinks}, isfunc, NULL, {{0}, {0}}},
+   {"disable_pcon", {&disable_pcon}, setbool, NULL, {{false}, {true}}},
+   {"enable_pcon", {&disable_pcon}, setnegbool, NULL, {{true}, {false}}},
++  {"winjitdebug", {&winjitdebug}, setbool, NULL, {{false}, {true}}},
+   {NULL, {0}, setdword, 0, {{0}, {0}}}
+ };
+ 
+diff --git a/winsup/cygwin/globals.cc b/winsup/cygwin/globals.cc
+index abe74f2..67103f4 100644
+--- a/winsup/cygwin/globals.cc
++++ b/winsup/cygwin/globals.cc
+@@ -72,6 +72,7 @@ bool reset_com;
+ bool wincmdln = true;
+ winsym_t allow_winsymlinks = WSYM_deepcopy;
+ bool disable_pcon = true;
++bool winjitdebug = false;
+ 
+ bool NO_COPY in_forkee;
+ 
+diff --git a/winsup/cygwin/spawn.cc b/winsup/cygwin/spawn.cc
+index c6bfcb1..6c580d7 100644
+--- a/winsup/cygwin/spawn.cc
++++ b/winsup/cygwin/spawn.cc
+@@ -462,7 +462,7 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
+ 	 get the default error mode instead of inheriting the mode Cygwin
+ 	 uses.  This allows things like Windows Error Reporting/JIT debugging
+ 	 to work with processes launched from a Cygwin shell. */
+-      if (!real_path.iscygexec ())
++      if (winjitdebug && !real_path.iscygexec ())
+ 	c_flags |= CREATE_DEFAULT_ERROR_MODE;
+ 
+       /* We're adding the CREATE_BREAKAWAY_FROM_JOB flag here to workaround
+-- 
+2.31.0
+

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -50,7 +50,8 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0025-Set-up-a-GitHub-Action-to-keep-in-sync-with-Cygwin.patch
         0026-recursiveCopy-Always-close-the-used-handle-with-Find.patch
         0027-Expose-full-command-lines-to-other-Win32-processes-b.patch
-        0028-Disable-the-cygwin-GitHub-workflow.patch)
+        0028-Disable-the-cygwin-GitHub-workflow.patch
+        0029-Do-not-show-Error-dialogs-by-default.patch)
 sha256sums=('SKIP'
             'd6032bec7df8503d87a011083154b24a8a261bfd704c8199dca5fa6c87908b60'
             '2b829e772918a238124c06606dfb3789635f7dadd83c0fe1b7f0cff4f530d3eb'
@@ -79,7 +80,8 @@ sha256sums=('SKIP'
             '364dbb9032aece79003badcd068c489c3222acb4e7e4360db48d34a25145bdde'
             'c1cb2706e4ad0bd162151153f1c087e03e6c19f40611abcfa31e2c409b35102d'
             'a302207244650d7230d63c5afc065a4d1eba2c14effe3e9c4fe9ec31b9faa789'
-            '892db0bbefb70ed962f46642974a77560a0e8829b09e2e2924ee0fe7d8c51a89')
+            '892db0bbefb70ed962f46642974a77560a0e8829b09e2e2924ee0fe7d8c51a89'
+            '7e31db8bf617d8588c4ff42b2a8cc5377c73479ece06d01ad9141c8d718ff22d')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -144,7 +146,8 @@ prepare() {
   0025-Set-up-a-GitHub-Action-to-keep-in-sync-with-Cygwin.patch \
   0026-recursiveCopy-Always-close-the-used-handle-with-Find.patch \
   0027-Expose-full-command-lines-to-other-Win32-processes-b.patch \
-  0028-Disable-the-cygwin-GitHub-workflow.patch
+  0028-Disable-the-cygwin-GitHub-workflow.patch \
+  0029-Do-not-show-Error-dialogs-by-default.patch
 }
 
 build() {


### PR DESCRIPTION
With this change we won't show that annoying message box e.g. when a DLL is missing, unless `MSYS` contains `winjitdebug`.

This PR is essentially forwarding https://github.com/msys2/msys2-runtime/pull/35 to MSYS2-packages.

Cc: @lazka @jeremyd2019 