### PR TITLE
Add Windows terminal for MinGW

### DIFF
--- a/filesystem/mingw32noMsys.bat
+++ b/filesystem/mingw32noMsys.bat
@@ -1,0 +1,2 @@
+@echo off
+msys2_shell.cmd -mingw32 -defterm -shell cmd

--- a/filesystem/mingw64noMsys.bat
+++ b/filesystem/mingw64noMsys.bat
@@ -1,0 +1,2 @@
+@echo off
+msys2_shell.cmd -mingw64 -defterm -shell cmd

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -145,7 +145,7 @@ set MSYSCON=
 if /I "%LOGINSHELL%"=="cmd" (
   set SHELLPATH=%LOGINSHELL%
   if exist "%~dp0%MSYSTEM%\bin\gcc.exe" (
-    set Path=%~dp0%MSYSTEM%\bin;%Path%
+    set Path=%~dp0%MSYSTEM%\bin;%~dp0%usr\bin;%Path%
   )
 ) else (
   set SHELLPATH=%WD%\%LOGINSHELL%

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -144,6 +144,9 @@ exit /b %ERRORLEVEL%
 set MSYSCON=
 if /I "%LOGINSHELL%"=="cmd" (
   set SHELLPATH=%LOGINSHELL%
+  if exist "%~dp0%MSYSTEM%\bin\gcc.exe" (
+    set Path=%~dp0%MSYSTEM%\bin;%Path%
+  )
 ) else (
   set SHELLPATH=%WD%\%LOGINSHELL%
 )

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -46,6 +46,7 @@ rem Console types
 if "x%~1" == "x-mintty" shift& set /a msys2_shiftCounter+=1& set MSYSCON=mintty.exe& goto :checkparams
 if "x%~1" == "x-conemu" shift& set /a msys2_shiftCounter+=1& set MSYSCON=conemu& goto :checkparams
 if "x%~1" == "x-defterm" shift& set /a msys2_shiftCounter+=1& set MSYSCON=defterm& goto :checkparams
+if "x%~1" == "x-wincon" shift& set /a msys2_shiftCounter+=1& set MSYSCON=wincon& goto :checkparams
 rem Other parameters
 if "x%~1" == "x-full-path" shift& set /a msys2_shiftCounter+=1& set MSYS2_PATH_TYPE=inherit& goto :checkparams
 if "x%~1" == "x-use-full-path" shift& set /a msys2_shiftCounter+=1& set MSYS2_PATH_TYPE=inherit& goto :checkparams
@@ -116,6 +117,7 @@ if "%MSYSTEM%" == "MINGW32" (
 if "x%MSYSCON%" == "xmintty.exe" goto startmintty
 if "x%MSYSCON%" == "xconemu" goto startconemu
 if "x%MSYSCON%" == "xdefterm" goto startsh
+if "x%MSYSCON%" == "xwincon" goto startwincon
 
 if NOT EXIST "%WD%mintty.exe" goto startsh
 set MSYSCON=mintty.exe
@@ -145,6 +147,22 @@ if not defined MSYS2_NOSTART (
   start "%CONTITLE%" "%WD%\%LOGINSHELL%" --login !SHELL_ARGS!
 ) else (
   "%WD%\%LOGINSHELL%" --login !SHELL_ARGS!
+)
+exit /b %ERRORLEVEL%
+
+:startwincon
+set MSYSCON=
+set _MSYSTEM_=%MSYSTEM:~0,5%
+if "%_MSYSTEM_%" == "MINGW" (
+  set _MSYSTEM_=
+  set Path=%__CD__%%MSYSTEM%\bin;%Path%
+) else (
+  exit /b
+)
+if not defined MSYS2_NOSTART (
+  start "%CONTITLE%" "cmd" !SHELL_ARGS!
+) else (
+  "cmd" !SHELL_ARGS!
 )
 exit /b %ERRORLEVEL%
 
@@ -199,7 +217,7 @@ echo     %~1 [options] [login shell parameters]
 echo.
 echo Options:
 echo     -mingw32 ^| -mingw64 ^| -ucrt64 ^| -clang64 ^| -msys[2]   Set shell type
-echo     -defterm ^| -mintty ^| -conemu                            Set terminal type
+echo     -defterm ^| -mintty ^| -conemu ^| -wincon                 Set terminal type
 echo     -here                            Use current directory as working
 echo                                      directory
 echo     -where DIRECTORY                 Use specified DIRECTORY as working

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -46,10 +46,10 @@ rem Console types
 if "x%~1" == "x-mintty" shift& set /a msys2_shiftCounter+=1& set MSYSCON=mintty.exe& goto :checkparams
 if "x%~1" == "x-conemu" shift& set /a msys2_shiftCounter+=1& set MSYSCON=conemu& goto :checkparams
 if "x%~1" == "x-defterm" shift& set /a msys2_shiftCounter+=1& set MSYSCON=defterm& goto :checkparams
-if "x%~1" == "x-wincon" shift& set /a msys2_shiftCounter+=1& set MSYSCON=wincon& goto :checkparams
 rem Other parameters
 if "x%~1" == "x-full-path" shift& set /a msys2_shiftCounter+=1& set MSYS2_PATH_TYPE=inherit& goto :checkparams
 if "x%~1" == "x-use-full-path" shift& set /a msys2_shiftCounter+=1& set MSYS2_PATH_TYPE=inherit& goto :checkparams
+if "x%~1" == "x-strict-path" shift& set /a msys2_shiftCounter+=1& set MSYS2_PATH_TYPE=strict& goto :checkparams
 if "x%~1" == "x-here" shift& set /a msys2_shiftCounter+=1& set CHERE_INVOKING=enabled_from_arguments& goto :checkparams
 if "x%~1" == "x-where" (
   if "x%~2" == "x" (
@@ -117,7 +117,6 @@ if "%MSYSTEM%" == "MINGW32" (
 if "x%MSYSCON%" == "xmintty.exe" goto startmintty
 if "x%MSYSCON%" == "xconemu" goto startconemu
 if "x%MSYSCON%" == "xdefterm" goto startsh
-if "x%MSYSCON%" == "xwincon" goto startwincon
 
 if NOT EXIST "%WD%mintty.exe" goto startsh
 set MSYSCON=mintty.exe
@@ -143,26 +142,15 @@ exit /b %ERRORLEVEL%
 
 :startsh
 set MSYSCON=
-if not defined MSYS2_NOSTART (
-  start "%CONTITLE%" "%WD%\%LOGINSHELL%" --login !SHELL_ARGS!
+if /I "%LOGINSHELL%"=="cmd" (
+  set SHELLPATH=%LOGINSHELL%
 ) else (
-  "%WD%\%LOGINSHELL%" --login !SHELL_ARGS!
-)
-exit /b %ERRORLEVEL%
-
-:startwincon
-set MSYSCON=
-set _MSYSTEM_=%MSYSTEM:~0,5%
-if "%_MSYSTEM_%" == "MINGW" (
-  set _MSYSTEM_=
-  set Path=%__CD__%%MSYSTEM%\bin;%Path%
-) else (
-  exit /b
+  set SHELLPATH=%WD%\%LOGINSHELL%
 )
 if not defined MSYS2_NOSTART (
-  start "%CONTITLE%" "cmd" !SHELL_ARGS!
+  start "%CONTITLE%" "%SHELLPATH%" --login !SHELL_ARGS!
 ) else (
-  "cmd" !SHELL_ARGS!
+  "%SHELLPATH%" --login !SHELL_ARGS!
 )
 exit /b %ERRORLEVEL%
 
@@ -217,13 +205,14 @@ echo     %~1 [options] [login shell parameters]
 echo.
 echo Options:
 echo     -mingw32 ^| -mingw64 ^| -ucrt64 ^| -clang64 ^| -msys[2]   Set shell type
-echo     -defterm ^| -mintty ^| -conemu ^| -wincon                 Set terminal type
+echo     -defterm ^| -mintty ^| -conemu                            Set terminal type
 echo     -here                            Use current directory as working
 echo                                      directory
 echo     -where DIRECTORY                 Use specified DIRECTORY as working
 echo                                      directory
 echo     -[use-]full-path                 Use full current PATH variable
 echo                                      instead of trimming to minimal
+echo     -strict-path                     Do not inherit Windows path
 echo     -no-start                        Do not use "start" command and
 echo                                      return login shell resulting 
 echo                                      errorcode as this batch file 

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -145,7 +145,7 @@ set MSYSCON=
 if /I "%LOGINSHELL%"=="cmd" (
   set SHELLPATH=%LOGINSHELL%
   if exist "%~dp0%MSYSTEM%\bin\gcc.exe" (
-    set Path=%~dp0%MSYSTEM%\bin;%~dp0%usr\bin;%Path%
+    set Path=%~dp0%MSYSTEM%\bin;%Path%
   )
 ) else (
   set SHELLPATH=%WD%\%LOGINSHELL%


### PR DESCRIPTION
Some programs to be built by MinGW expect Windows terminal (see https://cmake.org/cmake/help/latest/generator/MinGW%20Makefiles.html). This commit adds a launch mode based on the standard Windows terminal with MinGW bin in the path.
