### PR TITLE
filesystem, gnupg, msys2-keyring: avoid keeping gpg-agent/dirmngr around

### DIFF
--- a/filesystem/07-pacman-key.post
+++ b/filesystem/07-pacman-key.post
@@ -2,9 +2,11 @@ maybe_init_keyring ()
 {
   if [ ! -d /etc/pacman.d/gnupg ]
   then
+    export GNUPGHOME="$(pacman-conf.exe gpgdir)"
     /usr/bin/pacman-key --init
     /usr/bin/pacman-key --populate msys2 || true
     /usr/bin/pacman-key --refresh-keys || true
+    /usr/bin/gpgconf --kill all
     
     MAYBE_FIRST_START=true
   fi

--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=filesystem
 pkgver=2021.04
-pkgrel=1
+pkgrel=2
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -76,7 +76,7 @@ sha256sums=('742a7d66b7a5ebd2b8461728c5b44a46b2305fd2116208eecae5f45828938ea0'
             'd7b7eb4cd9e1f9bc227b009cdcacf700f5523ccc109fbd3c1c0331726d314c9e'
             '9c126262051a047450ed97397ee89a7148098c03ae00a1cd67c3f3425d8e4b12'
             'fedaf4d9ae282f6c1698d04d280dd48c8d3247321a5cb5e309e61e2c655102c6'
-            'fd6eb255b5a35e62a34a54bf39598134296a11bddd3e6a30edd008cbe136b9f3'
+            '574564607e5ea8d877f42d59c164801e3efa4393a0a74c0714d9b9a778dec43f'
             'ad8533809ea2b1bce0a41b3a0a24dbc7a9f58b992ceb40cc9f862b1978032790'
             'caf25e3390331c6a22cc91f1c1bc551a9f87c59171dd3ef7b3b6016859a10fb5'
             '8e0c468c5186d769d5303d92efd05b7e1018afe4b0915cb71356808ee1601f07'

--- a/gnupg/PKGBUILD
+++ b/gnupg/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=gnupg
 pkgver=2.2.27
-pkgrel=1
+pkgrel=2
 pkgdesc='Complete and free implementation of the OpenPGP standard'
 provides=('dirmngr' "gnupg2=${pkgver}")
 url='https://gnupg.org/'

--- a/gnupg/gnupg.install
+++ b/gnupg/gnupg.install
@@ -2,6 +2,8 @@ post_upgrade() {
   # See FS#42798 and FS#47371
   dirmngr </dev/null &>/dev/null
   if usr/bin/pacman-key -l >/dev/null 2>&1; then
+    export GNUPGHOME="$(pacman-conf.exe gpgdir)"
     usr/bin/pacman-key --populate msys2
+    usr/bin/gpgconf --kill all
   fi
 }

--- a/msys2-keyring/PKGBUILD
+++ b/msys2-keyring/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=msys2-keyring
 epoch=1
 pkgver=20210213
-pkgrel=1
+pkgrel=2
 pkgdesc='MSYS2 PGP keyring'
 arch=('any')
 url='https://github.com/Alexpux/MSYS2-keyring'

--- a/msys2-keyring/msys2-keyring.install
+++ b/msys2-keyring/msys2-keyring.install
@@ -1,6 +1,8 @@
 post_upgrade() {
   if usr/bin/pacman-key -l >/dev/null 2>&1; then
+    export GNUPGHOME="$(pacman-conf.exe gpgdir)"
     usr/bin/pacman-key --populate msys2
+    usr/bin/gpgconf --kill all
   fi
 }
 


### PR DESCRIPTION
They get started in the background and stay around which comes with various problems:
* The files can't be deleted until they are stopped
* Some CI systems wait until all programs are stopped
* On a cygwin update we have to restart everything or forking will be broken
  (though pacman takes care of that now by killing everything cygwin-like on a core update)

Ideally though they would just exit in a controlled way after we no longer need them.

The reason this uses GNUPGHOME instead of passing --home to gpgconf is that dirmngr started by
"pacman-key --refresh-keys" somehow couldn't be killed that way.
Maybe because gpg doesn't forward --homedir in that case. Setting GNUPGHOME helped.