### PR TITLE
less: upgrade to v581

### DIFF
--- a/less/PKGBUILD
+++ b/less/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=less
-pkgver=563
-pkgrel=2
+pkgver=581
+pkgrel=1
 pkgdesc="A terminal based program for viewing text files"
 license=('GPL3')
 arch=('i686' 'x86_64')
@@ -12,7 +12,7 @@ makedepends=('ncurses-devel' 'pcre-devel')
 source=("http://www.greenwoodsoftware.com/${pkgname}/${pkgname}-${pkgver}.tar.gz")
 # pgp check still fails with FAILED (unknown public key F153A7C833235259)
 #        "$pkgname-$pkgver.tar.gz.sig::http://www.greenwoodsoftware.com/$pkgname/$pkgname-$pkgver.sig")
-sha256sums=('ce5b6d2b9fc4442d7a07c93ab128d2dff2ce09a1d4f2d055b95cf28dd0dc9a9a')
+sha256sums=('1d077f83fe7867e0ecfd278eab3122326b21c22c9161366189c38e09b96a2c65')
 #            'SKIP')
 validpgpkeys=('AE27252BD6846E7D6EAE1DD6F153A7C833235259') # Mark Nudelman
 


### PR DESCRIPTION
It was released for general use [yesterday](http://www.greenwoodsoftware.com/less/news.581.html).