### PR TITLE
filesystem: set XDG_DATA_DIRS for mingw bash-completion

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=filesystem
 pkgver=2021.04
-pkgrel=2
+pkgrel=3
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -36,6 +36,7 @@ source=('bash.bash_logout'
         'profile'
         'profile.lang.sh'
         'profile.tzset.sh'
+        'profile.000-msys2.sh'
         'shell'
         'shells'
         'start'
@@ -69,6 +70,7 @@ sha256sums=('742a7d66b7a5ebd2b8461728c5b44a46b2305fd2116208eecae5f45828938ea0'
             '6446359419e13310d74ab54086271acc2f4ed0dfe97a474cdd06cd7c55ee59a4'
             '6c0ca979c7b146b3750103b1296a399764f4e1b222ee091d3aa072b6da16c1a5'
             'cbec90c9403826bf6d8dd1fed16240b9d8695ec15df5dcdab7e485bb46c016ab'
+            'd7f787849de5753d7430d7be749d52d785f1e4c59585cf4e4091f8c35f8e85e0'
             'ed6c5d64be516a6d29131a5d8fe3d8c3f0d3fd21bffafdd85690a8818336c357'
             'f63241cc56aa7b7ec6962d19991d211b4e1641b78ba5226835118ab493830a8b'
             'e96c1f54ffff792e738aa032815c82c30821b0683806e5ed0ba2a759db2fd494'
@@ -118,6 +120,7 @@ package() {
 
   install -m644 ${srcdir}/profile.tzset.sh etc/profile.d/tzset.sh
   install -m644 ${srcdir}/profile.lang.sh etc/profile.d/lang.sh
+  install -m644 ${srcdir}/profile.000-msys2.sh etc/profile.d/000-msys2.sh
 
   install -m644 ${srcdir}/mingw32.ico mingw32.ico
   install -m644 ${srcdir}/mingw64.ico mingw64.ico

--- a/filesystem/profile.000-msys2.sh
+++ b/filesystem/profile.000-msys2.sh
@@ -1,0 +1,6 @@
+# Setting XDG_DATA_DIRS allows bash-completion to find completion files
+# installed in the mingw package prefixes as well
+if [ ! "${MINGW_PREFIX}" = "" ]; then
+    XDG_DATA_DIRS="/usr/local/share/:/usr/share/"
+    export XDG_DATA_DIRS="$MINGW_PREFIX/share/:$XDG_DATA_DIRS"
+fi


### PR DESCRIPTION
This adds a new profile.d/ script where we can add stuff without changing
/etc/profile and triggering a pacman backup.

Fixes #2438