### PR TITLE
pacman: require databases to be signed

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=5.2.2
-pkgrel=20
+pkgrel=21
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -62,7 +62,7 @@ source=(https://sources.archlinux.org/other/pacman/${pkgname}-${pkgver}.tar.gz
 validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@archlinux.org>
               'B8151B117037781095514CA7BBDFFC92306B1121') # Andrew Gregory (pacman) <andrew@archlinux.org>
 sha256sums=('bb201a9f2fb53c28d011f661d50028efce6eef2c1d2a36728bdd0130189349a0'
-            '9015f0a87639dcfe597e68996584d58d5f5177b478f5e3afbfb6081a22fc93f5'
+            'f5a84c5642d57044ddb40387822bfcb01bdbdcd885b46bc93d116aaf0e5741a6'
             '822af13248f04690377cd193370f33ac2f00a41234ead9cf3b7e5d5aba8bd0c5'
             'e533985757a4fef1e72c3349eb62aebbd14c1d457faf10306218cf637b207030'
             '2bd27c3fc5443b367e5025c9b9a35670b02202e48e92eead90755fef8d08fa83'

--- a/pacman/pacman.conf
+++ b/pacman/pacman.conf
@@ -37,7 +37,7 @@ CheckSpace
 # By default, pacman accepts packages signed by keys that its local keyring
 # trusts (see pacman-key and its man page), as well as unsigned packages.
 #SigLevel = Never
-SigLevel    = Required DatabaseOptional
+SigLevel    = Required
 LocalFileSigLevel = Optional
 #RemoteFileSigLevel = Required
 


### PR DESCRIPTION
We used the defaults from Arch, but Arch doesn't sign its databases.
We do sign them, so there is no reason to not enforce this.

Fixes #2453