### PR TITLE
pacman-mirrors: Backup mirrorlist.*

### DIFF
--- a/pacman-mirrors/PKGBUILD
+++ b/pacman-mirrors/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=pacman-mirrors
 pkgver=20210423
-pkgrel=1
+pkgrel=2
 pkgdesc="MSYS2 mirror list for use by pacman"
 arch=('any')
 url="https://www.msys2.org/dev/mirrors/"

--- a/pacman-mirrors/PKGBUILD
+++ b/pacman-mirrors/PKGBUILD
@@ -17,7 +17,13 @@ sha256sums=('5f42bba7bbea81d5dbbbf88a29f76d49fee1ed4b9b009442e8752e54ce69c5e6'
             '67b1de24db0be5bccc356fcd008d8c47210d3bd3764c77946c8394511c659d00'
             '8e9fca797b6cb154eae5d7658ac6c1c4e0829ac80a360b8604937eb0c9b5e852'
             '53f8963c9be64467fa89b3c37ec5688c58c1605d336239f49b10e7dc0c6ce8ca')
-
+backup=(
+  'etc/pacman.d/mirrorlist.msys' 
+  'etc/pacman.d/mirrorlist.mingw32'
+  'etc/pacman.d/mirrorlist.mingw64'
+  'etc/pacman.d/mirrorlist.ucrt64'
+  'etc/pacman.d/mirrorlist.clang64'
+)
 package() {
   mkdir -p ${pkgdir}/etc/pacman.d
   install -m644 ${srcdir}/mirrorlist.msys ${pkgdir}/etc/pacman.d/


### PR DESCRIPTION
They just get overwritten but they shouldn't.
https://wiki.archlinux.org/index.php/PKGBUILD#backup