### PR TITLE
git: Add security patch from Cygwin project.

### DIFF
--- a/git/PKGBUILD
+++ b/git/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=git
 pkgver=2.31.1
-pkgrel=1
+pkgrel=2
 pkgdesc="The fast distributed version control system"
 arch=('i686' 'x86_64')
 url="https://git-scm.com/"
@@ -50,6 +50,7 @@ source=("${pkgname}-${pkgver}.tar.gz"::https://github.com/git/git/archive/v${pkg
         git-1.8.4-msys2.patch
         git-2.3.5-mingw-pwd.patch
         git-2.8.2-Cygwin-Allow-DOS-paths.patch
+	git-2.31.1-Cygwin-check-backslash-safety.patch
 	git-tcsh-completion-fixes.patch)
 sha256sums=('b1c0e95e9861b5d1b9ad3d8deaa2d8c7f02304ffc1b5e8869dd9fb98f9a0d436'
             'c5e735d829e11f79e2d508b663d0924030498f48fc716881031fb975dbf187a5'
@@ -57,6 +58,7 @@ sha256sums=('b1c0e95e9861b5d1b9ad3d8deaa2d8c7f02304ffc1b5e8869dd9fb98f9a0d436'
             '340d289f8a9d82975b34bd635e8c734c0c8529d5ac1ad9bbc8a77ed752502b02'
             'f67412f829e026b677d4c3ceacfb21da0549ad4636fb07c283e52c3fd5aa3e22'
             '905e35e145be34f6affad830155a193d869da4898e46726f36cef2e89c073d23'
+	    '843d51d248335c0443e450c81116e2d7fabd5443d34b4a70a02faf53bf8c4579'
 	    'b28b3e13de08911f027d19a557967fc21128318a8d6ca74b20b26ee997a9b992')
 
 prepare() {
@@ -68,6 +70,7 @@ prepare() {
   patch -p1 -i "${srcdir}"/git-1.9.0-manifest-msys2.patch
   patch -p2 -i "${srcdir}"/git-2.3.5-mingw-pwd.patch
   patch -p1 -i "${srcdir}"/git-2.8.2-Cygwin-Allow-DOS-paths.patch
+  patch -p2 -i "${srcdir}"/git-2.31.1-Cygwin-check-backslash-safety.patch
   patch -p1 -i "${srcdir}"/git-tcsh-completion-fixes.patch
 
   local _arch=

--- a/git/git-2.31.1-Cygwin-check-backslash-safety.patch
+++ b/git/git-2.31.1-Cygwin-check-backslash-safety.patch
@@ -1,0 +1,11 @@
+--- origsrc/git-v2.31.1/read-cache.c	2021-03-26 21:49:41.000000000 +0000
++++ src/git-v2.31.1/read-cache.c	2021-04-22 13:58:29.584542300 +0100
+@@ -985,7 +985,7 @@ inside:
+ 				}
+ 			}
+ 			if (protect_ntfs) {
+-#ifdef GIT_WINDOWS_NATIVE
++#if defined GIT_WINDOWS_NATIVE || defined __CYGWIN__
+ 				if (c == '\\')
+ 					return 0;
+ #endif


### PR DESCRIPTION
Add patch from Cygwin project that fixes arbitrary code execution vulnerability.

References:
https://cygwin.com/pipermail/cygwin-announce/2021-April/010018.html
https://github.com/me-and/Cygwin-Git/security/advisories/GHSA-rmp3-wq55-f557