### PR TITLE
pacman: fix "-F" not working after "-Sc"

### DIFF
--- a/pacman/0020-fix-wrong-files-sig-clean.patch
+++ b/pacman/0020-fix-wrong-files-sig-clean.patch
@@ -1,0 +1,42 @@
+From 05aefb8f82d856626598ef6a3f49ff8d5f623bf5 Mon Sep 17 00:00:00 2001
+From: Pascal Ernster <pacman-dev@hardfalcon.net>
+Date: Thu, 21 Jan 2021 03:49:58 +0100
+Subject: pacman: correct length of ".files.sig" string
+
+Running "pacman -Sc" deletes /var/lib/pacman/sync/*.files.sig due to a
+wrong string length being used when checking filename suffixes in that
+directory. In turn, these missing signature files cause both the
+corresponding "*.files" files and their signatures being forcibly
+re-downloaded again when "pacman -Sy" is executed.
+
+Since official Arch Linux repos don't use signed database files yet, this
+only affects people who use custom repos with signed database files, for
+which they have set the "SigLevel" directive to "Required" or
+"DatabaseRequired" in /etc/pacman.conf.
+
+Fixes FS#66472
+
+Signed-off-by: Pascal Ernster <pacman-dev@hardfalcon.net>
+Signed-off-by: Allan McRae <allan@archlinux.org>
+---
+ src/pacman/sync.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+(limited to 'src/pacman/sync.c')
+
+diff --git a/src/pacman/sync.c b/src/pacman/sync.c
+index a05af5da..9ec4c92e 100644
+--- a/src/pacman/sync.c
++++ b/src/pacman/sync.c
+@@ -105,7 +105,7 @@ static int sync_cleandb(const char *dbpath)
+ 			dbname = strndup(dname, len - 7);
+ 		} else if(len > 6 && strcmp(dname + len - 6, ".files") == 0) {
+ 			dbname = strndup(dname, len - 6);
+-		} else if(len > 6 && strcmp(dname + len - 6, ".files.sig") == 0) {
++		} else if(len > 10 && strcmp(dname + len - 10, ".files.sig") == 0) {
+ 			dbname = strndup(dname, len - 10);
+ 		} else {
+ 			ret += unlink_verbose(path, 0);
+-- 
+cgit v1.2.3-1-gf6bb5
+

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=5.2.2
-pkgrel=21
+pkgrel=22
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -58,7 +58,8 @@ source=(https://sources.archlinux.org/other/pacman/${pkgname}-${pkgver}.tar.gz
         "0016-excise-fakeroot.patch"
         "0017-excise-sudo.patch"
         "0018-use-msys-tools.patch"
-        "0019-doxyfile-in-missing.patch")
+        "0019-doxyfile-in-missing.patch"
+        "0020-fix-wrong-files-sig-clean.patch")
 validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@archlinux.org>
               'B8151B117037781095514CA7BBDFFC92306B1121') # Andrew Gregory (pacman) <andrew@archlinux.org>
 sha256sums=('bb201a9f2fb53c28d011f661d50028efce6eef2c1d2a36728bdd0130189349a0'
@@ -83,7 +84,8 @@ sha256sums=('bb201a9f2fb53c28d011f661d50028efce6eef2c1d2a36728bdd0130189349a0'
             'd6b6accddc890aff38b5ded3300e9dde35e1d7ed3f767e1655772e2cc7871739'
             '8346a5799be41bd3524fa6fdc57b6175d9d6a00b366f99bd5cd7fa3d43d0ae98'
             '7f60108a372718cfec5d883167a33983be7c5df33fc48bfc21f664449ac7a0a4'
-            '43eb9548ddff92fb08c0c7636c4978541ff225e220bf4ba6512118cf75e76b07')
+            '43eb9548ddff92fb08c0c7636c4978541ff225e220bf4ba6512118cf75e76b07'
+            '876d8d726ed6cc069f947daa1c3d6ffe07ee51e3019dd40f6b77576e8900d1da')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
@@ -105,6 +107,8 @@ prepare() {
   patch -p1 -i ${srcdir}/0017-excise-sudo.patch
   patch -p1 -i ${srcdir}/0018-use-msys-tools.patch
   patch -p1 -i ${srcdir}/0019-doxyfile-in-missing.patch
+  # https://git.archlinux.org/pacman.git/commit/src/pacman/sync.c?id=05aefb8f82d856626598ef6a3f49ff8d5f623bf5
+  patch -p1 -i ${srcdir}/0020-fix-wrong-files-sig-clean.patch
 }
 
 build() {


### PR DESCRIPTION
-Sc would clean *.files.sig file which after our change to require
signatures for DBs resulted in -F complaining about missing signatures.

This was already fixed upstream master, so backport.

See https://github.com/msys2/MSYS2-packages/issues/2453#issuecomment-826881435