### PR TITLE
gdb: fix i686 build

### DIFF
--- a/gdb/0005-msysize.patch
+++ b/gdb/0005-msysize.patch
@@ -787,7 +787,7 @@ index a3e11c4b9b8..0bf83c1c61b 100644
  	;;
 +i[34567]86-*-msys*)
 +	# Target: Intel 386 running win32
-+	gdb_target_obs="i386-cygwin-tdep.o windows-tdep.o"
++	gdb_target_obs="i386-windows-tdep.o windows-tdep.o"
 +	build_gdbserver=yes
 +	;;
  i[34567]86-*-mingw32*)

--- a/gdb/PKGBUILD
+++ b/gdb/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=gdb
 pkgver=10.2
-pkgrel=1
+pkgrel=2
 _gcc_ver=10.2.0
 pkgdesc="GNU Debugger (MSYS2 version)"
 arch=('i686' 'x86_64')
@@ -28,7 +28,7 @@ sha256sums=('aaa1223d534c9b700a8bec952d9748ee1977513f178727e1bee520ee000b4f29'
             'cbb6162bb222161906f1425e76f630b724bdfe807d11748803e887e2f6ec3b13'
             'cdf8e29386848652069754d95089c6fd3f93cad939a8eed6e6a9875550eac3e0'
             'caa97f691e22e10c0b57251f31ca79a17a25bb77a351dbb80ec47a95fa577d49'
-            'cd13a9b84472399e2ae41efc74e9cc0c85bad0d8769a76ab1ea769e8de7e83d2')
+            '10193948948d6dd8334dff410e058d90dbaea8af66d74a2a9d058270a2a336ae')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}


### PR DESCRIPTION
the msysize patch had a hunk that was missed that needed to be updated for i686.