### PR TITLE
mm-common: new package in support of gnome mm.

### DIFF
--- a/mm-common/PKGBUILD
+++ b/mm-common/PKGBUILD
@@ -1,4 +1,4 @@
-# Contributor: Ionut Biru <ibiru@archlinux.org>
+# Maintainer: Jeremy Drake <github@jdrake.com>
 
 pkgname=mm-common
 pkgver=1.0.2

--- a/mm-common/PKGBUILD
+++ b/mm-common/PKGBUILD
@@ -1,0 +1,47 @@
+# Contributor: Ionut Biru <ibiru@archlinux.org>
+
+pkgname=mm-common
+pkgver=1.0.2
+pkgrel=1
+pkgdesc="Common build files of the C++ bindings"
+url="https://www.gtkmm.org/"
+arch=('i686' 'x86_64')
+makedepends=('git' 'meson')
+license=('GPL2')
+_commit=85381b86dcc2490d2b080c178477df9eb65103ca  # tags/1.0.2^0
+source=("git+https://gitlab.gnome.org/GNOME/mm-common.git#commit=$_commit"
+        https://gcc.gnu.org/onlinedocs/libstdc++/latest-doxygen/libstdc++.tag)
+sha256sums=('SKIP'
+            'f6c8c74e8293aefaefb4d25fd154d5f537b3bc80e7ceecaa02c5a01836fc09e6')
+
+pkgver() {
+  cd "${srcdir}/${pkgname}"
+  git describe --tags | sed 's/-/+/g'
+}
+
+prepare() {
+  cd "${srcdir}/${pkgname}"
+  cp ../libstdc++.tag doctags
+}
+
+build() {
+  mkdir "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
+  meson \
+    --buildtype=plain \
+    --prefix=/usr \
+    "../${pkgname}"
+
+  meson compile
+}
+
+check() {
+  cd "${srcdir}/build-${CARCH}"
+  meson test --print-errorlogs
+}
+
+package() {
+  cd "${srcdir}/build-${CARCH}"
+  DESTDIR="${pkgdir}" meson install
+}
+
+# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
This includes autoconf m4 macros necessary to autoreconf gnome
<whatever>mm projects.  Since autoconf is msys2, this is too.

PKGBUILD largely lifted [from arch](https://github.com/archlinux/svntogit-packages/blob/13ac84ebfee343a2a452207d6c029e165676e972/trunk/PKGBUILD).