### PR TITLE
ci: list dll bases and lengths

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -55,6 +55,7 @@ for package in "${packages[@]}"; do
 
     echo "::group::[dll check] ${package}"
     execute 'Checking dll depencencies' list_dll_deps ./pkg
+    execute 'Checking dll bases' list_dll_bases ./pkg
     echo "::endgroup::"
 
     mv "${package}"/*.pkg.tar.* artifacts

--- a/.ci/ci-library.sh
+++ b/.ci/ci-library.sh
@@ -157,6 +157,13 @@ list_dll_deps(){
     || echo "        None"
 }
 
+list_dll_bases(){
+    local target="${1}"
+    echo "$(tput setaf 2)MSYS2 DLL bases:$(tput sgr0)"
+    find "$target" -regex ".*\.\(exe\|dll\)" -print | rebase -iT - | GREP_COLOR="1;35" grep --color=always "msys-.*\|" \
+    || echo "        None"
+}
+
 # Status functions
 failure() { local status="${1}"; local items=("${@:2}"); _status failure "${status}." "${items[@]}"; exit 1; }
 success() { local status="${1}"; local items=("${@:2}"); _status success "${status}." "${items[@]}"; exit 0; }


### PR DESCRIPTION
By calling `rebase -i`.  Trying to help diagnose #2487.
