### PR TITLE
filesystem/dot.inputrc: remove an unused and incorrect keybinding

### DIFF
--- a/filesystem/dot.inputrc
+++ b/filesystem/dot.inputrc
@@ -13,8 +13,6 @@
 # would be benifitial to all, please feel free to send
 # a patch to the msys2 mailing list.
 
-# the following line is actually
-# equivalent to "\C-?": delete-char
 # "\e[3~": delete-char
 
 # VT
@@ -76,7 +74,6 @@
 # MSYSTEM is emacs based
 $if mode=emacs
   # Common to Console & RXVT
-  "\C-?": backward-kill-line         # Ctrl-BackSpace
   "\e[2~": paste-from-clipboard      # "Ins. Key"
   "\e[5~": beginning-of-history      # Page up
   "\e[6~": end-of-history            # Page down


### PR DESCRIPTION
I have already reported this to the `msys2-users` mailing list, but it seems there is no reply. I found this repository on GitHub so I decided to submit a PR here.

- [[Msys2-users] MSYS2 .inputrc contains an unintended and ineffective keybinding which causes a problem](https://sourceforge.net/p/msys2/mailman/msys2-users/thread/CAFLRLk-UX7S%3DTAerNix7HvxDAv4aY2FwZuFZz%3DU%2BTLBAWxCLEg%40mail.gmail.com/#msg37275646)

The main change is the removal of a keybinding:

```diff
diff --git a/filesystem/dot.inputrc b/filesystem/dot.inputrc
index e79e07a4..818cfba0 100644
--- a/filesystem/dot.inputrc
+++ b/filesystem/dot.inputrc
@@ -76,7 +74,6 @@
 # MSYSTEM is emacs based
 $if mode=emacs
   # Common to Console & RXVT
-  "\C-?": backward-kill-line         # Ctrl-BackSpace
   "\e[2~": paste-from-clipboard      # "Ins. Key"
   "\e[5~": beginning-of-history      # Page up
   "\e[6~": end-of-history            # Page down
```

- First of all, `"\C-?"` is typically <kbd>Backspace</kbd> but not <kbd>Ctrl-BackSpace</kbd>. Actually the escape sequences of <kbd>Backspace</kbd> and <kbd>Ctrl-Backspace</kbd> depend on the terminal, but `\C-?` is <kbd>Backspace</kbd> in modern terminal emulators in particular in Windows systems (where MSYS2 bases).
- Next, this keybinding is overwritten by another keybinding which is automatically set up by Bash/Readline based on terminfo/termcap. So, by default, this keybinding is inactive.
- If one reloads the inputrc setting by pressing `\C-x\C-r` (<kbd>Ctrl-x</kbd><kbd>Ctrl-r</kbd>), this keybinding can be enabled. However, this results in an unintuitive behavior; the entire line is erased by <kbd>Backspace</kbd>. The normal behavior of <kbd>Backspace</kbd> delete one character backward at the current cursor position.

Actually, there is no reliable way to bind a readline function to <kbd>Ctrl-Backspace</kbd> because the escape sequence depends on terminals. It is typically `"\C-_"` in Linux terminals (including mintty), but it seems some terminals send `"\C-h"` or `"\C-w"` for <kbd>Ctrl-Backspace</kbd>. There are some terminals that send the same escape sequence for <kbd>Ctrl-Backspace</kbd> as <kbd>Backspace</kbd>. Anyway, all of these sequences have already a default keybinding in Bash. `"\C-_"` is for `undo`, `"\C-h"` is for `backward-delete-char`, `"\C-w"` is for `unix-word-rubout`, etc. Also, `backward-kill-line` is already available with `"\C-u"`, so there is no need to bind `backward-kill-line` to something different.

----

Also, I have removed the following wrong information in the comment. `"\C-?"` and `"\e[3~"` are different keys in modern terminal emulators. `"\C-?"` is usually used for <kbd>Backspace</kbd> (the top-right key of regular key area) and `"\e[3~"` is used for <kbd>Delete</kbd> (the left-bottom key of 3x2 function keys). In some keyboards, the same word `Delete` is printed on the keytops of the both keys, but even in that case, the roles of the keys are different.

```diff
diff --git a/filesystem/dot.inputrc b/filesystem/dot.inputrc
index e79e07a4..818cfba0 100644
--- a/filesystem/dot.inputrc
+++ b/filesystem/dot.inputrc
@@ -13,8 +13,6 @@
 # would be benifitial to all, please feel free to send
 # a patch to the msys2 mailing list.

-# the following line is actually
-# equivalent to "\C-?": delete-char
 # "\e[3~": delete-char

 # VT
```

Thank you.
