### PR TITLE
binutils: increase the address range for auto-image-base

### DIFF
--- a/binutils/3000-more-base-entropy.patch
+++ b/binutils/3000-more-base-entropy.patch
@@ -1,0 +1,11 @@
+--- binutils-2.36.1/ld/emultempl/pep.em.orig	2021-05-10 08:58:40.005554200 +0200
++++ binutils-2.36.1/ld/emultempl/pep.em	2021-05-10 09:01:58.002803000 +0200
+@@ -117,7 +117,7 @@
+ 					: 0x1C0000000LL))
+ #undef NT_DLL_AUTO_IMAGE_MASK
+ #define NT_DLL_AUTO_IMAGE_MASK \
+-  ((bfd_vma) (${move_default_addr_high} ? 0x1ffff0000LL \
++  ((bfd_vma) (${move_default_addr_high} ? 0x7fffff0000LL \
+ 					: 0x1ffff0000LL))
+ #else
+ #undef  NT_EXE_IMAGE_BASE

--- a/binutils/PKGBUILD
+++ b/binutils/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=binutils
 pkgver=2.36.1
-pkgrel=3
+pkgrel=4
 pkgdesc="A set of programs to assemble and manipulate binary and object files"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/binutils/"
@@ -16,13 +16,15 @@ source=(https://ftp.gnu.org/gnu/binutils/binutils-${pkgver}.tar.xz{,.sig}
         0050-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
         0100-binutils-2.36-msys2.patch
         2000-Temporarily-revert-default-dll-characteristics.patch
-        2002-Allow-spaces-in-the-name-of-the-external-preprocesso.patch)
+        2002-Allow-spaces-in-the-name-of-the-external-preprocesso.patch
+        3000-more-base-entropy.patch)
 sha256sums=('e81d9edf373f193af428a0f256674aea62a9d74dfe93f65192d4eae030b0f3b0'
             'SKIP'
             '604e76e0f702ced493ee22aa3c1768b4776b2008a7d70ae0dd35fe5be3522141'
             'fd67c34cbe827bd1a720de3e5ee2029c5788a02fe76f63221b6d20507be90a85'
             '29c1aab1eb96bc188c1ad29422f611e7c946cca901aed29ee2d0b9e861c75a23'
-            '57478b9971183d430c93701b1d533e3724dab5334bbf44db924777e4a93c1063')
+            '57478b9971183d430c93701b1d533e3724dab5334bbf44db924777e4a93c1063'
+            'ce3cda1ad8ff8379869142226178b5f7fdb5b93f85a43d3437475ea0314dbf1b')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
 
@@ -36,6 +38,9 @@ prepare() {
 
   # https://github.com/msys2/MSYS2-packages/issues/2379
   patch -R -p1 -i "${srcdir}"/2002-Allow-spaces-in-the-name-of-the-external-preprocesso.patch
+
+  # https://github.com/msys2/MSYS2-packages/issues/2487
+  patch -p1 -i "${srcdir}"/3000-more-base-entropy.patch
 
   # hack! - libiberty configure tests for header files using "$CPP $CPPFLAGS"
   sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure


### PR DESCRIPTION
We get conflicts in Python modules now. Their paths contain the cygwin
version and that happened to trigger a base image collision when being hashed
since the last update.

This change uses a bit more of the path based hash to increase the possible base addresses
and make collisions less likely.

Hopefully without any negative side effects.