### PR TITLE
rhash: disable --dynamicbase etc.

### DIFF
--- a/rhash/002-no-dynamicbase.patch
+++ b/rhash/002-no-dynamicbase.patch
@@ -1,0 +1,11 @@
+--- rhash-1.4.1/configure.orig	2021-05-10 23:43:36.396000000 +0200
++++ rhash-1.4.1/configure	2021-05-10 23:44:36.134593900 +0200
+@@ -665,7 +665,7 @@
+ fi
+ 
+ WIN_LDFLAGS=
+-if win32; then
++if win32 && ! cygwin && ! msys; then
+   start_check "linker support for --nxcompat --no-seh --dynamicbase"
+   cc_check_cflag "-Wl,--nxcompat,--no-seh,--dynamicbase" &&
+     WIN_LDFLAGS="-Wl,--nxcompat,--no-seh,--dynamicbase"

--- a/rhash/PKGBUILD
+++ b/rhash/PKGBUILD
@@ -3,24 +3,27 @@
 pkgbase=rhash
 pkgname=("lib${pkgbase}" "lib${pkgbase}-devel" "${pkgbase}")
 pkgver=1.4.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Utility for verifying hash sums of files'
 url='https://sourceforge.net/projects/rhash/'
 license=('custom' 'MIT')
 arch=('i686' 'x86_64')
 source=(${pkgbase}-${pkgver}.tar.gz::https://github.com/rhash/RHash/archive/v${pkgver}.tar.gz
         ${pkgbase}-${pkgver}.tar.gz.asc::https://github.com/rhash/RHash/releases/download/v${pkgver}/v${pkgver}.tar.gz.asc
-        1.4.0_rhash-CYGWIN.patch)
+        1.4.0_rhash-CYGWIN.patch
+        002-no-dynamicbase.patch)
 makedepends=('openssl-devel')
 sha256sums=('430c812733e69b78f07ce30a05db69563450e41e217ae618507a4ce2e144a297'
             'SKIP'
-            'fb29ee491f6d32b3c1a4bcdef459ae84087f1e1b5ed308b382300cdc084d612f')
+            'fb29ee491f6d32b3c1a4bcdef459ae84087f1e1b5ed308b382300cdc084d612f'
+            '44cda291787236afc04b0578e20ad40363ea0e26b7b5ca971a6aae8c494ece8a')
 # https://sourceforge.net/p/rhash/wiki/PublicKey/
 validpgpkeys=('2875F6B1C2D27A4F0C8AF60B2A714497E37363AE')
 
 prepare() {
   cd RHash-${pkgver}
   patch -p2 -i ${srcdir}/1.4.0_rhash-CYGWIN.patch
+  patch -p1 -i ${srcdir}/002-no-dynamicbase.patch
 }
 
 build() {


### PR DESCRIPTION
This can't be good for cygwin magic, so disable.