### PR TITLE
filesystem: remove empty mingw root directories

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -4,8 +4,8 @@
 # Contributor: Alethea Rose <alethea@alethearose.com>
 
 pkgname=filesystem
-pkgver=2021.04
-pkgrel=4
+pkgver=2021.05
+pkgrel=1
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -155,12 +155,4 @@ package() {
   #
   install -m644 ${srcdir}/main-config.site etc/config.site
   install -D -m644 ${srcdir}/redirect-config.site usr/local/etc/config.site
-
-  # setup /mingw hierarchies
-  for m in mingw32 mingw64 clang32 clang64 clangarm64 ucrt64; do
-    install -d -m755 ${m}
-    for d in bin etc include lib share; do
-      install -d -m755 ${m}/${d}
-    done
-  done
 }


### PR DESCRIPTION
I don't think they are actually needed anymore