### PR TITLE
Update fish to 3.2.2

### DIFF
--- a/fish/PKGBUILD
+++ b/fish/PKGBUILD
@@ -1,22 +1,23 @@
 pkgname=fish
-pkgver=3.2.1
+pkgver=3.2.2
 pkgrel=1
 epoch=
 pkgdesc="a smart and user-friendly command line shell"
 arch=('i686' 'x86_64')
 url="https://fishshell.com/"
-license=('GPL')
+license=('GPL2')
 groups=()
 depends=('bc' 'gcc-libs' 'gettext' 'libiconv' 'libpcre2_16' 'man-db' 'ncurses')
 makedepends=('doxygen' 'gcc' 'gettext-devel' 'intltool' 'libiconv-devel' 'ncurses-devel' 'pcre2-devel' 'cmake')
 optdepends=('python: for manual page completion parser and web configuration tool')
 install=fish.install
+backup=('etc/fish/config.fish' 'etc/fish/msys2.fish' 'etc/fish/perlbin.fish')
 source=("https://github.com/fish-shell/fish-shell/releases/download/${pkgver}/${pkgname}-${pkgver}.tar.xz"{,.asc}
         config.fish
         msys2.fish
         msystem.fish
         perlbin.fish)
-sha256sums=('d8e49f4090d3778df17dd825e4a2a80192015682423cd9dd02b6675d65c3af5b'
+sha256sums=('5944da1a8893d11b0828a4fd9136ee174549daffb3d0adfdd8917856fe6b4009'
             'SKIP'
             '983c3273e0249957ed6c40785e005739da30f31d4f029383f257f9990d38811a'
             '2a66474cc0aa632c173ec7d5f33a6b9166d09cb58e3bccc1996bff9ee24e75bc'
@@ -26,19 +27,17 @@ validpgpkeys=('003837986104878835FA516D7A67D962D88A709A') # David Adam <zanchey@
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
-  mkdir -p build && cd build
   cmake \
+    -B build \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_INSTALL_SYSCONFDIR=/etc \
-    -DCMAKE_BUILD_TYPE=Release \
-    ..
-
-  make
+    -DCMAKE_BUILD_TYPE=None \
+    -Wno-dev
+  make -C build VERBOSE=1
 }
 
 package() {
   cd "${srcdir}/${pkgname}-${pkgver}/build"
-  backup=('etc/fish/config.fish' 'etc/fish/msys2.fish' 'etc/fish/perlbin.fish')
   rm -rf "${srcdir}/${pkgname}-${pkgver}/build/user_doc"
   make DESTDIR="${pkgdir}" install
   install -D -m644 "${srcdir}/config.fish" "${pkgdir}/etc/fish/config.fish"


### PR DESCRIPTION
Update fish shell to version 3.2.2. Tested build, installation and usage for ~ 2 weeks. No issues encountered.