### PR TITLE
Update bash to bash-5.1.008

### DIFF
--- a/bash/PKGBUILD
+++ b/bash/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=bash
 pkgname=('bash' 'bash-devel')
 _basever=5.1
-_patchlevel=004 #prepare for some patches
+_patchlevel=008 #prepare for some patches
 pkgver=${_basever}.${_patchlevel}
 pkgrel=1
 pkgdesc="The GNU Bourne Again shell"
@@ -137,4 +137,12 @@ sha256sums=('cc012bc860406dcf42f64431bcd3d2fa7560c02915a601aba9cd597a39329baa'
             '22f2cc262f056b22966281babf4b0a2f84cb7dd2223422e5dcd013c3dcbab6b1'
             'SKIP'
             '9aaeb65664ef0d28c0067e47ba5652b518298b3b92d33327d84b98b28d873c86'
+            'SKIP'
+            'cccbb5e9e6763915d232d29c713007a62b06e65126e3dd2d1128a0dc5ef46da5'
+            'SKIP'
+            '75e17d937de862615c6375def40a7574462210dce88cf741f660e2cc29473d14'
+            'SKIP'
+            'acfcb8c7e9f73457c0fb12324afb613785e0c9cef3315c9bbab4be702f40393a'
+            'SKIP'
+            'f22cf3c51a28f084a25aef28950e8777489072628f972b12643b4534a17ed2d1'
             'SKIP')


### PR DESCRIPTION
Update bash to the most recent patch level. Tested build and installation - no issues encountered.  

PKGBUILD changes modeled from the ones in Arch: https://github.com/archlinux/svntogit-packages/commit/fe58caae338735a1a67a09c3f5fa7d4e03342b58#diff-37538beb61ff63edebbf735dfcf39e5d732f49183d6beb097169d971875ca422