### PR TITLE
pacman: make makepkg handle CMAKE_BUILD_PARALLEL_LEVEL

### DIFF
--- a/pacman/0021-export-build-vars.patch
+++ b/pacman/0021-export-build-vars.patch
@@ -5,7 +5,7 @@
  
  	# ensure all necessary build variables are exported
 -	export CPPFLAGS CFLAGS CXXFLAGS LDFLAGS RUSTFLAGS MAKEFLAGS CHOST
-+	export CC CXX CPPFLAGS CFLAGS CXXFLAGS LDFLAGS RUSTFLAGS MAKEFLAGS CHOST
++	export CC CXX CPPFLAGS CFLAGS CXXFLAGS LDFLAGS RUSTFLAGS MAKEFLAGS CMAKE_BUILD_PARALLEL_LEVEL CHOST
  }
 --- pacman-5.2.2/scripts/libmakepkg/buildenv/buildflags.sh.in.orig	2021-05-15 07:55:29.592543800 +0100
 +++ pacman-5.2.2/scripts/libmakepkg/buildenv/buildflags.sh.in	2021-05-15 07:55:42.773495200 +0100
@@ -15,5 +15,15 @@
  	if check_option "buildflags" "n"; then
 -		unset CPPFLAGS CFLAGS DEBUG_CFLAGS CXXFLAGS DEBUG_CXXFLAGS LDFLAGS RUSTFLAGS DEBUG_RUSTFLAGS
 +		unset CC CXX CPPFLAGS CFLAGS DEBUG_CFLAGS CXXFLAGS DEBUG_CXXFLAGS LDFLAGS RUSTFLAGS DEBUG_RUSTFLAGS
+ 	fi
+ }
+--- pacman-5.2.2/scripts/libmakepkg/buildenv/makeflags.sh.in.orig	2021-05-20 20:36:40.970218800 -0700
++++ pacman-5.2.2/scripts/libmakepkg/buildenv/makeflags.sh.in	2021-05-20 20:37:18.690028900 -0700
+@@ -30,6 +30,6 @@
+ 
+ buildenv_makeflags() {
+ 	if check_option "makeflags" "n"; then
+-		unset MAKEFLAGS
++		unset MAKEFLAGS CMAKE_BUILD_PARALLEL_LEVEL
  	fi
  }

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=5.2.2
-pkgrel=23
+pkgrel=24
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -60,13 +60,13 @@ source=(https://sources.archlinux.org/other/pacman/${pkgname}-${pkgver}.tar.gz
         "0018-use-msys-tools.patch"
         "0019-doxyfile-in-missing.patch"
         "0020-fix-wrong-files-sig-clean.patch"
-        "0021-export-cc-cxx.patch")
+        "0021-export-build-vars.patch")
 validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@archlinux.org>
               'B8151B117037781095514CA7BBDFFC92306B1121') # Andrew Gregory (pacman) <andrew@archlinux.org>
 sha256sums=('bb201a9f2fb53c28d011f661d50028efce6eef2c1d2a36728bdd0130189349a0'
             'f5a84c5642d57044ddb40387822bfcb01bdbdcd885b46bc93d116aaf0e5741a6'
-            '178ff34e13f7d558a4410f909667c07faeaf7a83b15b00e7db342c0796675733'
-            'b9ad2fb4b0e686b96db0a50d411f4d9344ec8950f50906fb502272037246e4b8'
+            '77af9e52865a5290302249acc31526e0a8eb80133e7f51537abf87c90fc34660'
+            '28bcda2f0dcf9a166d620e7aca57747ee23d1116a5ba063d0c0ea3a32dd30992'
             '2bd27c3fc5443b367e5025c9b9a35670b02202e48e92eead90755fef8d08fa83'
             '2e2dde573b971011abad5340cb2cd5a4b9a0e8470a2ed94d7a969525e0bed0c1'
             '24ea2c8dca37847e04894ebfd05d1cf5df49dc0c8089f5581c99caa19b77a7ef'
@@ -87,7 +87,7 @@ sha256sums=('bb201a9f2fb53c28d011f661d50028efce6eef2c1d2a36728bdd0130189349a0'
             '7f60108a372718cfec5d883167a33983be7c5df33fc48bfc21f664449ac7a0a4'
             '43eb9548ddff92fb08c0c7636c4978541ff225e220bf4ba6512118cf75e76b07'
             '876d8d726ed6cc069f947daa1c3d6ffe07ee51e3019dd40f6b77576e8900d1da'
-            'b766c7d7fc12f0d2b00d853cca8b15add7170e5e33fd03434ab991ddaa1de7af')
+            'ce597f677f99c38ae5b3cb305ebfd600d19f89b6ec19ca2c907180793ec84215')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
@@ -111,7 +111,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0019-doxyfile-in-missing.patch
   # https://git.archlinux.org/pacman.git/commit/src/pacman/sync.c?id=05aefb8f82d856626598ef6a3f49ff8d5f623bf5
   patch -p1 -i ${srcdir}/0020-fix-wrong-files-sig-clean.patch
-  patch -p1 -i ${srcdir}/0021-export-cc-cxx.patch
+  patch -p1 -i ${srcdir}/0021-export-build-vars.patch
 }
 
 build() {

--- a/pacman/makepkg.conf
+++ b/pacman/makepkg.conf
@@ -52,7 +52,8 @@ CFLAGS="@CARCHFLAGS@ -mtune=generic -O2 -pipe"
 CXXFLAGS="@CARCHFLAGS@ -mtune=generic -O2 -pipe"
 LDFLAGS="-pipe"
 #-- Make Flags: change this for DistCC/SMP systems
-MAKEFLAGS="-j$(($(nproc)+1))"
+CMAKE_BUILD_PARALLEL_LEVEL="$(($(nproc)+1))"
+MAKEFLAGS="-j$CMAKE_BUILD_PARALLEL_LEVEL"
 #-- Debugging flags
 DEBUG_CFLAGS="-ggdb -Og"
 DEBUG_CXXFLAGS="-ggdb -Og"

--- a/pacman/makepkg_mingw.conf
+++ b/pacman/makepkg_mingw.conf
@@ -121,7 +121,8 @@ fi
 DXSDK_DIR=${MINGW_PREFIX}/${MINGW_CHOST}
 
 #-- Make Flags: change this for DistCC/SMP systems
-MAKEFLAGS="-j$(($(nproc)+1))"
+CMAKE_BUILD_PARALLEL_LEVEL="$(($(nproc)+1))"
+MAKEFLAGS="-j$CMAKE_BUILD_PARALLEL_LEVEL"
 #-- Debugging flags
 DEBUG_CFLAGS="-ggdb -Og"
 DEBUG_CXXFLAGS="-ggdb -Og"


### PR DESCRIPTION
As discussed on [discord recently](https://discord.com/channels/792780131906617355/794220101741838401/844763658637672478).

Add `CMAKE_BUILD_PARALLEL_LEVEL` to `makepkg{,_mingw}.conf`.  Teach makepkg to export it, and unset it when `!makeflags` option is used.

This came about because I am concerned the forthcoming switch of mingw-w64-clang to using ninja will make building on my raspberry pi too swappy to be useful, as the pi 3B+ has 4 cores but only 1GB of RAM, and ninja will default to `-j6` [in that case](https://github.com/ninja-build/ninja/blob/0a632d11eb1e8b7becbd9756c3e3439777924f6d/src/ninja.cc#L246).