### PR TITLE
cygutils: add package

### DIFF
--- a/cygutils/0001-cygdrop-fix-return-type-of-usageCore.patch
+++ b/cygutils/0001-cygdrop-fix-return-type-of-usageCore.patch
@@ -1,0 +1,27 @@
+From f4821db24d4e4feca16e4aea58843128e233ef4e Mon Sep 17 00:00:00 2001
+From: Jeremy Drake <cygwin@jdrake.com>
+Date: Tue, 25 May 2021 16:13:17 -0700
+Subject: [PATCH] cygdrop: fix return type of usageCore
+
+Fixes a warning "no return statement in function returning non-void",
+and solves a crash running --help.
+---
+ src/cygdrop/cygdrop.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/cygdrop/cygdrop.cc b/src/cygdrop/cygdrop.cc
+index 35bcc19..dc403c9 100644
+--- a/src/cygdrop/cygdrop.cc
++++ b/src/cygdrop/cygdrop.cc
+@@ -39,7 +39,7 @@ static void help (FILE * f, const char *name);
+ static void version (FILE * f, const char *name);
+ static void license (FILE * f, const char *name);
+ 
+-static int
++static void
+ usageCore (FILE * f, const char * name)
+ {
+   fprintf (f,
+-- 
+2.31.1
+

--- a/cygutils/PKGBUILD
+++ b/cygutils/PKGBUILD
@@ -1,0 +1,52 @@
+# Maintainer: Jeremy Drake <github@jdrake.com>
+
+pkgname=cygutils
+pkgver=1.4.16
+pkgrel=1
+pkgdesc="${pkgname} is a collection of simple utilities"
+arch=('i686' 'x86_64')
+url="https://cygwin.org/"
+license=('GPL')
+#options=('debug' '!strip')
+# Nothing in this package directly depends on libintl/libiconv, only indirectly
+# via popt
+depends=('gcc-libs' 'popt')
+makedepends=('gcc'
+             'gettext-devel'
+             'git'
+             'libiconv-devel'
+             'make')
+source=(${pkgname}-${pkgver}::git+https://sourceware.org/git/cygwin-apps/${pkgname}.git#tag=v${pkgver//./_}
+        msysize.patch
+        0001-cygdrop-fix-return-type-of-usageCore.patch)
+sha256sums=(SKIP
+            '814b5a1df4f5a5071387feb948a951ba3756e3be13d405bf8180a80cc6443ac0'
+            'dbc669301dfc54411da1f5128738a9750af5b4dcf6bd254db52ea2c628515851')
+
+prepare(){
+  cd ${pkgname}-${pkgver}
+  patch -p1 -i ${srcdir}/msysize.patch
+  patch -p1 -i ${srcdir}/0001-cygdrop-fix-return-type-of-usageCore.patch
+
+  autoreconf -fi
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${CHOST}"
+  cd "${srcdir}/build-${CHOST}"
+
+  ../${pkgname}-${pkgver}/configure \
+    --prefix=/usr \
+    --build=${CHOST} \
+    --host=${CHOST} \
+    --target=${CHOST}
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${CHOST}"
+  make DESTDIR="${pkgdir}" install
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  install -Dm644 COPYING "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/cygutils/msysize.patch
+++ b/cygutils/msysize.patch
@@ -1,0 +1,22 @@
+diff --git a/configure.ac b/configure.ac
+index 830f1bf..a009590 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -79,7 +79,7 @@ dnl should only exist on windows, I hope
+ AC_CHECK_STDCALL_FUNC([OpenClipboard],[void *])
+ AC_CHECK_DECLS([cygwin_conv_path], [],[
+ case "$host" in
+-*cygwin* ) AC_MSG_ERROR([At least cygwin-1.7 is required]) ;;
++*cygwin* | *msys* ) AC_MSG_ERROR([At least cygwin-1.7 is required]) ;;
+ esac],dnl
+   [[#include <sys/cygwin.h>]])
+ 
+@@ -88,7 +88,7 @@ AM_CONDITIONAL(WITH_WINDOWS_PROGRAMS, test "$ac_cv_func_OpenClipboard" = yes)
+ AM_CONDITIONAL(WITH_NATIVE_IPC_PROGRAMS, test "$HAVE_INTRINSIC_IPC" = yes)
+ host_is_cygwin=no
+ case "$host" in
+-*cygwin* ) host_is_cygwin=yes ;;
++*cygwin* | *msys* ) host_is_cygwin=yes ;;
+ esac
+ AM_CONDITIONAL(WITH_CYGWIN_SPECIFIC_PROGRAMS, test "$host_is_cygwin" = yes)
+ 

--- a/popt/1.18-cygwin.patch
+++ b/popt/1.18-cygwin.patch
@@ -1,0 +1,11 @@
+--- popt-1.18.ORIG/src/poptconfig.c	2020-04-16 12:32:54.000000000 +0200
++++ popt-1.18/src/poptconfig.c	2020-12-31 11:33:48.634910900 +0100
+@@ -21,7 +21,7 @@
+ #if defined(HAVE_GLOB_H)
+ #include <glob.h>
+ 
+-#if !defined(__GLIBC__)
++#if !defined(__GLIBC__) && !defined(__CYGWIN__)
+ /* Return nonzero if PATTERN contains any metacharacters.
+    Metacharacters can be quoted with backslashes if QUOTE is nonzero.  */
+ static int

--- a/popt/1.18-testit.patch
+++ b/popt/1.18-testit.patch
@@ -1,0 +1,20 @@
+--- popt-1.18.ORIG/tests/testit.sh	2020-03-24 12:01:52.000000000 +0100
++++ popt-1.18/tests/testit.sh	2020-12-31 12:38:00.002702800 +0100
+@@ -115,7 +115,7 @@
+ run test1 "test1 - 57" "arg1: 0 arg2: (none) aBits: foo,baz" --bits foo,bar,baz,!bar
+ 
+ run test1 "test1 - 58" "\
+-Usage: lt-test1 [-I?] [-c|--cb2=STRING] [--arg1] [-2|--arg2=ARG]
++Usage: test1 [-I?] [-c|--cb2=STRING] [--arg1] [-2|--arg2=ARG]
+         [-3|--arg3=ANARG] [-onedash] [--optional=STRING] [--val]
+         [-i|--int=INT] [-s|--short=SHORT] [-l|--long=LONG]
+         [-L|--longlong=LONGLONG] [-f|--float=FLOAT] [-d|--double=DOUBLE]
+@@ -124,7 +124,7 @@
+         [--bitxor] [--nstr=STRING] [--lstr=STRING] [-I|--inc]
+         [-c|--cb=STRING] [--longopt] [-?|--help] [--usage] [--simple=ARG]" --usage
+ run test1 "test1 - 59" "\
+-Usage: lt-test1 [OPTION...]
++Usage: test1 [OPTION...]
+       --arg1                      First argument with a really long
+                                   description. After all, we have to test
+                                   argument help wrapping somehow, right?

--- a/popt/PKGBUILD
+++ b/popt/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: Jeremy Drake <github@jdrake.com>
+
+pkgname=popt
+pkgver=1.18
+pkgrel=1
+pkgdesc="A command-line option parser library"
+arch=('i686' 'x86_64')
+url="http://rpm.org/"
+license=('custom')
+depends=('libiconv' 'libintl')
+makedepends=('gcc'
+             'gettext-devel'
+             'libiconv-devel'
+             'make')
+options=('staticlibs') #'debug' '!strip')
+source=(http://ftp.rpm.org/popt/releases/popt-1.x/${pkgname}-${pkgver}.tar.gz
+        1.18-cygwin.patch
+        1.18-testit.patch)
+sha256sums=('5159bc03a20b28ce363aa96765f37df99ea4d8850b1ece17d1e6ad5c24fdc5d1'
+            'cbc8c5266dd3d4564fe950ff5ef497d9bc04a2344c845a5e94108067878fd529'
+            '1d7dd99eac24225bcd1ae1a195692ae1a95ed68409922b2d93c89a975c6f66ee')
+
+prepare(){
+  cd ${pkgname}-${pkgver}
+  # Cygwin patches
+  patch -Np1 -i "${srcdir}"/1.18-cygwin.patch
+  patch -Np1 -i "${srcdir}"/1.18-testit.patch
+  autoreconf -fi
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${CHOST}"
+  cd "${srcdir}/build-${CHOST}"
+
+  ../${pkgname}-${pkgver}/configure \
+    --prefix=/usr \
+    --build=${CHOST} \
+    --host=${CHOST} \
+    --target=${CHOST} \
+    --enable-shared \
+    --enable-static
+
+  make
+}
+
+check() {
+  cd "${srcdir}/build-${CHOST}"
+  make check
+}
+
+package() {
+  cd "${srcdir}/build-${CHOST}"
+  make DESTDIR="${pkgdir}" install
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  install -Dm644 COPYING "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}


### PR DESCRIPTION
Note that several of the programs here depend on popt, so that has been packaged as well.

This package contains (from the package's `PROGLIST`):
* dump.exe: hex dump of file to stdout, using a nice format
* putclip.exe: copies stdin to the Windows clipboard. does NOT use Cygwin's /dev/clipboard
* getclip.exe: copies the Windows clipboard to stdout. does NOT use Cygwin's /dev/clipboard
* conv.exe: program for converting line endings of text files between DOS and UNIX format.
* msgtool.exe: A command line tool for tinkering with SysV style Message Queues
* semtool.exe: A command line tool for tinkering with SysV style Semaphore Sets
* semstat.exe: Another tool for tinkering with Semaphore Sets
* shmtool.exe: A command line tool for tinkering with shared memory
* banner.exe: prints a large banner to stdout.
* lpr.exe: can be used to spool to a windows printer
* mkshortcut.exe: can be used to create "full featured" windows shortcuts (as opposed to cygwin-symlinks implemented using .lnk files, which aren't really "full-featured")
* readshortcut.exe: can be used to read information from windows shortcuts (such as target, icon, window state, etc)
* cygstart.exe: A command-line tool which allows you to let Windows start a program or open a file or URL in its associated application. It is similar to the Windows command-line start command.
* cygdrop.exe: A command-line tool which allows you to let start a Cygwin or Windows program with a restricted access token. All administrative rights are dropped by default. The tool also provides options for finer control of groups and privileges.
* ipck: IPC utility brought over from cygipc.
* winln.exe: Drop-in replacement for ln(1) that creates Windows symbolic links instead of Cygwin ones.
* cygicons.dll: DLL containing cygwin-related icons (named `msys-icons-0.dll` here)

Of these I personally think `cygdrop` `cygstart` and maybe `mk`/`readshortcut` might actually be useful in msys2.