### PR TITLE
popt: split -devel package

### DIFF
--- a/cygutils/PKGBUILD
+++ b/cygutils/PKGBUILD
@@ -15,7 +15,8 @@ makedepends=('gcc'
              'gettext-devel'
              'git'
              'libiconv-devel'
-             'make')
+             'make'
+             'popt-devel')
 source=(${pkgname}-${pkgver}::git+https://sourceware.org/git/cygwin-apps/${pkgname}.git#tag=v${pkgver//./_}
         msysize.patch
         0001-cygdrop-fix-return-type-of-usageCore.patch)

--- a/popt/PKGBUILD
+++ b/popt/PKGBUILD
@@ -1,18 +1,17 @@
 # Maintainer: Jeremy Drake <github@jdrake.com>
 
-pkgname=popt
+pkgname=('popt' 'popt-devel')
 pkgver=1.18
-pkgrel=1
+pkgrel=2
 pkgdesc="A command-line option parser library"
 arch=('i686' 'x86_64')
 url="http://rpm.org/"
 license=('custom')
-depends=('libiconv' 'libintl')
 makedepends=('gcc'
              'gettext-devel'
              'libiconv-devel'
              'make')
-options=('staticlibs') #'debug' '!strip')
+#options=('debug' '!strip')
 source=(http://ftp.rpm.org/popt/releases/popt-1.x/${pkgname}-${pkgver}.tar.gz
         1.18-cygwin.patch
         1.18-testit.patch)
@@ -20,7 +19,7 @@ sha256sums=('5159bc03a20b28ce363aa96765f37df99ea4d8850b1ece17d1e6ad5c24fdc5d1'
             'cbc8c5266dd3d4564fe950ff5ef497d9bc04a2344c845a5e94108067878fd529'
             '1d7dd99eac24225bcd1ae1a195692ae1a95ed68409922b2d93c89a975c6f66ee')
 
-prepare(){
+prepare() {
   cd ${pkgname}-${pkgver}
   # Cygwin patches
   patch -Np1 -i "${srcdir}"/1.18-cygwin.patch
@@ -41,6 +40,7 @@ build() {
     --enable-static
 
   make
+  make DESTDIR="${srcdir}/dest" install
 }
 
 check() {
@@ -48,9 +48,23 @@ check() {
   make check
 }
 
-package() {
-  cd "${srcdir}/build-${CHOST}"
-  make DESTDIR="${pkgdir}" install
+package_popt() {
+  depends=('libiconv' 'libintl')
+
+  mkdir -p "${pkgdir}/usr/share"
+  cp -rf "${srcdir}/dest/usr/bin" "${pkgdir}/usr/"
+  cp -rf "${srcdir}/dest/usr/share/locale" "${pkgdir}/usr/share/"
   cd "${srcdir}/${pkgname}-${pkgver}"
   install -Dm644 COPYING "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}
+
+package_popt-devel() {
+  options=('staticlibs')
+  depends=("popt=${pkgver}-${pkgrel}")
+  pkgdesc="popt headers and libraries"
+
+  mkdir -p "${pkgdir}/usr/share"
+  cp -rf "${srcdir}/dest/usr/include" "${pkgdir}/usr/"
+  cp -rf "${srcdir}/dest/usr/lib" "${pkgdir}/usr/"
+  cp -rf "${srcdir}/dest/usr/share/man" "${pkgdir}/usr/share/"
 }


### PR DESCRIPTION
Per @elieux [on discord](https://discord.com/channels/792780131906617355/794220101741838401/847925167665184769).

Did not bump pkgrel on `cygutils` because the files present while building will be the same.