### PR TITLE
ci: explicitly install pactoys-git

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MSYS
-          install: git base-devel msys2-devel
+          install: git base-devel msys2-devel pactoys-git
           update: true
 
       - name: Add staging repo


### PR DESCRIPTION
For some reason it seems to have stopped being installed, so do it explicitly.

Fixes #2524