### PR TITLE
etc-update: new package

### DIFF
--- a/etc-update/PKGBUILD
+++ b/etc-update/PKGBUILD
@@ -1,0 +1,26 @@
+# Maintainer: Jeremy Drake <github@jdrake.com>
+pkgname='etc-update'
+pkgdesc="CLI to interactively merge .pacnew configuration files"
+pkgver=2.3.99
+pkgrel=1
+arch=('any')
+url="https://wiki.gentoo.org/wiki/Handbook:X86/Portage/Tools#etc-update"
+license=('GPL')
+depends=('bash' 'diffutils')
+optdepends=('dialog: for the menu mode (not automode)')
+backup=("etc/etc-update.conf")
+source=("https://github.com/gentoo/portage/archive/portage-${pkgver}.tar.gz")
+sha256sums=('fc5dcc37033d876360c8427d1b6afbdb29786a675d6741909fb341da54568a1d')
+noextract=("portage-${pkgver}.tar.gz")
+
+prepare() {
+  plain "Extracting portage-${pkgver}.tar.gz due to symlink(s) without pre-existing target(s)"
+  cd "${srcdir}"
+  [[ -d portage-portage-${pkgver} ]] && rm -rf portage-portage-${pkgver}
+  tar zxf "${srcdir}/portage-${pkgver}.tar.gz" || true
+}
+
+package() {
+  install -Dm 0755 -t "${pkgdir}/usr/bin" "portage-portage-${pkgver}/bin/${pkgname}"
+  install -Dm 0644 -t "${pkgdir}/etc" "portage-portage-${pkgver}/cnf/${pkgname}.conf"
+}

--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -4,8 +4,8 @@
 # Contributor: Alethea Rose <alethea@alethearose.com>
 
 pkgname=filesystem
-pkgver=2021.04
-pkgrel=4
+pkgver=2021.06
+pkgrel=1
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -48,7 +48,8 @@ source=('bash.bash_logout'
         '08-xml-catalog.post'
         'cygwin.ldif'
         'main-config.site'
-        'redirect-config.site')
+        'redirect-config.site'
+        'os-release')
 sha256sums=('742a7d66b7a5ebd2b8461728c5b44a46b2305fd2116208eecae5f45828938ea0'
             'dfb0a5c21b1b1dcec942f556fe32967bd78207c47ff28093837a37d2ed457e92'
             '99eae6e37081edd73b399009c85f4a67a0c14481241ee4937ab45c4178b540fb'
@@ -82,7 +83,8 @@ sha256sums=('742a7d66b7a5ebd2b8461728c5b44a46b2305fd2116208eecae5f45828938ea0'
             'ad8533809ea2b1bce0a41b3a0a24dbc7a9f58b992ceb40cc9f862b1978032790'
             'caf25e3390331c6a22cc91f1c1bc551a9f87c59171dd3ef7b3b6016859a10fb5'
             '8e0c468c5186d769d5303d92efd05b7e1018afe4b0915cb71356808ee1601f07'
-            '26bf8d1acade9431d60c035a7ddfa9cb0775d5b9a457c5aca56f51c5f2f93f98')
+            '26bf8d1acade9431d60c035a7ddfa9cb0775d5b9a457c5aca56f51c5f2f93f98'
+            '1fef172ac99eef561100da9eecb7712786dff8dd73f4a97eb39462bde0275af8')
 
 build() {
   cd ${srcdir}
@@ -102,7 +104,7 @@ package() {
   # setup /etc
   #
   install -d etc/{fstab.d,skel,profile.d,post-install}
-  for f in bash.bashrc bash.bash_logout fstab shells profile nsswitch.conf msystem; do
+  for f in bash.bashrc bash.bash_logout fstab shells profile nsswitch.conf msystem os-release; do
     install -m644 ${srcdir}/${f} etc/
   done
 

--- a/filesystem/os-release
+++ b/filesystem/os-release
@@ -1,0 +1,6 @@
+NAME=MSYS2
+ID=msys2
+PRETTY_NAME="MSYS2"
+ID_LIKE="cygwin arch"
+HOME_URL="https://www.msys2.org"
+BUG_REPORT_URL="https://github.com/msys2/MSYS2-packages/issues"


### PR DESCRIPTION
Gentoo's tool to manage config file updates.  Based on Arch's PKGBUILD.

etc-update looks at `/etc/os-release` to determine how config file updates are handled.  Add this to `filesystem` package, specifying that MSYS2 is like cygwin and arch (being like arch is how it decides to look at `.pacnew` files).

Word to the wise, you probably want to set the `EDITOR` environment variable.   I was testing this from a fresh install from an old installer, and `sdiff` tried to run `ed`.