### PR TITLE
btyacc & reflex: Upgrade to 20210510

### DIFF
--- a/btyacc/0001-btyacc-20210520-tests-fix-handle-dynamically-determined-YYINT.patch
+++ b/btyacc/0001-btyacc-20210520-tests-fix-handle-dynamically-determined-YYINT.patch
@@ -1,0 +1,31 @@
+From 4ddeb68f35d0ba78a0d6f90ac32796812c265234 Mon Sep 17 00:00:00 2001
+From: Jannick <thirdedition@gmx.net>
+Date: Sun, 13 Jun 2021 22:18:23 +0200
+Subject: [PATCH] tests(fix): handle YYINT dynamically determined at compile
+ time
+
+At compile time YYINT is determined to be one of 'short', 'int', 'long'
+in 'defs.h'.
+
+* test/run_test.sh(test_diffs):
+  - add regular expression mapping 'typedef (long|short) YYINT;' to
+    'typedef int YYINT;' used throughout the expected files
+---
+ test/run_test.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/test/run_test.sh b/test/run_test.sh
+index 908a7d0..af39361 100755
+--- a/test/run_test.sh
++++ b/test/run_test.sh
+@@ -25,6 +25,7 @@ test_diffs() {
+ 			-e 's,#line \([1-9][0-9]*\) "'$REF_DIR'/,#line \1 ",' \
+ 			-e 's,#line \([1-9][0-9]*\) "'$TEST_DIR'/,#line \1 ",' \
+ 			-e 's,\(YACC:.* line [0-9][0-9]* of "\)'$TEST_DIR/',\1./,' \
++			-e 's/^typedef \(short\|long\) YYINT;$/typedef int YYINT;/' \
+ 			< $CMP >$tmpfile \
+ 			&& mv $tmpfile $CMP
+ 		if test ! -f $REF
+-- 
+2.32.0.windows.1
+

--- a/btyacc/PKGBUILD
+++ b/btyacc/PKGBUILD
@@ -1,7 +1,7 @@
 
 _realname=byacc
 pkgname=btyacc
-pkgver=20210328
+pkgver=20210520
 pkgrel=1
 pkgdesc="btyacc - an LALR(1) parser generator with support for backtracking"
 arch=('i686' 'x86_64')
@@ -9,12 +9,15 @@ url="https://invisible-island.net/byacc"
 license=('Public Domain')
 groups=('base-devel')
 
-source=(${_realname}-${pkgver}.tar.gz::https://github.com/ThomasDickey/byacc-snapshots/archive/t${pkgver}.tar.gz)
-sha256sums=('646c961d0fea096f38b023fa26e969647ac3208ac59721a14f25f70ef78073d8')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/ThomasDickey/byacc-snapshots/archive/t${pkgver}.tar.gz"
+        '0001-btyacc-20210520-tests-fix-handle-dynamically-determined-YYINT.patch')
+sha256sums=('bd83953a3599ed3acc9ed76323f468154e724b3ab0a408218e53a441cc6d5b82'
+            '5bb5a18dd52e95621c113331e4e04a22efb913bcb79f3d64ac3b8a643058580d')
 
 
 prepare() {
   cd ${_realname}-snapshots-t${pkgver}
+  patch -b -p1 -i '../0001-btyacc-20210520-tests-fix-handle-dynamically-determined-YYINT.patch'
   autoreconf -vfi
 }
 

--- a/reflex/PKGBUILD
+++ b/reflex/PKGBUILD
@@ -1,7 +1,7 @@
 
 _realname=reflex
 pkgname=${_realname}
-pkgver=20200715
+pkgver=20210510
 pkgrel=1
 pkgdesc="A variant of the flex fast lexical scanner"
 arch=('i686' 'x86_64')
@@ -11,7 +11,7 @@ groups=('base-devel')
 
 # source=("${_realname}-${pkgver}.tar.gz::https://invisible-island.net/datafiles/release/${_realname}.tar.gz")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/ThomasDickey/${_realname}-snapshots/archive/t${pkgver}.tar.gz")
-sha256sums=('80ebbadd26e96a95cc7e4c752608c7dfec7fe9a569258a3dc5f0e4de9a36ffc7')
+sha256sums=('12b4f1b7b4d69bd43a8c976c5807fd1aeb2495ac4497c02d63f443c02d0eb900')
 
 
 _src_dir=${_realname}-snapshots-t${pkgver}


### PR DESCRIPTION
The btyacc testsuite needs a patch added in the btyacc the commit.