### PR TITLE
msys2-runtime: copy `usr/libexec` folder also

### DIFF
--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.2.0
-pkgrel=9
+pkgrel=10
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -228,6 +228,7 @@ package_msys2-runtime() {
 
   mkdir -p "${pkgdir}"/usr
   cp -rf "${srcdir}"/dest/usr/bin "${pkgdir}"/usr/
+  cp -rf "${srcdir}"/dest/usr/libexec "${pkgdir}"/usr/
   rm -f "${pkgdir}"/usr/bin/msys-2.0.dbg
   rm -f "${pkgdir}"/usr/bin/cyglsa-config
   rm -f "${pkgdir}"/usr/bin/cyglsa.dll


### PR DESCRIPTION
it was missed in https://github.com/msys2/MSYS2-packages/pull/2547