### PR TITLE
sqlite: Upgrade to 3.36.0

### DIFF
--- a/sqlite/0007-sqlite3.36.0-Makefile.in-fix-libtclsqlite-package-installation-bug.patch
+++ b/sqlite/0007-sqlite3.36.0-Makefile.in-fix-libtclsqlite-package-installation-bug.patch
@@ -8,8 +8,6 @@ placed next to pkgIndex.tcl after installation by libtool.
 
 - using the flag -module instructs libtool to place the shared object
   libtclsqlite3 in TCLLIBDIR upon installation.
-- paste the shared library name from the libtool file 'libtclsqlite3.la'
-  into 'pkgIndex.tcl'.
 ---
  Makefile.in | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
@@ -27,17 +25,6 @@ index f92741f..589c9f6 100644
  		libsqlite3.la @TCL_STUB_LIB_SPEC@ $(TLIBS) \
  		-rpath "$(TCLLIBDIR)" \
  		-version-info "8:6:8" \
-@@ -1434,8 +1434,8 @@ install:	sqlite3$(TEXE) lib_install sqlite3.h sqlite3.pc ${HAVE_TCL:1=tcl_instal
- 	$(INSTALL) -d $(DESTDIR)$(pkgconfigdir)
- 	$(INSTALL) -m 0644 sqlite3.pc $(DESTDIR)$(pkgconfigdir)
-
--pkgIndex.tcl:
--	echo 'package ifneeded sqlite3 $(RELEASE) [list load [file join $$dir libtclsqlite3[info sharedlibextension]] sqlite3]' > $@
-+pkgIndex.tcl: libtclsqlite3.la
-+	echo 'package ifneeded sqlite3 $(RELEASE) [list load [file join $$dir '`source ./$< && echo $$dlname`'] sqlite3]' > $@
- tcl_install:	lib_install libtclsqlite3.la pkgIndex.tcl
- 	$(INSTALL) -d $(DESTDIR)$(TCLLIBDIR)
- 	$(LTINSTALL) libtclsqlite3.la $(DESTDIR)$(TCLLIBDIR)
 --
 2.28.0.windows.1
 

--- a/sqlite/Makefile.ext.in
+++ b/sqlite/Makefile.ext.in
@@ -1,3 +1,5 @@
+# PLEASE KEEP IN SYNC WITH CORRESPONDING FILE IN MINGW64-SQLITE.
+#
 # Makefile template to generate sqlite extensions
 # in sub-folder ext/misc of sqlite-src-xxxxx package.
 
@@ -34,6 +36,10 @@ docdir          = $(datadir)/sqlite/extensions
 CSRCS           = $(filter-out $(addprefix $(srcdir)/,$(CSRCS_IGNORE)),$(wildcard $(srcdir)/*.c))
 # c-sources not to compile as standalone sqlite-extensions
 CSRCS_IGNORE    = memtrace.c json1.c
+# c-source already compiled into sqlite3 client
+CSRCS_IGNORE   += regexp.c
+# c-source to be ignored because of compilation errors
+#CSRCS_IGNORE   +=
 
 DLLS            = $(patsubst %.c,$(DLL_PREFIX)%$(DLL_SUFFIX).dll,$(notdir $(CSRCS)))
 

--- a/sqlite/PKGBUILD
+++ b/sqlite/PKGBUILD
@@ -7,8 +7,8 @@ pkgname=('sqlite' 'libsqlite' 'libsqlite-devel' 'sqlite-doc'
          'sqlite-extensions'
          'lemon')
 _sqlite_year=2021
-_amalgamationver=3350500
-pkgver=3.35.5
+_amalgamationver=3360000
+pkgver=3.36.0
 pkgrel=1
 pkgdesc="A C library that implements an SQL database engine"
 arch=('i686' 'x86_64')
@@ -22,16 +22,16 @@ source=(https://www.sqlite.org/${_sqlite_year}/sqlite-src-${_amalgamationver}.zi
         0010-sqlite-3.34.0-lemon.patch
         0001-sqlite3.32.3-configure.ac-fix-OS-recognition-on-MSYS2.patch
         0002-sqlite3.32.3-Makefile.in-fix-rule-compiling-rbu.exe.patch
-        0007-sqlite3.32.3-Makefile.in-fix-libtclsqlite-package-installation-bug.patch
+        0007-sqlite3.36.0-Makefile.in-fix-libtclsqlite-package-installation-bug.patch
         Makefile.ext.in README.md.in)
-sha256sums=('f4beeca5595c33ab5031a920d9c9fd65fe693bad2b16320c3a6a6950e66d3b11'
-            '098257e33eb50254cccd31333b09eeafd5843fdd446e1c856c4b48b758573cb9'
+sha256sums=('25a3b9d08066b3a9003f06a96b2a8d1348994c29cc912535401154501d875324'
+            '79f03bf2b4afd845b66e7d07c7fa08c46a30c2484a4a5f8508db653c9da5d32d'
             '0b76663a90e034f3d7f2af5bfada4cedec5ebc275361899eccc5c18e6f01ff1f'
             'ee6bdd979a97205a1a2dd760e90c8588f45523cecb5256c0d927f24494f7fc9f'
             '589b7182343dba3dd8225c13ff1d7d275e5f714e7793bac1c88f7cfdd569d9e0'
             'b717c73804be44b82048d90bbb8e0c61ff081339a5757194e9769bd4d9c048e5'
-            '12507108d633a6b0a01534e30bcc807a4dcd5c8f955e6336b9ebe505a986fce0'
-            '572fe2e1492de5643018bcbb2ba7d69747d20a2b021c32cec868b87c92ccb18f'
+            '10f30378e83423f8b84462c1dd5b58501913816865cfd595f69a7b9ddd7e4e2b'
+            'f7da5d5fb4b4b3588fa59d7282244495afe546e01c73c2369e50c3930e461ea9'
             'ef3a1faa02a88e05539d160d51679f164dfa23cc5a637ff36bc504bf04d6d7a6')
 
 _sqlite_tools="sqlite3.exe sqlite3_analyzer.exe sqldiff.exe dbhash.exe rbu.exe"
@@ -61,7 +61,7 @@ prepare() {
   cd "${srcdir}"/sqlite-src-${_amalgamationver}
   apply_patch_with_msg 0001-sqlite3.32.3-configure.ac-fix-OS-recognition-on-MSYS2.patch
   apply_patch_with_msg 0002-sqlite3.32.3-Makefile.in-fix-rule-compiling-rbu.exe.patch
-  apply_patch_with_msg 0007-sqlite3.32.3-Makefile.in-fix-libtclsqlite-package-installation-bug.patch
+  apply_patch_with_msg 0007-sqlite3.36.0-Makefile.in-fix-libtclsqlite-package-installation-bug.patch
   autoreconf -vfi
 
   msg2 "Preparing files for lemon.exe to be distributed..."
@@ -121,7 +121,8 @@ build() {
 check() {
   cd build-${_amalgamationver}-${MSYSTEM_CHOST}
   # This test run lasts very loooong ... despite the target name
-  # sqlite 3.35.0: 53 errors out of 303220 tests on MSYS_NT-10.0-19042 64-bit little-endian
+  # sqlite 3.36.0: 54 errors out of 303582 tests on MSYS_NT-10.0-19043 64-bit little-endian
+  # !Failures on these tests: attach-6.2 attach-6.2.2 journal3-1.2.2.1 journal3-1.2.2.4 journal3-1.2.3.1 journal3-1.2.3.4 journal3-1.2.4.1 journal3-1.2.4.4 symlink-1.1 symlink-1.1.2 symlink-1.1.4 symlink-1.2.2 symlink-1.2.3 symlink-1.3 symlink-2.1.2 symlink-2.1.4 symlink-2.1.6 symlink-2.2.2 symlink-2.2.4 symlink-2.2.6 symlink-4.2.1 symlink-4.2.2 symlink-4.3.1 symlink-4.3.2 symlink-4.4.2 tableapi-7.transient.37 tkt3457-1.3 triggerA-3.transient.94 triggerA-3.transient.118 triggerA-3.transient.119 triggerA-3.transient.275 triggerA-3.transient.305 triggerA-3.transient.306 triggerA-3.transient.317 triggerA-3.transient.318 triggerA-3.transient.319 triggerA-3.transient.320 wal2-12.2.2.1 wal2-12.2.2.4 wal2-12.2.3.1 wal2-12.2.3.4 wal2-12.2.4.1 wal2-12.2.4.4 wal2-13.3.1 wal2-13.4.1 wal2-13.5.1 wal2-13.7.1 wal2-13.7.3 wal2-13.7.4 wal2-13.8.1 wal2-13.8.3 wal2-13.8.4 wal2-13.9.1 wal2-13.9.2
   make quicktest || true
 }
 _install_license() {


### PR DESCRIPTION
* PKGBUILD
  - upgrade version numbers and related hashes
  - rename patch
* Makefile.ext.in
  - add regexp.c to CSRC_IGNORE, since module is compiled into sqlite client
    since version 3.36.0
* 0007-sqlite3.36.0-Makefile.in-fix-libtclsqlite-package-installation-bug.patch
  - renamed from 0007-sqlite3.32.3-Makefile.in-fix-libtclsqlite-package-installation-bug.patch
  - remove patch about 'info sharedlibextension' which now works with tclsh
* 0007-sqlite3.32.3-Makefile.in-fix-libtclsqlite-package-installation-bug.patch
  - renamed