### PR TITLE
pacman-mirrors: downloads.sourceforge.net -> sourceforge.net

### DIFF
--- a/pacman-mirrors/PKGBUILD
+++ b/pacman-mirrors/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Ray Donnelly <mingwandroid@gmail.com>
 
 pkgname=pacman-mirrors
-pkgver=20210702
+pkgver=20210703
 pkgrel=1
 pkgdesc="MSYS2 mirror list for use by pacman"
 arch=('any')
@@ -9,8 +9,8 @@ url="https://www.msys2.org/dev/mirrors/"
 license=('GPL')
 source=(mirrorlist.msys
         mirrorlist.mingw)
-sha256sums=('1264eadb0824b9d9e1ae797c5ec962aa3101ca465ed3256422c8ef2bb72bc580'
-            '9c28815f465a382ce564936f99ca8ed6727a9063a0611f335709964b7502f7b3')
+sha256sums=('2a54e0b017edc04c8ad30fce18e6b3184e9aad9b9b0c56d687cca75a20a2c66a'
+            'db5144ece7add6e84ff822ad5c61541033af5473b6b54dcaade14c46ba329881')
 backup=(
   'etc/pacman.d/mirrorlist.msys'
   'etc/pacman.d/mirrorlist.mingw'

--- a/pacman-mirrors/mirrorlist.mingw
+++ b/pacman-mirrors/mirrorlist.mingw
@@ -18,7 +18,7 @@ Server = https://mirrors.tuna.tsinghua.edu.cn/msys2/mingw/$repo/
 Server = https://mirrors.ustc.edu.cn/msys2/mingw/$repo/
 
 ## Tier 2
-Server = https://downloads.sourceforge.net/project/msys2/REPOS/MINGW/$repo/
+Server = https://sourceforge.net/projects/msys2/files/REPOS/MINGW/$repo/
 Server = https://fastmirror.pp.ua/msys2/mingw/$repo/
 Server = https://ftp.cc.uoc.gr/mirrors/msys2/mingw/$repo/
 Server = https://mirror.jmu.edu/pub/msys2/mingw/$repo/

--- a/pacman-mirrors/mirrorlist.msys
+++ b/pacman-mirrors/mirrorlist.msys
@@ -18,7 +18,7 @@ Server = https://mirrors.tuna.tsinghua.edu.cn/msys2/msys/$arch/
 Server = https://mirrors.ustc.edu.cn/msys2/msys/$arch/
 
 ## Tier 2
-Server = https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/$arch/
+Server = https://sourceforge.net/projects/msys2/files/REPOS/MSYS2/$arch/
 Server = https://fastmirror.pp.ua/msys2/msys/$arch/
 Server = https://ftp.cc.uoc.gr/mirrors/msys2/msys/$arch/
 Server = https://mirror.jmu.edu/pub/msys2/msys/$arch/


### PR DESCRIPTION
The former, while faster, doesn't support symlinks and we want to
use/depend on that in the future.