### PR TITLE
Add IAA mirror to pacman-mirrors

### DIFF
--- a/pacman-mirrors/PKGBUILD
+++ b/pacman-mirrors/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Ray Donnelly <mingwandroid@gmail.com>
 
 pkgname=pacman-mirrors
-pkgver=20210703
+pkgver=20210706
 pkgrel=1
 pkgdesc="MSYS2 mirror list for use by pacman"
 arch=('any')
@@ -9,8 +9,8 @@ url="https://www.msys2.org/dev/mirrors/"
 license=('GPL')
 source=(mirrorlist.msys
         mirrorlist.mingw)
-sha256sums=('2a54e0b017edc04c8ad30fce18e6b3184e9aad9b9b0c56d687cca75a20a2c66a'
-            'db5144ece7add6e84ff822ad5c61541033af5473b6b54dcaade14c46ba329881')
+sha256sums=('6961a99e50e933c6af99cabeca32250454a444b4353df0a98fb34c43272c9e25'
+            '32d82b82b05d55c660309aaefa1199d6eb6b7920aeaf8c04d39caa51885b7751')
 backup=(
   'etc/pacman.d/mirrorlist.msys'
   'etc/pacman.d/mirrorlist.mingw'

--- a/pacman-mirrors/mirrorlist.mingw
+++ b/pacman-mirrors/mirrorlist.mingw
@@ -11,6 +11,7 @@ Server = https://ftp.acc.umu.se/mirror/msys2.org/mingw/$repo/
 Server = https://ftp.nluug.nl/pub/os/windows/msys2/builds/mingw/$repo/
 Server = https://ftp.osuosl.org/pub/msys2/mingw/$repo/
 Server = https://mirror.clarkson.edu/msys2/mingw/$repo/
+Server = https://mirror.internet.asn.au/pub/msys2/mingw/$repo/
 Server = https://mirror.selfnet.de/msys2/mingw/$repo/
 Server = https://mirror.ufro.cl/msys2/mingw/$repo/
 Server = https://mirrors.dotsrc.org/msys2/mingw/$repo/

--- a/pacman-mirrors/mirrorlist.msys
+++ b/pacman-mirrors/mirrorlist.msys
@@ -11,6 +11,7 @@ Server = https://ftp.acc.umu.se/mirror/msys2.org/msys/$arch/
 Server = https://ftp.nluug.nl/pub/os/windows/msys2/builds/msys/$arch/
 Server = https://ftp.osuosl.org/pub/msys2/msys/$arch/
 Server = https://mirror.clarkson.edu/msys2/msys/$arch/
+Server = https://mirror.internet.asn.au/pub/msys2/msys/$arch/
 Server = https://mirror.selfnet.de/msys2/msys/$arch/
 Server = https://mirror.ufro.cl/msys2/msys/$arch/
 Server = https://mirrors.dotsrc.org/msys2/msys/$arch/


### PR DESCRIPTION
The Internet Association of Australia has kindly agreed to mirror msys2 - both via https/rsync:

https://mirror.internet.asn.au/pub/msys2
rsync://mirror.internet.asn.au/msys2

It has been set up to sync every 4 hours. 