### PR TITLE
Fix issue with certificates not being uniformly updated by update-ca-trust

### DIFF
--- a/ca-certificates/PKGBUILD
+++ b/ca-certificates/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=ca-certificates
 pkgver=20210119
-pkgrel=1
+pkgrel=2
 pkgdesc='Common CA certificates'
 arch=('any')
 url='https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/'
@@ -16,7 +16,7 @@ makedepends=('asciidoc' 'python3' 'libxslt' 'sed' 'grep')
 install='ca-certificates.install'
 sha256sums=('daa3afae563711c30a0586ddae4336e8e3974c2b627faaca404c4e0141b64665'
             'aae6aa5d2bd31064eb923a00a0d37789d3e2f2aa2ef0b39c10228d8d7a3ceb30'
-            '0f3e97846494ad41330352bb6b2fa0f8d264bf16d8d02f04b759ca8c26b3e092'
+            'f411cb774da977d3bf6647f53030cb0d584fea09591cec8b6fcc3065f7652c98'
             'a73c6430e734178b9aa4d303709470383bc2b1cfbeb0d44fe34615df812f479d')
 
 prepare() {

--- a/ca-certificates/update-ca-trust
+++ b/ca-certificates/update-ca-trust
@@ -18,6 +18,7 @@ DEST=/etc/pki/ca-trust/extracted
 /usr/bin/p11-kit extract --format=java-cacerts --filter=ca-anchors --overwrite --purpose server-auth $DEST/java/cacerts
 
 # The usual symbolic links are not present to keep these file in sync in MSYS2, so copying is necessary
+mkdir -p /usr/ssl/certs
 cp -f $DEST/pem/tls-ca-bundle.pem /usr/ssl/certs/ca-bundle.crt
 cp -f $DEST/pem/tls-ca-bundle.pem /usr/ssl/cert.pem
 cp -f $DEST/openssl/ca-bundle.trust.crt /usr/ssl/certs/ca-bundle.trust.crt

--- a/ca-certificates/update-ca-trust
+++ b/ca-certificates/update-ca-trust
@@ -16,3 +16,8 @@ DEST=/etc/pki/ca-trust/extracted
 /usr/bin/p11-kit extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose email $DEST/pem/email-ca-bundle.pem
 /usr/bin/p11-kit extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose code-signing $DEST/pem/objsign-ca-bundle.pem
 /usr/bin/p11-kit extract --format=java-cacerts --filter=ca-anchors --overwrite --purpose server-auth $DEST/java/cacerts
+
+# The usual symbolic links are not present to keep these file in sync in MSYS2, so copying is necessary
+cp -f $DEST/pem/tls-ca-bundle.pem /usr/ssl/certs/ca-bundle.crt
+cp -f $DEST/pem/tls-ca-bundle.pem /usr/ssl/cert.pem
+cp -f $DEST/openssl/ca-bundle.trust.crt /usr/ssl/certs/ca-bundle.trust.crt


### PR DESCRIPTION
This change should fix this issue, which is quite a pain to work through as it's not obvious why pacman fails even when updating ca-trust.

https://github.com/msys2/MSYS2-packages/issues/1222