### PR TITLE
pacman: add patch for handling cr on stdin

### DIFF
--- a/pacman/00019-pacman.c-handle-cr-on-stdin-as-well.patch
+++ b/pacman/00019-pacman.c-handle-cr-on-stdin-as-well.patch
@@ -1,0 +1,33 @@
+From aeaae2dd533fe6475dd02d858d982b9b22e6996d Mon Sep 17 00:00:00 2001
+From: Christopher Degawa <ccom@randomderp.com>
+Date: Wed, 18 Aug 2021 10:00:26 -0500
+Subject: [PATCH 19/N] pacman.c: handle cr on stdin as well
+
+Improves compatibility with Windows targets, specifically when using
+powershell for string transforming package names and piping into
+pacman as it's virtually impossible to send newline only terminated
+strings through pipes
+
+Signed-off-by: Christopher Degawa <ccom@randomderp.com>
+---
+ src/pacman/pacman.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/pacman/pacman.c b/src/pacman/pacman.c
+index e398855a..a495fd86 100644
+--- a/src/pacman/pacman.c
++++ b/src/pacman/pacman.c
+@@ -1152,6 +1152,10 @@ int main(int argc, char *argv[])
+ 				if(line[nread - 1] == '\n') {
+ 					/* remove trailing newline */
+ 					line[nread - 1] = '\0';
++					if (line[nread - 2] == '\r') {
++						/* remove trailing carriage returns */
++						line[nread - 2] = '\0';
++					}
+ 				}
+ 				if(line[0] == '\0') {
+ 					/* skip empty lines */
+-- 
+2.32.0
+

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.0.0
-pkgrel=5
+pkgrel=6
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -60,7 +60,8 @@ source=(pacman-${pkgver}::git+https://gitlab.archlinux.org/pacman/pacman.git#com
         0015-Remove-sudo.patch
         0016-Use-msys-tools.patch
         0017-Export-CC-and-CXX-variables-explicitly.patch
-        0018-Add-a-CI-job.patch)
+        0018-Add-a-CI-job.patch
+        00019-pacman.c-handle-cr-on-stdin-as-well.patch)
 validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@archlinux.org>
               'B8151B117037781095514CA7BBDFFC92306B1121') # Andrew Gregory (pacman) <andrew@archlinux.org>
 sha256sums=('SKIP'
@@ -86,7 +87,8 @@ sha256sums=('SKIP'
             'e3aef7b31ff56d128ac8b213437987c57a1490f52b31185199241da43233547d'
             'bc16b167293aca73eec011d42b6d69a88e7a51be778e56e4d9a0ab1bc421efaa'
             '8388d3c5edfe66f5f023fe5df275e7223cc5d92f9163a8a85a99987f538b30f0'
-            '94f1f32544311713ec4f76a1058625d4215e0a7582ca3f08208841c0bf4ed723')
+            '94f1f32544311713ec4f76a1058625d4215e0a7582ca3f08208841c0bf4ed723'
+            'f46f5eb952895e53af2ac3afb76eebc98491960b27106a61e02f133b42854a2f')
 
 apply_git_am_with_msg() {
   for _patch in "$@"
@@ -123,7 +125,8 @@ prepare() {
   0015-Remove-sudo.patch \
   0016-Use-msys-tools.patch \
   0017-Export-CC-and-CXX-variables-explicitly.patch \
-  0018-Add-a-CI-job.patch
+  0018-Add-a-CI-job.patch \
+  00019-pacman.c-handle-cr-on-stdin-as-well.patch
 }
 
 build() {


### PR DESCRIPTION
Allows for stuff such as 
```powershell
$a="vim nano"
$b="cmake ninja"
$a.Split(' '), $b.Split(' ').ForEach({Write-Output mingw-w64-ucrt-x86_64-$_}) |
  pacman -S --needed -
```