### PR TITLE
pacman: switch mingw i686 -march to pentium4

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.0.0
-pkgrel=5
+pkgrel=6
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -66,7 +66,7 @@ validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@a
 sha256sums=('SKIP'
             'fff047d9514c4810eee9ab798b51d3300cbf7ee1b5e2e494e1350499d28dd448'
             'ee9f8a5ec60a1334725adb102f531f38badfe1bb66bde82c4aeb3131a2becc2f'
-            '49452621003656e5ad09c5ed38d37f62187ede8b6456a2ba2919846b430dfb74'
+            '606e4b2808a40e856b7043244fc993d426dab25bc2e03b2b8ee5b869f5102507'
             '2bd27c3fc5443b367e5025c9b9a35670b02202e48e92eead90755fef8d08fa83'
             '3687b6ed122d607fc549c0ec2fc29b61e7da246fd42443680e442e8526a18ab2'
             '6dd930f5da349959deb128b0fa875da11184df90afe250a51862b39beffd1240'

--- a/pacman/makepkg_mingw.conf
+++ b/pacman/makepkg_mingw.conf
@@ -63,8 +63,8 @@ elif [[ "$MSYSTEM" == "MINGW32" ]]; then
   CC="gcc"
   CXX="g++"
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
-  CFLAGS="-march=i686 -mtune=generic -O2 -pipe"
-  CXXFLAGS="-march=i686 -mtune=generic -O2 -pipe"
+  CFLAGS="-march=pentium4 -mtune=generic -O2 -pipe"
+  CXXFLAGS="-march=pentium4 -mtune=generic -O2 -pipe"
   LDFLAGS="-pipe -Wl,--dynamicbase,--nxcompat,--no-seh"
 elif [[ "$MSYSTEM" == "CLANG64" ]]; then
   CARCH="x86_64"
@@ -87,8 +87,8 @@ elif [[ "$MSYSTEM" == "CLANG32" ]]; then
   CC="clang"
   CXX="clang++"
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
-  CFLAGS="-march=i686 -mtune=generic -O2 -pipe"
-  CXXFLAGS="-march=i686 -mtune=generic -O2 -pipe"
+  CFLAGS="-march=pentium4 -mtune=generic -O2 -pipe"
+  CXXFLAGS="-march=pentium4 -mtune=generic -O2 -pipe"
   LDFLAGS="-pipe -Wl,--dynamicbase,--no-seh"
 elif [[ "$MSYSTEM" == "CLANGARM64" ]]; then
   CARCH="aarch64"


### PR DESCRIPTION
We had discussed this on Discord a while ago.  `-march=pentium4` seemed like a reasonable minimum, requiring instruction sets through sse2.  This has been the default 32-bit instruction set for Visual Studio starting in Visual Studio 2012, and is also the default in clang (though the `-march=i686` option here has been overriding it to target Pentium Pro instead).

My personal recollection of the last CPU I had to deal with that didn't have SSE2 was the Athlon XP, circa 2005.  All 64-bit capable CPUs support SSE2.