### PR TITLE
wget: build without libmetalink

### DIFF
--- a/wget/PKGBUILD
+++ b/wget/PKGBUILD
@@ -2,14 +2,14 @@
 
 pkgname=wget
 pkgver=1.21.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A network utility to retrieve files from the Web"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/wget/"
 license=('GPL3')
 groups=('base-devel')
-depends=('gcc-libs' 'libiconv' 'libidn2' 'libintl' 'libgpgme' 'libmetalink' 'libpcre2_8' 'libpsl' 'libuuid' 'openssl' 'zlib')
-makedepends=('gettext-devel' 'libidn2-devel' 'libgpgme-devel' 'libmetalink-devel' 'libuuid-devel' 'libpsl-devel' 'openssl-devel' 'pcre2-devel' 'zlib-devel' 'python' 'libunistring-devel')
+depends=('gcc-libs' 'libiconv' 'libidn2' 'libintl' 'libgpgme' 'libpcre2_8' 'libpsl' 'libuuid' 'openssl' 'zlib')
+makedepends=('gettext-devel' 'libidn2-devel' 'libgpgme-devel' 'libuuid-devel' 'libpsl-devel' 'openssl-devel' 'pcre2-devel' 'zlib-devel' 'python' 'libunistring-devel')
 checkdepends=('perl-HTTP-Daemon' 'perl-IO-Socket-SSL')
 optdepends=('ca-certificates: HTTPS downloads')
 backup=('etc/wgetrc')
@@ -50,7 +50,8 @@ build() {
     --without-libiconv-prefix \
     --without-libintl-prefix \
     --without-libpth-prefix \
-    --without-libgnutls-prefix
+    --without-libgnutls-prefix \
+    --without-metalink
 
   make
 }


### PR DESCRIPTION
curl removed it because it's unmaintained and has security issues, so
we should try to remove it too.