### PR TITLE
python-pyalpm: depend on libarchive not libarchive-devel

### DIFF
--- a/python-pyalpm/PKGBUILD
+++ b/python-pyalpm/PKGBUILD
@@ -4,12 +4,12 @@ _realname=pyalpm
 pkgbase="python-${_realname}"
 pkgname=("python-${_realname}")
 pkgver=0.10.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Libalpm bindings for Python"
 arch=('i686' 'x86_64')
 license=('GPL')
 url="https://gitlab.archlinux.org/archlinux/pyalpm"
-depends=("python" "libarchive-devel")
+depends=("python" "libarchive")
 makedepends=('gettext-devel'
              'heimdal-devel'
              'libarchive-devel'


### PR DESCRIPTION
I tested this locally and it ran fine without libarchive-devel.  Fixes #2618