### PR TITLE
filesystem/shell: list the new environments in help too

### DIFF
--- a/filesystem/shell
+++ b/filesystem/shell
@@ -8,7 +8,7 @@ if [[ -z "${1}" || "${1}" =~ ^(--help|-h)$ ]]; then tee <<done
     Copyright (C) 2016 Renato Silva
     Licensed under public domain
 
-Usage: source $(basename "${0}") mingw32|mingw64|msys
+Usage: source $(basename "${0}") mingw32|mingw64|ucrt64|clang64|msys
 
     Switch between shells without restarting MSYS2. This is done by setting the
     MSYSTEM variable and sourcing /etc/profile. For interactive shells,


### PR DESCRIPTION
This commit changes the set of environments accepted in the help to match what is given in the actual code. A slightly fishy thing is that it does not yet do anything for clang32 -- is that even a real environment?