### PR TITLE
pacman: try to improve makepkg-mingw defaults

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -67,7 +67,7 @@ sha256sums=('SKIP'
             'fff047d9514c4810eee9ab798b51d3300cbf7ee1b5e2e494e1350499d28dd448'
             'ee9f8a5ec60a1334725adb102f531f38badfe1bb66bde82c4aeb3131a2becc2f'
             '606e4b2808a40e856b7043244fc993d426dab25bc2e03b2b8ee5b869f5102507'
-            '2bd27c3fc5443b367e5025c9b9a35670b02202e48e92eead90755fef8d08fa83'
+            '55e26c3d3c54b210ccd9b8205907f538250c74e7dfcbc056f2e6c6dc0480eba9'
             '57fd01cd215294e2a9c91b616fe3854e96acddfb3de6a758912d9d8ea61fdc18'
             '9c1b99443d26732b21aec3943c17678aa9c7add584b413476873dafb1de4a9c0'
             'b1f3ade9e06f2cdfc23ae09a8598ae3c5603182c13d53d664af8a06eed74590b'

--- a/pacman/makepkg-mingw
+++ b/pacman/makepkg-mingw
@@ -62,31 +62,51 @@ fi
 
 readonly ALL_OFF BOLD BLUE GREEN RED YELLOW
 
-# For backwards compatibility
-if [[ -z "${MINGW_ARCH}" ]] && [[ -n "${MINGW_INSTALLS}" ]]; then
-  plain "MINGW_INSTALLS is deprecated, use MINGW_ARCH instead"
-  MINGW_ARCH="${MINGW_INSTALLS}";
-fi
-
-MINGW_ARCH="${MINGW_ARCH,,}"
-MINGW_ARCH="${MINGW_ARCH:-mingw64 mingw32}"
-MINGW_ARCH_ALLOWED=('mingw32' 'mingw64' 'clang32' 'clang64' 'clangarm64' 'ucrt64')
-
-for _mingw in ${MINGW_ARCH}; do
-  if [[ ! " ${MINGW_ARCH_ALLOWED[*]} " = *" ${_mingw} "* ]]; then
-    print_error "MINGW_ARCH: '${_mingw}' unknown, possible values: ${MINGW_ARCH_ALLOWED[*]}"
-    exit 1
-  fi
-done
-
+# For certain flags skip our processing and just forward to makepkg
 for _arg in "$@"; do
-  if [ "${_arg}" = "--help" ] || [ "${_arg}" = "-h" ] || [ "${_arg}" = "--version" ] || [ "${_arg}" = "-V" ]; then
+  if [ "${_arg}" = "--help" ] || [ "${_arg}" = "-h" ]; then
+    /usr/bin/makepkg "$@"
+    echo -e "makepkg-mingw:\n"
+    echo '  $MINGW_ARCH      Space separated list of environments to build for.'
+    echo '                   Defaults to the active environment.'
+    exit 0
+  fi
+  if [ "${_arg}" = "--version" ] || [ "${_arg}" = "-V" ]; then
     /usr/bin/makepkg "$@"
     exit 0
   fi
 done
 
+# For backwards compatibility
+if [[ -z "${MINGW_ARCH}" ]] && [[ -n "${MINGW_INSTALLS}" ]]; then
+  print_warning "MINGW_INSTALLS is deprecated, use MINGW_ARCH instead"
+  MINGW_ARCH="${MINGW_INSTALLS}";
+fi
+
+# Validate or set MINGW_ARCH
+MINGW_ARCH_ALLOWED=('mingw32' 'mingw64' 'clang32' 'clang64' 'clangarm64' 'ucrt64')
+MINGW_ARCH="${MINGW_ARCH,,}"
+if [[ -z "$MINGW_ARCH" ]]; then
+  # In case MINGW_ARCH isn't set we default to MSYSTEM, or error out
+  if [[ " ${MINGW_ARCH_ALLOWED[*]} " = *" ${MSYSTEM,,} "* ]]; then
+    MINGW_ARCH="${MSYSTEM,,}"
+  else
+    print_warning 'MINGW_ARCH not set and not called from a MINGW environment, defaulting to mingw64. This will fail in the future!'
+    MINGW_ARCH='mingw64'
+  fi
+else
+  # Make sure MINGW_ARCH is valid
+  for _mingw in ${MINGW_ARCH}; do
+    if [[ ! " ${MINGW_ARCH_ALLOWED[*]} " = *" ${_mingw} "* ]]; then
+      print_error "MINGW_ARCH: '${_mingw}' unknown, possible values: ${MINGW_ARCH_ALLOWED[*]}"
+      exit 1
+    fi
+  done
+fi
+print_msg1 "MINGW_ARCH: ${MINGW_ARCH}"
+
 for _mingw in ${MINGW_ARCH}; do
+  print_msg2 "Building ${_mingw}..."
   case ${_mingw} in
     mingw32)
       _msystem=MINGW32


### PR DESCRIPTION
* Print MINGW_ARCH info when passing --help/-h
* Change behaviour when MINGW_ARCH isn't set
  * Default to MSYSTEM if in a mingw environment
  * Default to mingw64 otherwise (but warn)
* Print some feedback on what is getting built right away.
  makepkg can take some time at the start and this makes
  things clear right away.

The goal of the MINGW_ARCH change is to make it more likely to do the right thing by
default and to not special case any environment.

This has the potential of breaking existing users if MINGW_ARCH isn't set
and they want exactly "mingw32/mingw64" to be built like before. This will now build
only mingw64 if called in a msys environment and either mingw32/64 if called
in those environments.

To restore the old behavior set MINGW_ARCH="mingw64 mingw32" first.