### PR TITLE
Workaround for issue on clang64 and some debug code.    Clang warns a…

### DIFF
--- a/libtool/0015-Support-llvm-Wformat-nonliteral.patch
+++ b/libtool/0015-Support-llvm-Wformat-nonliteral.patch
@@ -1,0 +1,25 @@
+--- libtool-2.4.6/build-aux/ltmain.in.orig	2021-08-29 04:58:24.267126800 -0400
++++ libtool-2.4.6/build-aux/ltmain.in	2021-08-29 05:04:21.377405000 -0400
+@@ -4270,6 +4270,11 @@ strendzap (char *str, const char *pat)
+   return str;
+ }
+ 
++#ifdef __clang__
++#pragma clang diagnostic push
++#pragma clang diagnostic ignored "-Wformat-nonliteral"
++#endif
++
+ void
+ lt_debugprintf (const char *file, int line, const char *fmt, ...)
+ {
+@@ -4296,6 +4301,10 @@ lt_error_core (int exit_status, const ch
+     exit (exit_status);
+ }
+ 
++#ifdef __clang__
++#pragma clang diagnostic pop    
++#endif   
++
+ void
+ lt_fatal (const char *file, int line, const char *message, ...)
+ {

--- a/libtool/PKGBUILD
+++ b/libtool/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=('libtool' 'libltdl')
 pkgver=2.4.6
 _gccver=10.2.0
-pkgrel=11
+pkgrel=12
 pkgdesc="A generic library support script"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/libtool/"
@@ -22,7 +22,8 @@ source=(https://ftp.gnu.org/pub/gnu/libtool/${pkgname}-${pkgver}.tar.xz{,.sig}
         0011-Pick-up-clang_rt-static-archives-compiler-internal-l.patch
         0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
         0013-Allow-statically-linking-compiler-support-libraries-.patch
-        0014-Support-llvm-objdump-f-output.patch)
+        0014-Support-llvm-objdump-f-output.patch
+        0015-Support-llvm-Wformat-nonliteral.patch)
 sha256sums=('7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f'
             'SKIP'
             'fe8b80efd34f9385220ebc90aaec945e44de8c343c75719d6ac0d4e472a6eed5'
@@ -35,7 +36,8 @@ sha256sums=('7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f'
             'c727b2b017163cfdeca60820d3cff2dac8968c5630745602b150f92b159af313'
             'c95a65e890b1ae6362807abc66809e72cf81aeea5f9f556e38f9752f974bf435'
             '8069e887aeeab7491f15e00547fa66d9b9e86407f5a23f37a6d8c7d165de752e'
-            'db16cd322e0ebc578c906e94b0788810af17ce617c700a50db2e3c598dbbed7e')
+            'db16cd322e0ebc578c906e94b0788810af17ce617c700a50db2e3c598dbbed7e'
+            '50b30761a2d00fba719d2a54d3bcb3fb6a2940f1741c0448d463a1a8d96f34af')
 
  validpgpkeys=('CFE2BE707B538E8B26757D84151308092983D606') #Gary Vaughan (Free Software Developer) <gary@vaughan.pe>
 
@@ -54,7 +56,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
   patch -p1 -i ${srcdir}/0013-Allow-statically-linking-compiler-support-libraries-.patch
   patch -p1 -i ${srcdir}/0014-Support-llvm-objdump-f-output.patch
-
+  patch -p1 -i ${srcdir}/0015-Support-llvm-Wformat-nonliteral.patch
 }
 
 build() {


### PR DESCRIPTION
…nd will sometimes generate an error  if the format string is not not a litteral constant ( -Wformat-nonliteral ).  That causes some packages to fail to compile.  Note that this warning is correct but I consider it harmless in libtool since it is used by libraries for testing and debuggng.  libtool really should be properly fixed for this.