### PR TITLE
pacman: backport .sig redirect fix and rework patch mngmt

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.0.0
-pkgrel=8
+pkgrel=9
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -36,12 +36,17 @@ makedepends=('asciidoc'
 backup=("etc/pacman.conf"
         "etc/makepkg.conf"
         "etc/makepkg_mingw.conf")
-_commit="0147de169a2abd193699957d4e76aec522901fd2"
+_commit="75eb3f4cd348c29f81645624428d02aa04dd3cbc"
 source=(pacman-${pkgver}::git+https://gitlab.archlinux.org/pacman/pacman.git#commit=${_commit}
         "pacman.conf"
         "makepkg.conf"
         "makepkg_mingw.conf"
         "makepkg-mingw"
+        pacman-6.0.0-fix-404-download.patch::https://gitlab.archlinux.org/pacman/pacman/-/commit/3401f9e142ac4c701cd98c52618cb13164f2146b.patch
+        pacman-6.0.0-fix-sig-retry.patch::https://gitlab.archlinux.org/pacman/pacman/-/commit/238109760d79924811121fe3e8d08365fbb2774b.patch
+        pacman-6.0.0-fix-key-import-double-free.patch::https://gitlab.archlinux.org/pacman/pacman/-/commit/542910d684191eb7f25ddc5d3d8fe3060028a267.patch
+        pacman-6.0.0-fix-sig-file-naming.patch::https://gitlab.archlinux.org/pacman/pacman/-/commit/0147de169a2abd193699957d4e76aec522901fd2.patch
+        pacman-6.0.0-fix-redirect-sig-name.patch::https://gitlab.archlinux.org/pacman/pacman/-/commit/2ec6de96a67bec4c5f17f518fb559688d0755349.patch
         0001-Msysize.patch
         0002-More-debugging-info.patch
         0003-Core-update.patch
@@ -68,6 +73,11 @@ sha256sums=('SKIP'
             'ee9f8a5ec60a1334725adb102f531f38badfe1bb66bde82c4aeb3131a2becc2f'
             '606e4b2808a40e856b7043244fc993d426dab25bc2e03b2b8ee5b869f5102507'
             '2bd27c3fc5443b367e5025c9b9a35670b02202e48e92eead90755fef8d08fa83'
+            'f4c1c39b43b52ba19b656b32913688b81085c73685afe32d2018dbb695d5a1e6'
+            'c6246669a8f4ed2654d85275d316e94467de96d425901b93956f8663805baad3'
+            'defdf1686d65fc896c19f41d1bc166912fccf9134b72e50da3b24538366cecdf'
+            'b3d10677e8036126b2ce7e33e00fabf16e4f8a0e1b627d0cd8e8920987db9a78'
+            '717efdde3a57b9bf94b4d581d8c27ec3e04fc8f9c262c3ba8b8ebf27bfa518cd'
             '0f7875bafbf224d7b376bedfde1c99a1050d86e699ecdad298d26544e340fbc6'
             'e8af0c7f5f1040749e317a97f64d4a7e66427a607bb46b25b4af946ef73c4a0b'
             '96108bce98683b3482b224b88eb6ca3aa69e236d0d20a5a4bb139a30aea1c051'
@@ -122,6 +132,12 @@ prepare() {
   0017-Export-CC-and-CXX-variables-explicitly.patch \
   0018-Add-a-CI-job.patch \
   0019-pacman.c-handle-cr-on-stdin-as-well.patch
+
+  patch -p1 -i "${srcdir}/pacman-6.0.0-fix-404-download.patch"
+  patch -p1 -i "${srcdir}/pacman-6.0.0-fix-sig-retry.patch"
+  patch -p1 -i "${srcdir}/pacman-6.0.0-fix-key-import-double-free.patch"
+  patch -p1 -i "${srcdir}/pacman-6.0.0-fix-sig-file-naming.patch"
+  patch -p1 -i "${srcdir}/pacman-6.0.0-fix-redirect-sig-name.patch"
 }
 
 build() {


### PR DESCRIPTION
explicitely fetch the patches we want to apply instead of changing the
base commit.