### PR TITLE
python-zstandard: new package

### DIFF
--- a/python-zstandard/PKGBUILD
+++ b/python-zstandard/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: Jeremy Drake <github@jdrake.com>
+
+pkgname=python-zstandard
+pkgver=0.15.2
+pkgrel=1
+pkgdesc='Python bindings to the Zstandard (zstd) compression library'
+arch=('i686' 'x86_64')
+url="https://github.com/indygreg/python-zstandard"
+license=('BSD')
+depends=("python")
+makedepends=("python-setuptools" "python-devel")
+options=('!emptydirs')
+source=("https://github.com/indygreg/${pkgname}/archive/${pkgver}.tar.gz")
+sha256sums=('5f947c9b0a2e5b3831bff2e7132cfbd7cc22ea8a400da2304e0c089d5c22a876')
+
+prepare() {  
+  cd "$srcdir"
+  rm -rf python-build-${CARCH} || true
+  cp -r "${pkgname}-${pkgver}" "python-build-${CARCH}"
+}
+
+build() {
+  msg "Python build for ${CARCH}"  
+  cd "${srcdir}/python-build-${CARCH}"
+  /usr/bin/python setup.py build
+}
+
+package() {
+  cd "${srcdir}/python-build-${CARCH}"
+  /usr/bin/python setup.py install --root="${pkgdir}" --optimize=1 --skip-build
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}


### PR DESCRIPTION
A python module for zstd is required to read .tar.zst files.  This is such a module, and is already packaged in MINGW-packages.