### PR TITLE
ca-certificates: drop expired "DST Root CA X3"

### DIFF
--- a/ca-certificates/PKGBUILD
+++ b/ca-certificates/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=ca-certificates
 pkgver=20210119
-pkgrel=2
+pkgrel=3
 pkgdesc='Common CA certificates'
 arch=('any')
 url='https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/'
@@ -10,14 +10,16 @@ license=('MPL' 'GPL')
 source=("http://ftp.debian.org/debian/pool/main/c/${pkgname}/${pkgname}_${pkgver}.tar.xz"
         'certdata2pem.py'
         'update-ca-trust'
-        'update-ca-trust.8')
+        'update-ca-trust.8'
+        'blacklist-dst-root-ca-x3.patch')
 depends=('bash' 'openssl' 'findutils' 'coreutils' 'sed' 'p11-kit')
 makedepends=('asciidoc' 'python3' 'libxslt' 'sed' 'grep')
 install='ca-certificates.install'
 sha256sums=('daa3afae563711c30a0586ddae4336e8e3974c2b627faaca404c4e0141b64665'
-            'aae6aa5d2bd31064eb923a00a0d37789d3e2f2aa2ef0b39c10228d8d7a3ceb30'
+            '9508738b61cc89bfc1f42580b1091a650f0acbf5c1b49edc2aa4e0313276ea0d'
             'f411cb774da977d3bf6647f53030cb0d584fea09591cec8b6fcc3065f7652c98'
-            'a73c6430e734178b9aa4d303709470383bc2b1cfbeb0d44fe34615df812f479d')
+            'a73c6430e734178b9aa4d303709470383bc2b1cfbeb0d44fe34615df812f479d'
+            'ded49e7b1a79f61ac02531b308a0a8cf96ca7476e669af5c29ec6e9d19b25e23')
 
 prepare() {
   mv "${srcdir}/work" "${srcdir}/${pkgname}-${pkgver}"
@@ -26,6 +28,7 @@ prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
   cp ${srcdir}/update-ca-trust sbin/
   cp ${srcdir}/update-ca-trust.8 sbin/
+  patch -p1 -i ${srcdir}/blacklist-dst-root-ca-x3.patch
 }
 
 build() {

--- a/ca-certificates/blacklist-dst-root-ca-x3.patch
+++ b/ca-certificates/blacklist-dst-root-ca-x3.patch
@@ -1,0 +1,7 @@
+--- a/mozilla/blacklist.txt       2021-01-19 11:11:04.000000000 +0100
++++ b/mozilla/blacklist.txt       2021-10-02 11:14:46.449980400 +0200
+@@ -7,3 +7,4 @@
+ "MITM subCA 2 issued by Trustwave"
+ "TURKTRUST Mis-issued Intermediate CA 1"
+ "TURKTRUST Mis-issued Intermediate CA 2"
++"DST Root CA X3"

--- a/ca-certificates/certdata2pem.py
+++ b/ca-certificates/certdata2pem.py
@@ -88,23 +88,39 @@ for line in open('certdata.txt', 'r', encoding='utf8'):
 if len(list(obj.items())) > 0:
     objects.append(obj)
 
+# Read blacklist.
+blacklist = []
+if os.path.exists('blacklist.txt'):
+    for line in open('blacklist.txt', 'r'):
+        line = line.strip()
+        if line.startswith('#') or len(line) == 0:
+            continue
+        item = line.split('#', 1)[0].strip()
+        blacklist.append(item)
+
 # Build up trust database.
 trustmap = dict()
 for obj in objects:
     if obj['CKA_CLASS'] != 'CKO_NSS_TRUST':
         continue
-    key = obj['CKA_LABEL'] + printable_serial(obj)
-    trustmap[key] = obj
-    print(" added trust", key)
+    if obj['CKA_LABEL'] in blacklist:
+        print("Certificate %s blacklisted, ignoring." % obj['CKA_LABEL'])
+    else:
+        key = obj['CKA_LABEL'] + printable_serial(obj)
+        trustmap[key] = obj
+        print(" added trust", key)
 
 # Build up cert database.
 certmap = dict()
 for obj in objects:
     if obj['CKA_CLASS'] != 'CKO_CERTIFICATE':
         continue
-    key = obj['CKA_LABEL'] + printable_serial(obj)
-    certmap[key] = obj
-    print(" added cert", key)
+    if obj['CKA_LABEL'] in blacklist:
+        print("Certificate %s blacklisted, ignoring." % obj['CKA_LABEL'])
+    else:
+        key = obj['CKA_LABEL'] + printable_serial(obj)
+        certmap[key] = obj
+        print(" added cert", key)
 
 def obj_to_filename(obj):
     label = obj['CKA_LABEL'][1:-1]


### PR DESCRIPTION
Let's encrypt signs current certificates based on their root
certificate "ISRG Root X1". They provide two different versions
of "ISRG Root X1", though. One is self-signed using "ISRG Root X1"
and one is cross-signed using "DST Root CA X3" [1]. Some systems
still distribute certificate chains with the cross-signed version.
"DST Root CA X3" expired on 2021-09-30. This can lead to valid
certificates being considered invalid on devices with the expired
certificate still in their CA certificate bundle.

Ubuntu[2] and RedHat[3][4] recently dropped this certificates from their
`ca-certificates` packages for the same reasons.

The blacklist code in certdata2pem is copied from the debian version
of the file as it comes with ca-certificates_20210119.tar.xz.

[1] https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021
[2] https://ubuntu.com/security/notices/USN-5089-1
[3] https://access.redhat.com/errata/RHBA-2021:3649
[4] https://access.redhat.com/articles/6338021