### PR TITLE
pactoys-git: support argument p, which uses envvar MINGW_PACKAGE_PREFIX

### DIFF
--- a/pactoys-git/0003-pacboy-support-argument-p.patch
+++ b/pactoys-git/0003-pacboy-support-argument-p.patch
@@ -1,0 +1,20 @@
+diff --git a/source/pacboy/pacboy.sh b/source/pacboy/pacboy.sh
+index 36f1c3d..8c455d6 100644
+--- a/source/pacboy/pacboy.sh
++++ b/source/pacboy/pacboy.sh
+@@ -20,6 +20,7 @@ help_and_exit() {
+             name:c means clang-x86_64-only
+             name:u means ucrt-x86_64-only
+             name:a means clang-aarch64-only
++            name:p means MINGW_PACKAGE_PREFIX-only
+
+         For MSYS shell:
+             name:m means mingw-w64
+@@ -215,6 +216,7 @@ for argument in "${arguments[@]}"; do
+      *:c) raw_argument=(mingw-w64-clang-x86_64-${argument%:c}) ;;
+      *:l) raw_argument=(mingw-w64-clang-x86_64-${argument%:l} mingw-w64-clang-i686-${argument%:l}) ;;
+      *:a) raw_argument=(mingw-w64-clang-aarch64-${argument%:a}) ;;
++     *:p) raw_argument=(${MINGW_PACKAGE_PREFIX}-${argument%:p}) ;;
+      *) parse_mingw_argument ;;
+     esac
+     [[ $argument =~ ^(-h|-[^-].*h|--help$) ]] && help_tip='true'

--- a/pactoys-git/PKGBUILD
+++ b/pactoys-git/PKGBUILD
@@ -3,7 +3,7 @@
 _realname='pactoys'
 pkgname="${_realname}-git"
 pkgver=r2.07ca37f
-pkgrel=2
+pkgrel=3
 pkgdesc='A set of pacman packaging utilities'
 url='https://github.com/renatosilva/pactoys'
 license=(BSD)


### PR DESCRIPTION
This is a minor patch to `pacboy` for allowing to install just the package corresponding to the environment defined by MINGW_PACKAGE_PREFIX.