### PR TITLE
pactoys-git: use fork 'msys2/pactoys'

### DIFF
--- a/pactoys-git/PKGBUILD
+++ b/pactoys-git/PKGBUILD
@@ -2,8 +2,8 @@
 
 _realname='pactoys'
 pkgname="${_realname}-git"
-pkgver=r2.07ca37f
-pkgrel=2
+pkgver=r51.43181b1
+pkgrel=1
 pkgdesc='A set of pacman packaging utilities'
 url='https://github.com/renatosilva/pactoys'
 license=(BSD)
@@ -12,35 +12,45 @@ arch=(i686 x86_64)
 provides=(${_realname})
 conflicts=(${_realname} repman-git updpkgver-git)
 replaces=(repman-git updpkgver-git)
-depends=(pacman pkgfile wget)
-makedepends=(gcc git)
+depends=(
+  pacman
+  pkgfile
+  wget
+)
+makedepends=(
+  gcc
+  git
+)
 install="${_realname}.install"
-source=('git+https://github.com/renatosilva/pactoys'
-		'0001-pacboy-new-architectures.patch'
-		'0002-disable-odd-msys2-check.patch')
-sha256sums=('SKIP'
-            'd329b4ed99faaa5e75198f441d7ea6622f4a46b7752d2ee5401b1deab75b0ba3'
-            '81d2cd124bf8f1b8980b7ec5fd38c686373dfd6630367bbb73d56a774bce9031')
-
+source=(
+  'git+https://github.com/msys2/pactoys'
+  '0001-pacboy-new-architectures.patch'
+  '0002-disable-odd-msys2-check.patch'
+)
+sha256sums=(
+  'SKIP'
+  'd329b4ed99faaa5e75198f441d7ea6622f4a46b7752d2ee5401b1deab75b0ba3'
+  '81d2cd124bf8f1b8980b7ec5fd38c686373dfd6630367bbb73d56a774bce9031'
+)
 
 pkgver() {
-    cd "${srcdir}/${_realname}"
-    printf "r%s.%s" $(git rev-list --count HEAD) $(git rev-parse --short HEAD)
+  cd "${srcdir}/${_realname}"
+  printf "r%s.%s" $(git rev-list --count HEAD) $(git rev-parse --short HEAD)
 }
 
 prepare() {
   cd "${srcdir}/${_realname}"
   for p in ${srcdir}/*.patch; do
-	patch -p1 -i $p
+    patch -p1 -i $p
   done
 }
 
 build() {
-    cd "${srcdir}/${_realname}"
-    make
+  cd "${srcdir}/${_realname}"
+  make
 }
 
 package() {
-    cd "${srcdir}/${_realname}"
-    make DESTDIR="${pkgdir}" install
+  cd "${srcdir}/${_realname}"
+  make DESTDIR="${pkgdir}" install
 }


### PR DESCRIPTION
Consume pactoys from https://github.com/msys2/pactoys, instead of the outdated https://github.com/renatosilva/pactoys.