### PR TITLE
coreutils: Re-add disabled stdbuf; some cleanup

### DIFF
--- a/coreutils/002-coreutils-8.32-enable-stdbuf.patch
+++ b/coreutils/002-coreutils-8.32-enable-stdbuf.patch
@@ -1,0 +1,31 @@
+--- coreutils-8.32/configure.ac
++++ coreutils-8.32/configure.ac
+@@ -509,7 +509,7 @@
+   ],
+   [stdbuf_supported=yes])
+ AC_MSG_RESULT([$stdbuf_supported])
+-if test "$stdbuf_supported" = "yes" && test -z "$EXEEXT"; then
++if test "$stdbuf_supported" = "yes"; then
+   gl_ADD_PROG([optional_bin_progs], [stdbuf])
+ fi
+ CFLAGS=$ac_save_CFLAGS
+@@ -530,7 +530,7 @@
+ # Note it adding to pkglibexec_PROGRAMS, $(transform) in src/local.mk
+ # may need to be updated accordingly.
+ case " $optional_bin_progs " in
+-  *' stdbuf '*) pkglibexec_PROGRAMS='src/libstdbuf.so';;
++  *' stdbuf '*) pkglibexec_PROGRAMS='src/libstdbuf.so$(EXEEXT)';;
+   *) pkglibexec_PROGRAMS='';;
+ esac
+ 
+--- coreutils-8.32/src/stdbuf.c
++++ coreutils-8.32/src/stdbuf.c
+@@ -33,7 +33,7 @@
+ 
+ /* The official name of this program (e.g., no 'g' prefix).  */
+ #define PROGRAM_NAME "stdbuf"
+-#define LIB_NAME "libstdbuf.so" /* FIXME: don't hardcode  */
++#define LIB_NAME "libstdbuf.dll" /* FIXME: don't hardcode  */
+ 
+ #define AUTHORS proper_name ("Padraig Brady")
+ 

--- a/coreutils/003-coreutils-8.32-fix-test-cases.patch
+++ b/coreutils/003-coreutils-8.32-fix-test-cases.patch
@@ -1,0 +1,11 @@
+--- coreutils-8.32/tests/init.sh
++++ coreutils-8.32/tests/init.sh
+@@ -349,7 +349,7 @@
+ 
+   # It must have 0700 permissions.  Handle sticky "S" bits.
+   perms=`ls -dgo "$d" 2>/dev/null` &&
+-  case $perms in drwx--[-S]---*) :;; *) false;; esac && {
++  case $perms in drwx*) :;; *) false;; esac && {
+     echo "$d"
+     return
+   }

--- a/coreutils/PKGBUILD
+++ b/coreutils/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=coreutils
 pkgver=8.32
-pkgrel=1
+pkgrel=2
 pkgdesc="The basic file, shell and text manipulation utilities of the GNU operating system"
 arch=('i686' 'x86_64')
 license=('GPL3')
@@ -11,23 +11,24 @@ depends=('gmp' 'libiconv' 'libintl')
 makedepends=('gmp-devel' 'libiconv-devel' 'gettext-devel' 'help2man')
 install=${pkgname}.install
 source=(https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz{,.sig}
-        001-coreutils-8.30.patch)
+        001-coreutils-8.30.patch
+        002-coreutils-8.32-enable-stdbuf.patch
+        003-coreutils-8.32-fix-test-cases.patch)
 sha256sums=('4458d8de7849df44ccab15e16b1548b285224dbba5f08fac070c1c0e0bcc4cfa'
             'SKIP'
-            '467bde24da0ccea48260f58d3c94a84de4e027ab598a926003642f791da47ca2')
+            '467bde24da0ccea48260f58d3c94a84de4e027ab598a926003642f791da47ca2'
+            'e3be62b9aceb3231f09f05bc3bd8b18f6aaa495f5063781cdd261d560a7e80d0'
+            'ad9e0582373500c0668e38483401169f48d6a2f8ad8d28ef8e7b06e4a3e08a74')
 validpgpkeys=('6C37DC12121A5006BC1DB804DF6FD971306037D9')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
 
   patch -p1 -i ${srcdir}/001-coreutils-8.30.patch
+  patch -p1 -i ${srcdir}/002-coreutils-8.32-enable-stdbuf.patch
+  patch -p1 -i ${srcdir}/003-coreutils-8.32-fix-test-cases.patch
 
   autoreconf -fi
-  sed -i -e 's|\(libstdbuf\.so\)$(EXEEXT)|\1|g' Makefile.in
-
-  #make test cases work
-  sed -i "s|case \$perms in drwx--\[-S\]---\*|case \$perms in drwx\*|" tests/init.sh
-
 }
 
 build() {
@@ -62,8 +63,7 @@ package() {
 
   test ! -f ${pkgdir}/usr/lib/coreutils/libstdbuf.so.exe ||
   mv ${pkgdir}/usr/lib/coreutils/libstdbuf.so.exe \
-    ${pkgdir}/usr/lib/coreutils/libstdbuf.so
+    ${pkgdir}/usr/lib/coreutils/libstdbuf.dll
 
-  #mkdir -p ${pkgdir}/usr/etc
   install -Dm644 ${srcdir}/${pkgname}-${pkgver}/src/dircolors.hin ${pkgdir}/etc/DIR_COLORS
 }


### PR DESCRIPTION
Fix for #2657. 

`stdbuf` has been in and out of MSYS2/coreutils since 2014. Here's a short history for reference:

| coreutils | what happened | stdbuf status (presumed?) |
| --- | --- | --- |
| 8.23-1 | 1) A local [patch](https://github.com/msys2/MSYS2-packages/blob/5c64d6da84b6a3ad9cc651a33031e33ff335334c/coreutils/003-fix-libstdbuf-link.patch) was added to fix a build problem (I assume introduced by upstream putting libstdbuf in pkglibexec_PROGRAMS) | (worked?) |
| 8.24 upstream | 2) Building stdbuf on Windows was [disabled](https://git.savannah.gnu.org/cgit/coreutils.git/commit/?id=0cf66cbe85009213bcf2608eceeee1355f367667) for the same problem | |
| 8.23-2 | 1) was removed and 2) was downstreamed [here](https://github.com/msys2/MSYS2-packages/commit/61ff57c053088cc7240d83acaef8cf2f392fe609) | (no stdbuf?) |
| 8.24-1 | 2) was reverted [locally](https://github.com/msys2/MSYS2-packages/commit/d9773f0a8cdb2ce28dbe6f2088cbd65256afb9d6), and a [different build fix](https://github.com/msys2/MSYS2-packages/blame/d9773f0a8cdb2ce28dbe6f2088cbd65256afb9d6/coreutils/PKGBUILD#L38) added | (works(?), but not OOB due to wrong file extension) |
| 8.25-1 | #541 | ditto (I tested this version on an old setup) |
| 8.26-2 | `libstdbuf.so.exe` fixed in #1019 | (works?) |
| 8.30-1 | reversion of 2) was removed (accidentally?) in #1416 | gone again |

This PR:
1. Uses the original fix from 8.23, instead of from 8.24. Adding rather than removing `$EXEEXT` makes more sense to me because
A. upstream's choice of `pkglibexec_PROGRAMS` [creates executables, not libraries](https://github.com/msys2/MSYS2-packages/issues/541#issuecomment-333266581) (note that libstdbuf is built as a DLL either way),
B. it's compatible with upstream, and
C. it can be a patch instead of a sed script in PKGBUILD
2. Converts remaining post-autoreconf stuff to a patch
3. Renames libstdbuf.so to libstdbuf.dll because why not

I skipped checking after my first build run, since `check()` still fails as in #1416.