### PR TITLE
Add Windows fix for smart cards

### DIFF
--- a/gnupg/0002-fix-pcsc_io_request_s-layout-for-SCardTransmit-in-64.patch
+++ b/gnupg/0002-fix-pcsc_io_request_s-layout-for-SCardTransmit-in-64.patch
@@ -1,0 +1,27 @@
+From 55d8b959cee7b461fb8ee6d08c29fb06417b9f96 Mon Sep 17 00:00:00 2001
+From: "j0t" <j0t@inbox.lv>
+Date: Sun, 7 Apr 2019 11:31:32 +0300
+Subject: [PATCH] fix pcsc_io_request_s layout for SCardTransmit in 64-bit
+
+---
+ scd/apdu.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/scd/apdu.c b/scd/apdu.c
+index 816938ac5..05f380dd9 100644
+--- a/scd/apdu.c
++++ b/scd/apdu.c
+@@ -266,8 +266,8 @@ static npth_mutex_t reader_table_lock;
+ 
+ struct pcsc_io_request_s
+ {
+-  unsigned long protocol;
+-  unsigned long pci_len;
++  pcsc_dword_t protocol;
++  pcsc_dword_t pci_len;
+ };
+ 
+ typedef struct pcsc_io_request_s *pcsc_io_request_t;
+-- 
+2.17.0
+

--- a/gnupg/PKGBUILD
+++ b/gnupg/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=gnupg
 pkgver=2.2.32
-pkgrel=1
+pkgrel=2
 pkgdesc='Complete and free implementation of the OpenPGP standard'
 provides=('dirmngr' "gnupg2=${pkgver}")
 url='https://gnupg.org/'
@@ -46,10 +46,12 @@ depends=('bzip2'
          'zlib'
         )
 source=("https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2"{,.sig}
-        '0001-gnupg-2.2.8-msys2.patch')
+        '0001-gnupg-2.2.8-msys2.patch'
+        '0002-fix-pcsc_io_request_s-layout-for-SCardTransmit-in-64.patch')
 sha256sums=('b2571b35f82c63e7d278aa6a1add0d73453dc14d3f0854be490c844fca7e0614'
             'SKIP'
-            'cb23f1a61fd213c25e85b6ba8afb190b7da14a8cfa59cc56ce82df941db8c3c9')
+            'cb23f1a61fd213c25e85b6ba8afb190b7da14a8cfa59cc56ce82df941db8c3c9'
+            '8c28135361d628296aff5e51facabb2f0dd99b93488a7b417f2e70296d63eded')
 validpgpkeys=('D8692123C4065DEA5E0F3AB5249B39D24F25E3B6'
               '46CC730865BB5C78EBABADCF04376F3EE0856959'
               '031EC2536E580D8EA286A9F22071B08A33BD3F06'
@@ -62,7 +64,9 @@ prepare() {
   sed '/noinst_SCRIPTS = gpg-zip/c sbin_SCRIPTS += gpg-zip' -i tools/Makefile.in
 
   patch -p1 -i ${srcdir}/0001-gnupg-2.2.8-msys2.patch
-
+  # https://dev.gnupg.org/T4454
+  patch -p1 -i ${srcdir}/0002-fix-pcsc_io_request_s-layout-for-SCardTransmit-in-64.patch
+  
   ./autogen.sh --force
 
   sed 's/development_version=yes/development_version=no/' -i configure


### PR DESCRIPTION
### What?
Apply patch from GPG's issue [T4454](https://dev.gnupg.org/T4454) to fix scdaemon not running on WIndows (adds support for smart cards)

Addresses #2329 

### How was it tested?
Tested locally with Yubikey 5 NFC. Encryption/Decryption works just fine with GPG as well as ssh.
