### PR TITLE
expect: also drop the mkpasswd man page

### DIFF
--- a/expect/PKGBUILD
+++ b/expect/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=expect
 pkgver=5.45.4
-pkgrel=2
+pkgrel=3
 pkgdesc="A tool for automating interactive applications"
 arch=('i686' 'x86_64')
 url="https://www.nist.gov/el/msid/expect.cfm"
@@ -47,7 +47,10 @@ package() {
   make DESTDIR=${pkgdir} install
 
   mv ${pkgdir}/usr/lib/expect${pkgver}/libexpect${pkgver}.dll ${pkgdir}/usr/bin/libexpect${pkgver}.dll
+
+  # mkpasswd is provided by cygwin, so this would conflict
   rm ${pkgdir}/usr/bin/mkpasswd
+  rm ${pkgdir}/usr/share/man/man1/mkpasswd.1
   
   sed -i -e 's|\(\$dir\)|\1 .. .. bin|' ${pkgdir}/usr/lib/expect${pkgver}/pkgIndex.tcl
 


### PR DESCRIPTION
The binary was already removed, but the man page is still there.
Since it conflicts with cygwin, remove it as well.

See https://github.com/msys2/MSYS2-packages/pull/2687#issuecomment-965162412