### PR TITLE
filesystem: Avoid trying to chmod /dev/{shm,mqueue} during mkdir

### DIFF
--- a/filesystem/01-devices.post
+++ b/filesystem/01-devices.post
@@ -44,7 +44,7 @@ maybe_create_devs ()
   # Create it if necessary
   if [ ! -e "${DEVDIR}/shm" ]
   then
-    mkdir -m 1777 "${DEVDIR}/shm"
+    mkdir "${DEVDIR}/shm"
     if [ ! -e "${DEVDIR}/shm" ]
     then
       echo
@@ -71,7 +71,7 @@ maybe_create_devs ()
   # Create it if necessary
   if [ ! -e "${DEVDIR}/mqueue" ]
   then
-    mkdir -m 1777 "${DEVDIR}/mqueue"
+    mkdir "${DEVDIR}/mqueue"
     if [ ! -e "${DEVDIR}/mqueue" ]
     then
       echo

--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=filesystem
 pkgver=2021.11
-pkgrel=1
+pkgrel=2
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -79,7 +79,7 @@ sha256sums=('742a7d66b7a5ebd2b8461728c5b44a46b2305fd2116208eecae5f45828938ea0'
             'ad9873e18169ca87194af3413bdcbda536d9600b4f7d24fa9f7d59928309ff4a'
             'f63241cc56aa7b7ec6962d19991d211b4e1641b78ba5226835118ab493830a8b'
             'e96c1f54ffff792e738aa032815c82c30821b0683806e5ed0ba2a759db2fd494'
-            'a5b9c91241d5e1f0bb461119b3e36f5f661ff6f0758e63e756275fa5cb31a410'
+            '42191d0e5a56c1da2adb6f665fceb82555de276f9a50af47ff9fa7b59b4d3848'
             'd7b7eb4cd9e1f9bc227b009cdcacf700f5523ccc109fbd3c1c0331726d314c9e'
             '9c126262051a047450ed97397ee89a7148098c03ae00a1cd67c3f3425d8e4b12'
             'fedaf4d9ae282f6c1698d04d280dd48c8d3247321a5cb5e309e61e2c655102c6'


### PR DESCRIPTION
When launching a custom msys2 environment, and it does "first-run"
operations, it complains that: "cannot change permissions of
'/dev/shm': Permission denied".

This is related to the previous work in this area that happened
in #2337: Since "/" is mounted with noacl and chmod() is a no-op,
this error is cosmetic and can be removed.

However, in #2337, the access modifying behaviour was not removed
from the "mkdir" branch, which this patch aims to address.