### PR TITLE
curl: fix static deps

### DIFF
--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=curl
 pkgname=('curl' 'libcurl' 'libcurl-devel')
 pkgver=7.80.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Multi-protocol file transfer utility"
 arch=('i686' 'x86_64')
 url="https://curl.haxx.se"
@@ -21,7 +21,7 @@ sha256sums=('a132bd93188b938771135ac7c1f3ac1d3ce507c1fcbef8c471397639214ae2ab'
             'SKIP'
             'e5ba067afcfd726403cf7e6cb2349ff3fe6fe093c2853a4196a8f57f9f56d8d6'
             'ad3d76013c2dd683c44ad4cdc5108ea5218056c87b66f6ed2a90502e785a39af'
-            '662590f9f7e99c5b394da634de9c20703ad07208c1e22224f4132b9205485efa'
+            '39a5caed671a9c2b2011328ac344bf38362fa6cb1723650cd79c96542df380cb'
             '870a91d09480cd0d1dc74119376350fc430e5223e2d4b3c0606af17793ecc310')
 validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2'   # Daniel Stenberg
               '914C533DF9B2ADA2204F586D78E11C6B279D5C91')  # Daniel Stenberg (old key)

--- a/curl/curl-7.60.0-gssapi-static-libs.patch
+++ b/curl/curl-7.60.0-gssapi-static-libs.patch
@@ -1,6 +1,26 @@
---- curl-7.60.0/configure.ac.orig	2018-07-06 15:08:41.153181400 +0300
-+++ curl-7.60.0/configure.ac	2018-07-06 15:08:45.489989000 +0300
-@@ -1776,10 +1776,10 @@
+--- curl-7.80.0/configure.ac.orig	2021-11-09 08:35:38.000000000 +0100
++++ curl-7.80.0/configure.ac	2021-11-15 22:56:06.438790700 +0100
+@@ -1682,12 +1682,12 @@
+ if test x"$want_gss" = xyes; then
+   AC_MSG_RESULT(yes)
+ 
+-  CURL_CHECK_PKGCONFIG(mit-krb5-gssapi)
++  CURL_CHECK_PKGCONFIG(krb5-gssapi)
+   if test -z "$GSSAPI_INCS"; then
+      if test -n "$host_alias" -a -f "$GSSAPI_ROOT/bin/$host_alias-krb5-config"; then
+         GSSAPI_INCS=`$GSSAPI_ROOT/bin/$host_alias-krb5-config --cflags gssapi`
+      elif test "$PKGCONFIG" != "no" ; then
+-        GSSAPI_INCS=`$PKGCONFIG --cflags mit-krb5-gssapi`
++        GSSAPI_INCS=`$PKGCONFIG --cflags krb5-gssapi`
+      elif test "$GSSAPI_ROOT" != "yes"; then
+         GSSAPI_INCS="-I$GSSAPI_ROOT/include"
+      fi
+@@ -1772,15 +1772,16 @@
+         LIBS="-lgssapi_krb5 -lresolv $LIBS"
+         ;;
+      *)
+-        CURL_CHECK_PKGCONFIG(mit-krb5-gssapi)
++        CURL_CHECK_PKGCONFIG(krb5-gssapi)
          if test -n "$host_alias" -a -f "$GSSAPI_ROOT/bin/$host_alias-krb5-config"; then
             dnl krb5-config doesn't have --libs-only-L or similar, put everything
             dnl into LIBS
@@ -9,7 +29,10 @@
             LIBS="$gss_libs $LIBS"
          elif test "$PKGCONFIG" != "no" ; then
 -           gss_libs=`$PKGCONFIG --libs mit-krb5-gssapi`
-+           gss_libs=`$KRB5CONFIG --deps --libs gssapi`
-            LIBS="$gss_libs $LIBS"
+-           LIBS="$gss_libs $LIBS"
++           gss_libs=`$PKGCONFIG --static --libs krb5-gssapi`
++           # XXX: sqlite3 is missing due to https://github.com/msys2/MSYS2-packages/issues/2701
++           LIBS="$gss_libs -lsqlite3 $LIBS"
          else
             case $host in
+            *-hp-hpux*)


### PR DESCRIPTION
upstream no longers uses krb5-config so we switch to pkg-config too.
But the krb5 .pc file is missing sqlite3, and heimdal fails to build currently
so add it hackily..