### PR TITLE
MSYS2 runtime: fix pasting emojis in the Windows Terminal

### DIFF
--- a/msys2-runtime/0036-console-handle-Unicode-surrogate-pairs.patch
+++ b/msys2-runtime/0036-console-handle-Unicode-surrogate-pairs.patch
@@ -1,0 +1,61 @@
+From 65b14c9139ea59221e2c600295d207e750a9cd2e Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 16 Nov 2021 11:26:10 +0100
+Subject: [PATCH 36/N] console: handle Unicode surrogate pairs
+
+When running Cygwin's Bash in the Windows Terminal (see
+https://docs.microsoft.com/en-us/windows/terminal/ for details), Cygwin
+is receiving keyboard input in the form of UTF-16 characters.
+
+UTF-16 has that awkward challenge that it cannot map the full Unicode
+range, and to make up for it, there are the ranges U+D800-U+DBFF and
+U+DC00-U+DFFF which are illegal except when they come in a pair encoding
+for Unicode characters beyond U+FFFF.
+
+Cygwin does not handle such surrogate pairs correctly at the moment, as
+can be seen e.g. when running Cygwin's Bash in the Windows Terminal and
+then inserting an emoji (e.g. via Windows + <dot>, which opens an emoji
+picker on recent Windows versions): Instead of showing an emoji, this
+shows the infamous question mark in a black triangle, i.e. the invalid
+Unicode character.
+
+Let's special-case surrogate pairs in this scenario.
+
+This fixes https://github.com/git-for-windows/git/issues/3281
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/fhandler_console.cc | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/fhandler_console.cc b/winsup/cygwin/fhandler_console.cc
+index 2e754a1..a7e9723 100644
+--- a/winsup/cygwin/fhandler_console.cc
++++ b/winsup/cygwin/fhandler_console.cc
+@@ -919,7 +919,22 @@ fhandler_console::process_input_message (void)
+ 	    }
+ 	  else
+ 	    {
+-	      nread = con.con_to_str (tmp + 1, 59, unicode_char);
++	      WCHAR second = unicode_char >= 0xd800 && unicode_char <= 0xdbff
++		  && i + 1 < total_read ?
++		  input_rec[i + 1].Event.KeyEvent.uChar.UnicodeChar : 0;
++
++	      if (second < 0xdc00 || second > 0xdfff)
++		{
++		  nread = con.con_to_str (tmp + 1, 59, unicode_char);
++		}
++	      else
++		{
++		  /* handle surrogate pairs */
++		  WCHAR pair[2] = { unicode_char, second };
++		  nread = sys_wcstombs (tmp + 1, 59, pair, 2);
++		  i++;
++		}
++
+ 	      /* Determine if the keystroke is modified by META.  The tricky
+ 		 part is to distinguish whether the right Alt key should be
+ 		 recognized as Alt, or as AltGr. */
+-- 
+2.33.0
+

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.3.2
-pkgrel=3
+pkgrel=4
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -58,7 +58,8 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0032-docs-skip-building-texinfo-and-PDF-files.patch
         0033-install-libs-depend-on-the-toollibs.patch
         0034-Cygwin-pipe-Handle-WAIT_CANCELED-when-waiting-read_m.patch
-        0035-Cygwin-pipe-Fix-raw_write-for-non-cygwin-pipe-with-s.patch)
+        0035-Cygwin-pipe-Fix-raw_write-for-non-cygwin-pipe-with-s.patch
+        0036-console-handle-Unicode-surrogate-pairs.patch)
 sha256sums=('SKIP'
             'e23ef64ef0c824f4ba92709e4b6e135e7abba13c170d1caf00af5bfb8ef4c609'
             '93d59e341ba55a9679242b9623e96dd5d3e365170773272e9b774fa524f5b3b0'
@@ -94,7 +95,8 @@ sha256sums=('SKIP'
             'f74308a457525260e59ca2581a95fe6ed8818033fc43a8b2e861581f0240f1f2'
             '878131329128d7a3acbb450abb16bba0a682206732a557d752ace37dcee9c894'
             '3d1409fa9eb2194a259133595120dc2d27f38f701e53edb87abac5d08f3d9cd5'
-            'cfe72cf596dda4573b5ca74c27a33feaa3201c97d2381d9bfdcc8be8d1a09d4c')
+            'cfe72cf596dda4573b5ca74c27a33feaa3201c97d2381d9bfdcc8be8d1a09d4c'
+            '5d6de0f753aee2519e8b607da113239a35e7fa699bffe69a90e8720ce3be4fa0')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -166,7 +168,8 @@ prepare() {
   0032-docs-skip-building-texinfo-and-PDF-files.patch \
   0033-install-libs-depend-on-the-toollibs.patch \
   0034-Cygwin-pipe-Handle-WAIT_CANCELED-when-waiting-read_m.patch \
-  0035-Cygwin-pipe-Fix-raw_write-for-non-cygwin-pipe-with-s.patch
+  0035-Cygwin-pipe-Fix-raw_write-for-non-cygwin-pipe-with-s.patch \
+  0036-console-handle-Unicode-surrogate-pairs.patch
 }
 
 build() {


### PR DESCRIPTION
When running MSYS2 inside the Windows Terminal, it is currently impossible to paste an emoji (e.g. via recent Windows' <kbd>Windows</kbd>+<kbd>.</kbd> shortcut).

The reason is that emojis cannot be represented by single UTF-16 values, they require _surrogate pairs_. This was recently fixed in Cygwin (not in any official version as yet), and we backported this in https://github.com/msys2/msys2-runtime/pull/67.

This fixes https://github.com/msys2/msys2-runtime/pull/66.