### PR TITLE
python: Update to 3.9.9

### DIFF
--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgbase=python
 pkgname=('python' 'python-devel')
-pkgver=3.9.6
+pkgver=3.9.9
 pkgrel=1
 _pybasever=${pkgver%.*}
 pkgdesc="Next generation of the python high-level scripting language"
@@ -47,7 +47,7 @@ source=(https://www.python.org/ftp/python/${pkgver%rc*}/Python-${pkgver}.tar.xz
         940-rebase-python-dll.patch
         950-rebase-dlls.patch
         960-fix-parallel-make.patch)
-sha256sums=('397920af33efc5b97f2e0b57e91923512ef89fc5b3c1d21dbfc8c4828ce0108a'
+sha256sums=('06828c04a573c073a4e51c4292a27c1be4ae26621c3edc7cf9318418ce3b6d27'
             'be96ddaca58a39ddaf1e3e5bb7900b34c0e6d00e9b64c4e0f8a3565a74a44e84'
             '82cfafc5b31ad4c9bb4c9786044c39c75762dbc2656abdfdc433c23fee69c02f'
             'f0bb75ca69c63894fc43e0f8218c9dbcc746935bf5ea095a724e6fb2f5dcc566'
@@ -178,5 +178,5 @@ package_python() {
 
 package_python-devel() {
   pkgdesc="Python headers and dev dependencies"
-  depends=("python=${pkgver}" 'libcrypt-devel')
+  depends=("python=${pkgver}")
 }


### PR DESCRIPTION
remove libcrypt-devel since that was removed upstream, see
https://bugs.python.org/issue44751