### PR TITLE
Revert "libffi: Update to 3.4.2"

### DIFF
--- a/glib2/PKGBUILD
+++ b/glib2/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=glib2
 pkgname=(glib2 glib2-devel glib2-docs)
 pkgver=2.68.4
-pkgrel=2
+pkgrel=1
 pkgdesc="Common C routines used by GTK+ and other libs"
 license=(LGPL2)
 url="https://www.gtk.org/"

--- a/guile/PKGBUILD
+++ b/guile/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=guile
 pkgname=("$pkgbase" "lib${pkgbase}" "lib${pkgbase}-devel")
 pkgver=2.2.7
-pkgrel=2
+pkgrel=1
 pkgdesc="a portable, embeddable Scheme implementation written in C"
 url="https://www.gnu.org/software/guile/"
 arch=(i686 x86_64)

--- a/libffi/PKGBUILD
+++ b/libffi/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=libffi
 pkgname=('libffi' 'libffi-devel')
-pkgver=3.4.2
+pkgver=3.3
 pkgrel=1
 pkgdesc="Portable, high level programming interface to various calling conventions"
 arch=('i686' 'x86_64')
@@ -11,16 +11,18 @@ groups=('libraries')
 license=('MIT')
 depends=()
 checkdepends=('dejagnu')
-source=(https://github.com/libffi/libffi/releases/download/v$pkgver/libffi-$pkgver.tar.gz
+#options=('!strip' 'debug')
+install=libffi.install
+source=(https://sourceware.org/pub/libffi/libffi-${pkgver}.tar.gz
         libffi-3.3-msysize.patch)
-sha256sums=('540fb721619a6aba3bdeef7d940d8e9e0e6d2c193595bc243241b77ff9e93620'
-            '75903de0b39311775e2d5d2f0d7f1b5935168698a54198e0f33ffb9e32c16c84')
+sha256sums=('72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056'
+            '8fbdab06b3c42561060d73aae2c1cfdc535797e96f53411eab0fe44869203246')
 
 prepare() {
   cd ${pkgname}-${pkgver}
   patch -p1 -i ${srcdir}/libffi-3.3-msysize.patch
 
-  autoreconf -vfi
+  autoreconf -fi
 }
 
 build() {

--- a/libffi/libffi-3.3-msysize.patch
+++ b/libffi/libffi-3.3-msysize.patch
@@ -1,3 +1,37 @@
+diff -Naur libffi-3.3-orig/compile libffi-3.3/compile
+--- libffi-3.3-orig/compile	2019-11-01 12:30:05.000000000 +0300
++++ libffi-3.3/compile	2020-04-15 11:28:38.782598900 +0300
+@@ -53,7 +53,7 @@
+ 	  MINGW*)
+ 	    file_conv=mingw
+ 	    ;;
+-	  CYGWIN*)
++	  CYGWIN* | MSYS*)
+ 	    file_conv=cygwin
+ 	    ;;
+ 	  *)
+@@ -67,7 +67,7 @@
+ 	mingw/*)
+ 	  file=`cmd //C echo "$file " | sed -e 's/"\(.*\) " *$/\1/'`
+ 	  ;;
+-	cygwin/*)
++	cygwin/* | msys/*)
+ 	  file=`cygpath -m "$file" || echo "$file"`
+ 	  ;;
+ 	wine/*)
+diff -Naur libffi-3.3-orig/config.guess libffi-3.3/config.guess
+--- libffi-3.3-orig/config.guess	2019-10-31 17:49:54.000000000 +0300
++++ libffi-3.3/config.guess	2020-04-15 11:29:05.639223800 +0300
+@@ -892,6 +892,9 @@
+     amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
+ 	echo x86_64-unknown-cygwin
+ 	exit ;;
++    amd64:MSYS*:*:* | x86_64:MSYS*:*:*)
++	echo x86_64-unknown-cygwin
++	exit ;;
+     p*:CYGWIN*:*)
+ 	echo powerpcle-unknown-cygwin
+ 	exit ;;
 diff -Naur libffi-3.3-orig/configure.host libffi-3.3/configure.host
 --- libffi-3.3-orig/configure.host	2019-11-23 02:55:36.000000000 +0300
 +++ libffi-3.3/configure.host	2020-04-15 11:34:06.382013100 +0300

--- a/libffi/libffi.install
+++ b/libffi/libffi.install
@@ -1,0 +1,20 @@
+infodir=usr/share/info
+filelist=libffi.info.gz
+
+post_install() {
+  [ -x usr/bin/install-info ] || return 0
+  for file in ${filelist}; do
+    install-info $infodir/$file $infodir/dir 2> /dev/null
+  done
+}
+
+post_upgrade() {
+  post_install $1
+}
+
+pre_remove() {
+  [ -x usr/bin/install-info ] || return 0
+  for file in ${filelist}; do
+    install-info --delete $infodir/$file $infodir/dir 2> /dev/null
+  done
+}

--- a/p11-kit/PKGBUILD
+++ b/p11-kit/PKGBUILD
@@ -5,7 +5,7 @@
 pkgbase=p11-kit
 pkgname=('p11-kit' 'libp11-kit' 'libp11-kit-devel')
 pkgver=0.24.0
-pkgrel=2
+pkgrel=1
 pkgdesc="Library to work with PKCS#11 modules"
 arch=('i686' 'x86_64')
 url="https://p11-glue.freedesktop.org/p11-kit.html"

--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=python
 pkgname=('python' 'python-devel')
 pkgver=3.9.9
-pkgrel=2
+pkgrel=1
 _pybasever=${pkgver%.*}
 pkgdesc="Next generation of the python high-level scripting language"
 arch=('i686' 'x86_64')


### PR DESCRIPTION
Reverts msys2/MSYS2-packages#2721

This seems to have broken python pretty badly, to the point where the CI python script doesn't even work anymore.

```
      0 [main] python3 312 child_info_fork::abort: address space needed by '_random.cpython-39-x86_64-msys.dll' (0x190000) is already occupied
Traceback (most recent call last):
  File "/C/_/.ci/ci-get-build-order.py", line 91, in <module>
    packages = "\n".join(get_build_order(list_packages()))
  File "/C/_/.ci/ci-get-build-order.py", line 35, in list_packages
    changes = list_changes("--pretty=format:", "--name-only")
  File "/C/_/.ci/ci-get-build-order.py", line 30, in list_changes
    out += run("git", "log", *git_args, "HEAD^..").splitlines()
  File "/C/_/.ci/ci-get-build-order.py", line 20, in run
    return subprocess.check_output(args, **kwargs).decode("utf-8").strip()
  File "/usr/lib/python3.9/subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.9/subprocess.py", line 505, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.9/subprocess.py", line 1754, in _execute_child
    self.pid = _posixsubprocess.fork_exec(
BlockingIOError: [Errno 11] Resource temporarily unavailable

[MSYS2 CI] Processing changes

	[94111feb] Revert "libffi: Update to 3.4.2"

[MSYS2 CI] SUCCESS: No changes in package recipes.
```