### PR TITLE
pactoys: update

### DIFF
--- a/pactoys/PKGBUILD
+++ b/pactoys/PKGBUILD
@@ -2,8 +2,8 @@
 
 _realname='pactoys'
 pkgname="${_realname}"
-pkgver=r54.fa231e8
-pkgrel=2
+pkgver=r55.8860e1f
+pkgrel=1
 pkgdesc='A set of pacman packaging utilities'
 url='https://github.com/renatosilva/pactoys'
 license=(BSD)
@@ -26,7 +26,6 @@ replaces=(
 )
 depends=(
   pacman
-  pkgfile
   wget
 )
 makedepends=(
@@ -34,7 +33,7 @@ makedepends=(
   git
 )
 install="${_realname}.install"
-_commit="fa231e8b"
+_commit="8860e1f8ec93fa6487906659e2ac1abe5a082436"
 source=("pactoys::git+https://github.com/msys2/pactoys#commit=${_commit}")
 sha256sums=('SKIP')
 


### PR DESCRIPTION
no longer depends on pkgfile