### PR TITLE
Add an autotools meta package

### DIFF
--- a/autotools/PKGBUILD
+++ b/autotools/PKGBUILD
@@ -1,0 +1,19 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+pkgname=autotools
+pkgver=2021.12.10
+pkgrel=1
+pkgdesc="A meta package for the GNU autotools build system"
+arch=('any')
+license=('GPL')
+url="https://www.gnu.org/software/automake/manual/html_node/Autotools-Introduction.html"
+depends=(
+  'autoconf'
+  'automake-wrapper'
+  'gettext'
+  'libtool'
+  'make'
+  'pkg-config'
+)
+source=(README.md)
+sha256sums=('de6ec37dee4875be8e2759dea340f6c1bbdc04457333dc666dcb81b00962a145')

--- a/autotools/README.md
+++ b/autotools/README.md
@@ -1,0 +1,3 @@
+The goal of this package is to depend on everything that is (usually)
+needed for running autogen/autoreconf if needed,
+configure and make, but not a compiler.


### PR DESCRIPTION
The goal of this package is to depend on everything that is (usually)
needed for running autogen/autoreconf if needed,
configure and make, but not a compiler.

If packages would makedepend on this then we could make base-devel smaller and remove all the autotools things from there. So if a package builds with meson or cmake, it doesn't install autoconf in CI.

autotools is then just another build system