### PR TITLE
cocom: remove from msys2-devel group

### DIFF
--- a/cocom/PKGBUILD
+++ b/cocom/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=cocom
 pkgver=0.996
-pkgrel=2
+pkgrel=3
 pkgdesc="Toolset for creation of compilers and interpreters"
 arch=('i686' 'x86_64')
 url="https://cocom.sourceforge.io/"
 license=('custom')
-groups=('msys2-devel')
 depends=()
 makedepends=('autotools')
 source=(https://downloads.sourceforge.net/sourceforge/${pkgname}/${pkgname}-${pkgver}.tar.gz)


### PR DESCRIPTION
from what I see this is only needed for building cygwin, and it's already
a makedep there.