### PR TITLE
Remove autotools from base-devel

### DIFF
--- a/autoconf/PKGBUILD
+++ b/autoconf/PKGBUILD
@@ -3,12 +3,11 @@
 
 pkgname=autoconf
 pkgver=2.71
-pkgrel=1
+pkgrel=2
 pkgdesc="A GNU tool for automatically configuring source code"
 arch=('any')
 license=('GPL2' 'GPL3' 'custom')
 url="https://www.gnu.org/software/autoconf"
-groups=('base-devel')
 depends=('awk' 'm4' 'diffutils' 'bash' 'perl' 'sed')
 # for test-suite
 makedepends=('gcc-fortran' 'make')

--- a/autoconf2.13/PKGBUILD
+++ b/autoconf2.13/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=autoconf2.13
 pkgver=2.13
-pkgrel=3
+pkgrel=4
 pkgdesc="A GNU tool for automatically configuring source code"
 arch=('any')
 license=('GPL2' 'GPL3' 'custom')
 url="https://www.gnu.org/software/autoconf"
-groups=('base-devel')
 depends=('awk' 'm4' 'diffutils' 'bash' 'perl')
 makedepends=('make')
 # for test-suite

--- a/autogen/PKGBUILD
+++ b/autogen/PKGBUILD
@@ -2,11 +2,10 @@
 
 pkgname=autogen
 pkgver=5.18.16
-pkgrel=1
+pkgrel=2
 pkgdesc="A tool designed to simplify the creation and maintenance of programs that contain large amounts of repetitious text"
 arch=('i686' 'x86_64')
 url="https://autogen.sourceforge.io/"
-groups=('base-devel')
 license=('GPL3')
 makedepends=('gcc' 'gmp-devel' 'libcrypt-devel' 'libffi-devel' 'libgc-devel' 'libguile-devel' 'libxml2-devel' 'make')
 depends=('gcc-libs' 'gmp' 'libcrypt' 'libffi' 'libgc' 'libguile' 'libxml2')
@@ -26,7 +25,7 @@ prepare() {
 
 build() {
   LDFLAGS+=' -Wl,--export-all-symbols'
-  CFLAGS+=" -Wno-implicit-fallthrough -Wno-format-overflow -Wno-format-truncation"
+  CFLAGS+=" -Wno-implicit-fallthrough -Wno-format-overflow -Wno-format-truncation -Wno-char-subscripts"
   cd "${srcdir}/${pkgname}-${pkgver}"
   ./configure \
     --build=${CHOST} \

--- a/automake-wrapper/PKGBUILD
+++ b/automake-wrapper/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=automake-wrapper
 pkgver=11
-pkgrel=1
+pkgrel=2
 pkgdesc="Wrapper scripts for automake and aclocal"
 arch=('any')
 license=('GPL')
 url="https://www.gentoo.org/"
-groups=('base-devel')
 depends=('bash' 'gawk'
          #'automake1.4'
          #'automake1.5'

--- a/automake1.10/PKGBUILD
+++ b/automake1.10/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=automake1.10
 pkgver=1.10.3
-pkgrel=4
+pkgrel=5
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
 url="https://www.gnu.org/software/automake"
-groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf' 'make')
 checkdepends=('dejagnu')

--- a/automake1.11/PKGBUILD
+++ b/automake1.11/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=automake1.11
 pkgver=1.11.6
-pkgrel=4
+pkgrel=5
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
 url="https://www.gnu.org/software/automake"
-groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf' 'make')
 checkdepends=('dejagnu')

--- a/automake1.12/PKGBUILD
+++ b/automake1.12/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=automake1.12
 pkgver=1.12.6
-pkgrel=4
+pkgrel=5
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
 url="https://www.gnu.org/software/automake"
-groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf' 'make')
 checkdepends=('dejagnu')

--- a/automake1.13/PKGBUILD
+++ b/automake1.13/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=automake1.13
 pkgver=1.13.4
-pkgrel=5
+pkgrel=6
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
 url="https://www.gnu.org/software/automake"
-groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf' 'make')
 checkdepends=('dejagnu')

--- a/automake1.14/PKGBUILD
+++ b/automake1.14/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=automake1.14
 pkgver=1.14.1
-pkgrel=4
+pkgrel=5
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
 url="https://www.gnu.org/software/automake"
-groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf' 'make')
 checkdepends=('dejagnu')

--- a/automake1.15/PKGBUILD
+++ b/automake1.15/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=automake1.15
 pkgver=1.15.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
 url="https://www.gnu.org/software/automake"
-groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf' 'make')
 checkdepends=('dejagnu')

--- a/automake1.16/PKGBUILD
+++ b/automake1.16/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=automake1.16
 pkgver=1.16.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
 url="https://www.gnu.org/software/automake"
-groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf' 'make')
 checkdepends=('dejagnu')

--- a/automake1.6/PKGBUILD
+++ b/automake1.6/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=automake1.6
 pkgver=1.6.3
-pkgrel=3
+pkgrel=4
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
 url="https://www.gnu.org/software/automake"
-groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf' 'make')
 checkdepends=('dejagnu')

--- a/automake1.7/PKGBUILD
+++ b/automake1.7/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=automake1.7
 pkgver=1.7.9
-pkgrel=3
+pkgrel=4
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
 url="https://www.gnu.org/software/automake"
-groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf' 'make')
 checkdepends=('dejagnu')

--- a/automake1.8/PKGBUILD
+++ b/automake1.8/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=automake1.8
 pkgver=1.8.5
-pkgrel=4
+pkgrel=5
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
 url="https://www.gnu.org/software/automake"
-groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf' 'make')
 checkdepends=('dejagnu')

--- a/automake1.9/PKGBUILD
+++ b/automake1.9/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=automake1.9
 pkgver=1.9.6
-pkgrel=3
+pkgrel=4
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
 license=('GPL')
 url="https://www.gnu.org/software/automake"
-groups=('base-devel')
 depends=('perl' 'bash')
 makedepends=('autoconf' 'make')
 checkdepends=('dejagnu')

--- a/libtool/PKGBUILD
+++ b/libtool/PKGBUILD
@@ -2,13 +2,13 @@
 
 pkgname=('libtool' 'libltdl')
 pkgver=2.4.6
-_gccver=10.2.0
-pkgrel=11
+_gccver=11.2.0
+pkgrel=12
 pkgdesc="A generic library support script"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/libtool/"
 license=('GPL')
-makedepends=("gcc=${_gccver}" 'autotools')
+makedepends=("gcc>=${_gccver}" 'autotools')
 source=(https://ftp.gnu.org/pub/gnu/libtool/${pkgname}-${pkgver}.tar.xz{,.sig}
         #https://alpha.gnu.org/gnu/libtool/${pkgname}-${pkgver}.tar.xz{,.sig}
         #${pkgname}-${pkgver}::git+https://git.savannah.gnu.org/git/libtool.git
@@ -70,7 +70,6 @@ check() {
 
 package_libtool() {
   depends=('sh' "libltdl=${pkgver}" 'tar')
-  groups=('base-devel')
   install=libtool.install
 
   cd ${srcdir}/${pkgbase}-${pkgver}

--- a/m4/PKGBUILD
+++ b/m4/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=m4
 pkgver=1.4.19
-pkgrel=1
+pkgrel=2
 pkgdesc="The GNU macro processor"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/m4"
 license=('GPL3')
-groups=('base-devel')
 depends=('bash' 'gcc-libs' 'libiconv')
 makedepends=('libiconv-devel' 'autotools' 'gcc')
 source=(https://ftp.gnu.org/gnu/m4/$pkgname-$pkgver.tar.xz{,.sig}


### PR DESCRIPTION
All packages depend on it explicitly now.