### PR TITLE
Add back a autoconf2.69 package

### DIFF
--- a/autoconf2.69/0001-fix-texinfo.patch
+++ b/autoconf2.69/0001-fix-texinfo.patch
@@ -1,0 +1,68 @@
+--- a/doc/autoconf.texi
++++ b/doc/autoconf.texi
+@@ -15,7 +15,7 @@
+ @c The ARG is an optional argument.  To be used for macro arguments in
+ @c their documentation (@defmac).
+ @macro ovar{varname}
+-@r{[}@var{\varname\}@r{]}@c
++@r{[}@var{\varname\}@r{]}
+ @end macro
+ 
+ @c @dvar(ARG, DEFAULT)
+@@ -23,7 +23,7 @@
+ @c The ARG is an optional argument, defaulting to DEFAULT.  To be used
+ @c for macro arguments in their documentation (@defmac).
+ @macro dvar{varname, default}
+-@r{[}@var{\varname\} = @samp{\default\}@r{]}@c
++@r{[}@var{\varname\} = @samp{\default\}@r{]}
+ @end macro
+ 
+ @c Handling the indexes with Texinfo yields several different problems.
+@@ -8013,10 +8013,10 @@ variables, respectively.  The computed linker flags are cached in
+ @code{ac_cv_f77_libs} or @code{ac_cv_fc_libs}, respectively.
+ @end defmac
+ 
+-@defmac AC_F77_DUMMY_MAIN (@ovar{action-if-found}, @dvar{action-if-not-found, @
+-  AC_MSG_FAILURE})
+-@defmacx AC_FC_DUMMY_MAIN (@ovar{action-if-found}, @dvar{action-if-not-found, @
+-  AC_MSG_FAILURE})
++@defmac AC_F77_DUMMY_MAIN (@ovar{action-if-found}, @
++  @dvar{action-if-not-found, AC_MSG_FAILURE})
++@defmacx AC_FC_DUMMY_MAIN (@ovar{action-if-found}, @
++  @dvar{action-if-not-found, AC_MSG_FAILURE})
+ @acindex{F77_DUMMY_MAIN}
+ @cvindex F77_DUMMY_MAIN
+ @acindex{FC_DUMMY_MAIN}
+@@ -8267,8 +8267,8 @@ results in @code{ac_cv_fc_srcext_@var{ext}} and
+ @code{ac_cv_fc_pp_srcext_@var{ext}} variables, respectively.
+ @end defmac
+ 
+-@defmac AC_FC_PP_DEFINE (@ovar{action-if-success}, @dvar{action-if-failure, @
+-  AC_MSG_FAILURE})
++@defmac AC_FC_PP_DEFINE (@ovar{action-if-success}, @
++  @dvar{action-if-failure, AC_MSG_FAILURE})
+ @acindex{FC_PP_DEFINE}
+ @caindex fc_pp_define
+ 
+@@ -8286,8 +8286,8 @@ The result of this test is cached in the @code{ac_cv_fc_pp_define}
+ variable.
+ @end defmac
+ 
+-@defmac AC_FC_FREEFORM (@ovar{action-if-success}, @dvar{action-if-failure, @
+-  AC_MSG_FAILURE})
++@defmac AC_FC_FREEFORM (@ovar{action-if-success}, @
++  @dvar{action-if-failure, AC_MSG_FAILURE})
+ @acindex{FC_FREEFORM}
+ @caindex fc_freeform
+ 
+@@ -8313,8 +8313,8 @@ The result of this test, or @samp{none} or @samp{unknown}, is cached in
+ the @code{ac_cv_fc_freeform} variable.
+ @end defmac
+ 
+-@defmac AC_FC_FIXEDFORM (@ovar{action-if-success}, @dvar{action-if-failure, @
+-  AC_MSG_FAILURE})
++@defmac AC_FC_FIXEDFORM (@ovar{action-if-success}, @
++  @dvar{action-if-failure, AC_MSG_FAILURE})
+ @acindex{FC_FIXEDFORM}
+ @caindex fc_fixedform
+ 

--- a/autoconf2.69/0002-msys2.patch
+++ b/autoconf2.69/0002-msys2.patch
@@ -1,0 +1,49 @@
+diff -Naur autoconf-2.69/build-aux/config.guess autoconf-2.69m/build-aux/config.guess
+--- autoconf-2.69/build-aux/config.guess	2012-04-25 02:15:10.000000000 +0000
++++ autoconf-2.69m/build-aux/config.guess	2013-02-23 20:44:30.000000000 +0000
+@@ -844,6 +844,9 @@
+     amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
+ 	echo x86_64-unknown-cygwin
+ 	exit ;;
++    amd64:MSYS*:*:* | x86_64:MSYS*:*:*)
++	echo x86_64-unknown-msys
++	exit ;;
+     p*:CYGWIN*:*)
+ 	echo powerpcle-unknown-cygwin
+ 	exit ;;
+diff -Naur autoconf-2.69/lib/autoconf/fortran.m4 autoconf-2.69m/lib/autoconf/fortran.m4
+--- autoconf-2.69/lib/autoconf/fortran.m4	2012-03-07 17:35:25.000000000 +0000
++++ autoconf-2.69m/lib/autoconf/fortran.m4	2013-02-23 20:46:35.000000000 +0000
+@@ -666,7 +666,7 @@
+ 	  ;;
+ 	-lkernel32)
+ 	  case $host_os in
+-	  *cygwin*) ;;
++	  *cygwin* | *msys*) ;;
+ 	  *) ac_cv_[]_AC_LANG_ABBREV[]_libs="$ac_cv_[]_AC_LANG_ABBREV[]_libs $ac_arg"
+ 	    ;;
+ 	  esac
+diff -Naur autoconf-2.69/lib/autoconf/specific.m4 autoconf-2.69m/lib/autoconf/specific.m4
+--- autoconf-2.69/lib/autoconf/specific.m4	2012-01-21 13:46:39.000000000 +0000
++++ autoconf-2.69m/lib/autoconf/specific.m4	2013-02-23 20:47:16.000000000 +0000
+@@ -321,7 +321,7 @@
+ AU_DEFUN([AC_CYGWIN],
+ [AC_CANONICAL_HOST
+ case $host_os in
+-  *cygwin* ) CYGWIN=yes;;
++  *cygwin* | *msys*) CYGWIN=yes;;
+ 	 * ) CYGWIN=no;;
+ esac
+ ], [$0 is obsolete: use AC_CANONICAL_HOST and check if $host_os
+diff -Naur autoconf-2.69/tests/local.at autoconf-2.69m/tests/local.at
+--- autoconf-2.69/tests/local.at	2012-04-24 20:44:15.000000000 +0000
++++ autoconf-2.69m/tests/local.at	2013-02-23 20:48:14.000000000 +0000
+@@ -313,7 +313,7 @@
+       [OPENMP_CFLAGS],
+       [LIBS|LIB@&t@OBJS|LTLIBOBJS|LDFLAGS],
+       [INSTALL(_(DATA|PROGRAM|SCRIPT))?],
+-      [CYGWIN|ISC|MINGW32|MINIX|EMXOS2|XENIX|EXEEXT|OBJEXT],
++      [CYGWIN|ISC|MSYS|MINGW32|MINIX|EMXOS2|XENIX|EXEEXT|OBJEXT],
+       [X_(CFLAGS|(EXTRA_|PRE_)?LIBS)|x_(includes|libraries)|(have|no)_x],
+       [(host|build|target)(_(alias|cpu|vendor|os))?],
+       [cross_compiling|U],

--- a/autoconf2.69/0003-autotest-remove-cr-from-prog-stdout-stderr.patch
+++ b/autoconf2.69/0003-autotest-remove-cr-from-prog-stdout-stderr.patch
@@ -1,0 +1,32 @@
+diff -urN autoconf-2.69.orig/lib/autotest/general.m4 autoconf-2.69/lib/autotest/general.m4
+--- autoconf-2.69.orig/lib/autotest/general.m4	2014-08-05 00:03:28.681954400 +0100
++++ autoconf-2.69/lib/autotest/general.m4	2014-08-05 00:21:04.944082600 +0100
+@@ -2149,6 +2149,19 @@
+ m4_define([AT_DIFF_STDOUT()],
+ 	  [at_fn_diff_devnull "$at_stdout" || at_failed=:])
+ 
++# Adapted from:
++# https://lists.gnu.org/archive/html/libtool-commit/2009-01/msg00012.html
++# Removed the host_os check (this is either harmful or it isn't let's not
++# hedge our bets - when cross-compiling build_os could be mingw* and that
++# would failed the host_os test anyway) and also the optional RESULT-FILE
++# AT_UNIFY_NL(FILE)
++# -----------------------------------
++# Ensure (text) FILE has predictable line endings.
++# Convert in-place.
++m4_define([AT_UNIFY_NL],
++[tr -d '\015' < $1 > $1.t
++mv -f $1.t $1])
++
+ # _AT_CHECK(COMMANDS, [STATUS = 0], STDOUT, STDERR,
+ #           [RUN-IF-FAIL], [RUN-IF-PASS])
+ # -------------------------------------------------
+@@ -2192,6 +2205,8 @@
+ ) >>"$at_stdout" 2>>"$at_stderr" AS_MESSAGE_LOG_FD>&-
+ at_status=$? at_failed=false
+ $at_check_filter
++AT_UNIFY_NL([$at_stderr])
++AT_UNIFY_NL([$at_stdout])
+ m4_ifdef([AT_DIFF_STDERR($4)], [m4_indir([AT_DIFF_STDERR($4)])],
+   [echo >>"$at_stderr"; AS_ECHO([["$4"]]) | \
+   $at_diff - "$at_stderr" || at_failed=:])

--- a/autoconf2.69/0004-docs.patch
+++ b/autoconf2.69/0004-docs.patch
@@ -1,0 +1,10 @@
+--- autoconf-2.69/doc/autoconf.texi.orig	2021-12-27 16:45:07.043999800 +0100
++++ autoconf-2.69/doc/autoconf.texi	2021-12-27 16:46:29.222069800 +0100
+@@ -6,7 +6,6 @@
+ @settitle Autoconf
+ @setchapternewpage odd
+ @ifnothtml
+-@setcontentsaftertitlepage
+ @end ifnothtml
+ @finalout
+ 

--- a/autoconf2.69/0005-package.patch
+++ b/autoconf2.69/0005-package.patch
@@ -1,0 +1,11 @@
+--- autoconf-2.69/configure.orig	2021-12-27 17:08:45.948999800 +0100
++++ autoconf-2.69/configure	2021-12-27 17:08:51.894818700 +0100
+@@ -2214,7 +2214,7 @@
+ 
+ 
+ # Define the identity of the package.
+- PACKAGE='autoconf'
++ PACKAGE='autoconf-2.69'
+  VERSION='2.69'
+ 
+ 

--- a/autoconf2.69/PKGBUILD
+++ b/autoconf2.69/PKGBUILD
@@ -1,0 +1,59 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Ray Donnelly <mingw.android@gmail.com>
+
+_realname=autoconf
+pkgname=${_realname}2.69
+pkgver=2.69
+pkgrel=1
+pkgdesc="A GNU tool for automatically configuring source code"
+arch=('any')
+license=('GPL2' 'GPL3' 'custom')
+url="https://www.gnu.org/software/autoconf"
+depends=('awk' 'm4' 'diffutils' 'bash' 'perl')
+# for test-suite
+makedepends=('gcc-fortran' 'make')
+source=(https://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.xz
+        0001-fix-texinfo.patch
+        0002-msys2.patch
+        0003-autotest-remove-cr-from-prog-stdout-stderr.patch
+        0004-docs.patch
+        0005-package.patch)
+sha256sums=('64ebcec9f8ac5b2487125a86a7760d2591ac9e1d3dbd59489633f9de62a57684'
+            'ad42ff57d1ff3dd6ba06fe94f913a369f9210963856e8c955efed9a164609a64'
+            '9f31df02eb41df57a05ceea1d1442424d1cca63cd9304c953732fa6c65279a5a'
+            '74e2135a3f34f5692a77de85c21cb2f0fd8a1dcf396f7fbba7deb0c59faa54eb'
+            'bc973e76f3ea3941818099cb5a22081c8a9703338b3194fce3534a07ac32c078'
+            'a9bd30264a812672bf7fa7b67135871ccac4c84b30113b82ea7c2f5987e0d951')
+
+prepare() {
+  cd ${srcdir}/${_realname}-${pkgver}
+
+  patch -p1 -i ${srcdir}/0001-fix-texinfo.patch
+  patch -p1 -i ${srcdir}/0002-msys2.patch
+  patch -p1 -i ${srcdir}/0003-autotest-remove-cr-from-prog-stdout-stderr.patch
+  patch -p1 -i ${srcdir}/0004-docs.patch
+  patch -p1 -i ${srcdir}/0005-package.patch
+}
+
+build() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  ./configure --prefix=/usr --program-suffix=-2.69
+  make
+}
+
+check() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  make check
+}
+
+package() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  make DESTDIR=${pkgdir} install
+
+  # license exception
+  install -Dm644 COPYING.EXCEPTION \
+    $pkgdir/usr/share/licenses/autoconf${pkgver}/COPYING.EXCEPTION
+
+  # conflicts with autoconf
+  rm -rf ${pkgdir}/usr/share/{emacs,info}
+}


### PR DESCRIPTION
Useful for rebuilding configure files when upstream only supports 2.69 such as bintuils and gcc