### PR TITLE
python: backport patch to not link against crypt

### DIFF
--- a/python/28881-backport.patch
+++ b/python/28881-backport.patch
@@ -1,0 +1,55 @@
+From 2e386cc70a7a719bbf664a9712e3c86ffbe63900 Mon Sep 17 00:00:00 2001
+From: Mike Gilbert <floppym@gentoo.org>
+Date: Mon, 11 Oct 2021 13:50:03 -0400
+Subject: [PATCH] bpo-45433: Do not link libpython against libcrypt
+
+Save/restore LIBS when calling AC_SEARCH_LIBS(..., crypt). This avoid
+linking libpython with libcrypt.
+---
+ Doc/whatsnew/3.11.rst                                          | 2 ++
+ .../NEWS.d/next/Build/2021-10-11-16-08-37.bpo-45433.pVDkMV.rst | 1 +
+ configure                                                      | 3 +++
+ configure.ac                                                   | 3 +++
+ 4 files changed, 9 insertions(+)
+ create mode 100644 Misc/NEWS.d/next/Build/2021-10-11-16-08-37.bpo-45433.pVDkMV.rst
+
+--- a/configure
++++ b/configure
+@@ -13227,6 +13227,8 @@ done
+ 
+ # We search for both crypt and crypt_r as one or the other may be defined
+ # This gets us our -lcrypt in LIBS when required on the target platform.
++# Save/restore LIBS to avoid linking libpython with libcrypt.
++LIBS_SAVE=$LIBS
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing crypt" >&5
+ $as_echo_n "checking for library containing crypt... " >&6; }
+ if ${ac_cv_search_crypt+:} false; then :
+@@ -13368,6 +13370,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ 
+ fi
+ 
++LIBS=$LIBS_SAVE
+ 
+ for ac_func in clock_gettime
+ do :
+diff --git a/configure.ac b/configure.ac
+index 6c65b2914bf66..afdc68363ceaf 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -4085,6 +4085,8 @@ AC_CHECK_FUNCS(setpgrp,
+ 
+ # We search for both crypt and crypt_r as one or the other may be defined
+ # This gets us our -lcrypt in LIBS when required on the target platform.
++# Save/restore LIBS to avoid linking libpython with libcrypt.
++LIBS_SAVE=$LIBS
+ AC_SEARCH_LIBS(crypt, crypt)
+ AC_SEARCH_LIBS(crypt_r, crypt)
+ 
+@@ -4099,6 +4101,7 @@ char *r = crypt_r("", "", &d);
+     [AC_DEFINE(HAVE_CRYPT_R, 1, [Define if you have the crypt_r() function.])],
+     [])
+ )
++LIBS=$LIBS_SAVE
+ 
+ AC_CHECK_FUNCS(clock_gettime, [], [
+     AC_CHECK_LIB(rt, clock_gettime, [

--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=python
 pkgname=('python' 'python-devel')
 pkgver=3.9.9
-pkgrel=1
+pkgrel=2
 _pybasever=${pkgver%.*}
 pkgdesc="Next generation of the python high-level scripting language"
 arch=('i686' 'x86_64')
@@ -48,7 +48,8 @@ source=(https://www.python.org/ftp/python/${pkgver%rc*}/Python-${pkgver}.tar.xz
         930-fix-missing-tcp-include.patch
         940-rebase-python-dll.patch
         950-rebase-dlls.patch
-        960-fix-parallel-make.patch)
+        960-fix-parallel-make.patch
+        28881-backport.patch)
 sha256sums=('06828c04a573c073a4e51c4292a27c1be4ae26621c3edc7cf9318418ce3b6d27'
             'be96ddaca58a39ddaf1e3e5bb7900b34c0e6d00e9b64c4e0f8a3565a74a44e84'
             '82cfafc5b31ad4c9bb4c9786044c39c75762dbc2656abdfdc433c23fee69c02f'
@@ -71,7 +72,8 @@ sha256sums=('06828c04a573c073a4e51c4292a27c1be4ae26621c3edc7cf9318418ce3b6d27'
             '17e4ac1b5f0fa8a6c410fb80d1ad99ec9185efef51b8450a31932b553c354ed1'
             'b439ff4f0a1f13858f8fb596414b74ed2c14fc3103d90287bb8e461ee89288b9'
             '612bc5bcbe24c2f623713172d318c65a69ae601d72bcc5a170fe7c4eee458d18'
-            'c59025ca9d1219bbb42d620ca8d19398610737c5754f1873db07d55c47b2dad1')
+            'c59025ca9d1219bbb42d620ca8d19398610737c5754f1873db07d55c47b2dad1'
+            '81e9e1a55fee1031b19dac55dbd068ed878abc5a6092cf4ab120486893ebb03a')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -113,6 +115,10 @@ prepare() {
   # https://bugs.python.org/issue41374
   apply_patch_with_msg \
     930-fix-missing-tcp-include.patch
+
+  # https://github.com/python/cpython/pull/28881
+  apply_patch_with_msg \
+    28881-backport.patch
 
   # Ensure that we are using the system copy of various libraries (expat, zlib and libffi),
   # rather than copies shipped in the tarball


### PR DESCRIPTION
Fixes #2759