### PR TITLE
Remove btyacc and reflex from base-devel

### DIFF
--- a/btyacc/PKGBUILD
+++ b/btyacc/PKGBUILD
@@ -2,12 +2,11 @@
 _realname=byacc
 pkgname=btyacc
 pkgver=20210619
-pkgrel=1
+pkgrel=2
 pkgdesc="btyacc - an LALR(1) parser generator with support for backtracking"
 arch=('i686' 'x86_64')
 url="https://invisible-island.net/byacc"
 license=('Public Domain')
-groups=('base-devel')
 makedepends=('autotools' 'gcc')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/ThomasDickey/byacc-snapshots/archive/t${pkgver}.tar.gz")
 sha256sums=('d19fc22dd1d5e5b18a4abfd2470a1513a2b8b2962f7fb94c21e6109ea571bfc0')

--- a/reflex/PKGBUILD
+++ b/reflex/PKGBUILD
@@ -2,13 +2,12 @@
 _realname=reflex
 pkgname=${_realname}
 pkgver=20210510
-pkgrel=1
+pkgrel=2
 pkgdesc="A variant of the flex fast lexical scanner"
 arch=('i686' 'x86_64')
 url="https://invisible-island.net/reflex"
 license=('BSD')
 makedepends=('autotools' 'gcc')
-groups=('base-devel')
 
 # source=("${_realname}-${pkgver}.tar.gz::https://invisible-island.net/datafiles/release/${_realname}.tar.gz")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/ThomasDickey/${_realname}-snapshots/archive/t${pkgver}.tar.gz")


### PR DESCRIPTION
They were added in 7452014cc2c6e4348d but it's not clear why.