### PR TITLE
Add a base-devel package

### DIFF
--- a/base-devel/PKGBUILD
+++ b/base-devel/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+pkgname=base-devel
+pkgver=2021.12
+pkgrel=1
+pkgdesc='Minimal package set for building packages with makepkg'
+url='https://www.msys2.org'
+arch=('any')
+license=('GPL')
+depends=(
+  'binutils'
+  'bison'
+  'diffstat'
+  'diffutils'
+  'dos2unix'
+  'file'
+  'flex'
+  'gawk'
+  'gettext'
+  'gperf'
+  'grep'
+  'groff'
+  'texinfo'
+  'texinfo-tex'
+  'intltool'
+  'make'
+  'pacman'
+  'patch'
+  'patchutils'
+  'pkgconf'
+  'sed'
+  'tar'
+)
+
+# these should be empty, but saneman in CI complains, so we keep them here
+# until that is fixed:
+source=('README.md')
+sha256sums=('3189b37877feaf3ab2bca4cb14aefe435c463aa0a3a74f7ee06327440b784a34')

--- a/base-devel/README.md
+++ b/base-devel/README.md
@@ -1,0 +1,2 @@
+This meta package depends on all packages needed for building a package with
+makepkg.


### PR DESCRIPTION
Replaces the package group 'base-devel'.
Easier to add/remove packages when it is a package.

```
$ pactree base-devel
base-devel
├─binutils
│ ├─libiconv
│ │ ├─gcc-libs
│ │ └─libintl
│ │   ├─gcc-libs
│ │   └─libiconv
│ ├─libintl
│ └─zlib
│   └─gcc-libs
├─bison
│ ├─m4
│ │ ├─bash
│ │ ├─gcc-libs
│ │ └─libiconv
│ └─bash provides sh
├─diffstat
├─diffutils
│ └─bash provides sh
├─dos2unix
│ └─libintl
├─file
│ ├─gcc-libs
│ ├─zlib
│ └─libbz2
│   └─gcc-libs
├─flex
│ ├─m4
│ ├─bash provides sh
│ ├─libiconv
│ └─libintl
├─gawk
│ ├─bash provides sh
│ ├─mpfr
│ │ └─gmp provides gmp>=5.0
│ ├─libintl
│ └─libreadline
│   └─ncurses
│     └─gcc-libs
├─gettext
│ ├─libintl
│ ├─libgettextpo
│ │ └─gcc-libs
│ └─libasprintf
│   └─gcc-libs
├─gperf
│ ├─gcc-libs
│ └─info
│   ├─gzip
│   │ ├─bash
│   │ └─less
│   │   ├─ncurses
│   │   └─libpcre
│   │     └─gcc-libs
│   ├─libcrypt
│   │ └─gcc-libs
│   ├─libintl
│   └─ncurses
├─grep
│ ├─libiconv
│ ├─libintl
│ ├─libpcre
│ └─bash provides sh
├─groff
│ ├─perl
│ │ ├─db
│ │ │ └─libdb provides libdb=5.3.28
│ │ │   └─gcc-libs
│ │ ├─gdbm
│ │ │ └─libgdbm provides libgdbm=1.22
│ │ │   ├─gcc-libs
│ │ │   └─libreadline
│ │ ├─libcrypt
│ │ ├─coreutils
│ │ │ ├─gmp
│ │ │ ├─libiconv
│ │ │ └─libintl
│ │ └─bash provides sh
│ └─gcc-libs
├─texinfo
│ ├─info
│ ├─perl
│ └─bash provides sh
├─texinfo-tex
│ ├─gawk
│ ├─perl
│ └─bash provides sh
├─intltool
│ └─perl-XML-Parser
│   ├─perl
│   ├─libexpat
│   │ └─gcc-libs
│   └─libcrypt
├─make
│ ├─msys2-runtime
│ ├─libintl
│ └─bash provides sh
├─pacman
│ ├─bash provides bash>=4.2.045
│ ├─gettext
│ ├─gnupg
│ │ ├─bzip2
│ │ │ └─libbz2
│ │ ├─libassuan
│ │ │ ├─gcc-libs
│ │ │ └─libgpg-error
│ │ │   ├─bash provides sh
│ │ │   ├─libiconv
│ │ │   └─libintl
│ │ ├─libbz2
│ │ ├─libcurl
│ │ │ ├─brotli
│ │ │ │ └─gcc-libs
│ │ │ ├─ca-certificates
│ │ │ │ ├─bash
│ │ │ │ ├─openssl
│ │ │ │ │ ├─libopenssl
│ │ │ │ │ │ └─zlib
│ │ │ │ │ └─zlib
│ │ │ │ ├─findutils
│ │ │ │ │ ├─libiconv
│ │ │ │ │ └─libintl
│ │ │ │ ├─coreutils
│ │ │ │ ├─sed
│ │ │ │ │ ├─libintl
│ │ │ │ │ └─bash provides sh
│ │ │ │ └─p11-kit
│ │ │ │   └─libp11-kit provides libp11-kit=0.24.0
│ │ │ │     ├─libffi
│ │ │ │     ├─libintl
│ │ │ │     ├─libtasn1
│ │ │ │     │ └─info
│ │ │ │     └─glib2
│ │ │ │       ├─libxslt
│ │ │ │       │ ├─libxml2
│ │ │ │       │ │ ├─coreutils
│ │ │ │       │ │ ├─icu provides icu>=68.1
│ │ │ │       │ │ │ └─gcc-libs
│ │ │ │       │ │ ├─liblzma
│ │ │ │       │ │ │ ├─bash provides sh
│ │ │ │       │ │ │ ├─libiconv
│ │ │ │       │ │ │ └─gettext
│ │ │ │       │ │ ├─libreadline
│ │ │ │       │ │ ├─ncurses
│ │ │ │       │ │ └─zlib
│ │ │ │       │ └─libgcrypt
│ │ │ │       │   └─libgpg-error
│ │ │ │       ├─libpcre
│ │ │ │       ├─libffi
│ │ │ │       ├─libiconv
│ │ │ │       └─zlib
│ │ │ ├─heimdal-libs
│ │ │ │ ├─libdb
│ │ │ │ ├─libcrypt
│ │ │ │ ├─libedit
│ │ │ │ │ ├─ncurses
│ │ │ │ │ └─bash provides sh
│ │ │ │ ├─libsqlite
│ │ │ │ │ ├─libreadline
│ │ │ │ │ ├─zlib
│ │ │ │ │ └─tcl
│ │ │ │ │   └─zlib
│ │ │ │ └─libopenssl
│ │ │ ├─libcrypt
│ │ │ ├─libidn2
│ │ │ │ ├─info
│ │ │ │ └─libunistring
│ │ │ │   ├─msys2-runtime
│ │ │ │   └─libiconv
│ │ │ ├─libunistring
│ │ │ ├─libnghttp2
│ │ │ │ └─gcc-libs
│ │ │ ├─libpsl
│ │ │ │ ├─libxslt
│ │ │ │ ├─libidn2
│ │ │ │ └─libunistring
│ │ │ ├─libssh2
│ │ │ │ ├─ca-certificates
│ │ │ │ ├─openssl
│ │ │ │ └─zlib
│ │ │ ├─openssl
│ │ │ ├─zlib
│ │ │ └─libzstd
│ │ │   └─gcc-libs
│ │ ├─libgcrypt
│ │ ├─libgpg-error
│ │ ├─libgnutls
│ │ │ ├─gcc-libs
│ │ │ ├─libidn2
│ │ │ ├─libiconv
│ │ │ ├─libintl
│ │ │ ├─gmp
│ │ │ ├─libnettle
│ │ │ │ └─libhogweed
│ │ │ │   └─gmp
│ │ │ ├─libp11-kit
│ │ │ ├─libtasn1
│ │ │ └─zlib
│ │ ├─libiconv
│ │ ├─libintl
│ │ ├─libksba
│ │ │ ├─gcc-libs
│ │ │ └─libgpg-error
│ │ ├─libnpth
│ │ │ └─gcc-libs
│ │ ├─libreadline
│ │ ├─libsqlite
│ │ ├─nettle
│ │ │ └─libnettle
│ │ ├─pinentry
│ │ │ ├─ncurses
│ │ │ ├─libassuan
│ │ │ └─libgpg-error
│ │ └─zlib
│ ├─curl
│ │ ├─ca-certificates
│ │ ├─libcurl
│ │ ├─libcrypt
│ │ ├─libunistring
│ │ ├─libnghttp2
│ │ ├─libpsl
│ │ ├─openssl
│ │ └─zlib
│ ├─pacman-mirrors
│ ├─msys2-keyring
│ ├─which
│ │ └─bash provides sh
│ ├─bzip2
│ ├─xz
│ │ ├─liblzma provides liblzma=5.2.5
│ │ ├─libiconv
│ │ └─libintl
│ └─zstd
│   ├─gcc-libs
│   └─libzstd
├─patch
│ └─msys2-runtime
├─patchutils
│ └─pcre2
│   ├─libreadline
│   ├─libbz2
│   ├─zlib
│   ├─libpcre2_8 provides libpcre2_8=10.37
│   │ └─gcc-libs
│   ├─libpcre2_16 provides libpcre2_16=10.37
│   │ └─gcc-libs
│   ├─libpcre2_32 provides libpcre2_32=10.37
│   │ └─gcc-libs
│   └─libpcre2posix provides libpcre2posix=10.37
│     └─libpcre2_8 provides libpcre2_8=10.37
├─pkgconf
├─sed
└─tar
  ├─libiconv
  ├─libintl
  └─bash provides sh
```