### PR TITLE
libtool: override the soname_spec for cygwin as well

### DIFF
--- a/libtool/0009-libtool-2.4.2.418-msysize.patch
+++ b/libtool/0009-libtool-2.4.2.418-msysize.patch
@@ -486,10 +486,9 @@ diff -Naur libtool-2.4.2.418-orig/build-aux/ltmain.sh libtool-2.4.2.418/build-au
  	      # If a -bindir argument was supplied, place the dll there.
  	      if test -n "$bindir"; then
  		func_relative_path "$install_libdir" "$bindir"
-diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
---- libtool-2.4.2.418-orig/configure	2014-09-02 09:54:56.372400000 +0400
-+++ libtool-2.4.2.418/configure	2014-09-02 10:08:13.716000000 +0400
-@@ -5759,7 +5759,7 @@
+--- libtool-2.4.6/configure.orig	2015-02-15 17:14:34.000000000 +0100
++++ libtool-2.4.6/configure	2022-01-01 18:00:52.657283300 +0100
+@@ -5881,7 +5881,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -498,7 +497,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -5925,7 +5925,7 @@
+@@ -6047,7 +6047,7 @@
        *-*-mingw* ) # actually msys
          lt_cv_to_host_file_cmd=func_convert_file_msys_to_w32
          ;;
@@ -507,7 +506,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
          lt_cv_to_host_file_cmd=func_convert_file_cygwin_to_w32
          ;;
        * ) # otherwise, assume *nix
-@@ -5933,12 +5933,12 @@
+@@ -6055,12 +6055,12 @@
          ;;
      esac
      ;;
@@ -522,7 +521,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
          lt_cv_to_host_file_cmd=func_convert_file_noop
          ;;
        * ) # otherwise, assume *nix
-@@ -6004,7 +6004,7 @@
+@@ -6126,7 +6126,7 @@
  esac
  reload_cmds='$LD$reload_flag -o $output$reload_objs'
  case $host_os in
@@ -531,7 +530,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
      if test yes != "$GCC"; then
        reload_cmds=false
      fi
-@@ -6159,7 +6159,7 @@
+@@ -6281,7 +6281,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -540,7 +539,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -6472,7 +6472,7 @@
+@@ -6597,7 +6597,7 @@
    lt_cv_sharedlib_from_linklib_cmd='unknown'
  
  case $host_os in
@@ -549,7 +548,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
    # two different shell functions defined in ltmain.sh;
    # decide which one to use based on capabilities of $DLLTOOL
    case `$DLLTOOL --help 2>&1` in
-@@ -6964,7 +6964,7 @@
+@@ -7089,7 +7089,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -558,7 +557,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -8456,7 +8456,7 @@
+@@ -8696,7 +8696,7 @@
  enable_win32_dll=yes
  
  case $host in
@@ -567,7 +566,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
    if test -n "$ac_tool_prefix"; then
    # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
  set dummy ${ac_tool_prefix}as; ac_word=$2
-@@ -9312,7 +9312,7 @@
+@@ -9597,7 +9597,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -576,7 +575,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -9410,7 +9410,7 @@
+@@ -9700,7 +9700,7 @@
        esac
        ;;
  
@@ -585,7 +584,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -9907,7 +9907,7 @@
+@@ -10202,7 +10202,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -594,7 +593,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -10022,7 +10022,7 @@
+@@ -10317,7 +10317,7 @@
        fi
        ;;
  
@@ -603,7 +602,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec='-L$libdir'
-@@ -10481,7 +10481,7 @@
+@@ -10857,7 +10857,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -612,7 +611,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -11434,7 +11434,7 @@
+@@ -11892,7 +11892,7 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -621,20 +620,19 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
    version_type=windows
    shrext_cmds=.dll
    need_version=no
-@@ -11466,6 +11466,12 @@
+@@ -11918,9 +11918,9 @@
+     shlibpath_overrides_runpath=yes
+ 
+     case $host_os in
+-    cygwin*)
++    cygwin* | msys*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+-      soname_spec='`echo $libname | sed -e 's/^lib/cyg/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
++      soname_spec='`echo $libname | sed -e 's/^lib/msys-/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
-+    msys*)
-+      # MSYS DLLs use 'msys-' prefix rather than 'lib'
-+      soname_spec='`echo $libname | sed -e 's/^lib/msys-/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
-+
-+      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
-+      ;;
-     mingw* | cegcc*)
-       # MinGW DLLs use traditional 'lib' prefix
-       soname_spec='$libname`echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
-@@ -11500,7 +11506,7 @@
+@@ -11958,7 +11958,7 @@
        # Convert to MSYS style.
        sys_lib_search_path_spec=`$ECHO "$sys_lib_search_path_spec" | sed -e 's|\\\\|/|g' -e 's| \\([a-zA-Z]\\):| /\\1|g' -e 's|^ ||'`
        ;;
@@ -643,7 +641,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # Convert to unix form, then to dos form, then back to unix form
        # but this time dos style (no spaces!) so that the unix form looks
        # like /cygdrive/c/PROGRA~1:/cygdr...
-@@ -12159,7 +12165,7 @@
+@@ -12660,7 +12660,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -652,7 +650,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
      lt_cv_dlopen=dlopen
      lt_cv_dlopen_libs=
      ;;
-@@ -13085,7 +13091,7 @@
+@@ -13598,7 +13598,7 @@
  beos*)
    LT_DLLOADERS="$LT_DLLOADERS ${lt_dlopen_dir+$lt_dlopen_dir/}load_add_on.la"
    ;;
@@ -661,7 +659,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
    ac_fn_c_check_decl "$LINENO" "cygwin_conv_path" "ac_cv_have_decl_cygwin_conv_path" "#include <sys/cygwin.h>
  "
  if test "x$ac_cv_have_decl_cygwin_conv_path" = xyes; then :
-@@ -13507,7 +13513,7 @@
+@@ -14013,7 +14013,7 @@
    $as_echo_n "(cached) " >&6
  else
    case $host_os in #(
@@ -670,7 +668,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
  	   lt_cv_sys_argz_works=no
  	   if test no != "$cross_compiling"; then
  	     lt_cv_sys_argz_works="guessing no"
-@@ -14742,7 +14748,7 @@
+@@ -15288,7 +15288,7 @@
          esac
          ;;
  
@@ -679,7 +677,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
  	case $GXX,$cc_basename in
  	,cl* | no,cl*)
  	  # Native MSVC
-@@ -15769,7 +15775,7 @@
+@@ -16298,7 +16298,7 @@
      beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
        # PIC is the default for these OSes.
        ;;
@@ -688,7 +686,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -15839,7 +15845,7 @@
+@@ -16373,7 +16373,7 @@
  	  ;;
  	esac
  	;;
@@ -697,7 +695,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
  	# This hack is so that the source file can tell whether it is being
  	# built for inclusion in a dll (and should export symbols for example).
  	lt_prog_compiler_pic_CXX='-DDLL_EXPORT'
-@@ -16324,7 +16330,7 @@
+@@ -16862,7 +16862,7 @@
    pw32*)
      export_symbols_cmds_CXX=$ltdll_cmds
      ;;
@@ -706,7 +704,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
      case $cc_basename in
      cl*)
        exclude_expsyms_CXX='_NULL_IMPORT_DESCRIPTOR|_IMPORT_DESCRIPTOR_.*'
-@@ -16593,7 +16599,7 @@
+@@ -17183,7 +17183,7 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -715,19 +713,19 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
    version_type=windows
    shrext_cmds=.dll
    need_version=no
-@@ -16624,6 +16630,11 @@
-       soname_spec='`echo $libname | sed -e 's/^lib/cyg/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
+@@ -17209,9 +17209,9 @@
+     shlibpath_overrides_runpath=yes
+ 
+     case $host_os in
+-    cygwin*)
++    cygwin* | msys*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+-      soname_spec='`echo $libname | sed -e 's/^lib/cyg/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
++      soname_spec='`echo $libname | sed -e 's/^lib/msys-/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
  
        ;;
-+    msys*)
-+      # MSYS DLLs use 'msys-' prefix rather than 'lib'
-+      soname_spec='`echo $libname | sed -e 's/^lib/msys-/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
-+
-+      ;;
      mingw* | cegcc*)
-       # MinGW DLLs use traditional 'lib' prefix
-       soname_spec='$libname`echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
-@@ -17662,7 +17673,7 @@
+@@ -18289,7 +18289,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -736,7 +734,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -17760,7 +17771,7 @@
+@@ -18392,7 +18392,7 @@
        esac
        ;;
  
@@ -745,7 +743,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic_F77='-DDLL_EXPORT'
-@@ -18242,7 +18253,7 @@
+@@ -18879,7 +18879,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -754,7 +752,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -18357,7 +18368,7 @@
+@@ -18994,7 +18994,7 @@
        fi
        ;;
  
@@ -763,7 +761,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, F77) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec_F77='-L$libdir'
-@@ -18804,7 +18815,7 @@
+@@ -19522,7 +19522,7 @@
        export_dynamic_flag_spec_F77=-rdynamic
        ;;
  
@@ -772,7 +770,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -19549,7 +19560,7 @@
+@@ -20349,7 +20349,7 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -781,19 +779,19 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
    version_type=windows
    shrext_cmds=.dll
    need_version=no
-@@ -19580,6 +19591,11 @@
-       soname_spec='`echo $libname | sed -e 's/^lib/cyg/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
+@@ -20375,9 +20375,9 @@
+     shlibpath_overrides_runpath=yes
+ 
+     case $host_os in
+-    cygwin*)
++    cygwin* | msys*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+-      soname_spec='`echo $libname | sed -e 's/^lib/cyg/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
++      soname_spec='`echo $libname | sed -e 's/^lib/msys-/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
  
        ;;
-+    msys*)
-+      # MSYS DLLs use 'msys-' prefix rather than 'lib'
-+      soname_spec='`echo $libname | sed -e 's/^lib/msys-/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
-+
-+      ;;
      mingw* | cegcc*)
-       # MinGW DLLs use traditional 'lib' prefix
-       soname_spec='$libname`echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
-@@ -19614,7 +19630,7 @@
+@@ -20414,7 +20414,7 @@
        # Convert to MSYS style.
        sys_lib_search_path_spec=`$ECHO "$sys_lib_search_path_spec" | sed -e 's|\\\\|/|g' -e 's| \\([a-zA-Z]\\):| /\\1|g' -e 's|^ ||'`
        ;;
@@ -802,7 +800,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # Convert to unix form, then to dos form, then back to unix form
        # but this time dos style (no spaces!) so that the unix form looks
        # like /cygdrive/c/PROGRA~1:/cygdr...
-@@ -20753,7 +20769,7 @@
+@@ -21590,7 +21590,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -811,7 +809,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -20851,7 +20867,7 @@
+@@ -21693,7 +21693,7 @@
        esac
        ;;
  
@@ -820,7 +818,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic_FC='-DDLL_EXPORT'
-@@ -21333,7 +21349,7 @@
+@@ -22180,7 +22180,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -829,7 +827,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -21448,7 +21464,7 @@
+@@ -22295,7 +22295,7 @@
        fi
        ;;
  
@@ -838,7 +836,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, FC) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec_FC='-L$libdir'
-@@ -21895,7 +21911,7 @@
+@@ -22823,7 +22823,7 @@
        export_dynamic_flag_spec_FC=-rdynamic
        ;;
  
@@ -847,7 +845,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -22640,7 +22656,7 @@
+@@ -23650,7 +23650,7 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -856,19 +854,19 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
    version_type=windows
    shrext_cmds=.dll
    need_version=no
-@@ -22671,6 +22687,11 @@
-       soname_spec='`echo $libname | sed -e 's/^lib/cyg/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
+@@ -23676,9 +23676,9 @@
+     shlibpath_overrides_runpath=yes
+ 
+     case $host_os in
+-    cygwin*)
++    cygwin* | msys*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+-      soname_spec='`echo $libname | sed -e 's/^lib/cyg/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
++      soname_spec='`echo $libname | sed -e 's/^lib/msys-/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
  
        ;;
-+    msys*)
-+      # MSYS DLLs use 'msys-' prefix rather than 'lib'
-+      soname_spec='`echo $libname | sed -e 's/^lib/msys-/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
-+
-+      ;;
      mingw* | cegcc*)
-       # MinGW DLLs use traditional 'lib' prefix
-       soname_spec='$libname`echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
-@@ -22705,7 +22726,7 @@
+@@ -23715,7 +23715,7 @@
        # Convert to MSYS style.
        sys_lib_search_path_spec=`$ECHO "$sys_lib_search_path_spec" | sed -e 's|\\\\|/|g' -e 's| \\([a-zA-Z]\\):| /\\1|g' -e 's|^ ||'`
        ;;
@@ -877,7 +875,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # Convert to unix form, then to dos form, then back to unix form
        # but this time dos style (no spaces!) so that the unix form looks
        # like /cygdrive/c/PROGRA~1:/cygdr...
-@@ -23567,7 +23588,7 @@
+@@ -24610,7 +24610,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -886,7 +884,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -23665,7 +23686,7 @@
+@@ -24713,7 +24713,7 @@
        esac
        ;;
  
@@ -895,7 +893,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic_GO='-DDLL_EXPORT'
-@@ -24147,7 +24168,7 @@
+@@ -25200,7 +25200,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -904,7 +902,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -24262,7 +24283,7 @@
+@@ -25315,7 +25315,7 @@
        fi
        ;;
  
@@ -913,7 +911,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, GO) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec_GO='-L$libdir'
-@@ -24721,7 +24742,7 @@
+@@ -25855,7 +25855,7 @@
        export_dynamic_flag_spec_GO=-rdynamic
        ;;
  
@@ -922,7 +920,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -25680,7 +25701,7 @@
+@@ -26837,7 +26837,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -931,7 +929,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -25778,7 +25799,7 @@
+@@ -26940,7 +26940,7 @@
        esac
        ;;
  
@@ -940,7 +938,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
  
-@@ -26260,7 +26281,7 @@
+@@ -27427,7 +27427,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -949,7 +947,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -26375,7 +26396,7 @@
+@@ -27542,7 +27542,7 @@
        fi
        ;;
  
@@ -958,7 +956,7 @@ diff -Naur libtool-2.4.2.418-orig/configure libtool-2.4.2.418/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, GCJ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec_GCJ='-L$libdir'
-@@ -26834,7 +26855,7 @@
+@@ -28082,7 +28082,7 @@
        export_dynamic_flag_spec_GCJ=-rdynamic
        ;;
  
@@ -1151,10 +1149,9 @@ diff -Naur libtool-2.4.2.418-orig/libltdl/configure libtool-2.4.2.418/libltdl/co
  	   lt_cv_sys_argz_works=no
  	   if test no != "$cross_compiling"; then
  	     lt_cv_sys_argz_works="guessing no"
-diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
---- libtool-2.4.2.418-orig/m4/libtool.m4	2013-10-26 03:37:46.000000000 +0400
-+++ libtool-2.4.2.418/m4/libtool.m4	2014-09-02 10:19:40.084800000 +0400
-@@ -1665,7 +1665,7 @@
+--- libtool-2.4.6/m4/libtool.m4.orig	2015-01-20 17:15:19.000000000 +0100
++++ libtool-2.4.6/m4/libtool.m4	2022-01-01 17:57:50.564363900 +0100
+@@ -1692,7 +1692,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -1163,7 +1160,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -1913,7 +1913,7 @@
+@@ -1940,7 +1940,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -1172,7 +1169,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
      lt_cv_dlopen=dlopen
      lt_cv_dlopen_libs=
      ;;
-@@ -2399,7 +2399,7 @@
+@@ -2521,7 +2521,7 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -1181,20 +1178,19 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
    version_type=windows
    shrext_cmds=.dll
    need_version=no
-@@ -2431,6 +2431,12 @@
+@@ -2547,9 +2547,9 @@
+     shlibpath_overrides_runpath=yes
+ 
+     case $host_os in
+-    cygwin*)
++    cygwin* | msys*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+-      soname_spec='`echo $libname | sed -e 's/^lib/cyg/'``echo $release | $SED -e 's/[[.]]/-/g'`$versuffix$shared_ext'
++      soname_spec='`echo $libname | sed -e 's/^lib/msys-/'``echo $release | $SED -e 's/[[.]]/-/g'`$versuffix$shared_ext'
  m4_if([$1], [],[
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"])
        ;;
-+    msys*)
-+      # MSYS DLLs use 'msys-' prefix rather than 'lib'
-+      soname_spec='`echo $libname | sed -e 's/^lib/msys-/'``echo $release | $SED -e 's/[[.]]/-/g'`$versuffix$shared_ext'
-+m4_if([$1], [],[
-+      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"])
-+      ;;
-     mingw* | cegcc*)
-       # MinGW DLLs use traditional 'lib' prefix
-       soname_spec='$libname`echo $release | $SED -e 's/[[.]]/-/g'`$versuffix$shared_ext'
-@@ -2465,7 +2471,7 @@
+@@ -2587,7 +2587,7 @@
        # Convert to MSYS style.
        sys_lib_search_path_spec=`$ECHO "$sys_lib_search_path_spec" | sed -e 's|\\\\|/|g' -e 's| \\([[a-zA-Z]]\\):| /\\1|g' -e 's|^ ||'`
        ;;
@@ -1203,7 +1199,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
        # Convert to unix form, then to dos form, then back to unix form
        # but this time dos style (no spaces!) so that the unix form looks
        # like /cygdrive/c/PROGRA~1:/cygdr...
-@@ -3203,7 +3209,7 @@
+@@ -3365,7 +3365,7 @@
  esac
  reload_cmds='$LD$reload_flag -o $output$reload_objs'
  case $host_os in
@@ -1212,7 +1208,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
      if test yes != "$GCC"; then
        reload_cmds=false
      fi
-@@ -3259,7 +3265,7 @@
+@@ -3458,7 +3458,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -1221,7 +1217,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -3564,7 +3570,7 @@
+@@ -3771,7 +3771,7 @@
  [lt_cv_sharedlib_from_linklib_cmd='unknown'
  
  case $host_os in
@@ -1230,7 +1226,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
    # two different shell functions defined in ltmain.sh;
    # decide which one to use based on capabilities of $DLLTOOL
    case `$DLLTOOL --help 2>&1` in
-@@ -3634,7 +3640,7 @@
+@@ -3841,7 +3841,7 @@
  [AC_REQUIRE([AC_CANONICAL_HOST])dnl
  LIBM=
  case $host in
@@ -1239,7 +1235,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
    # These system don't have libm, or don't need it
    ;;
  *-ncr-sysv4.3*)
-@@ -3709,7 +3715,7 @@
+@@ -3916,7 +3916,7 @@
  aix*)
    symcode='[[BCDT]]'
    ;;
@@ -1248,7 +1244,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
    symcode='[[ABCDGISTW]]'
    ;;
  hpux*)
-@@ -4015,7 +4021,7 @@
+@@ -4222,7 +4222,7 @@
      beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
        # PIC is the default for these OSes.
        ;;
@@ -1257,7 +1253,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -4086,7 +4092,7 @@
+@@ -4298,7 +4298,7 @@
  	  ;;
  	esac
  	;;
@@ -1266,7 +1262,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
  	# This hack is so that the source file can tell whether it is being
  	# built for inclusion in a dll (and should export symbols for example).
  	m4_if([$1], [GCJ], [],
-@@ -4334,7 +4340,7 @@
+@@ -4546,7 +4546,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -1275,7 +1271,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -4433,7 +4439,7 @@
+@@ -4650,7 +4650,7 @@
        esac
        ;;
  
@@ -1284,7 +1280,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        m4_if([$1], [GCJ], [],
-@@ -4699,7 +4705,7 @@
+@@ -4925,7 +4925,7 @@
    pw32*)
      _LT_TAGVAR(export_symbols_cmds, $1)=$ltdll_cmds
      ;;
@@ -1293,7 +1289,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
      case $cc_basename in
      cl*)
        _LT_TAGVAR(exclude_expsyms, $1)='_NULL_IMPORT_DESCRIPTOR|_IMPORT_DESCRIPTOR_.*'
-@@ -4757,7 +4763,7 @@
+@@ -4983,7 +4983,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -1302,7 +1298,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -4872,7 +4878,7 @@
+@@ -5098,7 +5098,7 @@
        fi
        ;;
  
@@ -1311,7 +1307,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
        # _LT_TAGVAR(hardcode_libdir_flag_spec, $1) is actually meaningless,
        # as there is no search path for DLLs.
        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
-@@ -5247,7 +5253,7 @@
+@@ -5554,7 +5554,7 @@
        _LT_TAGVAR(export_dynamic_flag_spec, $1)=-rdynamic
        ;;
  
@@ -1320,7 +1316,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -6241,7 +6247,7 @@
+@@ -6629,7 +6629,7 @@
          esac
          ;;
  
@@ -1329,7 +1325,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
  	case $GXX,$cc_basename in
  	,cl* | no,cl*)
  	  # Native MSVC
-@@ -7937,7 +7943,7 @@
+@@ -8317,7 +8317,7 @@
        *-*-mingw* ) # actually msys
          lt_cv_to_host_file_cmd=func_convert_file_msys_to_w32
          ;;
@@ -1338,7 +1334,7 @@ diff -Naur libtool-2.4.2.418-orig/m4/libtool.m4 libtool-2.4.2.418/m4/libtool.m4
          lt_cv_to_host_file_cmd=func_convert_file_cygwin_to_w32
          ;;
        * ) # otherwise, assume *nix
-@@ -7945,12 +7951,12 @@
+@@ -8325,12 +8325,12 @@
          ;;
      esac
      ;;

--- a/libtool/PKGBUILD
+++ b/libtool/PKGBUILD
@@ -3,12 +3,12 @@
 pkgname=('libtool' 'libltdl')
 pkgver=2.4.6
 _gccver=11.2.0
-pkgrel=12
+pkgrel=13
 pkgdesc="A generic library support script"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/libtool/"
 license=('GPL')
-makedepends=("gcc>=${_gccver}" 'autotools')
+makedepends=("gcc>=${_gccver}" 'autotools' 'help2man')
 source=(https://ftp.gnu.org/pub/gnu/libtool/${pkgname}-${pkgver}.tar.xz{,.sig}
         #https://alpha.gnu.org/gnu/libtool/${pkgname}-${pkgver}.tar.xz{,.sig}
         #${pkgname}-${pkgver}::git+https://git.savannah.gnu.org/git/libtool.git
@@ -30,7 +30,7 @@ sha256sums=('7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f'
             'dc39fbe066958178f96108f07db62b48b9339efddf2c21f800ff8d67110ca393'
             '6a94ada08b0a0aa36240efd9ccb826e22ab94ef0969270f2edb8be344dc8c62b'
             'd96beecfc5d15f94ce46bbe0e89d6e6fdb973a25ad6be98c30504b58453792c1'
-            'c7d7dccd4a0e7b8dfe6afc47cbaf3862b645179137a90afe1a15d2af606fcab8'
+            'd65cac53a601eff2301659333d37140306f587bc529782df13450c7f603d0926'
             '0f3defa657d353b9f55469f6d514abd96494ce7459ef76bbd63980d8994cafe9'
             'c727b2b017163cfdeca60820d3cff2dac8968c5630745602b150f92b159af313'
             'c95a65e890b1ae6362807abc66809e72cf81aeea5f9f556e38f9752f974bf435'


### PR DESCRIPTION
So that if we target a cygwin triplet we still get libraries with a "msys-" prefix.

This allows us to get rid of some msysize patches if we run autoreconf and
pass a cygwin triplet instead of a msys one.