### PR TITLE
pacman: no longer require toolchains to be installed when running makepkg-mingw

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.0.1
-pkgrel=8
+pkgrel=9
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -70,7 +70,7 @@ sha256sums=('SKIP'
             'fff047d9514c4810eee9ab798b51d3300cbf7ee1b5e2e494e1350499d28dd448'
             'ee9f8a5ec60a1334725adb102f531f38badfe1bb66bde82c4aeb3131a2becc2f'
             '606e4b2808a40e856b7043244fc993d426dab25bc2e03b2b8ee5b869f5102507'
-            '55e26c3d3c54b210ccd9b8205907f538250c74e7dfcbc056f2e6c6dc0480eba9'
+            '98198e1f0f252eae0560d271bee4b9149e127399dd0d3fd5d8d24579d9e0550f'
             '57fd01cd215294e2a9c91b616fe3854e96acddfb3de6a758912d9d8ea61fdc18'
             '9c1b99443d26732b21aec3943c17678aa9c7add584b413476873dafb1de4a9c0'
             'b1f3ade9e06f2cdfc23ae09a8598ae3c5603182c13d53d664af8a06eed74590b'

--- a/pacman/makepkg-mingw
+++ b/pacman/makepkg-mingw
@@ -107,45 +107,8 @@ print_msg1 "MINGW_ARCH: ${MINGW_ARCH}"
 
 for _mingw in ${MINGW_ARCH}; do
   print_msg2 "Building ${_mingw}..."
-  case ${_mingw} in
-    mingw32)
-      _msystem=MINGW32
-      _compiler="/${_mingw}/bin/gcc.exe"
-      _toolchain="mingw-w64-i686-toolchain"
-    ;;
-    mingw64)
-      _msystem=MINGW64
-      _compiler="/${_mingw}/bin/gcc.exe"
-      _toolchain="mingw-w64-x86_64-toolchain"
-    ;;
-    clang32)
-      _msystem=CLANG32
-      _compiler="/${_mingw}/bin/clang.exe"
-      _toolchain="mingw-w64-clang-i686-clang"
-    ;;
-    clang64)
-      _msystem=CLANG64
-      _compiler="/${_mingw}/bin/clang.exe"
-      _toolchain="mingw-w64-clang-x86_64-clang"
-    ;;
-    clangarm64)
-      _msystem=CLANGARM64
-      _compiler="/${_mingw}/bin/clang.exe"
-      _toolchain="mingw-w64-clang-aarch64-clang"
-    ;;
-    ucrt64)
-      _msystem=UCRT64
-      _compiler="/${_mingw}/bin/gcc.exe"
-      _toolchain="mingw-w64-ucrt-x86_64-gcc"
-    ;;
-  esac
 
-  if [ ! -f "${_compiler}" ]; then
-    print_warning "You don't have the required toolchain installed for ${_mingw}."
-    print_warning "To install it run: 'pacman -S ${_toolchain}'"
-  fi
-
-  MSYSTEM="${_msystem}" \
+  MSYSTEM="${_mingw^^}" \
   CHERE_INVOKING=1 \
     bash -leo pipefail -c "/usr/bin/makepkg --config /etc/makepkg_mingw.conf \"\$@\"" bash "$@"
 


### PR DESCRIPTION
See https://github.com/msys2/MINGW-packages/discussions/10506