### PR TITLE
make: rebuild without posix_spawn support

### DIFF
--- a/make/PKGBUILD
+++ b/make/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=make
 pkgver=4.3
-pkgrel=2
+pkgrel=3
 pkgdesc="GNU make utility to maintain groups of programs"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/make"
@@ -25,12 +25,18 @@ prepare() {
 
 build() {
   cd ${srcdir}/${pkgname}-${pkgver}
+
+  # 32bit msys make is broken without --disable-posix-spawn somehow.
+  # posix_spawn in cygwin likely isn't faster anway so just disable
+  # it everywhere: https://github.com/msys2/MSYS2-packages/issues/2801
+
   ./configure \
     --build=${CHOST} \
     --prefix=/usr \
     --without-libintl-prefix \
     --without-libiconv-prefix \
     --without-guile \
+    --disable-posix-spawn \
     ac_cv_dos_paths=yes
 
   make -j1 all


### PR DESCRIPTION
It makes problems on 32bit, so disable to fix that and just to
be safe.

See https://github.com/msys2/MSYS2-packages/issues/2801