### PR TITLE
filesystem/msys2_shell: help update (clang32/clangarm64)

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=filesystem
 pkgver=2023.02.07
-pkgrel=1
+pkgrel=2
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('spdx:BSD-3-Clause')
@@ -67,7 +67,7 @@ sha256sums=('742a7d66b7a5ebd2b8461728c5b44a46b2305fd2116208eecae5f45828938ea0'
             '56d4080c15dff89a6263f3d5f9aa68849b2062179cabd6d78edfe0e3af6bf64a'
             '58f7431d7d8d9d09ebd3185c090404682d760bf18c27f94085007b037a5889bd'
             '3b7af99516768485383b34d606749e6f98a250372a8191bc8d3a962d66bdfe35'
-            '22c0d481c7717eee7be0b29c69df15f65d39f16e4af50ad21919bd59259896d1'
+            '390b7471838d14fd41f97f49616dc444454ebc90aea1da54a20799720d4f3772'
             '5f7aa3a776dbdaae78a27e608bf004bf50d5aaace2c2b03581d940b771bc8582'
             '91f1f918cf13deab0124082086e990786113b0e710dbda4678d8fc14905ad94d'
             'b8abe6231cd2b089d708d3e3097ef8c279af1e1594aa15c6eaab4150ed9dffdc'

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -206,8 +206,9 @@ echo Usage:
 echo     %~1 [options] [login shell parameters]
 echo.
 echo Options:
-echo     -mingw32 ^| -mingw64 ^| -ucrt64 ^| -clang64 ^| -msys[2]   Set shell type
-echo     -defterm ^| -mintty ^| -conemu                            Set terminal type
+echo     -mingw32 ^| -mingw64 ^| -ucrt64 ^| -clang32 ^| -clang64 ^|
+echo     -msys[2] ^| -clangarm64           Set shell type
+echo     -defterm ^| -mintty ^| -conemu     Set terminal type
 echo     -here                            Use current directory as working
 echo                                      directory
 echo     -where DIRECTORY                 Use specified DIRECTORY as working


### PR DESCRIPTION
follow-up to 489a8aacde7ff649c77874838bf4e6a79d436e15, I suggest this to be included with another filesystem update (and therefore did not the PKGCONFIG)