### PR TITLE
msys2-runtime: special case the SHELL and ORIGINAL_PATH env vars

### DIFF
--- a/msys2-runtime/0036-Cygwin-path-Convert-UNC-path-prefix-back-to-drive-le.patch
+++ b/msys2-runtime/0036-Cygwin-path-Convert-UNC-path-prefix-back-to-drive-le.patch
@@ -66,5 +66,5 @@ index 3f24217..06b26d2 100644
  		  /* upath.Buffer is big enough and unused from this point on.
  		     Reuse it here, avoiding yet another buffer allocation. */
 -- 
-2.34.1.windows.1
+2.34.1
 

--- a/msys2-runtime/0037-Cygwin-path-Fix-path-conversion-of-virtual-drive.patch
+++ b/msys2-runtime/0037-Cygwin-path-Fix-path-conversion-of-virtual-drive.patch
@@ -81,5 +81,5 @@ index 06b26d2..36f15bd 100644
  		  issymlink = true;
  		  /* upath.Buffer is big enough and unused from this point on.
 -- 
-2.34.1.windows.1
+2.34.1
 

--- a/msys2-runtime/0038-fixup-CI-add-a-GHA-for-doing-a-basic-build-test.patch
+++ b/msys2-runtime/0038-fixup-CI-add-a-GHA-for-doing-a-basic-build-test.patch
@@ -22,5 +22,5 @@ index 8b0817c..8c8fd3e 100644
        - name: Build
          shell: msys2 {0}
 -- 
-2.34.1.windows.1
+2.34.1
 

--- a/msys2-runtime/0039-Cygwin-fhandler_pipe-get_query_hdl_per_process-avoid.patch
+++ b/msys2-runtime/0039-Cygwin-fhandler_pipe-get_query_hdl_per_process-avoid.patch
@@ -61,5 +61,5 @@ index 9ce1400..e4b71b5 100644
  	{
  	  /* Check for the peculiarity of cygwin read pipe */
 -- 
-2.34.1.windows.1
+2.34.1
 

--- a/msys2-runtime/0040-POSIX-ify-the-SHELL-variable.patch
+++ b/msys2-runtime/0040-POSIX-ify-the-SHELL-variable.patch
@@ -1,0 +1,111 @@
+From 390150d2b9f9bfbdccfa273a32c725fd2ad19190 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 23 Nov 2015 20:03:11 +0100
+Subject: [PATCH 40/N] POSIX-ify the SHELL variable
+
+When calling a non-MSys2 binary, all of the environment is converted from
+POSIX to Win32, including the SHELL environment variable. In Git for
+Windows, for example, `SHELL=/usr/bin/bash` is converted to
+`SHELL=C:\Program Files\Git\usr\bin\bash.exe` when calling the `git.exe`
+binary. This is appropriate because non-MSys2 binaries would not handle
+POSIX paths correctly.
+
+Under certain circumstances, however, `git.exe` calls an *MSys2* binary in
+turn, such as `git config --edit` calling `vim.exe` unless Git is
+configured to use another editor specifically.
+
+Now, when this "improved vi" calls shell commands, it uses that $SHELL
+variable *without quoting*, resulting in a nasty error:
+
+	C:\Program: No such file or directory
+
+Many other programs behave in the same manner, assuming that $SHELL does
+not contain spaces and hence needs no quoting, unfortunately including
+some of Git's own scripts.
+
+Therefore let's make sure that $SHELL gets "posified" again when entering
+MSys2 programs.
+
+Earlier attempts by Git for Windows contributors claimed that adding
+`SHELL` to the `conv_envvars` array does not have the intended effect.
+These reports just missed that the `conv_start_chars` array (which makes
+the code more performant) needs to be adjusted, too.
+
+Note that we set the `immediate` flag to `true` so that the environment
+variable is set immediately by the MSys2 runtime, i.e. not only spawned
+processes will see the POSIX-ified `SHELL` variable, but the MSys2 runtime
+*itself*, too.
+
+This fixes https://github.com/git-for-windows/git/issues/542,
+https://github.com/git-for-windows/git/issues/498, and
+https://github.com/git-for-windows/git/issues/468.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/environ.cc | 8 +++++++-
+ winsup/cygwin/environ.h  | 2 +-
+ 2 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index 18c37ee..5c197a6 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -327,6 +327,7 @@ static win_env conv_envvars[] =
+     {NL ("HOME="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
+     {NL ("LD_LIBRARY_PATH="), NULL, NULL,
+ 			       env_plist_to_posix, env_plist_to_win32, true},
++    {NL ("SHELL="), NULL, NULL, env_path_to_posix, env_path_to_win32, true, true},
+     {NL ("TMPDIR="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
+     {NL ("TMP="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
+     {NL ("TEMP="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
+@@ -355,7 +356,7 @@ static const unsigned char conv_start_chars[256] =
+     WC,       0,        0,        0,        WC,       0,        0,        0,
+     /*  80 */
+ /*  P         Q         R         S         T         U         V         W */
+-    WC,       0,        0,        0,        WC,       0,        0,        0,
++    WC,       0,        0,        WC,       WC,       0,        0,        0,
+     /*  88 */
+ /*  x         Y         Z                                                   */
+     0,        0,        0,        0,        0,        0,        0,        0,
+@@ -384,6 +385,7 @@ win_env::operator = (struct win_env& x)
+   toposix = x.toposix;
+   towin32 = x.towin32;
+   immediate = false;
++  skip_if_empty = x.skip_if_empty;
+   return *this;
+ }
+ 
+@@ -405,6 +407,8 @@ win_env::add_cache (const char *in_posix, const char *in_native)
+       native = (char *) realloc (native, namelen + 1 + strlen (in_native));
+       stpcpy (stpcpy (native, name), in_native);
+     }
++  else if (skip_if_empty && !*in_posix)
++    native = (char *) calloc(1, 1);
+   else
+     {
+       tmp_pathbuf tp;
+@@ -470,6 +474,8 @@ posify_maybe (char **here, const char *value, char *outenv)
+     return;
+ 
+   int len = strcspn (src, "=") + 1;
++  if (conv->skip_if_empty && !src[len])
++    return;
+ 
+   /* Turn all the items from c:<foo>;<bar> into their
+      mounted equivalents - if there is one.  */
+diff --git a/winsup/cygwin/environ.h b/winsup/cygwin/environ.h
+index 71c3f22..f33740d 100644
+--- a/winsup/cygwin/environ.h
++++ b/winsup/cygwin/environ.h
+@@ -21,7 +21,7 @@ struct win_env
+     char *native;
+     ssize_t (*toposix) (const void *, void *, size_t);
+     ssize_t (*towin32) (const void *, void *, size_t);
+-    bool immediate;
++    bool immediate, skip_if_empty;
+     void __reg3 add_cache (const char *in_posix, const char *in_native = NULL);
+     const char * get_native () const {return native ? native + namelen : NULL;}
+     const char * get_posix () const {return posix ? posix : NULL;}
+-- 
+2.34.1
+

--- a/msys2-runtime/0041-Handle-ORIGINAL_PATH-just-like-PATH.patch
+++ b/msys2-runtime/0041-Handle-ORIGINAL_PATH-just-like-PATH.patch
@@ -1,0 +1,51 @@
+From c04503a3e1a989a2655d832cad29b9ccd4f82f15 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 21 Mar 2017 13:18:38 +0100
+Subject: [PATCH 41/N] Handle ORIGINAL_PATH just like PATH
+
+MSYS2 recently introduced that hack where the ORIGINAL_PATH variable is
+set to the original PATH value in /etc/profile, unless previously set.
+In Git for Windows' default mode, that ORIGINAL_PATH value is the used
+to define the PATH variable explicitly.
+
+So far so good.
+
+The problem: when calling from inside an MSYS2 process (such as Bash) a
+MINGW executable (such as git.exe) that then calls another MSYS2
+executable (such as bash.exe), that latter call will try to re-convert
+ORIGINAL_PATH after the previous call converted ORIGINAL_PATH from POSIX
+to Windows paths. And this conversion may very well fail, e.g. when the
+path list contains mixed semicolons and colons.
+
+So let's just *force* the MSYS2 runtime to handle ORIGINAL_PATH in the
+same way as the PATH variable (which conversion works, as we know).
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/environ.cc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index 5c197a6..5afac8d 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -327,6 +327,7 @@ static win_env conv_envvars[] =
+     {NL ("HOME="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
+     {NL ("LD_LIBRARY_PATH="), NULL, NULL,
+ 			       env_plist_to_posix, env_plist_to_win32, true},
++    {NL ("ORIGINAL_PATH="), NULL, NULL, env_PATH_to_posix, env_plist_to_win32, true},
+     {NL ("SHELL="), NULL, NULL, env_path_to_posix, env_path_to_win32, true, true},
+     {NL ("TMPDIR="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
+     {NL ("TMP="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
+@@ -353,7 +354,7 @@ static const unsigned char conv_start_chars[256] =
+     0,        0,        0,        0,        0,        0,        0,        0,
+     /*  72 */
+ /*  H         I         J         K         L         M         N         O */
+-    WC,       0,        0,        0,        WC,       0,        0,        0,
++    WC,       0,        0,        0,        WC,       0,        0,        WC,
+     /*  80 */
+ /*  P         Q         R         S         T         U         V         W */
+     WC,       0,        0,        WC,       WC,       0,        0,        0,
+-- 
+2.34.1
+

--- a/msys2-runtime/0042-fixup-CI-add-a-GHA-for-doing-a-basic-build-test.patch
+++ b/msys2-runtime/0042-fixup-CI-add-a-GHA-for-doing-a-basic-build-test.patch
@@ -1,0 +1,28 @@
+From 08e8d57dd895d229ab5b6ad2a17eee8696772e1c Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 5 Jan 2022 15:23:47 +0100
+Subject: [PATCH 42/N] fixup! CI: add a GHA for doing a basic build test
+
+The `xmlto` command is also used, as well as the style sheets of docbook.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ .github/workflows/build.yaml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/.github/workflows/build.yaml b/.github/workflows/build.yaml
+index 8c8fd3e..4e1d498 100644
+--- a/.github/workflows/build.yaml
++++ b/.github/workflows/build.yaml
+@@ -15,7 +15,7 @@ jobs:
+         with:
+           msystem: MSYS
+           update: true
+-          install: msys2-devel base-devel autotools cocom diffutils gcc gettext-devel libiconv-devel make mingw-w64-cross-crt mingw-w64-cross-gcc mingw-w64-cross-zlib perl zlib-devel
++          install: msys2-devel base-devel autotools cocom diffutils gcc gettext-devel libiconv-devel make mingw-w64-cross-crt mingw-w64-cross-gcc mingw-w64-cross-zlib perl zlib-devel xmlto docbook-xsl
+ 
+       - name: Build
+         shell: msys2 {0}
+-- 
+2.34.1
+

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -19,7 +19,9 @@ makedepends=('cocom'
              'zlib-devel'
              'gettext-devel'
              'libiconv-devel'
-             'autotools')
+             'autotools'
+             'xmlto'
+             'docbook-xsl')
 # re zipman: https://github.com/msys2/MSYS2-packages/pull/2687#issuecomment-965714874
 options=('!zipman')
 source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-${pkgver//./_}-release

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.3.3
-pkgrel=4
+pkgrel=5
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -63,7 +63,10 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0036-Cygwin-path-Convert-UNC-path-prefix-back-to-drive-le.patch
         0037-Cygwin-path-Fix-path-conversion-of-virtual-drive.patch
         0038-fixup-CI-add-a-GHA-for-doing-a-basic-build-test.patch
-        0039-Cygwin-fhandler_pipe-get_query_hdl_per_process-avoid.patch)
+        0039-Cygwin-fhandler_pipe-get_query_hdl_per_process-avoid.patch
+        0040-POSIX-ify-the-SHELL-variable.patch
+        0041-Handle-ORIGINAL_PATH-just-like-PATH.patch
+        0042-fixup-CI-add-a-GHA-for-doing-a-basic-build-test.patch)
 sha256sums=('SKIP'
             'c933090fc69948f47dc6452fb9913750de9e341fd80534e7099c7a16f8391167'
             'c25197a13a4df28bd34283d830d14d1c091b6517a5f298ce0f50b14fd31b7e8f'
@@ -100,10 +103,13 @@ sha256sums=('SKIP'
             'db27ac00a4f1f5621cfcbbb215cd2b8af629d347b7d1de56145f18360fb90a58'
             '8257cf1beeb00b95eb1ac0a913de3aa1844ee7ea1b16cee59ecd205cf7deab9f'
             '8545ac529b2fa7d33b92735c3371a16b0377b5860c94254b78882da70af143f0'
-            '83d6900c52766855325a37a9f951b856c2015b67c6454f8a6ca0a0faac5f08e1'
-            '115e24f1ffb6986afd594f3e5f074a63291ff9dc53064e30617b97816e838946'
-            '22ad7003f66e3dca60871d4ff9c35d2461d9af72a91c33b622d105b587c0b64d'
-            'e37cb6ef13f15fd9eb21ecf9dec985a5bd0eedb8cfbf656f9932f3e609228982')
+            '8f0932a0595d54ab3ba50bc105c595f0083bb22eac4524fd69d624efce79f666'
+            '3dae0b2dbbf30c0b6c3ba55a64a897d46cb7ddd27fb8f4f25306159edbef0feb'
+            'bf719010c001455812dca85f54917668feaae88d2c3ff339754e6dc8b5cb0aa5'
+            '2d1f19222e917caae30f5640e18e812b92995533b181b0d1e315cec5bfc8feb1'
+            '4db81cd6dcabb23eb7e4b14781ce368021156b9dfc02397dc824407187687fd6'
+            '5517535ed08b2d28144311eb871c3d451635788bf7dc0b5ac0ebb66d44939ea9'
+            'c20f5238987778a6a46051e6b0c489de8fde7f7428b15bb8254f358b4b70f383')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -179,7 +185,10 @@ prepare() {
   0036-Cygwin-path-Convert-UNC-path-prefix-back-to-drive-le.patch \
   0037-Cygwin-path-Fix-path-conversion-of-virtual-drive.patch \
   0038-fixup-CI-add-a-GHA-for-doing-a-basic-build-test.patch \
-  0039-Cygwin-fhandler_pipe-get_query_hdl_per_process-avoid.patch
+  0039-Cygwin-fhandler_pipe-get_query_hdl_per_process-avoid.patch \
+  0040-POSIX-ify-the-SHELL-variable.patch \
+  0041-Handle-ORIGINAL_PATH-just-like-PATH.patch \
+  0042-fixup-CI-add-a-GHA-for-doing-a-basic-build-test.patch
 }
 
 build() {


### PR DESCRIPTION
Forward-porting https://github.com/msys2/msys2-runtime/pull/79:

In MSYS2 <-> MINGW transitions, we convert a couple of environment variables between Unix and Windows styles, most notably `PATH`.

In the Git for Windows project, we realized that the environment variables `SHELL` and `ORIGINAL_PATH` need the same treatment. These patches have proved their worth for years, and it is time for them to be integrated back into the actual MSYS2 runtime.

This should fix https://github.com/msys2/msys2-runtime/issues/43.