### PR TITLE
base-devel: remove patchutils/intltool

### DIFF
--- a/base-devel/PKGBUILD
+++ b/base-devel/PKGBUILD
@@ -22,7 +22,6 @@ depends=(
   'groff'
   'texinfo'
   'texinfo-tex'
-  'intltool'
   'make'
   'pacman'
   'patch'

--- a/base-devel/PKGBUILD
+++ b/base-devel/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
 
 pkgname=base-devel
-pkgver=2021.12
+pkgver=2022.01
 pkgrel=1
 pkgdesc='Minimal package set for building packages with makepkg'
 url='https://www.msys2.org'
@@ -26,7 +26,6 @@ depends=(
   'make'
   'pacman'
   'patch'
-  'patchutils'
   'pkgconf'
   'sed'
   'tar'


### PR DESCRIPTION
patchutils:

* It mostly contains tools that are useful to developers, but are not used in
   a PKGBUILD directly.

intltool:

* It's long abandoned and everyone should be using gettext
  and we want to get rid of it in the long run.
* Many packages that need it depend on it anyway