### PR TITLE
mingw-w64-cross-binutils: Update to version 2.37

### DIFF
--- a/mingw-w64-cross-binutils/0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
+++ b/mingw-w64-cross-binutils/0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
@@ -1,7 +1,7 @@
-From 1316395a096fd327efe88c171a08ba077f6f02df Mon Sep 17 00:00:00 2001
+From 520d5017366ff334c8a866aa15abb8cce22fb952 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Mon, 23 Nov 2015 22:42:53 +0000
-Subject: [PATCH 5/5] bfd: Increase _bfd_coff_max_nscns to 65279
+Subject: [PATCH] bfd: Increase _bfd_coff_max_nscns to 65279
 
 .. from 32768. This is the value that llvm uses. There's no
 indication in the PECOFF specs that 32768 is the limit.
@@ -13,50 +13,50 @@ indication in the PECOFF specs that 32768 is the limit.
  bfd/coffcode.h    | 2 +-
  5 files changed, 5 insertions(+), 5 deletions(-)
 
-diff --git binutils-2.28.orig/bfd/coff-alpha.c binutils-2.28/bfd/coff-alpha.c
-index 9ce1975..df65b5f 100644
---- binutils-2.28.orig/bfd/coff-alpha.c
-+++ binutils-2.28/bfd/coff-alpha.c
-@@ -2236,7 +2236,7 @@ static const struct ecoff_backend_data alpha_ecoff_backend_data =
+diff --git a/bfd/coff-alpha.c b/bfd/coff-alpha.c
+index 15fea1fde34..c5547259956 100644
+--- a/bfd/coff-alpha.c
++++ b/bfd/coff-alpha.c
+@@ -2304,7 +2304,7 @@ static const struct ecoff_backend_data alpha_ecoff_backend_data =
      alpha_ecoff_swap_filehdr_out, alpha_ecoff_swap_aouthdr_out,
      alpha_ecoff_swap_scnhdr_out,
-     FILHSZ, AOUTSZ, SCNHSZ, 0, 0, 0, 0, FILNMLEN, TRUE,
--    ECOFF_NO_LONG_SECTION_NAMES, 4, FALSE, 2, 32768,
-+    ECOFF_NO_LONG_SECTION_NAMES, 4, FALSE, 2, 65279,
+     FILHSZ, AOUTSZ, SCNHSZ, 0, 0, 0, 0, FILNMLEN, true,
+-    ECOFF_NO_LONG_SECTION_NAMES, 4, false, 2, 32768,
++    ECOFF_NO_LONG_SECTION_NAMES, 4, false, 2, 65279,
      alpha_ecoff_swap_filehdr_in, alpha_ecoff_swap_aouthdr_in,
      alpha_ecoff_swap_scnhdr_in, NULL,
      alpha_ecoff_bad_format_hook, _bfd_ecoff_set_arch_mach_hook,
-diff --git binutils-2.28.orig/bfd/coff-mips.c binutils-2.28/bfd/coff-mips.c
-index f872ebe..d11fddd 100644
---- binutils-2.28.orig/bfd/coff-mips.c
-+++ binutils-2.28/bfd/coff-mips.c
-@@ -1254,7 +1254,7 @@ static const struct ecoff_backend_data mips_ecoff_backend_data =
+diff --git a/bfd/coff-mips.c b/bfd/coff-mips.c
+index 963ab249119..935bb0c5702 100644
+--- a/bfd/coff-mips.c
++++ b/bfd/coff-mips.c
+@@ -1314,7 +1314,7 @@ static const struct ecoff_backend_data mips_ecoff_backend_data =
      mips_ecoff_swap_filehdr_out, mips_ecoff_swap_aouthdr_out,
      mips_ecoff_swap_scnhdr_out,
-     FILHSZ, AOUTSZ, SCNHSZ, 0, 0, 0, 0, FILNMLEN, TRUE,
--    ECOFF_NO_LONG_SECTION_NAMES, 4, FALSE, 2, 32768,
-+    ECOFF_NO_LONG_SECTION_NAMES, 4, FALSE, 2, 65279,
+     FILHSZ, AOUTSZ, SCNHSZ, 0, 0, 0, 0, FILNMLEN, true,
+-    ECOFF_NO_LONG_SECTION_NAMES, 4, false, 2, 32768,
++    ECOFF_NO_LONG_SECTION_NAMES, 4, false, 2, 65279,
      mips_ecoff_swap_filehdr_in, mips_ecoff_swap_aouthdr_in,
      mips_ecoff_swap_scnhdr_in, NULL,
      mips_ecoff_bad_format_hook, _bfd_ecoff_set_arch_mach_hook,
-diff --git binutils-2.28.orig/bfd/coff-rs6000.c binutils-2.28/bfd/coff-rs6000.c
-index 511f0c1..acda7d9 100644
---- binutils-2.28.orig/bfd/coff-rs6000.c
-+++ binutils-2.28/bfd/coff-rs6000.c
-@@ -4077,7 +4077,7 @@ static const struct xcoff_backend_data_rec bfd_xcoff_backend_data =
+diff --git a/bfd/coff-rs6000.c b/bfd/coff-rs6000.c
+index 45ba9b3cb00..744c61bafb9 100644
+--- a/bfd/coff-rs6000.c
++++ b/bfd/coff-rs6000.c
+@@ -4382,7 +4382,7 @@ static const struct xcoff_backend_data_rec bfd_xcoff_backend_data =
        3,			/* _bfd_coff_default_section_alignment_power */
-       FALSE,			/* _bfd_coff_force_symnames_in_strings */
+       false,			/* _bfd_coff_force_symnames_in_strings */
        2,			/* _bfd_coff_debug_string_prefix_length */
 -      32768,			/* _bfd_coff_max_nscns */
 +      65279,			/* _bfd_coff_max_nscns */
        coff_swap_filehdr_in,
        coff_swap_aouthdr_in,
        coff_swap_scnhdr_in,
-diff --git binutils-2.28.orig/bfd/coff-sh.c binutils-2.28/bfd/coff-sh.c
-index dd8090c..5e3605f 100644
---- binutils-2.28.orig/bfd/coff-sh.c
-+++ binutils-2.28/bfd/coff-sh.c
-@@ -3099,7 +3099,7 @@ static bfd_coff_backend_data bfd_coff_small_swap_table =
+diff --git a/bfd/coff-sh.c b/bfd/coff-sh.c
+index 10d203f5280..ef793612bf7 100644
+--- a/bfd/coff-sh.c
++++ b/bfd/coff-sh.c
+@@ -3094,7 +3094,7 @@ static bfd_coff_backend_data bfd_coff_small_swap_table =
  #else
    2,
  #endif
@@ -65,11 +65,11 @@ index dd8090c..5e3605f 100644
    coff_swap_filehdr_in, coff_swap_aouthdr_in, coff_swap_scnhdr_in,
    coff_swap_reloc_in, coff_bad_format_hook, coff_set_arch_mach_hook,
    coff_mkobject_hook, styp_to_sec_flags, coff_set_alignment_hook,
-diff --git binutils-2.28.orig/bfd/coffcode.h binutils-2.28/bfd/coffcode.h
-index a8eba93..98395bc 100644
---- binutils-2.28.orig/bfd/coffcode.h
-+++ binutils-2.28/bfd/coffcode.h
-@@ -5634,7 +5634,7 @@ static bfd_coff_backend_data bfd_coff_std_swap_table ATTRIBUTE_UNUSED =
+diff --git a/bfd/coffcode.h b/bfd/coffcode.h
+index f65f3352e46..25384adfde8 100644
+--- a/bfd/coffcode.h
++++ b/bfd/coffcode.h
+@@ -5415,7 +5415,7 @@ static bfd_coff_backend_data bfd_coff_std_swap_table ATTRIBUTE_UNUSED =
  #else
    2,
  #endif
@@ -78,3 +78,5 @@ index a8eba93..98395bc 100644
    coff_SWAP_filehdr_in, coff_SWAP_aouthdr_in, coff_SWAP_scnhdr_in,
    coff_SWAP_reloc_in, coff_bad_format_hook, coff_set_arch_mach_hook,
    coff_mkobject_hook, styp_to_sec_flags, coff_set_alignment_hook,
+-- 
+2.32.0

--- a/mingw-w64-cross-binutils/0100-binutils-2.37-msys2.patch
+++ b/mingw-w64-cross-binutils/0100-binutils-2.37-msys2.patch
@@ -1,6 +1,18 @@
-diff -Naur binutils-2.30.orig/bfd/acinclude.m4 binutils-2.30/bfd/acinclude.m4
---- binutils-2.30.orig/bfd/acinclude.m4	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/bfd/acinclude.m4	2018-06-13 08:19:13.199163100 +0300
+diff -Naur binutils-2.37-orig/ar-lib binutils-2.37/ar-lib
+--- binutils-2.37-orig/ar-lib	2021-11-30 08:19:41.276294300 +0100
++++ binutils-2.37/ar-lib	2021-11-30 08:20:03.101276300 +0100
+@@ -53,7 +53,7 @@
+ 	  MINGW*)
+ 	    file_conv=mingw
+ 	    ;;
+-	  CYGWIN*)
++	  CYGWIN*|MSYS*)
+ 	    file_conv=cygwin
+ 	    ;;
+ 	  *)
+diff -Naur binutils-2.37-orig/bfd/acinclude.m4 binutils-2.37/bfd/acinclude.m4
+--- binutils-2.37-orig/bfd/acinclude.m4	2021-11-30 08:19:40.652753800 +0100
++++ binutils-2.37/bfd/acinclude.m4	2021-11-30 08:27:31.060649000 +0100
 @@ -21,7 +21,7 @@
  [AC_REQUIRE([AC_CANONICAL_TARGET])
  case "${host}" in
@@ -10,40 +22,31 @@ diff -Naur binutils-2.30.orig/bfd/acinclude.m4 binutils-2.30/bfd/acinclude.m4
  changequote([,])dnl
    AC_DEFINE(USE_BINARY_FOPEN, 1, [Use b modifier when opening binary files?]) ;;
  esac])dnl
-diff -Naur binutils-2.30.orig/bfd/config.bfd binutils-2.30/bfd/config.bfd
---- binutils-2.30.orig/bfd/config.bfd	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/bfd/config.bfd	2018-06-13 08:19:13.199163100 +0300
-@@ -804,7 +804,7 @@
-     targ_archs="$targ_archs bfd_arm_arch"
+diff -Naur binutils-2.37-orig/bfd/config.bfd binutils-2.37/bfd/config.bfd
+--- binutils-2.37-orig/bfd/config.bfd	2021-11-30 08:19:40.737367900 +0100
++++ binutils-2.37/bfd/config.bfd	2021-11-30 08:30:09.344982700 +0100
+@@ -679,7 +679,7 @@
+     targ_selvecs="i386_elf32_vec iamcu_elf32_vec x86_64_elf32_vec i386_pei_vec x86_64_pe_vec x86_64_pei_vec l1om_elf64_vec k1om_elf64_vec"
      want64=true
      ;;
 -  x86_64-*-mingw* | x86_64-*-pe | x86_64-*-pep | x86_64-*-cygwin)
-+  x86_64-*-mingw* | x86_64-*-pe | x86_64-*-pep | x86_64-*-cygwin | x86_64-*-msys*)
++  x86_64-*-mingw* | x86_64-*-pe | x86_64-*-pep | x86_64-*-cygwin | x86_64-*-msys)
      targ_defvec=x86_64_pe_vec
-     targ_selvecs="x86_64_pe_vec x86_64_pei_vec x86_64_pe_be_vec x86_64_elf64_vec l1om_elf64_vec k1om_elf64_vec i386_pe_vec i386_pei_vec i386_elf32_vec iamcu_elf32_vec"
+     targ_selvecs="x86_64_pe_vec x86_64_pei_vec x86_64_pe_big_vec x86_64_elf64_vec l1om_elf64_vec k1om_elf64_vec i386_pe_vec i386_pei_vec i386_elf32_vec iamcu_elf32_vec"
      want64=true
-@@ -862,7 +862,7 @@
+@@ -729,7 +729,7 @@
      targ_defvec=i386_elf32_vec
      targ_selvecs="iamcu_elf32_vec i386_coff_vec"
      ;;
 -  i[3-7]86-*-mingw32* | i[3-7]86-*-cygwin* | i[3-7]86-*-winnt | i[3-7]86-*-pe)
 +  i[3-7]86-*-mingw32* | i[3-7]86-*-cygwin* | i[3-7]86-*-msys* | i[3-7]86-*-winnt | i[3-7]86-*-pe)
      targ_defvec=i386_pe_vec
-     targ_selvecs="i386_pe_vec i386_pei_vec i386_elf32_vec iamcu_elf32_vec"
+     targ_selvecs="i386_pe_vec i386_pe_big_vec i386_pei_vec i386_elf32_vec iamcu_elf32_vec"
      targ_underscore=yes
-@@ -1438,7 +1438,7 @@
-     targ_selvecs="rs6000_xcoff_vec powerpc_elf32_vec powerpc_boot_vec"
-     targ64_selvecs="powerpc_elf64_vec powerpc_elf64_le_vec"
-     ;;
--  powerpcle-*-pe | powerpcle-*-winnt* | powerpcle-*-cygwin*)
-+  powerpcle-*-pe | powerpcle-*-winnt* | powerpcle-*-cygwin* | powerpcle-*-msys*)
-     targ_defvec=powerpc_pe_le_vec
-     targ_selvecs="powerpc_pei_le_vec powerpc_pei_vec powerpc_pe_le_vec powerpc_pe_vec"
-     ;;
-diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
---- binutils-2.30.orig/bfd/configure	2018-01-27 17:58:29.000000000 +0300
-+++ binutils-2.30/bfd/configure	2018-06-13 08:19:13.199163100 +0300
-@@ -5997,7 +5997,7 @@
+diff -Naur binutils-2.37-orig/bfd/configure binutils-2.37/bfd/configure
+--- binutils-2.37-orig/bfd/configure	2021-11-30 08:19:40.674879200 +0100
++++ binutils-2.37/bfd/configure	2021-11-30 08:49:35.744747500 +0100
+@@ -5592,7 +5592,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -52,7 +55,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -6339,7 +6339,7 @@
+@@ -5934,7 +5934,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -61,7 +64,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -6919,7 +6919,7 @@
+@@ -6545,7 +6545,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -70,7 +73,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -8503,7 +8503,7 @@
+@@ -8129,7 +8129,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -79,7 +82,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -8585,7 +8585,7 @@
+@@ -8211,7 +8211,7 @@
        fi
        ;;
  
@@ -88,7 +91,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -9047,7 +9047,7 @@
+@@ -8673,7 +8673,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -97,7 +100,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -9162,7 +9162,7 @@
+@@ -8788,7 +8788,7 @@
        fi
        ;;
  
@@ -106,7 +109,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec='-L$libdir'
-@@ -9593,7 +9593,7 @@
+@@ -9219,7 +9219,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -115,7 +118,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -10494,14 +10494,14 @@
+@@ -10120,14 +10120,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -132,12 +135,12 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -10525,6 +10525,12 @@
+@@ -10151,6 +10151,12 @@
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
 +    msys*)
-+      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      # MSYS DLLs use 'msys-' prefix rather than 'lib'
 +      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
 +
 +      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
@@ -145,7 +148,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -11161,7 +11167,7 @@
+@@ -10777,7 +10783,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -154,7 +157,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
-@@ -13855,7 +13861,7 @@
+@@ -12904,7 +12910,7 @@
  
  
  case "${host}" in
@@ -163,7 +166,7 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
  
  $as_echo "#define USE_BINARY_FOPEN 1" >>confdefs.h
   ;;
-@@ -14031,7 +14037,7 @@
+@@ -12983,7 +12989,7 @@
  
  LIBM=
  case $host in
@@ -172,37 +175,35 @@ diff -Naur binutils-2.30.orig/bfd/configure binutils-2.30/bfd/configure
    # These system don't have libm, or don't need it
    ;;
  *-ncr-sysv4.3*)
-@@ -14181,6 +14187,11 @@
+@@ -13137,6 +13143,10 @@
      SHARED_LDFLAGS="-no-undefined"
-     SHARED_LIBADD="-L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lcygwin -lkernel32"
+     SHARED_LIBADD="-L`pwd`/../libiberty -liberty $SHARED_LIBADD -lcygwin -lkernel32"
    ;;
-+
 +  *-*-msys*)
 +    SHARED_LDFLAGS="-no-undefined"
-+    SHARED_LIBADD="-L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lmsys-2.0 -lkernel32"
++    SHARED_LIBADD="-L`pwd`/../libiberty -liberty $SHARED_LIBADD -lmsys-2.0 -lkernel32"
 +  ;;
+   esac
  
-   # Use built-in libintl on macOS, since it is not provided by libc.
-   *-*-darwin*)
-diff -Naur binutils-2.30.orig/bfd/configure.ac binutils-2.30/bfd/configure.ac
---- binutils-2.30.orig/bfd/configure.ac	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/bfd/configure.ac	2018-06-13 08:19:13.199163100 +0300
-@@ -299,6 +299,11 @@
+   if test -n "$SHARED_LIBADD"; then
+diff -Naur binutils-2.37-orig/bfd/configure.ac binutils-2.37/bfd/configure.ac
+--- binutils-2.37-orig/bfd/configure.ac	2021-11-30 08:19:40.768610800 +0100
++++ binutils-2.37/bfd/configure.ac	2021-11-30 08:50:01.708256300 +0100
+@@ -317,6 +317,10 @@
      SHARED_LDFLAGS="-no-undefined"
-     SHARED_LIBADD="-L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lcygwin -lkernel32"
+     SHARED_LIBADD="-L`pwd`/../libiberty -liberty $SHARED_LIBADD -lcygwin -lkernel32"
    ;;
-+
 +  *-*-msys*)
 +    SHARED_LDFLAGS="-no-undefined"
-+    SHARED_LIBADD="-L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lmsys-2.0 -lkernel32"
++    SHARED_LIBADD="-L`pwd`/../libiberty -liberty $SHARED_LIBADD -lmsys-2.0 -lkernel32"
 +  ;;
+   esac
  
-   # Use built-in libintl on macOS, since it is not provided by libc.
-   *-*-darwin*)
-diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configure
---- binutils-2.30.orig/binutils/configure	2018-01-27 18:02:51.000000000 +0300
-+++ binutils-2.30/binutils/configure	2018-06-13 08:19:13.214763200 +0300
-@@ -5764,7 +5764,7 @@
+   if test -n "$SHARED_LIBADD"; then
+diff -Naur binutils-2.37-orig/binutils/configure binutils-2.37/binutils/configure
+--- binutils-2.37-orig/binutils/configure	2021-11-30 08:19:29.844390400 +0100
++++ binutils-2.37/binutils/configure	2021-11-30 08:46:31.028660100 +0100
+@@ -5448,7 +5448,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -211,7 +212,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -6106,7 +6106,7 @@
+@@ -5790,7 +5790,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -220,7 +221,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -6686,7 +6686,7 @@
+@@ -6401,7 +6401,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -229,7 +230,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -8301,7 +8301,7 @@
+@@ -8016,7 +8016,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -238,7 +239,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -8383,7 +8383,7 @@
+@@ -8098,7 +8098,7 @@
        fi
        ;;
  
@@ -247,7 +248,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -8845,7 +8845,7 @@
+@@ -8560,7 +8560,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -256,7 +257,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -8960,7 +8960,7 @@
+@@ -8675,7 +8675,7 @@
        fi
        ;;
  
@@ -265,7 +266,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
        # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec='-L$libdir'
-@@ -9391,7 +9391,7 @@
+@@ -9106,7 +9106,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -274,7 +275,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -10292,14 +10292,14 @@
+@@ -10007,14 +10007,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -291,12 +292,12 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -10323,6 +10323,12 @@
+@@ -10038,6 +10038,12 @@
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
 +    msys*)
-+      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      # MSYS DLLs use 'msys-' prefix rather than 'lib'
 +      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
 +
 +      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
@@ -304,7 +305,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -10959,7 +10965,7 @@
+@@ -10664,7 +10670,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -313,7 +314,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
-@@ -13653,7 +13659,7 @@
+@@ -13677,7 +13683,7 @@
  
  
  case "${host}" in
@@ -322,7 +323,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
  
  $as_echo "#define USE_BINARY_FOPEN 1" >>confdefs.h
   ;;
-@@ -14505,7 +14511,7 @@
+@@ -14512,7 +14518,7 @@
  	  BUILD_WINDRES='$(WINDRES_PROG)$(EXEEXT)'
  	  BUILD_WINDMC='$(WINDMC_PROG)$(EXEEXT)'
  	  ;;
@@ -331,7 +332,7 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
    	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
  	  if test -z "$DLLTOOL_DEFAULT"; then
  	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_MX86_64"
-@@ -14515,7 +14521,7 @@
+@@ -14522,7 +14528,7 @@
  	  BUILD_WINDMC='$(WINDMC_PROG)$(EXEEXT)'
  	  BUILD_DLLWRAP='$(DLLWRAP_PROG)$(EXEEXT)'
  	  ;;
@@ -340,19 +341,10 @@ diff -Naur binutils-2.30.orig/binutils/configure binutils-2.30/binutils/configur
    	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
  	  if test -z "$DLLTOOL_DEFAULT"; then
  	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_I386"
-@@ -14537,7 +14543,7 @@
- 	powerpc*-aix[5-9].*)
- 	  OBJDUMP_DEFS="-DAIX_WEAK_SUPPORT"
- 	  ;;
--	powerpc*-*-pe* | powerpc*-*-cygwin*)
-+	powerpc*-*-pe* | powerpc*-*-cygwin* | powerpc*-*-msys*)
-   	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
- 	  if test -z "$DLLTOOL_DEFAULT"; then
- 	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_PPC"
-diff -Naur binutils-2.30.orig/binutils/configure.ac binutils-2.30/binutils/configure.ac
---- binutils-2.30.orig/binutils/configure.ac	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/configure.ac	2018-06-13 08:19:13.214763200 +0300
-@@ -315,7 +315,7 @@
+diff -Naur binutils-2.37-orig/binutils/configure.ac binutils-2.37/binutils/configure.ac
+--- binutils-2.37-orig/binutils/configure.ac	2021-11-30 08:19:29.866519000 +0100
++++ binutils-2.37/binutils/configure.ac	2021-11-30 08:30:09.344982700 +0100
+@@ -347,7 +347,7 @@
  	  BUILD_WINDRES='$(WINDRES_PROG)$(EXEEXT)'
  	  BUILD_WINDMC='$(WINDMC_PROG)$(EXEEXT)'
  	  ;;
@@ -361,7 +353,7 @@ diff -Naur binutils-2.30.orig/binutils/configure.ac binutils-2.30/binutils/confi
    	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
  	  if test -z "$DLLTOOL_DEFAULT"; then
  	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_MX86_64"
-@@ -326,7 +326,7 @@
+@@ -358,7 +358,7 @@
  	  BUILD_DLLWRAP='$(DLLWRAP_PROG)$(EXEEXT)'
  	  ;;
  changequote(,)dnl
@@ -370,18 +362,9 @@ diff -Naur binutils-2.30.orig/binutils/configure.ac binutils-2.30/binutils/confi
  changequote([,])dnl
    	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
  	  if test -z "$DLLTOOL_DEFAULT"; then
-@@ -355,7 +355,7 @@
- changequote([,])dnl
- 	  OBJDUMP_DEFS="-DAIX_WEAK_SUPPORT"
- 	  ;;
--	powerpc*-*-pe* | powerpc*-*-cygwin*)
-+	powerpc*-*-pe* | powerpc*-*-cygwin* | powerpc*-*-msys*)
-   	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
- 	  if test -z "$DLLTOOL_DEFAULT"; then
- 	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_PPC"
-diff -Naur binutils-2.30.orig/binutils/dllwrap.c binutils-2.30/binutils/dllwrap.c
---- binutils-2.30.orig/binutils/dllwrap.c	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/dllwrap.c	2018-06-13 08:19:13.214763200 +0300
+diff -Naur binutils-2.37-orig/binutils/dllwrap.c binutils-2.37/binutils/dllwrap.c
+--- binutils-2.37-orig/binutils/dllwrap.c	2021-11-30 08:19:29.866519000 +0100
++++ binutils-2.37/binutils/dllwrap.c	2021-11-30 08:55:46.638625700 +0100
 @@ -78,6 +78,7 @@
  typedef enum {
    UNKNOWN_TARGET,
@@ -390,7 +373,7 @@ diff -Naur binutils-2.30.orig/binutils/dllwrap.c binutils-2.30/binutils/dllwrap.
    MINGW_TARGET
  }
  target_type;
-@@ -832,6 +833,8 @@
+@@ -833,6 +834,8 @@
    /* Set the target platform.  */
    if (strstr (target, "cygwin"))
      which_target = CYGWIN_TARGET;
@@ -399,18 +382,18 @@ diff -Naur binutils-2.30.orig/binutils/dllwrap.c binutils-2.30/binutils/dllwrap.
    else if (strstr (target, "mingw"))
      which_target = MINGW_TARGET;
    else
-@@ -883,6 +886,10 @@
+@@ -884,6 +887,10 @@
  	  driver_flags = cygwin_driver_flags;
  	  break;
  
-+    case MSYS_TARGET:
++	case MSYS_TARGET:
 +	  driver_flags = cygwin_driver_flags;
 +	  break;
 +
  	case MINGW_TARGET:
  	  driver_flags = mingw32_driver_flags;
  	  break;
-@@ -916,6 +923,10 @@
+@@ -917,6 +924,10 @@
  	  name_entry = "_cygwin_dll_entry";
  	  break;
  
@@ -421,7 +404,7 @@ diff -Naur binutils-2.30.orig/binutils/dllwrap.c binutils-2.30/binutils/dllwrap.
  	case MINGW_TARGET:
  	  name_entry = "DllMainCRTStartup";
  	  break;
-@@ -979,7 +990,7 @@
+@@ -980,7 +991,7 @@
  	{
  	  dyn_string_append_cstr (step_pre1, " --export-all --exclude-symbol=");
  	  dyn_string_append_cstr (step_pre1,
@@ -430,21 +413,9 @@ diff -Naur binutils-2.30.orig/binutils/dllwrap.c binutils-2.30/binutils/dllwrap.
  	}
        dyn_string_append_cstr (step_pre1, " --output-def ");
        dyn_string_append_cstr (step_pre1, def_file_name);
-diff -Naur binutils-2.30.orig/binutils/testsuite/binutils-all/copy-3.d binutils-2.30/binutils/testsuite/binutils-all/copy-3.d
---- binutils-2.30.orig/binutils/testsuite/binutils-all/copy-3.d	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/testsuite/binutils-all/copy-3.d	2018-06-13 08:19:13.214763200 +0300
-@@ -3,7 +3,7 @@
- #objcopy: --set-section-flags .text=alloc,data
- #name: copy with setting section flags 3
- #source: bintest.s
--#notarget: *-*-*aout *-*-*coff *-*-cygwin* *-*-darwin *-*-mingw* *-*-go32 *-*-*pe hppa*-*-hpux* ns32k-*-* powerpc-*-aix* rs6000-*-* rx-*-*
-+#notarget: *-*-*aout *-*-*coff *-*-cygwin* *-*-msys* *-*-darwin *-*-mingw* *-*-go32 *-*-*pe hppa*-*-hpux* ns32k-*-* powerpc-*-aix* rs6000-*-* rx-*-*
- # The .text # section in PE/COFF has a fixed set of flags and these
- # cannot be changed.  We skip it for them.
- 
-diff -Naur binutils-2.30.orig/binutils/testsuite/binutils-all/dlltool.exp binutils-2.30/binutils/testsuite/binutils-all/dlltool.exp
---- binutils-2.30.orig/binutils/testsuite/binutils-all/dlltool.exp	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/testsuite/binutils-all/dlltool.exp	2018-06-13 08:19:13.214763200 +0300
+diff -Naur binutils-2.37-orig/binutils/testsuite/binutils-all/dlltool.exp binutils-2.37/binutils/testsuite/binutils-all/dlltool.exp
+--- binutils-2.37-orig/binutils/testsuite/binutils-all/dlltool.exp	2021-11-30 08:19:29.712912800 +0100
++++ binutils-2.37/binutils/testsuite/binutils-all/dlltool.exp	2021-11-30 08:31:03.111076800 +0100
 @@ -22,6 +22,7 @@
  
  if {![istarget "i*86-*-*pe*"] \
@@ -453,64 +424,9 @@ diff -Naur binutils-2.30.orig/binutils/testsuite/binutils-all/dlltool.exp binuti
      && ![istarget "i*86-*-mingw32*"] \
      && ![istarget "arm-*-pe*"] \
      && ![istarget "x86_64-*-mingw*"] } {
-diff -Naur binutils-2.30.orig/binutils/testsuite/binutils-all/objcopy.exp binutils-2.30/binutils/testsuite/binutils-all/objcopy.exp
---- binutils-2.30.orig/binutils/testsuite/binutils-all/objcopy.exp	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/testsuite/binutils-all/objcopy.exp	2018-06-13 08:19:13.214763200 +0300
-@@ -554,7 +554,7 @@
- 
- # Build a final executable.
- 
--if { [istarget *-*-cygwin] || [istarget *-*-mingw*] } {
-+if { [istarget *-*-cygwin] || [istarget *-*-mingw*] || [istarget *-*-msys*] } {
-     set test_prog "testprog.exe"
- } else {
-     set test_prog "testprog"
-@@ -661,6 +661,7 @@
- 	setup_xfail "arm*-*-pe"
- 	setup_xfail "*-*-mingw*"
- 	setup_xfail "*-*-cygwin*"
-+	setup_xfail "*-*-msys*"
- 
- 	fail $test1
-     }
-diff -Naur binutils-2.30.orig/binutils/testsuite/binutils-all/windres/windres.exp binutils-2.30/binutils/testsuite/binutils-all/windres/windres.exp
---- binutils-2.30.orig/binutils/testsuite/binutils-all/windres/windres.exp	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/testsuite/binutils-all/windres/windres.exp	2018-06-13 08:19:13.214763200 +0300
-@@ -19,7 +19,7 @@
- 
- # Written by DJ Delorie <dj@redhat.com>
- 
--if {![istarget "i*86-*-*"] && ![istarget "x86_64-*-mingw*"] && ![istarget "x86_64-*-cygwin"] } {
-+if {![istarget "i*86-*-*"] && ![istarget "x86_64-*-mingw*"] && ![istarget "x86_64-*-cygwin"] && ![istarget "x86_64-*-msys"] } {
-     verbose "Not a Cygwin/Mingw target" 1
-     return
- }
-diff -Naur binutils-2.30.orig/binutils/testsuite/lib/binutils-common.exp binutils-2.30/binutils/testsuite/lib/binutils-common.exp
---- binutils-2.30.orig/binutils/testsuite/lib/binutils-common.exp	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/testsuite/lib/binutils-common.exp	2018-06-13 08:19:13.230363200 +0300
-@@ -98,6 +98,7 @@
-     if { [istarget *-*-beospe*]
- 	 || [istarget *-*-cegcc*]
- 	 || [istarget *-*-cygwin*]
-+	 || [istarget *-*-msys*]
- 	 || [istarget *-*-interix*]
- 	 || [istarget *-*-mingw*]
- 	 || [istarget *-*-netbsdpe*]
-diff -Naur binutils-2.30.orig/binutils/testsuite/lib/utils-lib.exp binutils-2.30/binutils/testsuite/lib/utils-lib.exp
---- binutils-2.30.orig/binutils/testsuite/lib/utils-lib.exp	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/binutils/testsuite/lib/utils-lib.exp	2018-06-13 08:19:13.230363200 +0300
-@@ -136,7 +136,7 @@
- #	Returns target executable extension, if any.
- #
- proc exe_ext {} {
--    if { [istarget *-*-mingw*] || [istarget *-*-cygwin*] } {
-+    if { [istarget *-*-mingw*] || [istarget *-*-cygwin*] || [istarget *-*-msys*] } {
-         return ".exe"
-     } else {
-         return ""
-diff -Naur binutils-2.30.orig/compile binutils-2.30/compile
---- binutils-2.30.orig/compile	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/compile	2018-06-13 08:19:13.230363200 +0300
+diff -Naur binutils-2.37-orig/compile binutils-2.37/compile
+--- binutils-2.37-orig/compile	2021-11-30 08:19:41.276294300 +0100
++++ binutils-2.37/compile	2021-11-30 08:56:44.916376000 +0100
 @@ -53,7 +53,7 @@
  	  MINGW*)
  	    file_conv=mingw
@@ -525,16 +441,16 @@ diff -Naur binutils-2.30.orig/compile binutils-2.30/compile
  	  file=`cmd //C echo "$file " | sed -e 's/"\(.*\) " *$/\1/'`
  	  ;;
 -	cygwin/*)
-+	cygwin/* | msys*/)
++	cygwin/* | msys/*)
  	  file=`cygpath -m "$file" || echo "$file"`
  	  ;;
  	wine/*)
-diff -Naur binutils-2.30.orig/config/dfp.m4 binutils-2.30/config/dfp.m4
---- binutils-2.30.orig/config/dfp.m4	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config/dfp.m4	2018-06-13 08:19:13.230363200 +0300
+diff -Naur binutils-2.37-orig/config/dfp.m4 binutils-2.37/config/dfp.m4
+--- binutils-2.37-orig/config/dfp.m4	2021-11-30 08:19:29.512440500 +0100
++++ binutils-2.37/config/dfp.m4	2021-11-30 08:57:18.166527700 +0100
 @@ -23,7 +23,8 @@
      powerpc*-*-linux* | i?86*-*-linux* | x86_64*-*-linux* | s390*-*-linux* | \
-     i?86*-*-elfiamcu | i?86*-*-gnu* | \
+     i?86*-*-elfiamcu | i?86*-*-gnu* | x86_64*-*-gnu* | \
      i?86*-*-mingw* | x86_64*-*-mingw* | \
 -    i?86*-*-cygwin* | x86_64*-*-cygwin*)
 +    i?86*-*-cygwin* | x86_64*-*-cygwin* | \
@@ -542,9 +458,9 @@ diff -Naur binutils-2.30.orig/config/dfp.m4 binutils-2.30/config/dfp.m4
        enable_decimal_float=yes
        ;;
      *)
-diff -Naur binutils-2.30.orig/config/elf.m4 binutils-2.30/config/elf.m4
---- binutils-2.30.orig/config/elf.m4	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config/elf.m4	2018-06-13 08:19:13.230363200 +0300
+diff -Naur binutils-2.37-orig/config/elf.m4 binutils-2.37/config/elf.m4
+--- binutils-2.37-orig/config/elf.m4	2021-11-30 08:19:29.512440500 +0100
++++ binutils-2.37/config/elf.m4	2021-11-30 08:24:01.097546100 +0100
 @@ -15,7 +15,7 @@
  
  target_elf=no
@@ -554,9 +470,9 @@ diff -Naur binutils-2.30.orig/config/elf.m4 binutils-2.30/config/elf.m4
    *-msdosdjgpp* | *-vms* | *-wince* | *-*-pe* | \
    alpha*-dec-osf* | *-interix* | hppa[[12]]*-*-hpux* | \
    nvptx-*-none)
-diff -Naur binutils-2.30.orig/config/lthostflags.m4 binutils-2.30/config/lthostflags.m4
---- binutils-2.30.orig/config/lthostflags.m4	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config/lthostflags.m4	2018-06-13 08:19:13.230363200 +0300
+diff -Naur binutils-2.37-orig/config/lthostflags.m4 binutils-2.37/config/lthostflags.m4
+--- binutils-2.37-orig/config/lthostflags.m4	2021-11-30 08:19:29.512440500 +0100
++++ binutils-2.37/config/lthostflags.m4	2021-11-30 08:24:01.097546100 +0100
 @@ -13,7 +13,7 @@
  AC_REQUIRE([AC_CANONICAL_SYSTEM])
  
@@ -566,9 +482,9 @@ diff -Naur binutils-2.30.orig/config/lthostflags.m4 binutils-2.30/config/lthostf
      # 'host' will be top-level target in the case of a target lib,
      # we must compare to with_cross_host to decide if this is a native
      # or cross-compiler and select where to install dlls appropriately.
-diff -Naur binutils-2.30.orig/config/mmap.m4 binutils-2.30/config/mmap.m4
---- binutils-2.30.orig/config/mmap.m4	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config/mmap.m4	2018-06-13 08:19:13.230363200 +0300
+diff -Naur binutils-2.37-orig/config/mmap.m4 binutils-2.37/config/mmap.m4
+--- binutils-2.37-orig/config/mmap.m4	2021-11-30 08:19:29.543684000 +0100
++++ binutils-2.37/config/mmap.m4	2021-11-30 08:57:58.902485900 +0100
 @@ -42,7 +42,7 @@
     # Systems known to be in this category are Windows (all variants),
     # VMS, and Darwin.
@@ -587,9 +503,9 @@ diff -Naur binutils-2.30.orig/config/mmap.m4 binutils-2.30/config/mmap.m4
          gcc_cv_func_mmap_anon=no ;;
       *)
          gcc_cv_func_mmap_anon=yes;;
-diff -Naur binutils-2.30.orig/config/picflag.m4 binutils-2.30/config/picflag.m4
---- binutils-2.30.orig/config/picflag.m4	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config/picflag.m4	2018-06-13 08:19:13.230363200 +0300
+diff -Naur binutils-2.37-orig/config/picflag.m4 binutils-2.37/config/picflag.m4
+--- binutils-2.37-orig/config/picflag.m4	2021-11-30 08:19:29.512440500 +0100
++++ binutils-2.37/config/picflag.m4	2021-11-30 08:58:39.931459700 +0100
 @@ -25,6 +25,8 @@
  	;;
      i[[34567]]86-*-cygwin* | x86_64-*-cygwin*)
@@ -599,9 +515,9 @@ diff -Naur binutils-2.30.orig/config/picflag.m4 binutils-2.30/config/picflag.m4
      i[[34567]]86-*-mingw* | x86_64-*-mingw*)
  	;;
      i[[34567]]86-*-interix[[3-9]]*)
-diff -Naur binutils-2.30.orig/config/tcl.m4 binutils-2.30/config/tcl.m4
---- binutils-2.30.orig/config/tcl.m4	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config/tcl.m4	2018-06-13 08:19:13.230363200 +0300
+diff -Naur binutils-2.37-orig/config/tcl.m4 binutils-2.37/config/tcl.m4
+--- binutils-2.37-orig/config/tcl.m4	2021-11-30 08:19:29.543684000 +0100
++++ binutils-2.37/config/tcl.m4	2021-11-30 08:59:39.824595800 +0100
 @@ -33,7 +33,7 @@
  
  	    # First check to see if --with-tcl was specified.
@@ -620,22 +536,22 @@ diff -Naur binutils-2.30.orig/config/tcl.m4 binutils-2.30/config/tcl.m4
  		*) platDir="unix" ;;
  	    esac
  	    if test x"${ac_cv_c_tkconfig}" = x ; then
-diff -Naur binutils-2.30.orig/config.guess binutils-2.30/config.guess
---- binutils-2.30.orig/config.guess	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config.guess	2018-06-13 08:22:46.858542000 +0300
-@@ -876,6 +876,9 @@
+diff -Naur binutils-2.37-orig/config.guess binutils-2.37/config.guess
+--- binutils-2.37-orig/config.guess	2021-11-30 08:19:41.254169100 +0100
++++ binutils-2.37/config.guess	2021-11-30 08:20:52.847851300 +0100
+@@ -918,6 +918,9 @@
      amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
- 	echo x86_64-unknown-cygwin
+ 	echo x86_64-pc-cygwin
  	exit ;;
 +    amd64:MSYS*:*:* | x86_64:MSYS*:*:*)
 +	echo x86_64-unknown-msys
 +	exit ;;
      prep*:SunOS:5.*:*)
- 	echo powerpcle-unknown-solaris2`echo ${UNAME_RELEASE}|sed -e 's/[^.]*//'`
+ 	echo powerpcle-unknown-solaris2"$(echo "$UNAME_RELEASE"|sed -e 's/[^.]*//')"
  	exit ;;
-diff -Naur binutils-2.30.orig/config.rpath binutils-2.30/config.rpath
---- binutils-2.30.orig/config.rpath	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/config.rpath	2018-06-13 08:19:13.245963200 +0300
+diff -Naur binutils-2.37-orig/config.rpath binutils-2.37/config.rpath
+--- binutils-2.37-orig/config.rpath	2021-11-30 08:19:41.276294300 +0100
++++ binutils-2.37/config.rpath	2021-11-30 08:21:43.459094300 +0100
 @@ -109,7 +109,7 @@
  hardcode_minus_L=no
  
@@ -672,10 +588,10 @@ diff -Naur binutils-2.30.orig/config.rpath binutils-2.30/config.rpath
      shrext=.dll
      ;;
    darwin* | rhapsody*)
-diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
---- binutils-2.30.orig/configure	2018-01-13 16:43:23.000000000 +0300
-+++ binutils-2.30/configure	2018-06-13 08:24:38.459138200 +0300
-@@ -3037,7 +3037,7 @@
+diff -Naur binutils-2.37-orig/configure binutils-2.37/configure
+--- binutils-2.37-orig/configure	2021-11-30 08:19:41.254169100 +0100
++++ binutils-2.37/configure	2021-11-30 09:02:26.133574100 +0100
+@@ -3090,7 +3090,7 @@
  # Configure extra directories which are host specific
  
  case "${host}" in
@@ -684,7 +600,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
      configdirs="$configdirs libtermcap" ;;
  esac
  
-@@ -3457,7 +3457,7 @@
+@@ -3488,7 +3488,7 @@
  # Disable the go frontend on systems where it is known to not work. Please keep
  # this in sync with contrib/config-list.mk.
  case "${target}" in
@@ -693,7 +609,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
      unsupported_languages="$unsupported_languages go"
      ;;
  esac
-@@ -3470,7 +3470,7 @@
+@@ -3520,7 +3520,7 @@
  	# PR 46986
  	noconfigdirs="$noconfigdirs target-libgo"
  	;;
@@ -702,7 +618,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
  	noconfigdirs="$noconfigdirs target-libgo"
  	;;
      esac
-@@ -3738,7 +3738,7 @@
+@@ -3788,7 +3788,7 @@
    i[3456789]86-*-mingw*)
      target_configdirs="$target_configdirs target-winsup"
      ;;
@@ -711,7 +627,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
      target_configdirs="$target_configdirs target-libtermcap target-winsup"
      noconfigdirs="$noconfigdirs target-libgloss"
      # always build newlib if winsup directory is present.
-@@ -3876,7 +3876,7 @@
+@@ -3936,7 +3936,7 @@
    i[3456789]86-*-msdosdjgpp*)
      host_makefile_frag="config/mh-djgpp"
      ;;
@@ -720,7 +636,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
  
  { $as_echo "$as_me:${as_lineno-$LINENO}: checking to see if cat works as expected" >&5
  $as_echo_n "checking to see if cat works as expected... " >&6; }
-@@ -5994,7 +5994,7 @@
+@@ -6357,7 +6357,7 @@
  
  target_elf=no
  case $target in
@@ -729,7 +645,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
    *-msdosdjgpp* | *-vms* | *-wince* | *-*-pe* | \
    alpha*-dec-osf* | *-interix* | hppa[12]*-*-hpux* | \
    nvptx-*-none)
-@@ -6012,7 +6012,7 @@
+@@ -6375,7 +6375,7 @@
  else
    if test x"$default_enable_lto" = x"yes" ; then
      case $target in
@@ -738,16 +654,16 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
        # On other non-ELF platforms, LTO has yet to be validated.
        *) enable_lto=no ;;
      esac
-@@ -6023,7 +6023,7 @@
+@@ -6386,7 +6386,7 @@
    # warn during gcc/ subconfigure; unless you're bootstrapping with
    # -flto it won't be needed until after installation anyway.
      case $target in
 -      *-cygwin* | *-mingw* | *-apple-darwin* | *djgpp*) ;;
 +      *-cygwin* | *-msys* | *-mingw* | *-apple-darwin* | *djgpp*) ;;
        *) if test x"$enable_lto" = x"yes"; then
- 	as_fn_error "LTO support is not enabled for this target." "$LINENO" 5
+ 	as_fn_error $? "LTO support is not enabled for this target." "$LINENO" 5
          fi
-@@ -6033,7 +6033,7 @@
+@@ -6396,7 +6396,7 @@
    # Among non-ELF, only Windows platforms support the lto-plugin so far.
    # Build it unless LTO was explicitly disabled.
    case $target in
@@ -756,7 +672,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
      *) ;;
    esac
  
-@@ -6997,7 +6997,7 @@
+@@ -7360,7 +7360,7 @@
  case "${host}" in
    *-*-hpux*) RPATH_ENVVAR=SHLIB_PATH ;;
    *-*-darwin*) RPATH_ENVVAR=DYLD_LIBRARY_PATH ;;
@@ -765,7 +681,7 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
    *) RPATH_ENVVAR=LD_LIBRARY_PATH ;;
  esac
  
-@@ -7510,7 +7510,7 @@
+@@ -7894,7 +7894,7 @@
    case " $target_configargs " in
    *" --with-newlib "*)
     case "$target" in
@@ -774,10 +690,10 @@ diff -Naur binutils-2.30.orig/configure binutils-2.30/configure
        FLAGS_FOR_TARGET=$FLAGS_FOR_TARGET' -L$$r/$(TARGET_SUBDIR)/winsup/cygwin -isystem $$s/winsup/cygwin/include'
        ;;
     esac
-diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
---- binutils-2.30.orig/configure.ac	2018-01-27 18:13:40.000000000 +0300
-+++ binutils-2.30/configure.ac	2018-06-13 08:24:00.301471200 +0300
-@@ -403,7 +403,7 @@
+diff -Naur binutils-2.37-orig/configure.ac binutils-2.37/configure.ac
+--- binutils-2.37-orig/configure.ac	2021-11-30 08:19:41.276294300 +0100
++++ binutils-2.37/configure.ac	2021-11-30 09:21:29.929743500 +0100
+@@ -408,7 +408,7 @@
  # Configure extra directories which are host specific
  
  case "${host}" in
@@ -786,7 +702,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
      configdirs="$configdirs libtermcap" ;;
  esac
  
-@@ -788,7 +788,7 @@
+@@ -774,7 +774,7 @@
  # Disable the go frontend on systems where it is known to not work. Please keep
  # this in sync with contrib/config-list.mk.
  case "${target}" in
@@ -795,7 +711,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
      unsupported_languages="$unsupported_languages go"
      ;;
  esac
-@@ -801,7 +801,7 @@
+@@ -803,7 +803,7 @@
  	# PR 46986
  	noconfigdirs="$noconfigdirs target-libgo"
  	;;
@@ -804,7 +720,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
  	noconfigdirs="$noconfigdirs target-libgo"
  	;;
      esac
-@@ -1069,7 +1069,7 @@
+@@ -1071,7 +1071,7 @@
    i[[3456789]]86-*-mingw*)
      target_configdirs="$target_configdirs target-winsup"
      ;;
@@ -813,7 +729,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
      target_configdirs="$target_configdirs target-libtermcap target-winsup"
      noconfigdirs="$noconfigdirs target-libgloss"
      # always build newlib if winsup directory is present.
-@@ -1207,7 +1207,7 @@
+@@ -1219,7 +1219,7 @@
    i[[3456789]]86-*-msdosdjgpp*)
      host_makefile_frag="config/mh-djgpp"
      ;;
@@ -822,7 +738,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
      ACX_CHECK_CYGWIN_CAT_WORKS
      host_makefile_frag="config/mh-cygwin"
      ;;
-@@ -1697,7 +1697,7 @@
+@@ -1782,7 +1782,7 @@
    build_lto_plugin=yes
  ],[if test x"$default_enable_lto" = x"yes" ; then
      case $target in
@@ -831,7 +747,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
        # On other non-ELF platforms, LTO has yet to be validated.
        *) enable_lto=no ;;
      esac
-@@ -1708,7 +1708,7 @@
+@@ -1793,7 +1793,7 @@
    # warn during gcc/ subconfigure; unless you're bootstrapping with
    # -flto it won't be needed until after installation anyway.
      case $target in
@@ -840,7 +756,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
        *) if test x"$enable_lto" = x"yes"; then
  	AC_MSG_ERROR([LTO support is not enabled for this target.])
          fi
-@@ -1718,7 +1718,7 @@
+@@ -1803,7 +1803,7 @@
    # Among non-ELF, only Windows platforms support the lto-plugin so far.
    # Build it unless LTO was explicitly disabled.
    case $target in
@@ -849,7 +765,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
      *) ;;
    esac
  ])
-@@ -2591,7 +2591,7 @@
+@@ -2676,7 +2676,7 @@
  case "${host}" in
    *-*-hpux*) RPATH_ENVVAR=SHLIB_PATH ;;
    *-*-darwin*) RPATH_ENVVAR=DYLD_LIBRARY_PATH ;;
@@ -858,7 +774,7 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
    *) RPATH_ENVVAR=LD_LIBRARY_PATH ;;
  esac
  
-@@ -3099,7 +3099,7 @@
+@@ -3205,7 +3205,7 @@
    case " $target_configargs " in
    *" --with-newlib "*)
     case "$target" in
@@ -867,10 +783,10 @@ diff -Naur binutils-2.30.orig/configure.ac binutils-2.30/configure.ac
        FLAGS_FOR_TARGET=$FLAGS_FOR_TARGET' -L$$r/$(TARGET_SUBDIR)/winsup/cygwin -isystem $$s/winsup/cygwin/include'
        ;;
     esac
-diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
---- binutils-2.30.orig/gas/configure	2018-01-27 17:59:06.000000000 +0300
-+++ binutils-2.30/gas/configure	2018-06-13 08:19:13.277163300 +0300
-@@ -5525,7 +5525,7 @@
+diff -Naur binutils-2.37-orig/gas/configure binutils-2.37/gas/configure
+--- binutils-2.37-orig/gas/configure	2021-11-30 08:19:40.521276400 +0100
++++ binutils-2.37/gas/configure	2021-11-30 08:48:15.234691500 +0100
+@@ -5173,7 +5173,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -879,7 +795,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -5867,7 +5867,7 @@
+@@ -5515,7 +5515,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -888,7 +804,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -6447,7 +6447,7 @@
+@@ -6126,7 +6126,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -897,7 +813,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -8062,7 +8062,7 @@
+@@ -7741,7 +7741,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -906,7 +822,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -8144,7 +8144,7 @@
+@@ -7823,7 +7823,7 @@
        fi
        ;;
  
@@ -915,7 +831,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -8606,7 +8606,7 @@
+@@ -8285,7 +8285,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -924,7 +840,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -8721,7 +8721,7 @@
+@@ -8400,7 +8400,7 @@
        fi
        ;;
  
@@ -933,7 +849,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec='-L$libdir'
-@@ -9152,7 +9152,7 @@
+@@ -8831,7 +8831,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -942,7 +858,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -10053,14 +10053,14 @@
+@@ -9732,14 +9732,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -959,12 +875,12 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -10084,6 +10084,12 @@
+@@ -9763,6 +9763,12 @@
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
 +    msys*)
-+      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      # MSYS DLLs use 'msys-' prefix rather than 'lib'
 +      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
 +
 +      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
@@ -972,7 +888,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -10720,7 +10726,7 @@
+@@ -10389,7 +10395,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -981,7 +897,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
-@@ -13951,7 +13957,7 @@
+@@ -13537,7 +13543,7 @@
  yes)
    LIBM=
  case $host in
@@ -990,7 +906,7 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
    # These system don't have libm, or don't need it
    ;;
  *-ncr-sysv4.3*)
-@@ -14543,7 +14549,7 @@
+@@ -13869,7 +13875,7 @@
  
  
  case "${host}" in
@@ -999,10 +915,10 @@ diff -Naur binutils-2.30.orig/gas/configure binutils-2.30/gas/configure
  
  $as_echo "#define USE_BINARY_FOPEN 1" >>confdefs.h
   ;;
-diff -Naur binutils-2.30.orig/gas/configure.tgt binutils-2.30/gas/configure.tgt
---- binutils-2.30.orig/gas/configure.tgt	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/gas/configure.tgt	2018-06-13 08:19:13.277163300 +0300
-@@ -275,7 +275,7 @@
+diff -Naur binutils-2.37-orig/gas/configure.tgt binutils-2.37/gas/configure.tgt
+--- binutils-2.37-orig/gas/configure.tgt	2021-11-30 08:19:40.536897600 +0100
++++ binutils-2.37/gas/configure.tgt	2021-11-30 09:04:53.758984100 +0100
+@@ -244,7 +244,7 @@
    i386-*-msdos*)			fmt=aout ;;
    i386-*-moss*)				fmt=elf ;;
    i386-*-pe)				fmt=coff em=pe ;;
@@ -1011,10 +927,10 @@ diff -Naur binutils-2.30.orig/gas/configure.tgt binutils-2.30/gas/configure.tgt
     case ${cpu} in
       x86_64*)				fmt=coff em=pep ;;
       i*)				fmt=coff em=pe ;;
-diff -Naur binutils-2.30.orig/gas/testsuite/gas/all/gas.exp binutils-2.30/gas/testsuite/gas/all/gas.exp
---- binutils-2.30.orig/gas/testsuite/gas/all/gas.exp	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/gas/testsuite/gas/all/gas.exp	2018-06-13 08:19:13.277163300 +0300
-@@ -177,8 +177,8 @@
+diff -Naur binutils-2.37-orig/gas/testsuite/gas/all/gas.exp binutils-2.37/gas/testsuite/gas/all/gas.exp
+--- binutils-2.37-orig/gas/testsuite/gas/all/gas.exp	2021-11-30 08:19:40.452296100 +0100
++++ binutils-2.37/gas/testsuite/gas/all/gas.exp	2021-11-30 08:32:41.087032400 +0100
+@@ -173,8 +173,8 @@
  	# failures.
  	setup_xfail "bfin-*-*" "i\[3-7\]86-*-*coff" \
  	    "i\[3-7\]86-*-*pe" "i\[3-7\]86-*-go32*" \
@@ -1025,15 +941,15 @@ diff -Naur binutils-2.30.orig/gas/testsuite/gas/all/gas.exp binutils-2.30/gas/te
  	run_dump_test redef3
  	gas_test_error "redef4.s" "" ".set for symbol already used as label"
  	gas_test_error "redef5.s" "" ".set for symbol already defined through .comm"
-@@ -333,6 +333,7 @@
+@@ -322,6 +322,7 @@
       || [istarget i*86-*-isc*] \
       || [istarget i*86-*-go32*] \
       || [istarget i*86-*-cygwin*] \
 +     || [istarget i*86-*-msys*] \
       || [istarget x86_64-*-mingw*] \
       || [istarget i*86-*-*nt] \
-      || [istarget i*86-*-interix*] \
-@@ -381,6 +382,7 @@
+      || [istarget i*86-*-interix*] } {
+@@ -395,6 +396,7 @@
  
  if {  ([istarget "i*86-*-*pe*"] && ![istarget "i*86-*-openbsd*"]) \
      || [istarget "i*86-*-cygwin*"] \
@@ -1041,31 +957,10 @@ diff -Naur binutils-2.30.orig/gas/testsuite/gas/all/gas.exp binutils-2.30/gas/te
      || [istarget "i*86-*-mingw32*"] } {
    gas_test "fastcall.s" ""   "" "fastcall labels"
  }
-diff -Naur binutils-2.30.orig/gas/testsuite/gas/i386/i386.exp binutils-2.30/gas/testsuite/gas/i386/i386.exp
---- binutils-2.30.orig/gas/testsuite/gas/i386/i386.exp	2018-01-13 16:31:15.000000000 +0300
-+++ binutils-2.30/gas/testsuite/gas/i386/i386.exp	2018-06-13 08:19:13.277163300 +0300
-@@ -510,7 +510,7 @@
- 
-     # This is a PE specific test.
-     if { [istarget "*-*-cygwin*"] || [istarget "*-*-pe"]
--	 || [istarget "*-*-mingw*"]
-+	 || [istarget "*-*-mingw*"] || [istarget "*-*-msys*"]
-     } then {
- 	run_dump_test "secrel"
-     }
-@@ -667,7 +667,7 @@
-     run_dump_test "x86-64-addr32-intel"
-     run_dump_test "x86-64-opcode"
-     run_dump_test "x86-64-intel64"
--    if { ! [istarget "*-*-*cygwin*"] && ![istarget "*-*-mingw*"] } then {
-+    if { ! [istarget "*-*-*cygwin*"] && ![istarget "*-*-mingw*"] && ![istarget "*-*-msys*"] } then {
-       run_dump_test "x86-64-pcrel"
-       run_dump_test "x86-64-disassem"
-     } else {
-diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
---- binutils-2.30.orig/gprof/configure	2018-01-27 18:02:44.000000000 +0300
-+++ binutils-2.30/gprof/configure	2018-06-13 08:19:13.292763300 +0300
-@@ -5440,7 +5440,7 @@
+diff -Naur binutils-2.37-orig/gprof/configure binutils-2.37/gprof/configure
+--- binutils-2.37-orig/gprof/configure	2021-11-30 08:19:40.853224900 +0100
++++ binutils-2.37/gprof/configure	2021-11-30 08:46:42.537482200 +0100
+@@ -5075,7 +5075,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -1074,7 +969,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -5782,7 +5782,7 @@
+@@ -5417,7 +5417,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -1083,7 +978,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -6362,7 +6362,7 @@
+@@ -6028,7 +6028,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -1092,7 +987,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -7977,7 +7977,7 @@
+@@ -7643,7 +7643,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -1101,7 +996,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -8059,7 +8059,7 @@
+@@ -7725,7 +7725,7 @@
        fi
        ;;
  
@@ -1110,7 +1005,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -8521,7 +8521,7 @@
+@@ -8187,7 +8187,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -1119,7 +1014,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -8636,7 +8636,7 @@
+@@ -8302,7 +8302,7 @@
        fi
        ;;
  
@@ -1128,7 +1023,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec='-L$libdir'
-@@ -9067,7 +9067,7 @@
+@@ -8733,7 +8733,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -1137,7 +1032,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -9968,14 +9968,14 @@
+@@ -9634,14 +9634,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -1154,12 +1049,12 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -9999,6 +9999,12 @@
+@@ -9665,6 +9665,12 @@
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
 +    msys*)
-+      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      # MSYS DLLs use 'msys-' prefix rather than 'lib'
 +      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
 +
 +      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
@@ -1167,7 +1062,7 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -10635,7 +10641,7 @@
+@@ -10291,7 +10297,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -1176,10 +1071,22 @@ diff -Naur binutils-2.30.orig/gprof/configure binutils-2.30/gprof/configure
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
-diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
---- binutils-2.30.orig/ld/configure	2018-01-27 18:03:10.000000000 +0300
-+++ binutils-2.30/ld/configure	2018-06-13 08:19:13.292763300 +0300
-@@ -6262,7 +6262,7 @@
+diff -Naur binutils-2.37-orig/intl/configure binutils-2.37/intl/configure
+--- binutils-2.37-orig/intl/configure	2021-11-30 08:19:29.180460000 +0100
++++ binutils-2.37/intl/configure	2021-11-30 09:12:15.714525700 +0100
+@@ -6838,6 +6838,8 @@
+ 	;;
+     i[34567]86-*-cygwin* | x86_64-*-cygwin*)
+ 	;;
++    i[34567]86-*-msys* | x86_64-*-msys*)
++	;;
+     i[34567]86-*-mingw* | x86_64-*-mingw*)
+ 	;;
+     i[34567]86-*-interix[3-9]*)
+diff -Naur binutils-2.37-orig/ld/configure binutils-2.37/ld/configure
+--- binutils-2.37-orig/ld/configure	2021-11-30 08:19:34.423226900 +0100
++++ binutils-2.37/ld/configure	2021-11-30 08:46:47.738991300 +0100
+@@ -5928,7 +5928,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -1188,7 +1095,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -6604,7 +6604,7 @@
+@@ -6270,7 +6270,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -1197,7 +1104,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -7184,7 +7184,7 @@
+@@ -6881,7 +6881,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -1206,7 +1113,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -8800,7 +8800,7 @@
+@@ -8497,7 +8497,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -1215,7 +1122,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -8882,7 +8882,7 @@
+@@ -8579,7 +8579,7 @@
        fi
        ;;
  
@@ -1224,7 +1131,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -9344,7 +9344,7 @@
+@@ -9041,7 +9041,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -1233,7 +1140,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -9459,7 +9459,7 @@
+@@ -9156,7 +9156,7 @@
        fi
        ;;
  
@@ -1242,7 +1149,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec='-L$libdir'
-@@ -9890,7 +9890,7 @@
+@@ -9587,7 +9587,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -1251,7 +1158,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -10791,14 +10791,14 @@
+@@ -10488,14 +10488,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -1268,12 +1175,12 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -10822,6 +10822,12 @@
+@@ -10519,6 +10519,12 @@
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
 +    msys*)
-+      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      # MSYS DLLs use 'msys-' prefix rather than 'lib'
 +      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
 +
 +      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
@@ -1281,7 +1188,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -11458,7 +11464,7 @@
+@@ -11145,7 +11151,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -1290,7 +1197,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
-@@ -12680,7 +12686,7 @@
+@@ -12367,7 +12373,7 @@
          esac
          ;;
  
@@ -1299,7 +1206,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
          # _LT_TAGVAR(hardcode_libdir_flag_spec, CXX) is actually meaningless,
          # as there is no search path for DLLs.
          hardcode_libdir_flag_spec_CXX='-L$libdir'
-@@ -13649,7 +13655,7 @@
+@@ -13336,7 +13342,7 @@
      beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
        # PIC is the default for these OSes.
        ;;
@@ -1308,7 +1215,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -14189,7 +14195,7 @@
+@@ -13876,7 +13882,7 @@
    pw32*)
      export_symbols_cmds_CXX="$ltdll_cmds"
    ;;
@@ -1317,7 +1224,7 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
      export_symbols_cmds_CXX='$NM $libobjs $convenience | $global_symbol_pipe | $SED -e '\''/^[BCDGRS][ ]/s/.*[ ]\([^ ]*\)/\1 DATA/;/^.*[ ]__nm__/s/^.*[ ]__nm__\([^ ]*\)[ ][^ ]*/\1 DATA/;/^I[ ]/d;/^[AITW][ ]/s/.* //'\'' | sort | uniq > $export_symbols'
    ;;
    *)
-@@ -14453,14 +14459,14 @@
+@@ -14140,14 +14146,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -1334,19 +1241,19 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -14483,6 +14489,11 @@
+@@ -14170,6 +14176,11 @@
        soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
  
        ;;
 +    msys*)
-+      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      # MSYS DLLs use 'msys-' prefix rather than 'lib'
 +      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
 +
 +      ;;
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -16995,7 +17006,7 @@
+@@ -16302,7 +16313,7 @@
  
  
  case "${host}" in
@@ -1355,10 +1262,10 @@ diff -Naur binutils-2.30.orig/ld/configure binutils-2.30/ld/configure
  
  $as_echo "#define USE_BINARY_FOPEN 1" >>confdefs.h
   ;;
-diff -Naur binutils-2.30.orig/ld/configure.tgt binutils-2.30/ld/configure.tgt
---- binutils-2.30.orig/ld/configure.tgt	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/configure.tgt	2018-06-13 08:19:13.308363300 +0300
-@@ -388,7 +388,7 @@
+diff -Naur binutils-2.37-orig/ld/configure.tgt binutils-2.37/ld/configure.tgt
+--- binutils-2.37-orig/ld/configure.tgt	2021-11-30 08:19:34.438848400 +0100
++++ binutils-2.37/ld/configure.tgt	2021-11-30 09:22:49.586172000 +0100
+@@ -380,7 +380,7 @@
  i[3-7]86-*-pe)		targ_emul=i386pe ;
  			targ_extra_ofiles="deffilep.o pe-dll.o"
  			;;
@@ -1367,38 +1274,29 @@ diff -Naur binutils-2.30.orig/ld/configure.tgt binutils-2.30/ld/configure.tgt
  			targ_extra_ofiles="deffilep.o pe-dll.o" ;
  			test "$targ" != "$host" && LIB_PATH='${tooldir}/lib/w32api'
  			;;
-@@ -731,7 +731,7 @@
- powerpc-*-macos*)	targ_emul=ppcmacos
- 			targ_extra_ofiles=
- 			;;
--powerpcle-*-pe | powerpcle-*-winnt* | powerpcle-*-cygwin*)
-+powerpcle-*-pe | powerpcle-*-winnt* | powerpcle-*-cygwin* | powerpcle-*-msys*)
- 			targ_emul=ppcpe
- 			targ_extra_ofiles="deffilep.o pe-dll.o"
- 			;;
-@@ -988,7 +988,7 @@
+@@ -992,7 +992,7 @@
  			targ_extra_emuls=i386pe ;
  			targ_extra_ofiles="deffilep.o pep-dll.o pe-dll.o"
  			;;
 -x86_64-*-cygwin)	targ_emul=i386pep ;
-+x86_64-*-cygwin | x86_64-*-msys*)	targ_emul=i386pep ;
++x86_64-*-cygwin | x86_64-*-msys)	targ_emul=i386pep ;
  			targ_extra_emuls=i386pe
  			targ_extra_ofiles="deffilep.o pep-dll.o pe-dll.o"
  			test "$targ" != "$host" && LIB_PATH='${tooldir}/lib/w32api'
 @@ -1075,6 +1075,10 @@
- i[03-9x]86-*-cygwin* | x86_64-*-cygwin*)
    NATIVE_LIB_DIRS='/usr/lib /usr/lib/w32api'
    ;;
-+
+ 
 +i[03-9x]86-*-msys* | x86_64-*-msys*)
 +  NATIVE_LIB_DIRS='/usr/lib /usr/lib/w32api'
 +  ;;
- 
++
  *-*-linux*)
    ;;
-diff -Naur binutils-2.30.orig/ld/emultempl/pe.em binutils-2.30/ld/emultempl/pe.em
---- binutils-2.30.orig/ld/emultempl/pe.em	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/emultempl/pe.em	2018-06-13 08:19:13.308363300 +0300
+ 
+diff -Naur binutils-2.37-orig/ld/emultempl/pe.em binutils-2.37/ld/emultempl/pe.em
+--- binutils-2.37-orig/ld/emultempl/pe.em	2021-11-30 08:19:29.913382800 +0100
++++ binutils-2.37/ld/emultempl/pe.em	2021-11-30 09:07:25.784743500 +0100
 @@ -176,7 +176,7 @@
  # merge_rdata defaults to 0 for cygwin:
  #  http://cygwin.com/ml/cygwin-apps/2013-04/msg00187.html
@@ -1408,9 +1306,9 @@ diff -Naur binutils-2.30.orig/ld/emultempl/pe.em binutils-2.30/ld/emultempl/pe.e
      default_auto_import=1
      default_merge_rdata=0
      ;;
-diff -Naur binutils-2.30.orig/ld/emultempl/pep.em binutils-2.30/ld/emultempl/pep.em
---- binutils-2.30.orig/ld/emultempl/pep.em	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/emultempl/pep.em	2018-06-13 08:19:13.308363300 +0300
+diff -Naur binutils-2.37-orig/ld/emultempl/pep.em binutils-2.37/ld/emultempl/pep.em
+--- binutils-2.37-orig/ld/emultempl/pep.em	2021-11-30 08:19:29.913382800 +0100
++++ binutils-2.37/ld/emultempl/pep.em	2021-11-30 09:08:31.366954100 +0100
 @@ -7,7 +7,7 @@
  fi
  
@@ -1420,10 +1318,10 @@ diff -Naur binutils-2.30.orig/ld/emultempl/pep.em binutils-2.30/ld/emultempl/pep
      move_default_addr_high=1
      ;;
    *)
-diff -Naur binutils-2.30.orig/ld/pe-dll.c binutils-2.30/ld/pe-dll.c
---- binutils-2.30.orig/ld/pe-dll.c	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/pe-dll.c	2018-06-13 08:19:13.308363300 +0300
-@@ -207,6 +207,7 @@
+diff -Naur binutils-2.37-orig/ld/pe-dll.c binutils-2.37/ld/pe-dll.c
+--- binutils-2.37-orig/ld/pe-dll.c	2021-11-30 08:19:34.460975500 +0100
++++ binutils-2.37/ld/pe-dll.c	2021-11-30 09:10:49.291698800 +0100
+@@ -209,6 +209,7 @@
    { STRING_COMMA_LEN ("_NULL_IMPORT_DESCRIPTOR") },
    /* Entry point symbols, and entry hooks.  */
    { STRING_COMMA_LEN ("cygwin_crt0") },
@@ -1431,7 +1329,7 @@ diff -Naur binutils-2.30.orig/ld/pe-dll.c binutils-2.30/ld/pe-dll.c
  #ifdef pe_use_x86_64
    { STRING_COMMA_LEN ("DllMain") },
    { STRING_COMMA_LEN ("DllEntryPoint") },
-@@ -214,6 +215,9 @@
+@@ -216,6 +217,9 @@
    { STRING_COMMA_LEN ("_cygwin_dll_entry") },
    { STRING_COMMA_LEN ("_cygwin_crt0_common") },
    { STRING_COMMA_LEN ("_cygwin_noncygwin_dll_entry") },
@@ -1441,7 +1339,7 @@ diff -Naur binutils-2.30.orig/ld/pe-dll.c binutils-2.30/ld/pe-dll.c
  #else
    { STRING_COMMA_LEN ("DllMain@12") },
    { STRING_COMMA_LEN ("DllEntryPoint@0") },
-@@ -222,6 +226,10 @@
+@@ -224,6 +228,10 @@
    { STRING_COMMA_LEN ("_cygwin_crt0_common@8") },
    { STRING_COMMA_LEN ("_cygwin_noncygwin_dll_entry@12") },
    { STRING_COMMA_LEN ("cygwin_attach_dll") },
@@ -1452,7 +1350,7 @@ diff -Naur binutils-2.30.orig/ld/pe-dll.c binutils-2.30/ld/pe-dll.c
  #endif
    { STRING_COMMA_LEN ("cygwin_premain0") },
    { STRING_COMMA_LEN ("cygwin_premain1") },
-@@ -335,6 +343,7 @@
+@@ -337,6 +345,7 @@
  {
    { STRING_COMMA_LEN ("libcegcc") },
    { STRING_COMMA_LEN ("libcygwin") },
@@ -1460,83 +1358,78 @@ diff -Naur binutils-2.30.orig/ld/pe-dll.c binutils-2.30/ld/pe-dll.c
    { STRING_COMMA_LEN ("libgcc") },
    { STRING_COMMA_LEN ("libgcc_s") },
    { STRING_COMMA_LEN ("libstdc++") },
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-auto-import/auto-import.exp binutils-2.30/ld/testsuite/ld-auto-import/auto-import.exp
---- binutils-2.30.orig/ld/testsuite/ld-auto-import/auto-import.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-auto-import/auto-import.exp	2018-06-13 08:19:13.323963400 +0300
-@@ -56,7 +56,8 @@
- 
- # This test can only be run on a couple of platforms.
- # Square bracket expressions seem to confuse istarget.
--if { ![istarget *-pc-cygwin]    
-+if { ![istarget *-pc-cygwin]   
-+     && ![istarget *-pc-msys]
-      && ![istarget *-pc-mingw*] } {
-     return
+diff -Naur binutils-2.37-orig/ld/testsuite/ld-auto-import/auto-import.exp binutils-2.37/ld/testsuite/ld-auto-import/auto-import.exp
+--- binutils-2.37-orig/ld/testsuite/ld-auto-import/auto-import.exp	2021-11-30 08:19:30.668321600 +0100
++++ binutils-2.37/ld/testsuite/ld-auto-import/auto-import.exp	2021-11-30 08:50:55.788718200 +0100
+@@ -174,3 +174,65 @@
+     	fail $msg
+     }
  }
-@@ -113,17 +114,26 @@
- set tmpdir tmpdir
- set SHCFLAG ""
- 
--if [istarget *-pc-cygwin] {
-+if [istarget *-pc-cygwin || istarget *-pc-msys] {
-     # Set some libs needed for cygwin.
-+    if [istarget *-pc-cygwin] {
-     set MYLIBS "-L/usr/lib -lcygwin -L/usr/lib/w32api -lkernel32"
--    
-+	} else {
-+    set MYLIBS "-L/usr/lib -lmsys-2.0 -L/usr/lib/w32api -lkernel32"
-+	}
 +
-     # Compile the dll.
-     if ![ld_compile "$CC $CFLAGS $SHCFLAG" $srcdir/$subdir/dll.c $tmpdir/dll.o] {
- 	fail "compiling shared lib"
-     }
-+    if [istarget *-pc-cygwin] {
-     if ![ld_special_link "$ld -shared --enable-auto-import -e __cygwin_dll_entry@12 --out-implib=$tmpdir/libstandard.dll.a" $tmpdir/dll.dll "$tmpdir/dll.o $MYLIBS"] {
- 	fail "linking shared lib"
-     }
++if [istarget *-pc-msys] {
++    # Set some libs needed for msys.
++    set MYLIBS "-L/usr/lib -lmsys-2.0 -L/usr/lib/w32api -lkernel32"
++    
++    # Compile the dll.
++    if ![ld_compile "$CC $CFLAGS $SHCFLAG" $srcdir/$subdir/dll.c $tmpdir/dll.o] {
++	fail "compiling shared lib"
++    }
++    if ![ld_special_link "$ld -shared --enable-auto-import -e __cygwin_dll_entry@12 --out-implib=$tmpdir/libstandard.dll.a" $tmpdir/dll.dll "$tmpdir/dll.o $MYLIBS"] {
++	fail "linking shared lib"
++    }
++
++    # Create symbolic link.
++    catch "exec ln -fs dll.dll $tmpdir/libsymlinked_dll.dll.a" ln_catch
++
++    # Compile and link the client program.
++    if ![ld_compile "$CC $CFLAGS $SHCFLAG" $srcdir/$subdir/client.c $tmpdir/client.o] {
++        fail "compiling client"
++    }
++
++    # Check linking with import library.
++    set msg "linking auto-import client using a standard import library"
++    if [ld_special_link $ld $tmpdir/client-linklib.exe "--enable-auto-import --enable-runtime-pseudo-reloc /lib/crt0.o $tmpdir/client.o -L$tmpdir -lstandard $MYLIBS"] {
++	pass $msg
 +    } else {
-+    if ![ld_special_link "$ld -shared --enable-auto-import -e __msys_dll_entry@12 --out-implib=$tmpdir/libstandard.dll.a" $tmpdir/dll.dll "$tmpdir/dll.o $MYLIBS"] {
-+	fail "linking shared lib	
-+	}
- 
-     # Create symbolic link.
-     catch "exec ln -fs dll.dll $tmpdir/libsymlinked_dll.dll.a" ln_catch
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-bootstrap/bootstrap.exp binutils-2.30/ld/testsuite/ld-bootstrap/bootstrap.exp
---- binutils-2.30.orig/ld/testsuite/ld-bootstrap/bootstrap.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-bootstrap/bootstrap.exp	2018-06-13 08:19:13.323963400 +0300
-@@ -126,7 +126,7 @@
- 
-     # On Cygwin, -lintl may require -liconv when linking statically.
-     set extralibs ""
--    if { [istarget "*-*-cygwin*"]} {
-+    if { [istarget "*-*-cygwin*"] || [istarget "*-*-msys*"] } {
- 	if {"$flags" == "--static"} {
- 	    set extralibs "-liconv"
- 	}
-@@ -194,6 +194,7 @@
-     if {[istarget "*-*-pe"]
- 	|| [istarget "*-*-wince"]
- 	|| [istarget "*-*-cygwin*"]
-+	|| [istarget "*-*-msys*"]
- 	|| [istarget "*-*-winnt*"]
- 	|| [istarget "*-*-mingw*"]
- 	|| [istarget "*-*-interix*"]
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-cygwin/exe-export.exp binutils-2.30/ld/testsuite/ld-cygwin/exe-export.exp
---- binutils-2.30.orig/ld/testsuite/ld-cygwin/exe-export.exp	2018-06-13 08:38:48.028433800 +0300
-+++ binutils-2.30/ld/testsuite/ld-cygwin/exe-export.exp	2018-06-13 08:19:13.323963400 +0300
-@@ -23,7 +23,7 @@
- #
-  
- # This test can only be run on a cygwin platforms.
--if {![istarget *-pc-cygwin]} {
-+if {![istarget *-*-cygwin]} && ![istarget *-*-msys*]} {
-     verbose "Not a cygwin target."
-     return
- }
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-fastcall/fastcall.exp binutils-2.30/ld/testsuite/ld-fastcall/fastcall.exp
---- binutils-2.30.orig/ld/testsuite/ld-fastcall/fastcall.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-fastcall/fastcall.exp	2018-06-13 08:19:13.339563400 +0300
++	fail $msg 
++    }
++
++    # Check linking directly with dll.
++    set msg "linking auto-import client using the dll"
++    if [ld_special_link $ld $tmpdir/client-linkdll.exe "--enable-auto-import --enable-runtime-pseudo-reloc /lib/crt0.o $tmpdir/client.o -L$tmpdir -ldll $MYLIBS"] {
++	pass $msg
++    } else {
++	fail $msg 
++    }
++
++    # Check linking with symlinked dll.
++    set msg "linking auto-import client using symbolic linked dll"
++    if [ld_special_link $ld $tmpdir/client-symlinkeddll.exe "--enable-auto-import --enable-runtime-pseudo-reloc /lib/crt0.o $tmpdir/client.o -L$tmpdir -lsymlinked_dll $MYLIBS"] {
++	pass $msg
++    } else {
++	fail $msg 
++    }
++
++    # Check linking with disabled auto-import, this must produce linking error.
++    set msg "linking with disabled auto-import"
++    if ![ld_special_link $ld $tmpdir/client-failed.exe "--disable-auto-import --enable-runtime-pseudo-reloc /lib/crt0.o $tmpdir/client.o -L$tmpdir -ldll $MYLIBS"] {
++	pass $msg
++    } else {
++	fail $msg
++    }
++
++    # Check that the app works - ie that there is output when the applications runs.
++    set msg "application runtime segfault check" 
++    catch "exec $tmpdir/client-linklib.exe" exec_output
++    if ![string match "" $exec_output] then {
++    	pass $msg
++    } else {
++    	fail $msg
++    }
++}
+diff -Naur binutils-2.37-orig/ld/testsuite/ld-fastcall/fastcall.exp binutils-2.37/ld/testsuite/ld-fastcall/fastcall.exp
+--- binutils-2.37-orig/ld/testsuite/ld-fastcall/fastcall.exp	2021-11-30 08:19:30.683943200 +0100
++++ binutils-2.37/ld/testsuite/ld-fastcall/fastcall.exp	2021-11-30 08:34:07.572179100 +0100
 @@ -26,6 +26,7 @@
  
  if {  !([istarget "i*86-*-*pe*"] && ![istarget "i*86-*-opensd*"]) \
@@ -1545,36 +1438,25 @@ diff -Naur binutils-2.30.orig/ld/testsuite/ld-fastcall/fastcall.exp binutils-2.3
      && ![istarget "x86_64-*-mingw*"] \
      && ![istarget "i*86-*-mingw*"] } {
      return
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-pe/export_dynamic_warning.d binutils-2.30/ld/testsuite/ld-pe/export_dynamic_warning.d
---- binutils-2.30.orig/ld/testsuite/ld-pe/export_dynamic_warning.d	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-pe/export_dynamic_warning.d	2018-06-13 08:19:13.339563400 +0300
-@@ -1,5 +1,5 @@
- #name: PE-COFF --export-dynamic warning
--#target: *-*-mingw32 *-*-cygwin *-*-pe
-+#target: *-*-mingw32 *-*-cygwin *-*-msys *-*-pe
- #ld: --export-dynamic
- #warning: warning: --export-dynamic is not supported for PE\+? targets, did you mean --export-all-symbols\?
+diff -Naur binutils-2.37-orig/ld/testsuite/ld-pe/pe-compile.exp binutils-2.37/ld/testsuite/ld-pe/pe-compile.exp
+--- binutils-2.37-orig/ld/testsuite/ld-pe/pe-compile.exp	2021-11-30 08:19:32.434829300 +0100
++++ binutils-2.37/ld/testsuite/ld-pe/pe-compile.exp	2021-11-30 08:34:36.171916500 +0100
+@@ -118,6 +118,7 @@
+ run_ver_script_test "vers-script-4"
  
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-pe/image_size.d binutils-2.30/ld/testsuite/ld-pe/image_size.d
---- binutils-2.30.orig/ld/testsuite/ld-pe/image_size.d	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-pe/image_size.d	2018-06-13 08:19:13.339563400 +0300
-@@ -1,7 +1,7 @@
- #name: PE-COFF SizeOfImage
- #ld: -T image_size.t
- #objdump: -p
--#target: *-*-mingw32 *-*-cygwin
-+#target: *-*-mingw32 *-*-cygwin *-*-msys
- 
- .*:     file format .*
- #...
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-pe/pe.exp binutils-2.30/ld/testsuite/ld-pe/pe.exp
---- binutils-2.30.orig/ld/testsuite/ld-pe/pe.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-pe/pe.exp	2018-06-13 08:19:13.339563400 +0300
+ if {[istarget i*86-*-cygwin*]
++    || [istarget i*86-*-msys*]
+     || [istarget i*86-*-pe]
+     || [istarget i*86-*-mingw*]
+     || [istarget x86_64-*-mingw*] } {
+diff -Naur binutils-2.37-orig/ld/testsuite/ld-pe/pe.exp binutils-2.37/ld/testsuite/ld-pe/pe.exp
+--- binutils-2.37-orig/ld/testsuite/ld-pe/pe.exp	2021-11-30 08:19:32.450451500 +0100
++++ binutils-2.37/ld/testsuite/ld-pe/pe.exp	2021-11-30 08:35:22.773678100 +0100
 @@ -26,6 +26,7 @@
  
  # This test can only be run on PE/COFF platforms that support .secrel32.
  if {[istarget i*86-*-cygwin*]
-+	|| [istarget i*86-*-msys*]
++    || [istarget i*86-*-msys*]
      || [istarget i*86-*-pe]
      || [istarget i*86-*-mingw*]
      || [istarget x86_64-*-mingw*]
@@ -1585,9 +1467,9 @@ diff -Naur binutils-2.30.orig/ld/testsuite/ld-pe/pe.exp binutils-2.30/ld/testsui
 -    } elseif {[istarget i*86-*-cygwin*] } {
 +    } elseif {[istarget i*86-*-cygwin*] || [istarget i*86-*-msys*] } {
        set pe_tests {
- 	{".secrel32" "--disable-auto-import" "" "" {secrel1.s secrel2.s}
+ 	{".secrel32" "--disable-auto-import --disable-reloc-section" "" "" {secrel1.s secrel2.s}
  	 {{objdump -s secrel.d}} "secrel.x"}
-@@ -94,7 +95,7 @@
+@@ -97,7 +98,7 @@
  
  if {[istarget x86_64-*-mingw*] } {
  	run_dump_test "cfi"
@@ -1596,20 +1478,9 @@ diff -Naur binutils-2.30.orig/ld/testsuite/ld-pe/pe.exp binutils-2.30/ld/testsui
  	run_dump_test "cfi32"
  }
  
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-pe/pe-compile.exp binutils-2.30/ld/testsuite/ld-pe/pe-compile.exp
---- binutils-2.30.orig/ld/testsuite/ld-pe/pe-compile.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-pe/pe-compile.exp	2018-06-13 08:19:13.339563400 +0300
-@@ -118,6 +118,7 @@
- run_ver_script_test "vers-script-4"
- 
- if {[istarget i*86-*-cygwin*]
-+    || [istarget i*86-*-msys*]
-     || [istarget i*86-*-pe]
-     || [istarget i*86-*-mingw*]
-     || [istarget x86_64-*-mingw*] } {
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-pe/weakdef-1.d binutils-2.30/ld/testsuite/ld-pe/weakdef-1.d
---- binutils-2.30.orig/ld/testsuite/ld-pe/weakdef-1.d	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-pe/weakdef-1.d	2018-06-13 08:19:13.339563400 +0300
+diff -Naur binutils-2.37-orig/ld/testsuite/ld-pe/weakdef-1.d binutils-2.37/ld/testsuite/ld-pe/weakdef-1.d
+--- binutils-2.37-orig/ld/testsuite/ld-pe/weakdef-1.d	2021-11-30 08:19:32.456972500 +0100
++++ binutils-2.37/ld/testsuite/ld-pe/weakdef-1.d	2021-11-30 08:35:41.993086800 +0100
 @@ -1,5 +1,5 @@
  #source: weakdef-1.s
 -#target: i*86-*-cygwin* i*86-*-pe i*86-*-mingw*
@@ -1617,146 +1488,10 @@ diff -Naur binutils-2.30.orig/ld/testsuite/ld-pe/weakdef-1.d binutils-2.30/ld/te
  #ld: -e _start --gc-sections
  #objdump: -d
  
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-scripts/fill.d binutils-2.30/ld/testsuite/ld-scripts/fill.d
---- binutils-2.30.orig/ld/testsuite/ld-scripts/fill.d	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-scripts/fill.d	2018-06-13 08:19:13.339563400 +0300
-@@ -5,7 +5,7 @@
- #objdump: -s -j .text
- #skip: ia64-*-* mips*-*-freebsd* mips*-*-gnu* mips*-*-irix* mips*-*-kfreebsd*
- #skip: mips*-*-linux* mips*-*-netbsd* mips*-*-openbsd* mips*-*-sysv4*
--#skip: tilegx*-*-* tilepro-*-* x86_64-*-cygwin x86_64-*-mingw* x86_64-*-pe*
-+#skip: tilegx*-*-* tilepro-*-* x86_64-*-cygwin x86_64-*-msys x86_64-*-mingw* x86_64-*-pe*
- #xfail: alpha*-*-*ecoff sh-*-pe sparc*-*-coff
- #xfail: tic30-*-coff tic4x-*-* tic54x-*-* z8k-*-*
- #
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-scripts/pr20302.d binutils-2.30/ld/testsuite/ld-scripts/pr20302.d
---- binutils-2.30.orig/ld/testsuite/ld-scripts/pr20302.d	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-scripts/pr20302.d	2018-06-13 08:19:13.339563400 +0300
-@@ -1,7 +1,7 @@
- #ld: -Tdata=0x1000 -Tdata=0x2000 -Tcross2.t
- #source: align2a.s
- #objdump: -h
--#notarget: *-*-*aout *-*-netbsd *-*-vms ns32k-*-* rx-*-* x86_64-*-cygwin
-+#notarget: *-*-*aout *-*-netbsd *-*-vms ns32k-*-* rx-*-* x86_64-*-cygwin x86_64-*-msys
- # AOUT and NETBSD (ns32k is aout) have fixed address for the data section.
- # VMS targets need extra libraries.
- # RX uses non standard section names.
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-scripts/provide-6.d binutils-2.30/ld/testsuite/ld-scripts/provide-6.d
---- binutils-2.30.orig/ld/testsuite/ld-scripts/provide-6.d	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-scripts/provide-6.d	2018-06-13 08:19:13.339563400 +0300
-@@ -1,7 +1,7 @@
- #source: provide-5.s
- #ld: -T provide-6.t
- #nm: -B
--#xfail: x86_64-*-cygwin
-+#xfail: x86_64-*-cygwin x86_64-*-msys
- 
- #...
- 0+1000 D foo
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-scripts/provide-8.d binutils-2.30/ld/testsuite/ld-scripts/provide-8.d
---- binutils-2.30.orig/ld/testsuite/ld-scripts/provide-8.d	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-scripts/provide-8.d	2018-06-13 08:19:13.339563400 +0300
-@@ -1,7 +1,7 @@
- #source: provide-5.s
- #ld: -T provide-8.t
- #nm: -B
--#xfail: x86_64-*-cygwin mmix-*-* sh-*-pe spu-*-*
-+#xfail: x86_64-*-cygwin x86_64-*-msys mmix-*-* sh-*-pe spu-*-*
- 
- #...
- 0+4000 D __FOO
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-scripts/script.exp binutils-2.30/ld/testsuite/ld-scripts/script.exp
---- binutils-2.30.orig/ld/testsuite/ld-scripts/script.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-scripts/script.exp	2018-06-13 08:19:13.339563400 +0300
-@@ -163,6 +163,10 @@
- 	    pass $testname
- 	    return
- 	}
-+	[a-z]*-*-msys$ {
-+	    pass $testname
-+	    return
-+	}
-     }
- 
-     set extract_syms [run_host_cmd $nm $copyfile]
-@@ -185,6 +189,7 @@
- set flags ""
- if {[istarget "*-*-pe*"] \
-     || [istarget "*-*-cygwin*"] \
-+    || [istarget "*-*-msys*"] \
-     || [istarget "*-*-mingw*"] \
-     || [istarget "*-*-winnt*"] \
-     || [istarget "*-*-nt"] \
-diff -Naur binutils-2.30.orig/ld/testsuite/ld-srec/srec.exp binutils-2.30/ld/testsuite/ld-srec/srec.exp
---- binutils-2.30.orig/ld/testsuite/ld-srec/srec.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/ld-srec/srec.exp	2018-06-13 08:19:13.339563400 +0300
-@@ -407,7 +407,7 @@
- # The S-record linker doesn't support the special PE headers - the PE
- # emulation tries to write pe-specific information to the PE headers
- # in the output bfd, but it's not a PE bfd (it's an srec bfd)
--setup_xfail "*-*-cygwin*" "*-*-mingw*" "*-*-pe*" "*-*-winnt*"
-+setup_xfail "*-*-cygwin*" "*-*-msys*" "*-*-mingw*" "*-*-pe*" "*-*-winnt*"
- setup_xfail "score-*-*"
- 
- # The S-record linker doesn't support Blackfin ELF FDPIC ABI.
-@@ -451,7 +451,7 @@
- setup_xfail "alpha*-*-netbsd*"
- setup_xfail "hppa*-*-*" "mep-*-*"
- setup_xfail "ia64-*-*"
--setup_xfail "*-*-cygwin*" "*-*-mingw*" "*-*-pe*" "*-*-winnt*"
-+setup_xfail "*-*-cygwin*" "*-*-msys*" "*-*-mingw*" "*-*-pe*" "*-*-winnt*"
- setup_xfail "score-*-*"
- setup_xfail "bfin-*-linux-uclibc"
- setup_xfail "tile*-*-*"
-diff -Naur binutils-2.30.orig/ld/testsuite/lib/ld-lib.exp binutils-2.30/ld/testsuite/lib/ld-lib.exp
---- binutils-2.30.orig/ld/testsuite/lib/ld-lib.exp	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ld/testsuite/lib/ld-lib.exp	2018-06-13 08:19:13.339563400 +0300
-@@ -392,7 +392,7 @@
-     }
- 
-     # Windows targets need __main, some prefixed with underscore.
--    if {[istarget *-*-cygwin* ] || [istarget *-*-mingw*]} {
-+    if {[istarget *-*-cygwin* ] || [istarget *-*-mingw*] || [istarget *-*-msys*]} {
-         append flags " --defsym __main=0 --defsym ___main=0"
-     }
- 
-diff -Naur binutils-2.30.orig/libiberty/configure binutils-2.30/libiberty/configure
---- binutils-2.30.orig/libiberty/configure	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/libiberty/configure	2018-06-13 08:19:13.339563400 +0300
-@@ -5110,6 +5110,8 @@
- 	;;
-     i[34567]86-*-cygwin* | x86_64-*-cygwin*)
- 	;;
-+	i[34567]86-*-msys* | x86_64-*-msys*)
-+	;;
-     i[34567]86-*-mingw* | x86_64-*-mingw*)
- 	;;
-     i[34567]86-*-interix[3-9]*)
-@@ -6185,7 +6187,7 @@
- 
- 
- case "${host}" in
--  *-*-cygwin* | *-*-mingw*)
-+  *-*-cygwin* | *-*-msys* | *-*-mingw*)
-     $as_echo "#define HAVE_SYS_ERRLIST 1" >>confdefs.h
- 
-     $as_echo "#define HAVE_SYS_NERR 1" >>confdefs.h
-diff -Naur binutils-2.30.orig/libiberty/configure.ac binutils-2.30/libiberty/configure.ac
---- binutils-2.30.orig/libiberty/configure.ac	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/libiberty/configure.ac	2018-06-13 08:19:13.355163400 +0300
-@@ -550,7 +550,7 @@
- AC_SUBST(target_header_dir)
- 
- case "${host}" in
--  *-*-cygwin* | *-*-mingw*)
-+  *-*-cygwin* | *-*-msys* | *-*-mingw*)
-     AC_DEFINE(HAVE_SYS_ERRLIST)
-     AC_DEFINE(HAVE_SYS_NERR)
-     ;;
-diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
---- binutils-2.30.orig/libtool.m4	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/libtool.m4	2018-06-13 08:19:13.355163400 +0300
-@@ -1491,7 +1491,7 @@
+diff -Naur binutils-2.37-orig/libctf/configure binutils-2.37/libctf/configure
+--- binutils-2.37-orig/libctf/configure	2021-11-30 08:19:29.496823400 +0100
++++ binutils-2.37/libctf/configure	2021-11-30 08:51:35.857766900 +0100
+@@ -6133,7 +6133,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -1765,16 +1500,70 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -1733,7 +1733,7 @@
-     lt_cv_dlopen_libs=
-     ;;
+@@ -6475,7 +6475,7 @@
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
  
--  cygwin*)
-+  cygwin* | msys*)
-     lt_cv_dlopen="dlopen"
-     lt_cv_dlopen_libs=
-     ;;
-@@ -2204,14 +2204,14 @@
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -7086,7 +7086,7 @@
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8671,7 +8671,7 @@
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8753,7 +8753,7 @@
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9215,7 +9215,7 @@
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9330,7 +9330,7 @@
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9761,7 +9761,7 @@
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10662,14 +10662,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -1791,12 +1580,130 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -2235,6 +2235,12 @@
+@@ -10693,6 +10693,12 @@
+ 
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
++    msys*)
++      # MSYS DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
+     mingw* | cegcc*)
+       # MinGW DLLs use traditional 'lib' prefix
+       soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+@@ -11319,7 +11325,7 @@
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+@@ -13434,6 +13440,10 @@
+       SHARED_LDFLAGS="-no-undefined"
+       CTF_LIBADD="$CTF_LIBADD -lcygwin"
+       ;;
++    *-*-msys*)
++      SHARED_LDFLAGS="-no-undefined"
++      CTF_LIBADD="$CTF_LIBADD -lmsys-2.0"
++      ;;
+   esac
+ fi
+ 
+diff -Naur binutils-2.37-orig/libctf/configure.ac binutils-2.37/libctf/configure.ac
+--- binutils-2.37-orig/libctf/configure.ac	2021-11-30 08:19:29.496823400 +0100
++++ binutils-2.37/libctf/configure.ac	2021-11-30 08:51:53.235488400 +0100
+@@ -204,6 +204,10 @@
+       SHARED_LDFLAGS="-no-undefined"
+       CTF_LIBADD="$CTF_LIBADD -lcygwin"
+       ;;
++    *-*-msys*)
++      SHARED_LDFLAGS="-no-undefined"
++      CTF_LIBADD="$CTF_LIBADD -lmsys-2.0"
++      ;;
+   esac
+ fi
+ AC_SUBST(SHARED_LDFLAGS)
+diff -Naur binutils-2.37-orig/libiberty/configure binutils-2.37/libiberty/configure
+--- binutils-2.37-orig/libiberty/configure	2021-11-30 08:19:29.465581600 +0100
++++ binutils-2.37/libiberty/configure	2021-11-30 09:12:30.316655000 +0100
+@@ -5323,6 +5323,8 @@
+ 	;;
+     i[34567]86-*-cygwin* | x86_64-*-cygwin*)
+ 	;;
++    i[34567]86-*-msys* | x86_64-*-msys*)
++	;;
+     i[34567]86-*-mingw* | x86_64-*-mingw*)
+ 	;;
+     i[34567]86-*-interix[3-9]*)
+@@ -6614,7 +6616,7 @@
+ 
+ 
+ case "${host}" in
+-  *-*-cygwin* | *-*-mingw*)
++  *-*-cygwin* | *-*-msys* | *-*-mingw*)
+     $as_echo "#define HAVE_SYS_ERRLIST 1" >>confdefs.h
+ 
+     $as_echo "#define HAVE_SYS_NERR 1" >>confdefs.h
+diff -Naur binutils-2.37-orig/libiberty/configure.ac binutils-2.37/libiberty/configure.ac
+--- binutils-2.37-orig/libiberty/configure.ac	2021-11-30 08:19:29.449952600 +0100
++++ binutils-2.37/libiberty/configure.ac	2021-11-30 08:25:44.351678400 +0100
+@@ -565,7 +565,7 @@
+ AC_SUBST(target_header_dir)
+ 
+ case "${host}" in
+-  *-*-cygwin* | *-*-mingw*)
++  *-*-cygwin* | *-*-msys* | *-*-mingw*)
+     AC_DEFINE(HAVE_SYS_ERRLIST)
+     AC_DEFINE(HAVE_SYS_NERR)
+     ;;
+diff -Naur binutils-2.37-orig/libtool.m4 binutils-2.37/libtool.m4
+--- binutils-2.37-orig/libtool.m4	2021-11-30 08:19:41.269789200 +0100
++++ binutils-2.37/libtool.m4	2021-11-30 08:47:49.966774200 +0100
+@@ -1521,7 +1521,7 @@
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -1763,7 +1763,7 @@
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+@@ -2234,14 +2234,14 @@
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -2265,6 +2265,12 @@
  m4_if([$1], [],[
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"])
        ;;
 +    msys*)
-+      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      # MSYS DLLs use 'msys-' prefix rather than 'lib'
 +      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[[.]]/-/g'`${versuffix}${shared_ext}'
 +m4_if([$1], [],[
 +      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"])
@@ -1804,7 +1711,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[[.]]/-/g'`${versuffix}${shared_ext}'
-@@ -3001,7 +3007,7 @@
+@@ -3021,7 +3027,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -1813,7 +1720,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -3285,7 +3291,7 @@
+@@ -3305,7 +3311,7 @@
  [AC_REQUIRE([AC_CANONICAL_HOST])dnl
  LIBM=
  case $host in
@@ -1822,7 +1729,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
    # These system don't have libm, or don't need it
    ;;
  *-ncr-sysv4.3*)
-@@ -3360,7 +3366,7 @@
+@@ -3380,7 +3386,7 @@
  aix*)
    symcode='[[BCDT]]'
    ;;
@@ -1831,7 +1738,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
    symcode='[[ABCDGISTW]]'
    ;;
  hpux*)
-@@ -3607,7 +3613,7 @@
+@@ -3627,7 +3633,7 @@
      beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
        # PIC is the default for these OSes.
        ;;
@@ -1840,7 +1747,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -3920,7 +3926,7 @@
+@@ -3940,7 +3946,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -1849,7 +1756,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -4003,7 +4009,7 @@
+@@ -4023,7 +4029,7 @@
        fi
        ;;
  
@@ -1858,7 +1765,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        m4_if([$1], [GCJ], [],
-@@ -4236,7 +4242,7 @@
+@@ -4256,7 +4262,7 @@
    pw32*)
      _LT_TAGVAR(export_symbols_cmds, $1)="$ltdll_cmds"
    ;;
@@ -1867,7 +1774,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
      _LT_TAGVAR(export_symbols_cmds, $1)='$NM $libobjs $convenience | $global_symbol_pipe | $SED -e '\''/^[[BCDGRS]][[ ]]/s/.*[[ ]]\([[^ ]]*\)/\1 DATA/;/^.*[[ ]]__nm__/s/^.*[[ ]]__nm__\([[^ ]]*\)[[ ]][[^ ]]*/\1 DATA/;/^I[[ ]]/d;/^[[AITW]][[ ]]/s/.* //'\'' | sort | uniq > $export_symbols'
    ;;
    *)
-@@ -4288,7 +4294,7 @@
+@@ -4308,7 +4314,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -1876,7 +1783,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -4403,7 +4409,7 @@
+@@ -4423,7 +4429,7 @@
        fi
        ;;
  
@@ -1885,7 +1792,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
        # _LT_TAGVAR(hardcode_libdir_flag_spec, $1) is actually meaningless,
        # as there is no search path for DLLs.
        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
-@@ -4776,7 +4782,7 @@
+@@ -4796,7 +4802,7 @@
        _LT_TAGVAR(export_dynamic_flag_spec, $1)=-rdynamic
        ;;
  
@@ -1894,7 +1801,7 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -5720,7 +5726,7 @@
+@@ -5740,7 +5746,7 @@
          esac
          ;;
  
@@ -1903,9 +1810,9 @@ diff -Naur binutils-2.30.orig/libtool.m4 binutils-2.30/libtool.m4
          # _LT_TAGVAR(hardcode_libdir_flag_spec, $1) is actually meaningless,
          # as there is no search path for DLLs.
          _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
-diff -Naur binutils-2.30.orig/ltmain.sh binutils-2.30/ltmain.sh
---- binutils-2.30.orig/ltmain.sh	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ltmain.sh	2018-06-13 08:19:13.355163400 +0300
+diff -Naur binutils-2.37-orig/ltmain.sh binutils-2.37/ltmain.sh
+--- binutils-2.37-orig/ltmain.sh	2021-11-30 08:19:41.254169100 +0100
++++ binutils-2.37/ltmain.sh	2021-11-30 09:24:23.557793900 +0100
 @@ -976,7 +976,7 @@
  
  
@@ -2139,9 +2046,9 @@ diff -Naur binutils-2.30.orig/ltmain.sh binutils-2.30/ltmain.sh
  	      # If a -bindir argument was supplied, place the dll there.
  	      if test "x$bindir" != x ;
  	      then
-diff -Naur binutils-2.30.orig/ltoptions.m4 binutils-2.30/ltoptions.m4
---- binutils-2.30.orig/ltoptions.m4	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/ltoptions.m4	2018-06-13 08:19:13.355163400 +0300
+diff -Naur binutils-2.37-orig/ltoptions.m4 binutils-2.37/ltoptions.m4
+--- binutils-2.37-orig/ltoptions.m4	2021-11-30 08:19:41.276294300 +0100
++++ binutils-2.37/ltoptions.m4	2021-11-30 08:25:44.351678400 +0100
 @@ -126,7 +126,7 @@
  [enable_win32_dll=yes
  
@@ -2151,10 +2058,10 @@ diff -Naur binutils-2.30.orig/ltoptions.m4 binutils-2.30/ltoptions.m4
    AC_CHECK_TOOL(AS, as, false)
    AC_CHECK_TOOL(DLLTOOL, dlltool, false)
    AC_CHECK_TOOL(OBJDUMP, objdump, false)
-diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
---- binutils-2.30.orig/opcodes/configure	2018-01-27 17:58:57.000000000 +0300
-+++ binutils-2.30/opcodes/configure	2018-06-13 08:19:13.355163400 +0300
-@@ -5719,7 +5719,7 @@
+diff -Naur binutils-2.37-orig/opcodes/configure binutils-2.37/opcodes/configure
+--- binutils-2.37-orig/opcodes/configure	2021-11-30 08:19:29.265087000 +0100
++++ binutils-2.37/opcodes/configure	2021-11-30 09:18:26.113892100 +0100
+@@ -5355,7 +5355,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -2163,7 +2070,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -6061,7 +6061,7 @@
+@@ -5697,7 +5697,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -2172,7 +2079,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -6641,7 +6641,7 @@
+@@ -6308,7 +6308,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -2181,7 +2088,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -8226,7 +8226,7 @@
+@@ -7893,7 +7893,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -2190,7 +2097,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -8308,7 +8308,7 @@
+@@ -7975,7 +7975,7 @@
        fi
        ;;
  
@@ -2199,7 +2106,7 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -8770,7 +8770,7 @@
+@@ -8437,7 +8437,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -2208,150 +2115,16 @@ diff -Naur binutils-2.30.orig/opcodes/configure binutils-2.30/opcodes/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -8885,7 +8885,7 @@
-       fi
-       ;;
- 
--    cygwin* | mingw* | pw32* | cegcc*)
-+    cygwin* | msys* | mingw* | pw32* | cegcc*)
-       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
-       # as there is no search path for DLLs.
-       hardcode_libdir_flag_spec='-L$libdir'
-@@ -9316,7 +9316,7 @@
-       export_dynamic_flag_spec=-rdynamic
-       ;;
- 
--    cygwin* | mingw* | pw32* | cegcc*)
-+    cygwin* | msys* | mingw* | pw32* | cegcc*)
-       # When not using gcc, we currently assume that we are using
-       # Microsoft Visual C++.
-       # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -10217,14 +10217,14 @@
-   # libtool to hard-code these into programs
-   ;;
- 
--cygwin* | mingw* | pw32* | cegcc*)
-+cygwin* | msys* | mingw* | pw32* | cegcc*)
-   version_type=windows
-   shrext_cmds=".dll"
-   need_version=no
-   need_lib_prefix=no
- 
-   case $GCC,$host_os in
--  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
-+  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
-     library_names_spec='$libname.dll.a'
-     # DLL is installed to $(libdir)/../bin by postinstall_cmds
-     postinstall_cmds='base_file=`basename \${file}`~
-@@ -10248,6 +10248,12 @@
- 
-       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
-       ;;
-+    msys*)
-+      # Msys DLLs use 'msys-' prefix rather than 'lib'
-+      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-+
-+      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
-+      ;;
-     mingw* | cegcc*)
-       # MinGW DLLs use traditional 'lib' prefix
-       soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -10884,7 +10890,7 @@
-     lt_cv_dlopen_libs=
-     ;;
- 
--  cygwin*)
-+  cygwin* | msys*)
-     lt_cv_dlopen="dlopen"
-     lt_cv_dlopen_libs=
-     ;;
-@@ -12381,7 +12387,7 @@
- 
- LIBM=
- case $host in
--*-*-beos* | *-*-cegcc* | *-*-cygwin* | *-*-haiku* | *-*-pw32* | *-*-darwin*)
-+*-*-beos* | *-*-cegcc* | *-*-cygwin* | *-*-msys* | *-*-haiku* | *-*-pw32* | *-*-darwin*)
-   # These system don't have libm, or don't need it
-   ;;
- *-ncr-sysv4.3*)
-@@ -12551,6 +12557,10 @@
-       SHARED_LDFLAGS="-no-undefined"
-       SHARED_LIBADD="-L`pwd`/../bfd -lbfd -L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lcygwin"
-       ;;
-+    *-*-msys*)
-+      SHARED_LDFLAGS="-no-undefined"
-+      SHARED_LIBADD="-L`pwd`/../bfd -lbfd -L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lmsys-2.0"
-+      ;;
-    *-*-darwin*)
-      SHARED_LIBADD="-Wl,`pwd`/../bfd/.libs/libbfd.dylib ${SHARED_LIBADD}"
-      SHARED_DEPENDENCIES="../bfd/libbfd.la"
-diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
---- binutils-2.30.orig/zlib/configure	2018-01-13 16:31:16.000000000 +0300
-+++ binutils-2.30/zlib/configure	2018-06-13 08:19:13.370763400 +0300
-@@ -4644,7 +4644,7 @@
-     lt_cv_sys_max_cmd_len=-1;
-     ;;
- 
--  cygwin* | mingw* | cegcc*)
-+  cygwin* | msys* | mingw* | cegcc*)
-     # On Win9x/ME, this test blows up -- it succeeds, but takes
-     # about 5 minutes as the teststring grows exponentially.
-     # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -4986,7 +4986,7 @@
-   lt_cv_file_magic_test_file=/shlib/libc.so
-   ;;
- 
--cygwin*)
-+cygwin* | msys*)
-   # func_win32_libid is a shell function defined in ltmain.sh
-   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
-   lt_cv_file_magic_cmd='func_win32_libid'
-@@ -5566,7 +5566,7 @@
- aix*)
-   symcode='[BCDT]'
-   ;;
--cygwin* | mingw* | pw32* | cegcc*)
-+cygwin* | msys* | mingw* | pw32* | cegcc*)
-   symcode='[ABCDGISTW]'
-   ;;
- hpux*)
-@@ -7456,7 +7456,7 @@
-       # PIC is the default for these OSes.
-       ;;
- 
--    mingw* | cygwin* | pw32* | os2* | cegcc*)
-+    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
-       # This hack is so that the source file can tell whether it is being
-       # built for inclusion in a dll (and should export symbols for example).
-       # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -7538,7 +7538,7 @@
-       fi
-       ;;
- 
--    mingw* | cygwin* | pw32* | os2* | cegcc*)
-+    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
-       # This hack is so that the source file can tell whether it is being
-       # built for inclusion in a dll (and should export symbols for example).
-       lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -8000,7 +8000,7 @@
-   extract_expsyms_cmds=
- 
-   case $host_os in
--  cygwin* | mingw* | pw32* | cegcc*)
-+  cygwin* | msys* | mingw* | pw32* | cegcc*)
-     # FIXME: the MSVC++ port hasn't been tested in a loooong time
-     # When not using gcc, we currently assume that we are using
-     # Microsoft Visual C++.
-@@ -8115,7 +8115,7 @@
-       fi
-       ;;
- 
--    cygwin* | mingw* | pw32* | cegcc*)
-+    cygwin* | msys* | mingw* | pw32* | cegcc*)
-       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
-       # as there is no search path for DLLs.
-       hardcode_libdir_flag_spec='-L$libdir'
 @@ -8552,7 +8552,7 @@
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -8983,7 +8983,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -2360,7 +2133,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -9456,14 +9456,14 @@
+@@ -9884,14 +9884,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -2377,7 +2150,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -9487,6 +9487,12 @@
+@@ -9915,6 +9915,12 @@
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
@@ -2390,7 +2163,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -10126,7 +10132,7 @@
+@@ -10541,7 +10547,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -2399,9 +2172,44 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
---- binutils-2.34/libctf/configure.orig	2020-01-18 17:02:31.000000000 +0300
-+++ binutils-2.34/libctf/configure	2020-03-19 20:36:45.535998000 +0300
-@@ -5999,7 +5999,7 @@
+@@ -11956,7 +11962,7 @@
+ 
+ LIBM=
+ case $host in
+-*-*-beos* | *-*-cegcc* | *-*-cygwin* | *-*-haiku* | *-*-pw32* | *-*-darwin*)
++*-*-beos* | *-*-cegcc* | *-*-cygwin* | *-*-msys* | *-*-haiku* | *-*-pw32* | *-*-darwin*)
+   # These system don't have libm, or don't need it
+   ;;
+ *-ncr-sysv4.3*)
+@@ -12132,6 +12138,10 @@
+       SHARED_LDFLAGS="-no-undefined"
+       SHARED_LIBADD="-L`pwd`/../bfd -lbfd -L`pwd`/../libiberty -liberty $SHARED_LIBADD"
+       ;;
++    *-*-msys*)
++      SHARED_LDFLAGS="-no-undefined"
++      SHARED_LIBADD="-L`pwd`/../bfd -lbfd -L`pwd`/../libiberty -liberty $SHARED_LIBADD"
++      ;;
+    *-*-darwin*)
+      SHARED_LIBADD="-Wl,`pwd`/../bfd/.libs/libbfd.dylib ${SHARED_LIBADD}"
+      SHARED_DEPENDENCIES="../bfd/libbfd.la"
+diff -Naur binutils-2.37-orig/opcodes/configure.ac binutils-2.37/opcodes/configure.ac
+--- binutils-2.37-orig/opcodes/configure.ac	2021-11-30 08:19:29.327572400 +0100
++++ binutils-2.37/opcodes/configure.ac	2021-11-30 09:18:57.391348500 +0100
+@@ -193,6 +193,10 @@
+       SHARED_LDFLAGS="-no-undefined"
+       SHARED_LIBADD="-L`pwd`/../bfd -lbfd -L`pwd`/../libiberty -liberty $SHARED_LIBADD"
+       ;;
++    *-*-msys*)
++      SHARED_LDFLAGS="-no-undefined"
++      SHARED_LIBADD="-L`pwd`/../bfd -lbfd -L`pwd`/../libiberty -liberty $SHARED_LIBADD"
++      ;;
+    *-*-darwin*)
+      SHARED_LIBADD="-Wl,`pwd`/../bfd/.libs/libbfd.dylib ${SHARED_LIBADD}"
+      SHARED_DEPENDENCIES="../bfd/libbfd.la"
+diff -Naur binutils-2.37-orig/zlib/configure binutils-2.37/zlib/configure
+--- binutils-2.37-orig/zlib/configure	2021-11-30 08:19:41.456526700 +0100
++++ binutils-2.37/zlib/configure	2021-11-30 08:47:02.475326900 +0100
+@@ -4881,7 +4881,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -2410,7 +2218,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -6341,7 +6341,7 @@
+@@ -5223,7 +5223,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -2419,7 +2227,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -6921,7 +6921,7 @@
+@@ -5834,7 +5834,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -2428,7 +2236,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -8506,7 +8506,7 @@
+@@ -7723,7 +7723,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -2437,7 +2245,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -8588,7 +8588,7 @@
+@@ -7805,7 +7805,7 @@
        fi
        ;;
  
@@ -2446,7 +2254,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -9050,7 +9050,7 @@
+@@ -8267,7 +8267,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -2455,7 +2263,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -9165,7 +9165,7 @@
+@@ -8382,7 +8382,7 @@
        fi
        ;;
  
@@ -2464,7 +2272,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
        # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec='-L$libdir'
-@@ -9596,7 +9596,7 @@
+@@ -8819,7 +8819,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -2473,7 +2281,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -10497,14 +10497,14 @@
+@@ -9723,14 +9723,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -2490,12 +2298,12 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -10528,6 +10528,12 @@
+@@ -9754,6 +9754,12 @@
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
 +    msys*)
-+      # MSYS DLLs use 'cyg' prefix rather than 'lib'
++      # MSYS DLLs use 'msys-' prefix rather than 'lib'
 +      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
 +
 +      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
@@ -2503,7 +2311,7 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -11164,7 +11170,7 @@
+@@ -10383,7 +10389,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -2512,31 +2320,3 @@ diff -Naur binutils-2.30.orig/zlib/configure binutils-2.30/zlib/configure
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
-@@ -13195,6 +13201,12 @@
-       BFD_LIBADD="-L`pwd`/../bfd -lbfd"
-       ;;
- 
-+    *-*-msys*)
-+      SHARED_LDFLAGS="-no-undefined"
-+      SHARED_LIBADD="-L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lmsys-2.0"
-+      BFD_LIBADD="-L`pwd`/../bfd -lbfd"
-+      ;;
-+
-     *-*-darwin*)
-       BFD_LIBADD="-Wl,`pwd`/../bfd/.libs/libbfd.dylib"
-       BFD_DEPENDENCIES="../bfd/libbfd.la"
---- binutils-2.34/libctf/configure.ac.orig	2020-03-19 20:39:09.663478400 +0300
-+++ binutils-2.34/libctf/configure.ac	2020-03-19 20:39:41.375811400 +0300
-@@ -188,6 +188,12 @@
-       BFD_LIBADD="-L`pwd`/../bfd -lbfd"
-       ;;
- 
-+    *-*-msys*)
-+      SHARED_LDFLAGS="-no-undefined"
-+      SHARED_LIBADD="-L`pwd`/../libiberty -liberty -L`pwd`/../intl -lintl -lmsys-2.0"
-+      BFD_LIBADD="-L`pwd`/../bfd -lbfd"
-+      ;;
-+
-     *-*-darwin*)
-       BFD_LIBADD="-Wl,`pwd`/../bfd/.libs/libbfd.dylib"
-       BFD_DEPENDENCIES="../bfd/libbfd.la"

--- a/mingw-w64-cross-binutils/0110-binutils-mingw-gnu-print.patch
+++ b/mingw-w64-cross-binutils/0110-binutils-mingw-gnu-print.patch
@@ -1,8 +1,27 @@
-diff -urN binutils-2.27.orig/bfd/bfd-in.h binutils-2.27/bfd/bfd-in.h
---- binutils-2.27.orig/bfd/bfd-in.h	2016-08-03 09:36:50.000000000 +0200
-+++ binutils-2.27/bfd/bfd-in.h	2016-09-21 21:13:49.177148600 +0200
-@@ -137,7 +137,7 @@
+From 5ee25363627a01704e38cc828e745065982cb3a3 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Wed, 28 Jul 2021 21:47:18 +0200
+Subject: [PATCH] mingw printf
 
+---
+ bfd/bfd-in.h       | 2 +-
+ bfd/bfd-in2.h      | 2 +-
+ binutils/dwarf.c   | 2 +-
+ binutils/nm.c      | 2 +-
+ binutils/prdbg.c   | 2 +-
+ binutils/strings.c | 6 +++---
+ gas/as.h           | 4 ++--
+ gold/configure     | 2 +-
+ gold/configure.ac  | 2 +-
+ include/ansidecl.h | 4 ++--
+ 10 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/bfd/bfd-in.h b/bfd/bfd-in.h
+index a4888f9f7f2..85540462b15 100644
+--- a/bfd/bfd-in.h
++++ b/bfd/bfd-in.h
+@@ -126,7 +126,7 @@ typedef BFD_HOST_U_64_BIT symvalue;
+ 
  #if BFD_HOST_64BIT_LONG
  #define BFD_VMA_FMT "l"
 -#elif defined (__MSVCRT__)
@@ -10,11 +29,12 @@ diff -urN binutils-2.27.orig/bfd/bfd-in.h binutils-2.27/bfd/bfd-in.h
  #define BFD_VMA_FMT "I64"
  #else
  #define BFD_VMA_FMT "ll"
-diff -urN binutils-2.27.orig/bfd/bfd-in2.h binutils-2.27/bfd/bfd-in2.h
---- binutils-2.27.orig/bfd/bfd-in2.h	2016-08-03 09:36:50.000000000 +0200
-+++ binutils-2.27/bfd/bfd-in2.h	2016-09-21 21:13:49.185161800 +0200
-@@ -144,7 +144,7 @@
-
+diff --git a/bfd/bfd-in2.h b/bfd/bfd-in2.h
+index 9a698316980..4a9d597d60e 100644
+--- a/bfd/bfd-in2.h
++++ b/bfd/bfd-in2.h
+@@ -133,7 +133,7 @@ typedef BFD_HOST_U_64_BIT symvalue;
+ 
  #if BFD_HOST_64BIT_LONG
  #define BFD_VMA_FMT "l"
 -#elif defined (__MSVCRT__)
@@ -22,22 +42,24 @@ diff -urN binutils-2.27.orig/bfd/bfd-in2.h binutils-2.27/bfd/bfd-in2.h
  #define BFD_VMA_FMT "I64"
  #else
  #define BFD_VMA_FMT "ll"
-diff -urN binutils-2.27.orig/binutils/dwarf.c binutils-2.27/binutils/dwarf.c
---- binutils-2.27.orig/binutils/dwarf.c	2016-08-03 09:36:51.000000000 +0200
-+++ binutils-2.27/binutils/dwarf.c	2016-09-21 21:13:49.210178100 +0200
-@@ -164,7 +164,7 @@
+diff --git a/binutils/dwarf.c b/binutils/dwarf.c
+index 1e7f4db7b7c..f33de2a649e 100644
+--- a/binutils/dwarf.c
++++ b/binutils/dwarf.c
+@@ -218,7 +218,7 @@ get_encoded_value (unsigned char **pdata,
  }
-
- #if defined HAVE_LONG_LONG && SIZEOF_LONG_LONG > SIZEOF_LONG
+ 
+ #if SIZEOF_LONG_LONG > SIZEOF_LONG
 -# ifndef __MINGW32__
-+#if !defined(__MSVCRT__) || defined(__USE_MINGW_ANSI_STDIO)
++# ifndef __MINGW32__ || defined(__USE_MINGW_ANSI_STDIO)
  #  define DWARF_VMA_FMT		"ll"
  #  define DWARF_VMA_FMT_LONG	"%16.16llx"
  # else
-diff -urN binutils-2.27.orig/binutils/nm.c binutils-2.27/binutils/nm.c
---- binutils-2.27.orig/binutils/nm.c	2016-08-03 09:36:51.000000000 +0200
-+++ binutils-2.27/binutils/nm.c	2016-09-21 21:13:49.221191400 +0200
-@@ -1243,7 +1243,7 @@
+diff --git a/binutils/nm.c b/binutils/nm.c
+index 82ccec6801c..4925ea580dc 100644
+--- a/binutils/nm.c
++++ b/binutils/nm.c
+@@ -1312,7 +1312,7 @@ get_print_format (void)
  #if BFD_HOST_64BIT_LONG
        ;
  #elif BFD_HOST_64BIT_LONG_LONG
@@ -46,10 +68,11 @@ diff -urN binutils-2.27.orig/binutils/nm.c binutils-2.27/binutils/nm.c
        length = "ll";
  #else
        length = "I64";
-diff -urN binutils-2.27.orig/binutils/prdbg.c binutils-2.27/binutils/prdbg.c
---- binutils-2.27.orig/binutils/prdbg.c	2016-08-03 09:36:51.000000000 +0200
-+++ binutils-2.27/binutils/prdbg.c	2016-09-21 21:13:49.229194100 +0200
-@@ -502,7 +502,7 @@
+diff --git a/binutils/prdbg.c b/binutils/prdbg.c
+index 6c14dcac9a8..bedfffa022e 100644
+--- a/binutils/prdbg.c
++++ b/binutils/prdbg.c
+@@ -497,7 +497,7 @@ print_vma (bfd_vma vma, char *buf, bool unsignedp, bool hexp)
  #if BFD_HOST_64BIT_LONG_LONG
    else if (sizeof (vma) <= sizeof (unsigned long long))
      {
@@ -58,62 +81,43 @@ diff -urN binutils-2.27.orig/binutils/prdbg.c binutils-2.27/binutils/prdbg.c
        if (hexp)
  	sprintf (buf, "0x%llx", (unsigned long long) vma);
        else if (unsignedp)
-diff -urN binutils-2.27.orig/binutils/readelf.c binutils-2.27/binutils/readelf.c
---- binutils-2.35/binutils/readelf.c.orig	2020-07-24 11:12:19.000000000 +0200
-+++ binutils-2.35/binutils/readelf.c	2020-08-26 22:30:15.008358800 +0200
-@@ -1274,7 +1274,7 @@
- 		  : "%12.12lx  %12.12lx ",
- 		  offset, inf);
- #elif BFD_HOST_64BIT_LONG_LONG
--#ifndef __MSVCRT__
-+#if !defined(__MSVCRT__) || defined(__USE_MINGW_ANSI_STDIO)
- 	  printf (do_wide
- 		  ? "%16.16llx  %16.16llx "
- 		  : "%12.12llx  %12.12llx ",
-@@ -13927,7 +13927,7 @@
- 	    }
- 	  else
- 	    {
--#ifndef __MSVCRT__
-+#if !defined(__MSVCRT__) || defined(__USE_MINGW_ANSI_STDIO)
- 	      /* PR 11128: Use two separate invocations in order to work
- 		 around bugs in the Solaris 8 implementation of printf.  */
- 	      printf ("  [%6tx]  ", data - start);
-diff -urN binutils-2.27.orig/binutils/strings.c binutils-2.27/binutils/strings.c
---- binutils-2.27.orig/binutils/strings.c	2016-08-03 09:36:51.000000000 +0200
-+++ binutils-2.27/binutils/strings.c	2016-09-21 21:13:49.251195600 +0200
-@@ -613,7 +613,7 @@
- #ifdef HAVE_LONG_LONG
+diff --git a/binutils/strings.c b/binutils/strings.c
+index 44a8e1da644..4010829dc49 100644
+--- a/binutils/strings.c
++++ b/binutils/strings.c
+@@ -610,7 +610,7 @@ print_strings (const char *filename, FILE *stream, file_ptr address,
+ 	  case 8:
  	    if (sizeof (start) > sizeof (long))
  	      {
--# ifndef __MSVCRT__
-+# if !defined(__MSVCRT__) || defined(__USE_MINGW_ANSI_STDIO)
+-#ifndef __MSVCRT__
++#if !defined(__MSVCRT__) || defined(__USE_MINGW_ANSI_STDIO)
  		printf ("%7llo ", (unsigned long long) start);
- # else
+ #else
  		printf ("%7I64o ", (unsigned long long) start);
-@@ -632,7 +632,7 @@
- #ifdef HAVE_LONG_LONG
+@@ -623,7 +623,7 @@ print_strings (const char *filename, FILE *stream, file_ptr address,
+ 	  case 10:
  	    if (sizeof (start) > sizeof (long))
  	      {
--# ifndef __MSVCRT__
+-#ifndef __MSVCRT__
 +#if !defined(__MSVCRT__) || defined(__USE_MINGW_ANSI_STDIO)
  		printf ("%7llu ", (unsigned long long) start);
- # else
+ #else
  		printf ("%7I64d ", (unsigned long long) start);
-@@ -651,7 +651,7 @@
- #ifdef HAVE_LONG_LONG
+@@ -636,7 +636,7 @@ print_strings (const char *filename, FILE *stream, file_ptr address,
+ 	  case 16:
  	    if (sizeof (start) > sizeof (long))
  	      {
--# ifndef __MSVCRT__
-+# if !defined(__MSVCRT__) || defined(__USE_MINGW_ANSI_STDIO)
+-#ifndef __MSVCRT__
++#if !defined(__MSVCRT__) || defined(__USE_MINGW_ANSI_STDIO)
  		printf ("%7llx ", (unsigned long long) start);
- # else
+ #else
  		printf ("%7I64x ", (unsigned long long) start);
-diff -urN binutils-2.27.orig/gas/as.h binutils-2.27/gas/as.h
---- binutils-2.27.orig/gas/as.h	2016-08-03 09:36:51.000000000 +0200
-+++ binutils-2.27/gas/as.h	2016-09-21 21:25:33.955958500 +0200
-@@ -438,10 +438,10 @@
-
+diff --git a/gas/as.h b/gas/as.h
+index 14a768f8889..b1f056f115a 100644
+--- a/gas/as.h
++++ b/gas/as.h
+@@ -405,10 +405,10 @@ typedef struct _pseudo_type pseudo_typeS;
+ 
  #define PRINTF_LIKE(FCN) \
    void FCN (const char *format, ...) \
 -    __attribute__ ((__format__ (__printf__, 1, 2)))
@@ -122,49 +126,40 @@ diff -urN binutils-2.27.orig/gas/as.h binutils-2.27/gas/as.h
    void FCN (const char *file, unsigned int line, const char *format, ...) \
 -    __attribute__ ((__format__ (__printf__, 3, 4)))
 +    __attribute__ ((__format__ (gnu_printf, 3, 4)))
-
+ 
  #else /* __GNUC__ < 2 || defined(VMS) */
-
-diff -urN binutils-2.27.orig/gas/read.c binutils-2.27/gas/read.c
---- binutils-2.27.orig/gas/read.c	2016-08-03 09:36:51.000000000 +0200
-+++ binutils-2.27/gas/read.c	2016-09-21 21:13:49.262196200 +0200
-@@ -4415,7 +4415,7 @@
- 	{
- 	  /* Leading bits contain both 0s & 1s.  */
- #if defined (BFD64) && BFD_HOST_64BIT_LONG_LONG
--#ifndef __MSVCRT__
-+#if !defined(__MSVCRT__) || defined(__USE_MINGW_ANSI_STDIO)
- 	  as_warn (_("value 0x%llx truncated to 0x%llx"),
- 		   (unsigned long long) get, (unsigned long long) use);
- #else
-diff -urN binutils-2.27.orig/gold/configure binutils-2.27/gold/configure
---- binutils-2.27.orig/gold/configure	2016-08-03 09:36:53.000000000 +0200
-+++ binutils-2.27/gold/configure	2016-09-21 21:13:49.306197900 +0200
-@@ -7558,7 +7558,7 @@
+ 
+diff --git a/gold/configure b/gold/configure
+index b9f062b68eb..fde982191c5 100755
+--- a/gold/configure
++++ b/gold/configure
+@@ -10153,7 +10153,7 @@ else
  /* end confdefs.h.  */
-
+ 
  template<typename T> extern void foo(const char*, ...)
 -  __attribute__ ((__format__ (__printf__, 1, 2)));
 +  __attribute__ ((__format__ (gnu_printf, 1, 2)));
  template<typename T> void foo(const char* format, ...) {}
  void bar() { foo<int>("%s\n", "foo"); }
-
-diff -urN binutils-2.27.orig/gold/configure.ac binutils-2.27/gold/configure.ac
---- binutils-2.27.orig/gold/configure.ac	2016-08-03 09:36:53.000000000 +0200
-+++ binutils-2.27/gold/configure.ac	2016-09-21 21:13:49.317584300 +0200
-@@ -635,7 +635,7 @@
+ 
+diff --git a/gold/configure.ac b/gold/configure.ac
+index 1716a779416..cae29866f38 100644
+--- a/gold/configure.ac
++++ b/gold/configure.ac
+@@ -678,7 +678,7 @@ AC_CACHE_CHECK([whether we can use attributes with template functions],
  [gold_cv_template_attribute],
- [AC_COMPILE_IFELSE([
+ [AC_COMPILE_IFELSE([AC_LANG_SOURCE([
  template<typename T> extern void foo(const char*, ...)
 -  __attribute__ ((__format__ (__printf__, 1, 2)));
 +  __attribute__ ((__format__ (gnu_printf, 1, 2)));
  template<typename T> void foo(const char* format, ...) {}
  void bar() { foo<int>("%s\n", "foo"); }
- ], [gold_cv_template_attribute=yes], [gold_cv_template_attribute=no])])
-diff -urN binutils-2.27.orig/include/ansidecl.h binutils-2.27/include/ansidecl.h
---- binutils-2.27.orig/include/ansidecl.h	2016-08-03 09:36:53.000000000 +0200
-+++ binutils-2.27/include/ansidecl.h	2016-09-21 21:13:49.327082000 +0200
-@@ -195,7 +195,7 @@
+ ])], [gold_cv_template_attribute=yes], [gold_cv_template_attribute=no])])
+diff --git a/include/ansidecl.h b/include/ansidecl.h
+index 0515228f325..7c2b9f18306 100644
+--- a/include/ansidecl.h
++++ b/include/ansidecl.h
+@@ -195,7 +195,7 @@ So instead we use the macro below and test it against specific values.  */
     before GCC 3.3, but as of 3.3 we need to add the `nonnull'
     attribute to retain this behavior.  */
  #ifndef ATTRIBUTE_PRINTF
@@ -173,7 +168,7 @@ diff -urN binutils-2.27.orig/include/ansidecl.h binutils-2.27/include/ansidecl.h
  #define ATTRIBUTE_PRINTF_1 ATTRIBUTE_PRINTF(1, 2)
  #define ATTRIBUTE_PRINTF_2 ATTRIBUTE_PRINTF(2, 3)
  #define ATTRIBUTE_PRINTF_3 ATTRIBUTE_PRINTF(3, 4)
-@@ -223,7 +223,7 @@
+@@ -223,7 +223,7 @@ So instead we use the macro below and test it against specific values.  */
     NULL format specifier was allowed as of gcc 3.3.  */
  #ifndef ATTRIBUTE_NULL_PRINTF
  # if (GCC_VERSION >= 3003)
@@ -182,3 +177,5 @@ diff -urN binutils-2.27.orig/include/ansidecl.h binutils-2.27/include/ansidecl.h
  # else
  #  define ATTRIBUTE_NULL_PRINTF(m, n)
  # endif /* GNUC >= 3.3 */
+-- 
+2.32.0

--- a/mingw-w64-cross-binutils/PKGBUILD
+++ b/mingw-w64-cross-binutils/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=binutils
 _mingw_suff=mingw-w64-cross
 pkgname=("${_mingw_suff}-${_realname}")
-pkgver=2.35.1
+pkgver=2.37
 pkgrel=1
 pkgdesc="A set of programs to assemble and manipulate binary and object files"
 arch=('i686' 'x86_64')
@@ -20,17 +20,17 @@ source=(https://ftp.gnu.org/gnu/binutils/binutils-${pkgver}.tar.xz{,.sig}
         0002-check-for-unusual-file-harder.patch
         0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
         0020-binutils_2.31_mkdtemp_impl.patch
-        0100-binutils-2.30-msys2.patch
+        0100-binutils-2.37-msys2.patch
         0110-binutils-mingw-gnu-print.patch
         0120-windres-handle-spaces.patch)
-sha256sums=('3ced91db9bf01182b7e420eab68039f2083aed0a214c0424e257eae3ddee8607'
+sha256sums=('820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c'
             'SKIP'
             '93296b909e1a4f9d8a4bbe2437aafa17ca565ef6642a9812b0360c05be228c9d'
             '2c99345fc575c3a060d6677537f636c6c4154fac0fde508070f3b6296c1060d4'
-            '604e76e0f702ced493ee22aa3c1768b4776b2008a7d70ae0dd35fe5be3522141'
+            '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18'
             '34ba6c001ff7f95ae1da0619c73130112b76d0d2a31bb8a00602eb22f1f84cb8'
-            '21a5f835d8e9c1d7daba1ffb8369fce8e38be05949997c4039b5cb10d8589082'
-            '76658ef1bb8c5fc3fe6c26e2b5dd9ee0f1d12661988c0c65562b0a3e2d32ae1f'
+            '4c5b251beb036814992bc1b6538b5ff49259e073b7cc982e036c76050a866a51'
+            '15fd46de15db03aacff360d15be1ddf2d81092db78aae1eb1e60f6756958745d'
             '86ae90d997e986a54aaebb5251f3a71800b0c5c3f5b57b9094a42995e9f5c478')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
@@ -45,7 +45,7 @@ prepare() {
   patch -p1 -i "${srcdir}"/0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
   patch -p1 -i "${srcdir}"/0020-binutils_2.31_mkdtemp_impl.patch
 
-  patch -p1 -i "${srcdir}"/0100-binutils-2.30-msys2.patch
+  patch -p1 -i "${srcdir}"/0100-binutils-2.37-msys2.patch
   patch -p1 -i "${srcdir}"/0110-binutils-mingw-gnu-print.patch
   patch -p1 -i "${srcdir}"/0120-windres-handle-spaces.patch
 


### PR DESCRIPTION
The building of this package locks for me without this upgrade.
I have not used to package; but, plan to build the rest of these cross mingw packages (not doing the clang ones). I figure if they build then this package works.
See #2807 

Tim S.