### PR TITLE
msys2-runtime: a directory with .lnk suffix is not a .lnk file

### DIFF
--- a/msys2-runtime/0044-path_conv-a-directory-with-.lnk-suffix-is-not-a-.lnk.patch
+++ b/msys2-runtime/0044-path_conv-a-directory-with-.lnk-suffix-is-not-a-.lnk.patch
@@ -1,0 +1,38 @@
+From 7a2c16a75836948e1172e82edee8ea9e571c0c2a Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 17 Jan 2022 17:55:17 +0100
+Subject: [PATCH 44/N] path_conv: a directory with `.lnk` suffix is not a
+ `.lnk` file
+
+When trying to create a directory called `xyz` in the presence of a
+directory `xyz.lnk`, the MSYS2 runtime errors out with an `ENOENT`.
+
+The root cause is actually a bit deeper: the `symlink_info::check()`
+method tries to figure out whether the given path refers to a symbolic
+link as emulated via `.lnk` files, but since it is a directory, that is
+not the case. However, the `fileattr` field is not cleared, so that a
+later `.exists()` call on the instance mistakenly thinks that the
+symlink actually exists.
+
+This fixes https://github.com/msys2/msys2-runtime/issues/81
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/path.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/winsup/cygwin/path.cc b/winsup/cygwin/path.cc
+index 36f15bd..ca65127 100644
+--- a/winsup/cygwin/path.cc
++++ b/winsup/cygwin/path.cc
+@@ -3498,6 +3498,7 @@ restart:
+ 	 hasn't been found. */
+       if (ext_tacked_on && !had_ext && (fileattr & FILE_ATTRIBUTE_DIRECTORY))
+ 	{
++	  fileattr = INVALID_FILE_ATTRIBUTES;
+ 	  set_error (ENOENT);
+ 	  continue;
+ 	}
+-- 
+2.34.1
+

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.3.3
-pkgrel=6
+pkgrel=7
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -67,7 +67,8 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0040-POSIX-ify-the-SHELL-variable.patch
         0041-Handle-ORIGINAL_PATH-just-like-PATH.patch
         0042-fixup-CI-add-a-GHA-for-doing-a-basic-build-test.patch
-        0043-posix_spawn-fix-get-set-uid-gid-calls-for-32-bit-Cyg.patch)
+        0043-posix_spawn-fix-get-set-uid-gid-calls-for-32-bit-Cyg.patch
+        0044-path_conv-a-directory-with-.lnk-suffix-is-not-a-.lnk.patch)
 sha256sums=('SKIP'
             'c933090fc69948f47dc6452fb9913750de9e341fd80534e7099c7a16f8391167'
             'c25197a13a4df28bd34283d830d14d1c091b6517a5f298ce0f50b14fd31b7e8f'
@@ -111,7 +112,8 @@ sha256sums=('SKIP'
             '4db81cd6dcabb23eb7e4b14781ce368021156b9dfc02397dc824407187687fd6'
             '5517535ed08b2d28144311eb871c3d451635788bf7dc0b5ac0ebb66d44939ea9'
             'c20f5238987778a6a46051e6b0c489de8fde7f7428b15bb8254f358b4b70f383'
-            '9dd0bea8906d79fe47c1134a26379b777ca5016be0d01120e6a3d96b319a2f70')
+            '9dd0bea8906d79fe47c1134a26379b777ca5016be0d01120e6a3d96b319a2f70'
+            '0994c0f1bcd1bace12b970ff64be0b6b56a45ed70b06da32d08e85dded841e79')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -191,7 +193,8 @@ prepare() {
   0040-POSIX-ify-the-SHELL-variable.patch \
   0041-Handle-ORIGINAL_PATH-just-like-PATH.patch \
   0042-fixup-CI-add-a-GHA-for-doing-a-basic-build-test.patch \
-  0043-posix_spawn-fix-get-set-uid-gid-calls-for-32-bit-Cyg.patch
+  0043-posix_spawn-fix-get-set-uid-gid-calls-for-32-bit-Cyg.patch \
+  0044-path_conv-a-directory-with-.lnk-suffix-is-not-a-.lnk.patch
 }
 
 build() {


### PR DESCRIPTION
This corresponds to https://github.com/msys2/msys2-runtime/pull/82 and fixes https://github.com/msys2/msys2-runtime/issues/81.