### PR TITLE
filesystem: warn users that Windows 7/8 support is going away

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -4,8 +4,8 @@
 # Contributor: Alethea Rose <alethea@alethearose.com>
 
 pkgname=filesystem
-pkgver=2021.11
-pkgrel=2
+pkgver=2022.01
+pkgrel=1
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -75,7 +75,7 @@ sha256sums=('742a7d66b7a5ebd2b8461728c5b44a46b2305fd2116208eecae5f45828938ea0'
             '6446359419e13310d74ab54086271acc2f4ed0dfe97a474cdd06cd7c55ee59a4'
             '6c0ca979c7b146b3750103b1296a399764f4e1b222ee091d3aa072b6da16c1a5'
             'cbec90c9403826bf6d8dd1fed16240b9d8695ec15df5dcdab7e485bb46c016ab'
-            'd7f787849de5753d7430d7be749d52d785f1e4c59585cf4e4091f8c35f8e85e0'
+            'b5fd2a9fa1c34d49409469aa339551b785d9c3d565b55d2836f05dfc1e114924'
             'ad9873e18169ca87194af3413bdcbda536d9600b4f7d24fa9f7d59928309ff4a'
             'f63241cc56aa7b7ec6962d19991d211b4e1641b78ba5226835118ab493830a8b'
             'e96c1f54ffff792e738aa032815c82c30821b0683806e5ed0ba2a759db2fd494'

--- a/filesystem/profile.000-msys2.sh
+++ b/filesystem/profile.000-msys2.sh
@@ -4,3 +4,21 @@ if [ ! "${MINGW_PREFIX}" = "" ]; then
     XDG_DATA_DIRS="/usr/local/share/:/usr/share/"
     export XDG_DATA_DIRS="$MINGW_PREFIX/share/:$XDG_DATA_DIRS"
 fi
+
+# Warn the user on the first login shell in case we detect a too old Windows version
+function _warn_deprecated_winver()
+{
+    if [ "$__MSYS2_WINDOWS_VERSION_WARNING_DONE" = "true" ]; then
+        return;
+    fi
+    local winver;
+    winver="$(uname -s | sed -ne 's/\([^-]*\)-\([^-]*\).*/\2/p')"
+    if [ "$winver" = "6.1" ] || [ "$winver" = "6.2" ]; then
+        export __MSYS2_WINDOWS_VERSION_WARNING_DONE="true"
+        echo -e "\e[1;33mThe MSYS2 project is planning to drop active support of Windows 7 and 8.0 sometime during 2022.\e[1;0m" 1>&2;
+        echo -e "\e[1;33mFor more information visit https://www.msys2.org/docs/windows_support\e[1;0m" 1>&2;
+    fi
+}
+
+_warn_deprecated_winver;
+unset _warn_deprecated_winver;


### PR DESCRIPTION
This will be shown on a login shell, so the first two lines when
users open a MSYS2 terminal.

![image](https://user-images.githubusercontent.com/991986/151697214-0052752f-f504-4429-a116-4d6d81adaae6.png)

This is the linked website: https://www.msys2.org/docs/windows_support/

~~Maybe I should try set an en var, so it doesn't get shown again on nested login shells.~~ done