### PR TITLE
docbook-xml: install catalogs with http URI

### DIFF
--- a/docbook-xml/PKGBUILD
+++ b/docbook-xml/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=docbook-xml
 pkgver=4.5
-pkgrel=3
+pkgrel=4
 pkgdesc="A widely used XML scheme for writing documentation and help"
 arch=('any')
 url="https://www.oasis-open.org/docbook/"

--- a/docbook-xml/docbook-xml.install
+++ b/docbook-xml/docbook-xml.install
@@ -13,11 +13,11 @@ post_install() {
     "file:///etc/xml/docbook-xml" \
     etc/xml/catalog
   usr/bin/xmlcatalog --noout --add "delegateSystem" \
-    "https://www.oasis-open.org/docbook/" \
+    "http://www.oasis-open.org/docbook/" \
     "file:///etc/xml/docbook-xml" \
     etc/xml/catalog
   usr/bin/xmlcatalog --noout --add "delegateURI" \
-    "https://www.oasis-open.org/docbook/" \
+    "http://www.oasis-open.org/docbook/" \
     "file:///etc/xml/docbook-xml" \
     etc/xml/catalog
 }


### PR DESCRIPTION
It appears an overzealous conversion of http to https inadvertently
changed this, breaking the catalog registration.

Fixes #2834