### PR TITLE
Fix the install script of `docbook-mathml`, too

### DIFF
--- a/docbook-mathml/PKGBUILD
+++ b/docbook-mathml/PKGBUILD
@@ -12,7 +12,7 @@ depends=('libxml2')
 install=docbook-mathml.install
 source=("https://www.docbook.org/xml/mathml/${pkgver}/dbmathml.dtd" 'LICENSE')
 sha256sums=('70da7140035621330f1b5ab6926197c3c3af467f2207d55a41f6396d9ad96abd'
-            '276a366862b4c9f5d3b0f5796d49b09542bb2699f1282c0a15cdbda4cfe725dc')
+            '57645f7ba4189dfc34f16c08b6bbe041ff298b09cdf57c784bab577bf37ecb24')
 
 package() {
   install -D -m644 dbmathml.dtd "${pkgdir}/usr/share/xml/docbook/mathml/${pkgver}/dbmathml.dtd"

--- a/docbook-mathml/PKGBUILD
+++ b/docbook-mathml/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=docbook-mathml
 pkgver=1.1CR1
-pkgrel=1
+pkgrel=2
 pkgdesc="MathML XML scheme"
 arch=('any')
 url="https://www.oasis-open.org/docbook/"

--- a/docbook-mathml/docbook-mathml.install
+++ b/docbook-mathml/docbook-mathml.install
@@ -1,19 +1,19 @@
 post_install() {
   if [ ! -e etc/xml/catalog ]; then
-    xmlcatalog --noout --create etc/xml/catalog
+    usr/bin/xmlcatalog --noout --create etc/xml/catalog
   fi
-  xmlcatalog --noout --add "public" \
+  usr/bin/xmlcatalog --noout --add "public" \
     "-//OASIS//DTD DocBook MathML Module V1.1CR1//EN" \
     "file:///usr/share/xml/docbook/mathml/1.1CR1/dbmathml.dtd" \
     "etc/xml/catalog"
 
-  xmlcatalog --noout --add "system" \
+  usr/bin/xmlcatalog --noout --add "system" \
     "http://www.oasis-open.org/docbook/xml/mathml/1.1CR1/dbmathml.dtd" \
     "file:///usr/share/xml/docbook/mathml/1.1CR1/dbmathml.dtd" \
     "etc/xml/catalog"
 }
 
 post_remove() {
-  xmlcatalog --noout --del "-//OASIS//DTD DocBook MathML Module V1.1CR1//EN" etc/xml/catalog
-  xmlcatalog --noout --del "http://www.oasis-open.org/docbook/xml/mathml/1.1CR1/dbmathml.dtd" etc/xml/catalog
+  usr/bin/xmlcatalog --noout --del "-//OASIS//DTD DocBook MathML Module V1.1CR1//EN" etc/xml/catalog
+  usr/bin/xmlcatalog --noout --del "http://www.oasis-open.org/docbook/xml/mathml/1.1CR1/dbmathml.dtd" etc/xml/catalog
 }

--- a/docbook-mathml/docbook-mathml.install
+++ b/docbook-mathml/docbook-mathml.install
@@ -16,4 +16,4 @@ post_install() {
 post_remove() {
   xmlcatalog --noout --del "-//OASIS//DTD DocBook MathML Module V1.1CR1//EN" etc/xml/catalog
   xmlcatalog --noout --del "http://www.oasis-open.org/docbook/xml/mathml/1.1CR1/dbmathml.dtd" etc/xml/catalog
-    }
+}


### PR DESCRIPTION
This is in the same spirit as https://github.com/msys2/MSYS2-packages/pull/2826 (where I really should have `git grep`ed for similar instances, but forgot).

Note: after this, `docbook/PKGBUILD` still contains calls to `xmlcatalog` without any `/usr/bin/` prefix. This is intentional because the `PATH` should be set correctly when _building_ MSYS packages, anyway (in contrast to the scenario where `.install` is called, i.e. when the packages are _installed_).

So this is the rule: use `usr/bin/xmlcatalog` in the `.install` scripts, and `xmlcatalog` in `PKGBUILD`.