### PR TITLE
autoconf2.69: Add 0006-autoconf2.5-2.69-perl-5.22-autoscan.patch

### DIFF
--- a/autoconf2.69/0006-autoconf2.5-2.69-perl-5.22-autoscan.patch
+++ b/autoconf2.69/0006-autoconf2.5-2.69-perl-5.22-autoscan.patch
@@ -1,0 +1,28 @@
+From e5654a5591884b92633c7785f325626711e7f7aa Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Tue, 29 Jan 2013 13:46:48 -0800
+Subject: [PATCH] autoscan: port to perl 5.17
+
+* bin/autoscan.in (scan_sh_file): Escape '{'.  This avoids a
+feature that is deprecated in Perl 5.17.  Reported by Ray Lauff in
+<http://lists.gnu.org/archive/html/bug-autoconf/2013-01/msg00059.html>.
+---
+ bin/autoscan.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bin/autoscan.in b/bin/autoscan.in
+index 993a750..db1df79 100644
+--- a/bin/autoscan.in
++++ b/bin/autoscan.in
+@@ -358,7 +358,7 @@ sub scan_sh_file ($)
+     {
+       # Strip out comments and variable references.
+       s/#.*//;
+-      s/\${[^\}]*}//g;
++      s/\$\{[^\}]*}//g;
+       s/@[^@]*@//g;
+ 
+       # Tokens in the code.
+-- 
+2.1.0
+

--- a/autoconf2.69/PKGBUILD
+++ b/autoconf2.69/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=autoconf
 pkgname=${_realname}2.69
 pkgver=2.69
-pkgrel=1
+pkgrel=2
 pkgdesc="A GNU tool for automatically configuring source code"
 arch=('any')
 license=('GPL2' 'GPL3' 'custom')
@@ -17,13 +17,15 @@ source=(https://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.xz
         0002-msys2.patch
         0003-autotest-remove-cr-from-prog-stdout-stderr.patch
         0004-docs.patch
-        0005-package.patch)
+        0005-package.patch
+        0006-autoconf2.5-2.69-perl-5.22-autoscan.patch)
 sha256sums=('64ebcec9f8ac5b2487125a86a7760d2591ac9e1d3dbd59489633f9de62a57684'
             'ad42ff57d1ff3dd6ba06fe94f913a369f9210963856e8c955efed9a164609a64'
             '9f31df02eb41df57a05ceea1d1442424d1cca63cd9304c953732fa6c65279a5a'
             '74e2135a3f34f5692a77de85c21cb2f0fd8a1dcf396f7fbba7deb0c59faa54eb'
             'bc973e76f3ea3941818099cb5a22081c8a9703338b3194fce3534a07ac32c078'
-            'a9bd30264a812672bf7fa7b67135871ccac4c84b30113b82ea7c2f5987e0d951')
+            'a9bd30264a812672bf7fa7b67135871ccac4c84b30113b82ea7c2f5987e0d951'
+            'a1b6aafd4f42b244f8234b45132b130f26d5518ce202ca903c747a50f0020617')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -33,6 +35,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0003-autotest-remove-cr-from-prog-stdout-stderr.patch
   patch -p1 -i ${srcdir}/0004-docs.patch
   patch -p1 -i ${srcdir}/0005-package.patch
+  patch -p1 -i ${srcdir}/0006-autoconf2.5-2.69-perl-5.22-autoscan.patch
 }
 
 build() {


### PR DESCRIPTION
This patch was copied from cygwin.

This patch fixes check so it finishes without error.

Tim S.