### PR TITLE
Fix txt2tags dependency and grml-zsh-config empty man pages

### DIFF
--- a/grml-zsh-config/PKGBUILD
+++ b/grml-zsh-config/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Norbert Pfeiler <norbert.pfeiler+aur ät gmail.com>
 
 pkgname=grml-zsh-config
-pkgver=0.19.0
+pkgver=0.19.1
 pkgrel=1
 pkgdesc="grml's zsh setup"
 arch=('any')
@@ -11,7 +11,7 @@ provides=('grmlzshrc')
 depends=('zsh' 'coreutils' 'grep' 'sed' 'procps')
 makedepends=('txt2tags')
 source=("http://deb.grml.org/pool/main/g/grml-etc-core/grml-etc-core_${pkgver}.tar.gz")
-sha256sums=('ab604c71e39fa4f690815b8e47f133757064b88a0f6717aaeb3964f49eac97ee')
+sha256sums=('c8c42d8469116b403b512b7a5ffc680da98f454951fe26a8e04063ce8f7b99ae')
 
 build() {
   cd ${srcdir}/grml-etc-core-${pkgver}/doc

--- a/txt2tags/PKGBUILD
+++ b/txt2tags/PKGBUILD
@@ -8,7 +8,8 @@ pkgdesc='A text formatting and conversion tool.'
 arch=('any')
 url='https://www.txt2tags.org/'
 license=('GPL')
-depends=('python-setuptools')
+depends=('python')
+makedepends=('python-setuptools')
 source=(https://pypi.python.org/packages/source/t/txt2tags/txt2tags-${pkgver}.tar.gz)
 sha256sums=('27969387206d12b4e4a0eb13d0d5dd957d71dbb932451b0dceeab5e3dbb6178a')
 

--- a/txt2tags/PKGBUILD
+++ b/txt2tags/PKGBUILD
@@ -3,13 +3,12 @@
 
 pkgname=txt2tags
 pkgver=3.7
-pkgrel=2
+pkgrel=3
 pkgdesc='A text formatting and conversion tool.'
 arch=('any')
 url='https://www.txt2tags.org/'
 license=('GPL')
-depends=('python')
-makedepends=('python-setuptools')
+depends=('python-setuptools')
 source=(https://pypi.python.org/packages/source/t/txt2tags/txt2tags-${pkgver}.tar.gz)
 sha256sums=('27969387206d12b4e4a0eb13d0d5dd957d71dbb932451b0dceeab5e3dbb6178a')
 


### PR DESCRIPTION
The `/usr/bin/txt2tags` stub uses `pkg_resources` from python-setuptools, which was present on the older build system.
So on CI, without python-setuptools by default, `txt2tags` fails, generating empty man files.
And building grml-zsh-config succeeds even when `txt2tags` fails (I'm working on an upstream PR to address their Makefile, though there's no need here to wait for that).

Arch Community has done [the same thing](https://github.com/archlinux/svntogit-community/commit/29a507d5eb40b48cacba77349a0d17657ff46eed) with txt2tags, maybe for the same reason? I'm mostly python-illiterate, if there's a better way to fix this I'm all ears.

This PR includes a grml-zsh-config update "for free".