### PR TITLE
Enable security keys in OpenSSH

### DIFF
--- a/openssh/PKGBUILD
+++ b/openssh/PKGBUILD
@@ -45,7 +45,6 @@ build() {
     --with-libedit \
     --with-kerberos5=/usr \
     --without-hardening \
-    --disable-security-key \
     --disable-strip
 
   make

--- a/openssh/PKGBUILD
+++ b/openssh/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=openssh
 pkgver=8.8p1
-pkgrel=1
+pkgrel=2
 pkgdesc='Free version of the SSH connectivity tools'
 url='https://www.openssh.com/portable.html'
 license=('custom:BSD')


### PR DESCRIPTION
I'd like to use [openssh-sk-winhello](https://github.com/tavrez/openssh-sk-winhello) with OpenSSH in my MSYS2 environment, but I've found that security keys are disabled in the build.  I can't find any documentation on why this is disabled, and I am able to successfully build OpenSSH and use FIDO2 security keys by removing this flag.

I'm not sure if something else needs to be added to get this in to a current build without changing ssh version, so please help advise me what else is needed to make this PR successful.

Thank you!