### PR TITLE
bash: upgrade to v5.1 patchlevel 16

### DIFF
--- a/bash/PKGBUILD
+++ b/bash/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=bash
 pkgname=('bash' 'bash-devel')
 _basever=5.1
-_patchlevel=008 #prepare for some patches
+_patchlevel=016 #prepare for some patches
 pkgver=${_basever}.${_patchlevel}
 pkgrel=1
 pkgdesc="The GNU Bourne Again shell"
@@ -145,4 +145,20 @@ sha256sums=('cc012bc860406dcf42f64431bcd3d2fa7560c02915a601aba9cd597a39329baa'
             'acfcb8c7e9f73457c0fb12324afb613785e0c9cef3315c9bbab4be702f40393a'
             'SKIP'
             'f22cf3c51a28f084a25aef28950e8777489072628f972b12643b4534a17ed2d1'
+            'SKIP'
+            'e45cda953ab4b4b4bde6dc34d0d8ca40d1cc502046eb28070c9ebcd47e33c3ee'
+            'SKIP'
+            'a2c8d7b2704eeceff7b1503b7ad9500ea1cb6e9393faebdb3acd2afdd7aeae2a'
+            'SKIP'
+            '58191f164934200746f48459a05bca34d1aec1180b08ca2deeee3bb29622027b'
+            'SKIP'
+            '10f189c8367c4a15c7392e7bf70d0ff6953f78c9b312ed7622303a779273ab98'
+            'SKIP'
+            'c7acb66df435d284304c16ca83a5265f9edd9368612095b01a733d45c77ed5ad'
+            'SKIP'
+            '6a4ee0c81b437b96279a792c1efcec4ba56f009195a318083db6b53b096f83d0'
+            'SKIP'
+            '1b37692ef1f6cc3dcec246773443276066e6b1379868f8c14e01f4dfd4df80f0'
+            'SKIP'
+            '8899144f76a5db1fb41a89ed881c9f19add95728dd71db324f772ef225c5384f'
             'SKIP')


### PR DESCRIPTION
This seems to be the latest patch level.