### PR TITLE
filesystem: Improve compatibility of '_warn_deprecated_winver'

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=filesystem
 pkgver=2022.01
-pkgrel=3
+pkgrel=4
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -75,7 +75,7 @@ sha256sums=('742a7d66b7a5ebd2b8461728c5b44a46b2305fd2116208eecae5f45828938ea0'
             '6446359419e13310d74ab54086271acc2f4ed0dfe97a474cdd06cd7c55ee59a4'
             '6c0ca979c7b146b3750103b1296a399764f4e1b222ee091d3aa072b6da16c1a5'
             'cbec90c9403826bf6d8dd1fed16240b9d8695ec15df5dcdab7e485bb46c016ab'
-            'b5fd2a9fa1c34d49409469aa339551b785d9c3d565b55d2836f05dfc1e114924'
+            'd4dea6b907ff85dc55cc93d6089c3123af505e620311fc40b65d92bdb0fae65a'
             'ad9873e18169ca87194af3413bdcbda536d9600b4f7d24fa9f7d59928309ff4a'
             'f63241cc56aa7b7ec6962d19991d211b4e1641b78ba5226835118ab493830a8b'
             'e96c1f54ffff792e738aa032815c82c30821b0683806e5ed0ba2a759db2fd494'

--- a/filesystem/profile.000-msys2.sh
+++ b/filesystem/profile.000-msys2.sh
@@ -6,7 +6,7 @@ if [ ! "${MINGW_PREFIX}" = "" ]; then
 fi
 
 # Warn the user on the first login shell in case we detect a too old Windows version
-function _warn_deprecated_winver()
+_warn_deprecated_winver()
 {
     if [ "$__MSYS2_WINDOWS_VERSION_WARNING_DONE" = "true" ]; then
         return;

--- a/filesystem/profile.000-msys2.sh
+++ b/filesystem/profile.000-msys2.sh
@@ -15,8 +15,9 @@ _warn_deprecated_winver()
     winver="$(uname -s | sed -ne 's/\([^-]*\)-\([^-]*\).*/\2/p')"
     if [ "$winver" = "6.1" ] || [ "$winver" = "6.2" ]; then
         export __MSYS2_WINDOWS_VERSION_WARNING_DONE="true"
-        echo -e "\e[1;33mThe MSYS2 project is planning to drop active support of Windows 7 and 8.0 sometime during 2022.\e[1;0m" 1>&2;
-        echo -e "\e[1;33mFor more information visit https://www.msys2.org/docs/windows_support\e[1;0m" 1>&2;
+        printf "\e[1;33mThe MSYS2 project is planning to drop active support of Windows 7\e[1;0m\n" 1>&2;
+        printf "\e[1;33mand 8.0 sometime during 2022. For more information visit\e[1;0m\n" 1>&2;
+        printf "\e[1;33mhttps://www.msys2.org/docs/windows_support\e[1;0m\n" 1>&2;
     fi
 }
 


### PR DESCRIPTION
'function' causes an error when I execute a shell with 'dash'; removing it seems to restore expected behavior (unable to test the actual function as I don't have win7 or win8)