### PR TITLE
libfido2: fix openssh 8.9 winhello support

### DIFF
--- a/libfido2/0001-Advertise-uv-capability-not-clientPin.patch
+++ b/libfido2/0001-Advertise-uv-capability-not-clientPin.patch
@@ -1,0 +1,32 @@
+From 1259e7e047d5556f5552d4cf0d07c86165629be1 Mon Sep 17 00:00:00 2001
+From: Corinna Vinschen <vinschen@redhat.com>
+Date: Mon, 14 Feb 2022 21:34:46 +0100
+Subject: [PATCH 1/2] Advertise "uv" capability, not "clientPin".
+
+Per the CTAP protocol the "uv" capability indicates that the device is
+capable of verifying the user within itself, while "clientPin" indicates
+that the device is capable of accepting a PIN from the client.  WinHello
+only supports "uv", but not "clientPin", but current libfido2 advertises
+"clientPin", not "uv".  Change this in fido_winhello_get_cbor_info.
+
+Signed-off-by: Corinna Vinschen <vinschen@redhat.com>
+---
+ src/winhello.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/winhello.c b/src/winhello.c
+index 9de6c6c..2fc6a2a 100644
+--- a/src/winhello.c
++++ b/src/winhello.c
+@@ -883,7 +883,7 @@ fido_winhello_get_cbor_info(fido_dev_t *dev, fido_cbor_info_t *ci)
+ 	const char *v[3] = { "U2F_V2", "FIDO_2_0", "FIDO_2_1_PRE" };
+ 	const char *e[2] = { "credProtect", "hmac-secret" };
+ 	const char *t[2] = { "nfc", "usb" };
+-	const char *o[4] = { "rk", "up", "plat", "clientPin" };
++	const char *o[4] = { "rk", "up", "plat", "uv" };
+ 
+ 	(void)dev;
+ 
+-- 
+2.35.1.windows.2
+

--- a/libfido2/0002-winhello-sort-according-to-CTAP2-canonical-CBOR-enco.patch
+++ b/libfido2/0002-winhello-sort-according-to-CTAP2-canonical-CBOR-enco.patch
@@ -1,0 +1,26 @@
+From 0dde44f5f1a398bab333f66d000f5a67e20c6bb5 Mon Sep 17 00:00:00 2001
+From: pedro martelletto <pedro@yubico.com>
+Date: Tue, 15 Feb 2022 10:25:37 +0100
+Subject: [PATCH 2/2] winhello: sort according to CTAP2 canonical CBOR encoding
+ form
+
+---
+ src/winhello.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/winhello.c b/src/winhello.c
+index 2fc6a2a..63dd82c 100644
+--- a/src/winhello.c
++++ b/src/winhello.c
+@@ -883,7 +883,7 @@ fido_winhello_get_cbor_info(fido_dev_t *dev, fido_cbor_info_t *ci)
+ 	const char *v[3] = { "U2F_V2", "FIDO_2_0", "FIDO_2_1_PRE" };
+ 	const char *e[2] = { "credProtect", "hmac-secret" };
+ 	const char *t[2] = { "nfc", "usb" };
+-	const char *o[4] = { "rk", "up", "plat", "uv" };
++	const char *o[4] = { "rk", "up", "uv", "plat" };
+ 
+ 	(void)dev;
+ 
+-- 
+2.35.1.windows.2
+

--- a/libfido2/PKGBUILD
+++ b/libfido2/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=libfido2
 pkgname=("${pkgbase}" "fido2-tools" "${pkgbase}-devel" "${pkgbase}-docs")
 pkgver=1.10.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Library functionality for FIDO 2.0, including communication with a device over USB"
 arch=('i686' 'x86_64')
 url="https://developers.yubico.com/libfido2/"
@@ -11,10 +11,14 @@ license=('BSD-2-Clause')
 depends=("libcbor" "openssl")
 makedepends=("libcbor-devel" "openssl-devel" "cmake" "make" "gcc")
 source=("https://developers.yubico.com/libfido2/Releases/libfido2-${pkgver}.tar.gz"{,.sig}
-        msys2-fix-ln.diff)
+        msys2-fix-ln.diff
+        0001-Advertise-uv-capability-not-clientPin.patch
+        0002-winhello-sort-according-to-CTAP2-canonical-CBOR-enco.patch)
 sha256sums=('526efd3d56af706c05d09f3d21f18ee3b0b15ac0c1f5c5da1acbc27c2730b99b'
             'SKIP'
-            '3134757a26e80eb1917036d4402551fa517e4e0e678c54dcf6c166b714de2bf2')
+            '3134757a26e80eb1917036d4402551fa517e4e0e678c54dcf6c166b714de2bf2'
+            'cc81714f1218d0dff92ba90ae6923d3333a804586281b2d0b39e459881951a93'
+            'a9e63fc85c791ca975bddc24519646c194dbfe66258b8fe38767250bb5f24f37')
 validpgpkeys=(
   'EE90AE0D19774C8386628FAAB428949EF7914718' # pedro martelletto <pedro@yubico.com>
   '1D7308B0055F5AEF36944A8F27A9C24D9588EA0F' # Aveen Ismail <aveen.ismail@yubico.com>
@@ -24,6 +28,8 @@ validpgpkeys=(
 prepare() {
   cd ${pkgname}-${pkgver}
   patch -p1 -i ${srcdir}/msys2-fix-ln.diff
+  patch -p1 -i ${srcdir}/0001-Advertise-uv-capability-not-clientPin.patch
+  patch -p1 -i ${srcdir}/0002-winhello-sort-according-to-CTAP2-canonical-CBOR-enco.patch
 }
 
 build() {


### PR DESCRIPTION
import https://github.com/Yubico/libfido2/commit/1a77c380f1f5910bb7b2cdf3d9e9283a962fa3fd and https://github.com/Yubico/libfido2/commit/977f4687c24c7383c62955d4608f523d17b33dc0 to fix openssh5.9 winhello support
```
debug1: sk_probe: 1 device(s) detected
debug1: sk_probe: selecting sk by cred
debug1: check_sk_options: option uv is on
cbor_decode_assert_authdata: buf=0x800051580, len=37
debug1: main: reply len 111
debug3: ssh_msg_send: type 5
debug3: reap_helper: pid=1362
User presence confirmed
debug3: send packet: type 50
debug3: receive packet: type 52
```