### PR TITLE
git: default to nano instead of vim

### DIFF
--- a/git/PKGBUILD
+++ b/git/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=git
 pkgver=2.35.1
-pkgrel=1
+pkgrel=2
 pkgdesc="The fast distributed version control system"
 arch=('i686' 'x86_64')
 url="https://git-scm.com/"
@@ -14,7 +14,7 @@ depends=('curl'
          'libpcre2_8'
          'libexpat'
          'libintl'
-         'vim'
+         'nano'
          'openssh'
          'openssl'
          'perl-Error'
@@ -106,7 +106,7 @@ build() {
     --sysconfdir=/etc \
     --libexecdir=/usr/lib \
     --with-libpcre2 \
-    --with-editor=vim \
+    --with-editor=nano \
     --htmldir=/usr/share/doc/git/html \
     --mandir=/usr/share/man
 


### PR DESCRIPTION
It's also the default in Ubuntu/Debian, and vim users should be capable
of switching if they want. nano is generally easier to use for beginners.