### PR TITLE
Try to make "git gui" work again

### DIFF
--- a/git/PKGBUILD
+++ b/git/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=git
 pkgver=2.35.1
-pkgrel=2
+pkgrel=3
 pkgdesc="The fast distributed version control system"
 arch=('i686' 'x86_64')
 url="https://git-scm.com/"
@@ -55,14 +55,16 @@ source=("${pkgname}-${pkgver}.tar.gz"::https://github.com/git/git/archive/v${pkg
         git-1.8.4-msys2.patch
         git-2.3.5-mingw-pwd.patch
         git-2.8.2-Cygwin-Allow-DOS-paths.patch
-        git-tcsh-completion-fixes.patch)
+        git-tcsh-completion-fixes.patch
+        git-2.35.1-git-gui.patch)
 sha256sums=('ca2e1824fd084b51b52c71b18c11dc0cadb1eaaed1fdb412f09a2e49e8537eed'
             'e46e64081d1099d0c6835119e5e10cbcbee40df782dcbdee5d7bd2e26a74829e'
             'fd993519beb407c9276f3b209a1139616140d36e575ae91e421fac9a38dcdd91'
             '340d289f8a9d82975b34bd635e8c734c0c8529d5ac1ad9bbc8a77ed752502b02'
-            '887776D3E1319E673879B8A0C121D76A839163DE13DBE1FEC570C3737C6883AB'
+            '887776d3e1319e673879b8a0c121d76a839163de13dbe1fec570c3737c6883ab'
             '905e35e145be34f6affad830155a193d869da4898e46726f36cef2e89c073d23'
-            'b28b3e13de08911f027d19a557967fc21128318a8d6ca74b20b26ee997a9b992')
+            'b28b3e13de08911f027d19a557967fc21128318a8d6ca74b20b26ee997a9b992'
+            'b2b7a8e6128d3208116736c5fbf05cd293a08743e3be90ed0bc50c9f0e4c0433')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -84,6 +86,11 @@ prepare() {
     git-2.3.5-mingw-pwd.patch \
     git-2.8.2-Cygwin-Allow-DOS-paths.patch \
     git-tcsh-completion-fixes.patch
+
+  # https://github.com/gitgitgadget/git/pull/612
+  # hacky variant, since we have no cygwin tcl
+  apply_patch_with_msg \
+    git-2.35.1-git-gui.patch
 
   local _arch=
   if [ "${CARCH}" == 'x86_64' ]; then

--- a/git/git-2.35.1-git-gui.patch
+++ b/git/git-2.35.1-git-gui.patch
@@ -1,0 +1,25 @@
+--- git-2.35.1/git-gui/git-gui.sh.orig	2022-01-29 01:48:42.000000000 +0100
++++ git-2.35.1/git-gui/git-gui.sh	2022-03-12 18:51:13.610007600 +0100
+@@ -51,7 +51,10 @@
+ if { [info exists ::env(GIT_GUI_LIB_DIR) ] } {
+ 	set oguilib $::env(GIT_GUI_LIB_DIR)
+ } else {
+-	set oguilib {@@GITGUI_LIBDIR@@}
++	set oguilib [exec cygpath \
++			--windows \
++			--absolute \
++			{@@GITGUI_LIBDIR@@}]
+ }
+ set oguirel {@@GITGUI_RELATIVE@@}
+ if {$oguirel eq {1}} {
+@@ -274,10 +277,6 @@
+ 				set _iscygwin 0
+ 			} else {
+ 				set _iscygwin 1
+-				# Handle MSys2 which is only cygwin when MSYSTEM is MSYS.
+-				if {[info exists ::env(MSYSTEM)] && $::env(MSYSTEM) ne "MSYS"} {
+-					set _iscygwin 0
+-				}
+ 			}
+ 		} else {
+ 			set _iscygwin 0


### PR DESCRIPTION
based on https://github.com/msys2/MSYS2-packages/pull/1912, some old upstreaming process: https://github.com/gitgitgadget/git/pull/612

In theory the script needs some way to detect a MSYS2 mingw env and special case some
things on top of that in combination with is_Cygwin.

Since we want to keep this diff small, keep it hacky.