### PR TITLE
texi2dvi: backport, fix PATH separator detection to find tex

### DIFF
--- a/texinfo/0006-Msys2-OS-detection-in-texi2dvi.patch
+++ b/texinfo/0006-Msys2-OS-detection-in-texi2dvi.patch
@@ -1,0 +1,33 @@
+From df780e22a5898df4a0f52ceb0ae3579ea7c78646 Mon Sep 17 00:00:00 2001
+From: Gavin Smith <gavinsmith0123@gmail.com>
+Date: Fri, 8 Apr 2022 17:27:00 +0100
+Subject: [PATCH] Msys2 OS detection in texi2dvi
+
+* util/texi2dvi: Do not set MSYSTEM via OSTYPE environment
+variable before calling uname, as this is not working on
+Msys2.  Reverses change on 2015-09-23.  Instead, check the value of
+OSTYPE directly as well as calling uname.
+
+The change was stripped down removing the Changelog update and update
+of texi2dvi version.
+
+diff --git a/util/texi2dvi b/util/texi2dvi
+index 1f42b41907..84ddde517c 100755
+--- a/util/texi2dvi
++++ b/util/texi2dvi
+@@ -80,12 +80,9 @@ IFS="$space$tab$newline"
+ # directories in TEXINPUTS -- except for Cygwin and Msys, where COMSPEC
+ # might be inherited, but : is used.
+ 
+-# In the case of Msys, uname returns a value derived from MSYSTEM, as
+-# MSYSTEM is user configurable, it is not so safe to use it to detect
+-# Msys. It is safer to use OSTYPE, this is why we set MSYSTEM to
+-# $OSTYPE before calling uname
+ if test -n "$COMSPEC$ComSpec" \
+-   && MSYSTEM=$OSTYPE uname | $EGREP -iv 'cygwin|msys' >/dev/null; then
++   && uname | $EGREP -iv 'cygwin|msys' >/dev/null \
++   && test "$OSTYPE" != msys ; then
+   path_sep=";"
+ else
+   path_sep=":"
+

--- a/texinfo/PKGBUILD
+++ b/texinfo/PKGBUILD
@@ -16,6 +16,7 @@ source=(https://ftp.gnu.org/pub/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz{,.sig
         0002-manifest.all.patch
         0004-no-w32-stuff.msys2.patch
         0005-fix-makeinfo-exeext.msys2.patch
+        0006-Msys2-OS-detection-in-texi2dvi.patch
         gnulib-weak.patch)
 sha256sums=('8eb753ed28bca21f8f56c1a180362aed789229bd62fff58bf8368e9beb59fec4'
             'SKIP'
@@ -26,6 +27,7 @@ sha256sums=('8eb753ed28bca21f8f56c1a180362aed789229bd62fff58bf8368e9beb59fec4'
             'db2c67546da5f11dc8e374dbf70269227a0df15045dc3456f7a9e74c353083d5'
             'ccf696f2777ebd2c85c4cb311a4735957ffa40952ecbe50c7031b9f05dc6cdee'
             'e5b18f11d9a5d99f96f9228266e6204cfb2e076e2d9c336db0eceb72e2252873'
+            '85e2d04de8352c41b0b7b7df1905e17db1de9b1e058a1300eb97b7e006d05f1a'
             '511f2e0dd18244f59ea77985065be585ed572ff6ee9d7357305c64dd4821d062')
 validpgpkeys=('EAF669B31E31E1DECBD11513DDBC579DAB37FBA9') # Gavin Smith
 
@@ -36,6 +38,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0002-manifest.all.patch
   patch -p1 -i ${srcdir}/0004-no-w32-stuff.msys2.patch
   patch -p1 -i ${srcdir}/0005-fix-makeinfo-exeext.msys2.patch
+  patch -p1 -i ${srcdir}/0006-Msys2-OS-detection-in-texi2dvi.patch
   patch -p1 -i ${srcdir}/gnulib-weak.patch
 
   autoreconf -fiv


### PR DESCRIPTION
Without this fix, texi2dvi does not find tex on PATH, because it incorrectly detects the PATH separator. This is a backport of an upstream fix.

More at

https://github.com/msys2/MSYS2-packages/issues/2901
https://lists.gnu.org/archive/html/bug-texinfo/2022-04/msg00002.html