### PR TITLE
Update fish to 3.4.1

### DIFF
--- a/fish/PKGBUILD
+++ b/fish/PKGBUILD
@@ -1,8 +1,8 @@
 pkgname=fish
-pkgver=3.3.1
+pkgver=3.4.1
 pkgrel=1
 epoch=
-pkgdesc="a smart and user-friendly command line shell"
+pkgdesc='Smart and user friendly shell intended mostly for interactive use'
 arch=('i686' 'x86_64')
 url="https://fishshell.com/"
 license=('GPL2')
@@ -18,8 +18,8 @@ source=("https://github.com/fish-shell/fish-shell/releases/download/${pkgver}/${
         msystem.fish
         perlbin.fish)
         
-sha512sums=('fc50ca44fab3f2d942284d4f714150f7ccf1e49c73da36f8d4ae4a33a9b3280f98bed15848839f5d443b4274fd0ff90174bafa6a8e9a4da226dda63d7766a660'
-'1757ef4c93b302fe86f669d3549884d9e6f265b45be1945ec1c7551d2d0489b5f51dfe5c288f5b415f905f0ad1d9d0d1d304f08682459b171ac72a293651cc8a'
+sha512sums=('20a2892ec0c413c4c3fcfe5fbf52fb2398de35a9172758728bd2ccdccc5fb6e0e18712a664d02db67543d47180a4d04f3998a6297d23088926b6d03baefdf981'
+'6b0e8ca814a69f11609d7b185048246ea6f745436d6a49760fb280c1ea1018b40dfb4791d6a5390bb4711e4c128d8e1f2a63815b551c1d3d4846281826e1a137'
 '817195e2a6cdec1791b96666ee95f87f76569048268645a947f9283f711906fd3f2f5f1a4908b2b1edc0b9742215e0ac1c1cdaf10f9ec50d38b115fc05ae44b7'
 '81d0a0b436a5a9dd2973e0de932833605c9f3fc57cc71ba32a15856e29b5192fa8ab450bb17d6f53636c8724327901a2d8ecd72fecb4afe120c258dcc581129d'
 '13c512b5ea02bab2b81a502b0285c4c8b9654a45534138c71f079035d6cb90e39d960404ac111eb287ae7391ee6388ac3d97ed943961c8380066a9b2856ea307'
@@ -30,6 +30,7 @@ validpgpkeys=('003837986104878835FA516D7A67D962D88A709A') # David Adam <zanchey@
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
+  export CXXFLAGS+=" ${CPPFLAGS}"
   cmake \
     -B build \
     -DCMAKE_INSTALL_PREFIX=/usr \


### PR DESCRIPTION
This PR updates the PKGBUILD to build the latest release of `fish-shell` - `3.4.1`.

- Built and tested on a personal machine, works as expected. No issues encountered so far.
- PKGBUILD is based on Arch Linux `fish` https://github.com/archlinux/svntogit-community/blob/packages/fish/trunk/PKGBUILD