### PR TITLE
file: drop the text based magic DBs

### DIFF
--- a/file/PKGBUILD
+++ b/file/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=file
 pkgver=5.41
-pkgrel=3
+pkgrel=4
 pkgdesc="File type identification utility"
 arch=('i686' 'x86_64')
 license=('custom')
@@ -42,12 +42,6 @@ package() {
   install -Dm644 COPYING ${pkgdir}/usr/share/licenses/${pkgname}/COPYING
 
   PYTHON_SITELIB=$(/usr/bin/python -c 'from distutils.sysconfig import * ; print(get_python_lib(0,0));')
-
   mkdir -p ${pkgdir}/${PYTHON_SITELIB}
   cp -f ${srcdir}/${pkgname}-${pkgver}/python/magic.py ${pkgdir}/$PYTHON_SITELIB
-
-  cat ${srcdir}/${pkgname}-${pkgver}/magic/Magdir/* > ${pkgdir}/usr/share/misc/magic
-  cp -rf ${pkgdir}/usr/share/misc/magic ${pkgdir}/usr/share/magic
-  mkdir -p ${pkgdir}/usr/share/file
-  cp -rf ${pkgdir}/usr/share/magic ${pkgdir}/usr/share/file/magic
 }


### PR DESCRIPTION
We have three copies of this in the package, but
neither Arch, nor Debian ship them in their package.

Let's just drop them.

This was copied from cygwin, which copied from Fedora:
https://cygwin.com/git-cygwin-packages/?p=git/cygwin-packages/file.git;a=blob;f=file.cygport;h=803ce6b422d4ef316ec25f6587725720bb078f79;hb=HEAD
but it's not clear why it is needed.