### PR TITLE
u-boot-tools: Update to v2022.04

### DIFF
--- a/u-boot-tools/PKGBUILD
+++ b/u-boot-tools/PKGBUILD
@@ -1,17 +1,17 @@
 # Maintainer: Bin Meng <bmeng.cn@gmail.com>
 
 pkgname=u-boot-tools
-pkgver=2022.01
+pkgver=2022.04
 pkgrel=1
 pkgdesc="U-Boot Tools"
 arch=('i686' 'x86_64')
 url="https://github.com/u-boot/u-boot"
 license=('GPL2')
 depends=('dtc' 'openssl')
-makedepends=('openssl-devel' 'gcc' 'make')
+makedepends=('make' 'gcc' 'openssl-devel' 'libgnutls-devel' 'libuuid-devel')
 source=(https://ftp.denx.de/pub/u-boot/u-boot-${pkgver}.tar.bz2{,.sig})
 noextract=("u-boot-${pkgver}.tar.bz2")
-sha256sums=('81b4543227db228c03f8a1bf5ddbc813b0bb8f6555ce46064ef721a6fc680413'
+sha256sums=('68e065413926778e276ec3abd28bb32fa82abaa4a6898d570c1f48fbdb08bcd0'
             'SKIP')
 validpgpkeys=('1A3C7F70E08FAB1707809BBF147C39FF9634B72C')
 


### PR DESCRIPTION
U-Boot v2022.04 host tools (mkeficapsule) introduced new build
dependencies to libgnutls-devel and libuuid-devel. No runtime
dependencies are needed as the mkeficapsule executable is for
testing purpose and we didn't ship it since day 1.

Signed-off-by: Bin Meng <bmeng.cn@gmail.com>