### PR TITLE
readline: avoid linking the static library to the ncurses DLL

### DIFF
--- a/readline/PKGBUILD
+++ b/readline/PKGBUILD
@@ -5,7 +5,7 @@ pkgname=('libreadline' 'libreadline-devel')
 _basever=8.1
 _patchlevel=002 #prepare for some patches
 pkgver=${_basever}.${_patchlevel}
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU readline library"
 arch=('i686' 'x86_64')
 url="https://tiswww.case.edu/php/chet/readline/rltop.html"
@@ -17,7 +17,8 @@ source=(https://ftp.gnu.org/gnu/readline/readline-${_basever}.tar.gz{,.sig}
         readline-7.0.3-3.clipboard.patch
         readline-7.0.3-3.src.patch
         readline-6.3-msys2.patch
-        readline-6.3-paste-utf8.patch)
+        readline-6.3-paste-utf8.patch
+        readline-8.1-static.patch)
 if [ $_patchlevel -gt 0 ]; then
     for (( p=1; p<=$((10#${_patchlevel})); p++ )); do
         source=(${source[@]} https://ftp.gnu.org/gnu/readline/readline-${_basever}-patches/readline${_basever//./}-$(printf "%03d" $p){,.sig})
@@ -29,6 +30,7 @@ sha256sums=('f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02'
             'cdb4f97d641acde59ada6f22141e6a6743f756fc183f5cb43d6c9f8ae563da29'
             '96d002c8815b29ed5dbe89d9b251182c6e60111acc3d236acb8d1bbb2f896457'
             '8ce80150b6da67c551ffebb18650cfceef8d5e0eddbc848bcef20b8ec176af05'
+            'fba238958e4b5ba79c792aa4bf3378a67e757d9b9975a7ae2cec30ceb17caaf8'
             '682a465a68633650565c43d59f0b8cdf149c13a874682d3c20cb4af6709b9144'
             'SKIP'
             'e55be055a68cb0719b0ccb5edc9a74edcc1d1f689e8a501525b3bc5ebad325dc'
@@ -45,6 +47,7 @@ prepare() {
   patch -p1 -i ${srcdir}/readline-6.3-msys2.patch
   patch -p1 -i ${srcdir}/readline-6.3-paste-utf8.patch
   patch -p1 -i ${srcdir}/readline-7.0.3-3.clipboard.patch
+  patch -p1 -i ${srcdir}/readline-8.1-static.patch
 }
 
 build() {

--- a/readline/readline-8.1-static.patch
+++ b/readline/readline-8.1-static.patch
@@ -1,0 +1,27 @@
+diff --git a/support/shobj-conf b/support/shobj-conf
+index c885950..443034e 100644
+--- a/support/shobj-conf
++++ b/support/shobj-conf
+@@ -477,6 +477,7 @@ msdos*)
+ 	;;
+ 
+ cygwin*)
++	SHOBJ_CFLAGS=-DSHARED_READLINE
+ 	SHOBJ_LD='$(CC)'
+ 	SHOBJ_LDFLAGS='-shared -Wl,--enable-auto-import -Wl,--enable-auto-image-base -Wl,--export-all -Wl,--out-implib=$(@).a'
+ 	SHLIB_LIBPREF='msys-'
+diff --git a/tcap.h b/tcap.h
+index 859e6ee..f0c79fc 100644
+--- a/tcap.h
++++ b/tcap.h
+@@ -26,6 +26,10 @@
+ #  include "config.h"
+ #endif
+ 
++#if !defined (SHARED_READLINE)
++#  define NCURSES_STATIC
++#endif
++
+ #if defined (HAVE_TERMCAP_H)
+ #  if defined (__linux__) && !defined (SPEED_T_IN_SYS_TYPES)
+ #    include "rltty.h"


### PR DESCRIPTION
The ncurses headers [changes](https://github.com/ThomasDickey/ncurses-snapshots/commit/ba50399b8b9cc69cb56d8a51754c4366b2ae3f7e#diff-e468d12af06630d1a5e6bca47f23638abdcf3eccfda06a629387934c5196bbeaL71-L76), now defaulting to `dllimport` for its symbols.

Seeing as we definitely do not want to do that in the static version of libreadline, we now have to adjust our code. This is particularly important because we use that static library in Bash, where we definitely want to avoid linking to any MSYS DLL except `msys-2.0.dll`.

The symptom of an incorrectly-built library is this:

```console
$ nm /usr/lib/libreadline.a | grep tputs
                 U __imp_tputs
                 U __imp_tputs
```

In the correct case, the symbols would lack the `__imp_` prefix:

```console
$ nm /usr/lib/libreadline.a | grep tputs
                 U tputs
                 U tputs
```