### PR TITLE
pacman: enable clang32 by default

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.0.1
-pkgrel=13
+pkgrel=14
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -67,7 +67,7 @@ source=(pacman-${pkgver}::git+https://gitlab.archlinux.org/pacman/pacman.git#com
 validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@archlinux.org>
               'B8151B117037781095514CA7BBDFFC92306B1121') # Andrew Gregory (pacman) <andrew@archlinux.org>
 sha256sums=('SKIP'
-            'fff047d9514c4810eee9ab798b51d3300cbf7ee1b5e2e494e1350499d28dd448'
+            '26d141ead0b586e29ab6c49ffa45cf60eb2689f53f8e90c885ccd6d117e9ab67'
             'c12da01ede663a4924d0817a0d1bd6082b1380383cfb74cc1cea08f9d73e4902'
             '1b8033d17f23eb00c17b6303d854c4c6eae17cb2f59542f37ddfb83528437d6b'
             '98198e1f0f252eae0560d271bee4b9149e127399dd0d3fd5d8d24579d9e0550f'

--- a/pacman/pacman.conf
+++ b/pacman/pacman.conf
@@ -65,6 +65,15 @@ LocalFileSigLevel = Optional
 # repo name header and Include lines. You can add preferred servers immediately
 # after the header, and they will be used before the default mirrors.
 
+# Staging packages: enable at your own risk
+# [staging]
+# Server = https://repo.msys2.org/staging/
+# SigLevel = Never
+
+# Enable if you are on arm64
+# [clangarm64]
+# Include = /etc/pacman.d/mirrorlist.mingw
+
 [mingw32]
 Include = /etc/pacman.d/mirrorlist.mingw
 
@@ -72,6 +81,9 @@ Include = /etc/pacman.d/mirrorlist.mingw
 Include = /etc/pacman.d/mirrorlist.mingw
 
 [ucrt64]
+Include = /etc/pacman.d/mirrorlist.mingw
+
+[clang32]
 Include = /etc/pacman.d/mirrorlist.mingw
 
 [clang64]


### PR DESCRIPTION
And add commented out versions of clangarm64 and staging while at it,
so they are easy to enable if wanted.