### PR TITLE
filesystem: set `BASH_COMPLETION_COMPAT_DIR`

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=filesystem
 pkgver=2022.01
-pkgrel=4
+pkgrel=5
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -75,7 +75,7 @@ sha256sums=('742a7d66b7a5ebd2b8461728c5b44a46b2305fd2116208eecae5f45828938ea0'
             '6446359419e13310d74ab54086271acc2f4ed0dfe97a474cdd06cd7c55ee59a4'
             '6c0ca979c7b146b3750103b1296a399764f4e1b222ee091d3aa072b6da16c1a5'
             'cbec90c9403826bf6d8dd1fed16240b9d8695ec15df5dcdab7e485bb46c016ab'
-            'd4dea6b907ff85dc55cc93d6089c3123af505e620311fc40b65d92bdb0fae65a'
+            '0192c6a23449c89af90afa356e6ea2133225bdcf4afb96092e88db34d2418ccb'
             'ad9873e18169ca87194af3413bdcbda536d9600b4f7d24fa9f7d59928309ff4a'
             'f63241cc56aa7b7ec6962d19991d211b4e1641b78ba5226835118ab493830a8b'
             'e96c1f54ffff792e738aa032815c82c30821b0683806e5ed0ba2a759db2fd494'

--- a/filesystem/profile.000-msys2.sh
+++ b/filesystem/profile.000-msys2.sh
@@ -3,6 +3,7 @@
 if [ ! "${MINGW_PREFIX}" = "" ]; then
     XDG_DATA_DIRS="/usr/local/share/:/usr/share/"
     export XDG_DATA_DIRS="$MINGW_PREFIX/share/:$XDG_DATA_DIRS"
+    export BASH_COMPLETION_COMPAT_DIR="$MINGW_PREFIX/etc/bash_completion.d/"
 fi
 
 # Warn the user on the first login shell in case we detect a too old Windows version


### PR DESCRIPTION
Bash completions installed into `$MINGW_PREFIX/etc/bash_completion.d/`, eg. youtube-dl, do not get loaded because the script defaults to looking in `/etc/bash_completion.d/` instead.