### PR TITLE
Update git-extras to 6.4.0

### DIFF
--- a/git-extras/PKGBUILD
+++ b/git-extras/PKGBUILD
@@ -3,7 +3,7 @@ _realname=git-extras
 pkgname=${_realname}
 replaces=("${_realname}-git")
 conflicts=("${_realname}-git")
-pkgver=6.3.0
+pkgver=6.4.0
 pkgrel=1
 pkgdesc="GIT utilities -- repo summary, commit counting, repl, changelog population and more"
 arch=('any')
@@ -12,7 +12,7 @@ url='https://github.com/tj/git-extras'
 depends=('git')
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/tj/git-extras/archive/$pkgver.tar.gz")
 noextract=("${_realname}-${pkgver}.tar.gz")
-sha256sums=('8a218a0c8e10036d5ba14f26b70f994b0d11166b02ef3fed71c593cef026ec3d')
+sha256sums=('d8943c0caab43e70c23890816a9775844d33261c40d5be03c1e012c276b1aa63')
 
 build(){
   cd "${srcdir}"


### PR DESCRIPTION
Release notes for git-extras 6.4.0

https://github.com/tj/git-extras/releases/tag/6.4.0