### PR TITLE
libxml2: drop icu dependency

### DIFF
--- a/libxml2/PKGBUILD
+++ b/libxml2/PKGBUILD
@@ -3,11 +3,11 @@
 pkgbase=libxml2
 pkgname=('libxml2' 'libxml2-devel' 'libxml2-python')
 pkgver=2.9.14
-pkgrel=2
+pkgrel=3
 pkgdesc="XML parsing library, version 2"
 arch=(i686 x86_64)
 license=('spdx:MIT')
-makedepends=('gcc' 'python-devel' 'icu-devel>=68.1' 'libcrypt-devel' 'libreadline-devel'
+makedepends=('gcc' 'python-devel' 'libcrypt-devel' 'libreadline-devel'
              'ncurses-devel' 'liblzma-devel' 'zlib-devel' 'autotools')
 url="https://gitlab.gnome.org/GNOME/libxml2/-/wikis/"
 source=("https://download.gnome.org/sources/libxml2/${pkgver%.*}/${pkgbase}-${pkgver}.tar.xz"
@@ -77,7 +77,8 @@ build() {
     --target=${CHOST} \
     --enable-ipv6 \
     --with-history \
-    --with-icu \
+    --with-iconv \
+    --without-icu \
     --with-python=/usr/bin/python \
     --with-html-dir=/usr/share/doc \
     --with-html-subdir=libxml2/html
@@ -95,7 +96,7 @@ check() {
 }
 
 package_libxml2() {
-  depends=('coreutils' 'icu>=68.1' 'liblzma' 'libreadline' 'ncurses' 'zlib')
+  depends=('coreutils' 'liblzma' 'libreadline' 'ncurses' 'zlib')
   groups=('libraries')
   install=libxml2.install
 
@@ -111,7 +112,7 @@ package_libxml2-devel() {
   pkgdesc="Libxml2 headers and libraries"
   groups=('development')
   options=('staticlibs')
-  depends=("libxml2=${pkgver}" 'icu-devel>=68.1' 'libreadline-devel' 'ncurses-devel' 'liblzma-devel' 'zlib-devel')
+  depends=("libxml2=${pkgver}" 'libreadline-devel' 'ncurses-devel' 'liblzma-devel' 'zlib-devel')
 
   PYTHON_SITELIB="$(python -c 'import site, sys; sys.stdout.write(site.getsitepackages()[0])')"
   mkdir -p ${pkgdir}/usr/{bin,share}


### PR DESCRIPTION
from what I see this is only used for encoding/decoding and the
README says "Mainly useful as an
alternative to iconv on Windows. Unnecessary on most other systems."

Since this is the only user of icu in base this also helps the installer size.