### PR TITLE
base: add tar

### DIFF
--- a/base/PKGBUILD
+++ b/base/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
 
 pkgname=base
-pkgver=2020.12
+pkgver=2022.06
 pkgrel=1
 pkgdesc='Minimal package set to define a basic MSYS2 installation'
 url='https://www.msys2.org'
@@ -35,6 +35,7 @@ depends=(
   'pacman-mirrors'
   'rebase'
   'sed'
+  'tar'
   'time'
   'tzcode'
   'util-linux'


### PR DESCRIPTION
Windows nowadays has a tar.exe in System32 which is first in PATH
with a clean MSYS2 install.

This will both confuse users as well as scripts because it is
a non-cygwin bsdtar.

To avoid surprises add tar to base.