### PR TITLE
inetutils: only makedepend on tftp-hpa

### DIFF
--- a/inetutils/PKGBUILD
+++ b/inetutils/PKGBUILD
@@ -2,13 +2,13 @@
 
 pkgname=inetutils
 pkgver=1.9.4
-pkgrel=3
+pkgrel=4
 pkgdesc="A collection of common network programs."
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/inetutils/"
 license=('GPL3')
-depends=('gcc-libs' 'libintl' 'libcrypt' 'libreadline' 'ncurses' 'tftp-hpa')
-makedepends=('gettext-devel' 'libcrypt-devel' 'libreadline-devel' 'ncurses-devel' 'autotools' 'gcc')
+depends=('gcc-libs' 'libintl' 'libcrypt' 'libreadline' 'ncurses')
+makedepends=('gettext-devel' 'libcrypt-devel' 'libreadline-devel' 'ncurses-devel' 'autotools' 'gcc' 'tftp-hpa' 'help2man')
 options=('!emptydirs')
 install=inetutils.install
 source=(https://ftp.gnu.org/gnu/inetutils/${pkgname}-${pkgver}.tar.xz


### PR DESCRIPTION
It's only using a header, nothing more.
See https://cygwin.com/pipermail/cygwin-apps/2013-August/033227.html