### PR TITLE
pacman-contrib: Update to 1.5.3

### DIFF
--- a/pacman-contrib/0100-contrib.patch
+++ b/pacman-contrib/0100-contrib.patch
@@ -148,3 +148,14 @@
  
  if [[ -z $newsums ]]; then
  	die "$buildfile does not contain sources to update"
+--- pacman-contrib-v1.5.3/src/pacdiff.sh.in.orig	2022-06-09 20:11:26.000000000 +0200
++++ pacman-contrib-v1.5.3/src/pacdiff.sh.in	2022-06-28 09:14:25.345624300 +0200
+@@ -122,7 +122,7 @@
+ 	base="$(mktemp "$tempdir"/"$basename.base.XXX")"
+ 	merged="$(mktemp "$tempdir"/"$basename.merged.XXX")"
+ 
+-	if ! bsdtar -xqOf "$base_tar" "${file#/}" >"$base"; then
++	if ! /usr/bin/bsdtar -xqOf "$base_tar" "${file#/}" >"$base"; then
+ 		msg2 "Unable to extract the previous version of this file."
+ 		return 1
+ 	fi

--- a/pacman-contrib/PKGBUILD
+++ b/pacman-contrib/PKGBUILD
@@ -3,12 +3,12 @@
 # Contributor: Ray Donnelly <mingw.android@gmail.com>
 
 pkgname=pacman-contrib
-pkgver=1.5.2
+pkgver=1.5.3
 pkgrel=1
 pkgdesc="Contributed scripts and tools for pacman systems (MSYS2 port)"
 arch=('i686' 'x86_64')
-url="https://git.archlinux.org/pacman-contrib.git/about/"
-license=('GPL')
+url="https://gitlab.archlinux.org/pacman/pacman-contrib"
+license=('spdx:GPL-2.0-or-later')
 depends=('perl'
          'pacman'
          'bash')
@@ -22,8 +22,8 @@ makedepends=('asciidoc'
              )
 source=(https://gitlab.archlinux.org/pacman/pacman-contrib/-/archive/v$pkgver/$pkgname-v$pkgver.tar.gz
         "0100-contrib.patch")
-sha256sums=('38352c85e8dc08b04d9e0f28a613dd8c9af2bd095742959695030d03badcaddb'
-            'c9ee7a9a7c6ef43749e66c64886c7bdf3ac73a86c99ca0355207577538b52875')
+sha256sums=('56c0b1ae41ff8e72ae352739e80df0e9f0403a1c66b52d358c46e04f65a82057'
+            '74acb78f254e7749e67139156221aec50190463debc842b85568d4fb2fa8ac30')
 
 prepare() {
   cd ${srcdir}/${pkgname}-v${pkgver}


### PR DESCRIPTION
patch one new call to bsdtar to use an absolute path.