### PR TITLE
breezy: update to 3.2.1

### DIFF
--- a/breezy/PKGBUILD
+++ b/breezy/PKGBUILD
@@ -1,10 +1,10 @@
 # Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
 
 pkgname=breezy
-_verbase=3.1.0
-_verminor=8
+_verbase=3.2.1
+_verminor=1
 pkgver=${_verbase}.${_verminor}
-pkgrel=3
+pkgrel=1
 pkgdesc='A decentralized revision control system with support for Bazaar and Git file formats'
 arch=('i686' 'x86_64')
 url='https://www.breezy-vcs.org/'
@@ -15,13 +15,13 @@ depends=('python-configobj'
          'python-dulwich'
          'python-patiencediff'
          'python-six')
-makedepends=('python-setuptools' 'python-devel' 'gcc')
+makedepends=('python-setuptools' 'python-devel' 'gcc' 'cython')
 provides=(bzr)
 conflicts=(bzr)
 replaces=(bzr)
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/breezy-team/breezy/archive/${_verbase}-${_verminor}.tar.gz
         '0002-add-msys2-certs-location.patch')
-sha256sums=('a2781e9af980ceb62087a78894c2706b17f2ea044253dff7d03fc14f1e4f75d9'
+sha256sums=('6ef3dc8ade435e9641559e8e598148c49a6295f3767d3b64323d279bb25098c3'
             '8f3a1c151c9ceb8b2ace12dc1c80bd123810e2e77a2c784385d5ad039f0bd3bb')
 
 prepare(){
@@ -33,7 +33,7 @@ prepare(){
 build() {
   cd "${srcdir}/${pkgname}-${_verbase}-${_verminor}"
 
-  python setup.py build --parallel "$(nproc)"
+  python setup.py build --force --parallel "$(nproc)"
 }
 
 package() {


### PR DESCRIPTION
force cython rebuild
don't update to 3.2.2 for now since that requires a new dependency