### PR TITLE
coreutils: "uname -o" -> Cygwin if MSYSTEM=CYGWIN

### DIFF
--- a/coreutils/004-msystem-osname-cygwin.patch
+++ b/coreutils/004-msystem-osname-cygwin.patch
@@ -1,0 +1,18 @@
+--- coreutils-8.32/src/uname.c.orig	2020-02-04 20:27:08.000000000 +0100
++++ coreutils-8.32/src/uname.c	2022-07-04 16:21:23.554364400 +0200
+@@ -367,8 +367,13 @@
+         print_element (element);
+     }
+ 
+-  if (toprint & PRINT_OPERATING_SYSTEM)
+-    print_element (HOST_OPERATING_SYSTEM);
++  if (toprint & PRINT_OPERATING_SYSTEM) {
++    char* msystem = getenv("MSYSTEM");
++    if (msystem && strcmp(msystem, "CYGWIN") == 0)
++      print_element ("Cygwin");
++    else
++      print_element ("Msys");
++  }
+ 
+   putchar ('\n');
+ 

--- a/coreutils/PKGBUILD
+++ b/coreutils/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=coreutils
 pkgver=8.32
-pkgrel=3
+pkgrel=4
 pkgdesc="The basic file, shell and text manipulation utilities of the GNU operating system"
 arch=('i686' 'x86_64')
 license=('GPL3')
@@ -13,12 +13,14 @@ install=${pkgname}.install
 source=(https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz{,.sig}
         001-coreutils-8.30.patch
         002-coreutils-8.32-enable-stdbuf.patch
-        003-coreutils-8.32-fix-test-cases.patch)
+        003-coreutils-8.32-fix-test-cases.patch
+        004-msystem-osname-cygwin.patch)
 sha256sums=('4458d8de7849df44ccab15e16b1548b285224dbba5f08fac070c1c0e0bcc4cfa'
             'SKIP'
             '467bde24da0ccea48260f58d3c94a84de4e027ab598a926003642f791da47ca2'
             'e3be62b9aceb3231f09f05bc3bd8b18f6aaa495f5063781cdd261d560a7e80d0'
-            'ad9e0582373500c0668e38483401169f48d6a2f8ad8d28ef8e7b06e4a3e08a74')
+            'ad9e0582373500c0668e38483401169f48d6a2f8ad8d28ef8e7b06e4a3e08a74'
+            '3922afd54b2323772f5cbd0638d0887ef858199bbaf4076a1db318173021c3dc')
 validpgpkeys=('6C37DC12121A5006BC1DB804DF6FD971306037D9')
 
 prepare() {
@@ -27,6 +29,9 @@ prepare() {
   patch -p1 -i ${srcdir}/001-coreutils-8.30.patch
   patch -p1 -i ${srcdir}/002-coreutils-8.32-enable-stdbuf.patch
   patch -p1 -i ${srcdir}/003-coreutils-8.32-fix-test-cases.patch
+
+  # https://github.com/msys2/MSYS2-packages/issues/3012
+  patch -p1 -i ${srcdir}/004-msystem-osname-cygwin.patch
 
   autoreconf -fi
 }


### PR DESCRIPTION
If MSYSTEM=CYGWIN we output "Cygwin" as the operating system.
This is relevant in build scripts which call "uname -o" and
check for cygwin there.