### PR TITLE
isl: drop 0.22 dll

### DIFF
--- a/isl/PKGBUILD
+++ b/isl/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=isl
 pkgname=('isl' 'isl-devel')
 pkgver=0.25
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for manipulating sets and relations of integer points bounded by linear constraints"
 arch=('i686' 'x86_64')
 url="https://isl.gforge.inria.fr/"
@@ -11,20 +11,13 @@ groups=('libraries')
 depends=('gmp')
 makedepends=('gmp-devel' 'autotools' 'gcc')
 license=('spdx:MIT')
-source=(https://libisl.sourceforge.io/${pkgbase}-0.22.1.tar.xz
-        https://libisl.sourceforge.io/${pkgbase}-0.25.tar.xz
+source=(https://libisl.sourceforge.io/${pkgbase}-${pkgver}.tar.xz
         isl-0.14.1-no-undefined.patch)
-sha256sums=('28658ce0f0bdb95b51fd2eb15df24211c53284f6ca2ac5e897acc3169e55b60f'
-            'be7b210647ccadf90a2f0b000fca11a4d40546374a850db67adb32fad4b230d9'
+sha256sums=('be7b210647ccadf90a2f0b000fca11a4d40546374a850db67adb32fad4b230d9'
             '83655a7202f0a0dcce1782d4b365252bf1ad12a522b7ad82ab578ee5ec46433b')
 
 prepare() {
   cd "${srcdir}/${pkgbase}-${pkgver}"
-  patch -p1 -i ${srcdir}/isl-0.14.1-no-undefined.patch
-
-  autoreconf -fi
-
-  cd "${srcdir}/${pkgbase}-0.22.1"
   patch -p1 -i ${srcdir}/isl-0.14.1-no-undefined.patch
 
   autoreconf -fi
@@ -41,18 +34,6 @@ build() {
     --disable-static
   make
   make -j1 DESTDIR="${srcdir}/dest" install
-
-  cd "$srcdir/${pkgbase}-0.22.1"
-
-  local CYGWIN_CHOST="${CHOST/-msys/-cygwin}"
-  ./configure \
-    --build="${CYGWIN_CHOST}" \
-    --prefix=/usr \
-    --enable-shared \
-    --disable-static
-
-  make
-  make -j1 DESTDIR="${srcdir}/dest_old" install
 }
 
 check() {
@@ -63,7 +44,6 @@ check() {
 package_isl() {
   mkdir -p ${pkgdir}/usr/bin
   cp -f ${srcdir}/dest/usr/bin/*.dll ${pkgdir}/usr/bin
-  cp -f ${srcdir}/dest_old/usr/bin/*.dll ${pkgdir}/usr/bin
 
   install -Dm644 ${srcdir}/${pkgbase}-${pkgver}/LICENSE ${pkgdir}/usr/share/licenses/isl/LICENSE
 }


### PR DESCRIPTION
all users have been rebuilt, so we can drop the old DLL