### PR TITLE
python-setuptools: Update to 59.8.0

### DIFF
--- a/python-setuptools/PKGBUILD
+++ b/python-setuptools/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=setuptools
 pkgbase="python-${_realname}"
 pkgname=("python-${_realname}")
-pkgver=52.0.0
-pkgrel=2
+pkgver=59.8.0
+pkgrel=1
 pkgdesc="Easily download, build, install, upgrade, and uninstall Python packages"
 arch=('any')
 license=('PSF')
@@ -14,27 +14,16 @@ provides=("python3-${_realname}" 'python3-distribute')
 replaces=("python3-${_realname}" 'python3-distribute')
 conflicts=("python3-${_realname}")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/pypa/setuptools/archive/v${pkgver}.tar.gz")
-sha512sums=('f397181a94d1bd3afbf2d1279554df9d448af963886c53ab391eeb6482a4fc6baf9434b5c6a8da36ae0e1d8f5274c93cb2b37d996112880cb2bad8c7767ac1b1')
+sha512sums=('9aaaf0565f54c0b998de67a79be7ffb54369d05d516b1294d4aecf4f47a38619111836262013053fd73d84a8b5206072e542f59afc011e8b0331009a8f3d2c69')
 
 prepare() {
-  # Don't download and install deps
-  sed -i '/pip.main(args)/d' setuptools-${pkgver}/bootstrap.py
-
-  # Remove post-release tag since we are using stable tags
-  sed -e '/tag_build = .post/d' \
-      -e '/tag_date = 1/d' \
-      -i setuptools-${pkgver}/setup.cfg
-
-  cd "${srcdir}"/setuptools-${pkgver}
-  sed -i -e "s|^#\!.*/usr/bin/env python|#!/usr/bin/env python3|" setuptools/command/easy_install.py
-
   export SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES=0
 }
 
 build() {
-  # Build python module
-  cd "${srcdir}"/setuptools-${pkgver}
-  /usr/bin/python bootstrap.py
+  cd "${srcdir}/setuptools-${pkgver}"
+
+  /usr/bin/python setup.py egg_info
   /usr/bin/python setup.py build
 }
 
@@ -46,12 +35,12 @@ check() { (
   export PYTHONDONTWRITEBYTECODE=1
 
   # Check python module
-  # cd "${srcdir}"/setuptools-${pkgver}
+  # cd "${srcdir}/setuptools-${pkgver}"
   # /usr/bin/python setup.py pytest
 )}
 
 package() {
-  cd "${srcdir}"/setuptools-${pkgver}
+  cd "${srcdir}/setuptools-${pkgver}"
 
   /usr/bin/python setup.py install --prefix=/usr --root="${pkgdir}" --optimize=1 --skip-build
 }

--- a/txt2tags/PKGBUILD
+++ b/txt2tags/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=txt2tags
 pkgver=3.7
-pkgrel=4
+pkgrel=5
 pkgdesc='A text formatting and conversion tool.'
 arch=('any')
 url='https://www.txt2tags.org/'


### PR DESCRIPTION
The one before the distutils switch. In theory the latest should
include all cygwin patches and should work too, but let's do this
one change at a time.