### PR TITLE
python-setuptools: Update to 63.2.0

### DIFF
--- a/python-setuptools/PKGBUILD
+++ b/python-setuptools/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=setuptools
 pkgbase="python-${_realname}"
 pkgname=("python-${_realname}")
-pkgver=59.8.0
+pkgver=63.2.0
 pkgrel=1
 pkgdesc="Easily download, build, install, upgrade, and uninstall Python packages"
 arch=('any')
@@ -14,7 +14,7 @@ provides=("python3-${_realname}" 'python3-distribute')
 replaces=("python3-${_realname}" 'python3-distribute')
 conflicts=("python3-${_realname}")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/pypa/setuptools/archive/v${pkgver}.tar.gz")
-sha512sums=('9aaaf0565f54c0b998de67a79be7ffb54369d05d516b1294d4aecf4f47a38619111836262013053fd73d84a8b5206072e542f59afc011e8b0331009a8f3d2c69')
+sha512sums=('1e44bc5de2e9587a761c1a1060d5b7da405eca0711128ce35a524cb20e968456e85e48553f73ca9eb179d8b90e71250e02992ff16fceef62c7017a8c312e0a41')
 
 prepare() {
   export SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES=0


### PR DESCRIPTION
This version will take over the stdlib distutils