### PR TITLE
Add unifdef package

### DIFF
--- a/unifdef/PKGBUILD
+++ b/unifdef/PKGBUILD
@@ -1,0 +1,23 @@
+# Maintainer: Joel Holdsworth <jholdsworth@nvidia.com>
+
+pkgname=unifdef
+pkgver=2.12
+pkgrel=1
+pkgdesc="Selectively processes conditional C preprocessor #if and #ifdef directives"
+arch=('any')
+url="https://dotat.at/prog/unifdef/"
+license=("BSD")
+makedepends=("gcc")
+source=("https://dotat.at/prog/${pkgname}/${pkgname}-${pkgver}.tar.xz")
+sha256sums=("43ce0f02ecdcdc723b2475575563ddb192e988c886d368260bc0a63aee3ac400")
+
+build() {
+  cd "${srcdir}"/${pkgname}-${pkgver}
+  make
+}
+
+package() {
+  cd "${srcdir}"/${pkgname}-${pkgver}
+  make DESTDIR="${pkgdir}" prefix=/usr install
+  install -Dm644 COPYING ${pkgdir}/usr/share/licenses/${pkgname}/COPYING
+}


### PR DESCRIPTION
The `unifdef` utility selectively processes conditional C preprocessor `#if` and `#ifdef` directives. It removes from a file both the directives and the additional text that they delimit, while otherwise leaving the file alone.