### PR TITLE
less: upgrade to v608

### DIFF
--- a/less/PKGBUILD
+++ b/less/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=less
-pkgver=590
-pkgrel=2
+pkgver=608
+pkgrel=1
 pkgdesc="A terminal based program for viewing text files"
 license=('GPL3')
 arch=('i686' 'x86_64')
@@ -11,7 +11,7 @@ depends=('ncurses' 'libpcre')
 makedepends=('ncurses-devel' 'pcre-devel' 'autotools' 'gcc')
 source=("http://www.greenwoodsoftware.com/${pkgname}/${pkgname}-${pkgver}.tar.gz"
        "$pkgname-$pkgver.tar.gz.sig::http://www.greenwoodsoftware.com/$pkgname/$pkgname-$pkgver.sig")
-sha256sums=('6aadf54be8bf57d0e2999a3c5d67b1de63808bb90deb8f77b028eafae3a08e10'
+sha256sums=('a69abe2e0a126777e021d3b73aa3222e1b261f10e64624d41ec079685a6ac209'
             'SKIP')
 validpgpkeys=('AE27252BD6846E7D6EAE1DD6F153A7C833235259') # Mark Nudelman
 


### PR DESCRIPTION
See https://www.greenwoodsoftware.com/less/news.608.html

There is one news item that _sounds_ like it could cause trouble when not using the Win32 Console (such as running in a MinTTY window): "Fix bug in input of non-ASCII characters on Windows."

Following the "View git blame" trail leads to https://github.com/gwsw/less/commit/2bf67924e3be558bc6b9df61ae7ef510918f28b8 which sounds innocuous enough: we probably do not use `WIN32getch()` because we're compiling in Cygwin mode.