### PR TITLE
Add nnn terminal file manager

### DIFF
--- a/nnn/PKGBUILD
+++ b/nnn/PKGBUILD
@@ -6,42 +6,47 @@ pkgname=nnn
 pkgver=4.6.r33.gf6edcc41
 pkgrel=1
 pkgdesc="The fastest terminal file manager ever written."
-arch=(x86_64)
+arch=(i686 x86_64)
 url='https://github.com/jarun/nnn'
-license=(BSD)
-depends=('bash')
+license=('spdx:BSD-2-Clause')
+_commit="f6edcc41b90f9c6b79d190599465bbb4ce837a7c"
+depends=(
+  'bash'
+  'ncurses'
+  'libreadline'
+)
 optdepends=(
-    'atool: for more archive formats'
-    'libarchive: for more archive formats'
-    'zip: for zip archive format'
-    'unzip: for zip archive format'
-    'rclone: mount remotes'
-    )
+  'atool: for more archive formats'
+  'libarchive: for more archive formats'
+  'zip: for zip archive format'
+  'unzip: for zip archive format'
+  'rclone: mount remotes'
+)
 makedepends=(git gcc libreadline-devel ncurses-devel)
-source=("git+${url}.git")
-md5sums=('SKIP')
+source=("git+https://github.com/jarun/nnn.git#commit=${_commit}")
+sha256sums=('SKIP')
 
 pkgver() {
-    cd nnn
-      git describe --long --tags | sed -r 's/([^-]*-g)/r\1/;s/-/./g;s/v//g'
+  cd nnn
+  git describe --long --tags | sed -r 's/([^-]*-g)/r\1/;s/-/./g;s/v//g'
 }
 
 prepare() {
-    sed -i 's/install: all/install:/' nnn/Makefile
+  sed -i 's/install: all/install:/' nnn/Makefile
 }
 
 build() {
-    cd nnn
-      make
+  cd nnn
+  make
 }
 
 package() {
-    cd nnn
-      make DESTDIR="${pkgdir}" PREFIX=/usr strip install
+  cd nnn
+  make DESTDIR="${pkgdir}" PREFIX=/usr strip install
 
-    install -Dm644 misc/auto-completion/fish/nnn.fish "${pkgdir}/usr/share/fish/vendor_completions.d/nnn.fish"
-    install -Dm644 misc/auto-completion/bash/nnn-completion.bash "${pkgdir}/usr/share/bash-completion/completions/nnn"
-    install -Dm644 misc/auto-completion/zsh/_nnn "${pkgdir}/usr/share/zsh/site-functions/_nnn"
+  install -Dm644 misc/auto-completion/fish/nnn.fish "${pkgdir}/usr/share/fish/vendor_completions.d/nnn.fish"
+  install -Dm644 misc/auto-completion/bash/nnn-completion.bash "${pkgdir}/usr/share/bash-completion/completions/nnn"
+  install -Dm644 misc/auto-completion/zsh/_nnn "${pkgdir}/usr/share/zsh/site-functions/_nnn"
 
-    install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/nnn/PKGBUILD
+++ b/nnn/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: John Khoo <john underscore khoo AT u dot nus DOT edu>
+# Contributor: 
+# Adapted from Arch PKGBUILD: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=nnn-git
+
+pkgname=nnn
+pkgver=4.6.r33.gf6edcc41
+pkgrel=1
+pkgdesc="The fastest terminal file manager ever written."
+arch=(x86_64)
+url='https://github.com/jarun/nnn'
+license=(BSD)
+depends=('bash')
+optdepends=(
+    'atool: for more archive formats'
+    'libarchive: for more archive formats'
+    'zip: for zip archive format'
+    'unzip: for zip archive format'
+    'rclone: mount remotes'
+    )
+makedepends=(git gcc libreadline-devel ncurses-devel)
+provides=(nnn)
+conflicts=(nnn)
+source=("git+${url}.git")
+md5sums=('SKIP')
+
+pkgver() {
+    cd nnn
+      git describe --long --tags | sed -r 's/([^-]*-g)/r\1/;s/-/./g;s/v//g'
+}
+
+prepare() {
+    sed -i 's/install: all/install:/' nnn/Makefile
+}
+
+build() {
+    cd nnn
+      make
+}
+
+package() {
+    cd nnn
+      make DESTDIR="${pkgdir}" PREFIX=/usr strip install
+
+    install -Dm644 misc/auto-completion/fish/nnn.fish "${pkgdir}/usr/share/fish/vendor_completions.d/nnn.fish"
+    install -Dm644 misc/auto-completion/bash/nnn-completion.bash "${pkgdir}/usr/share/bash-completion/completions/nnn"
+    install -Dm644 misc/auto-completion/zsh/_nnn "${pkgdir}/usr/share/zsh/site-functions/_nnn"
+
+    install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/nnn/PKGBUILD
+++ b/nnn/PKGBUILD
@@ -18,8 +18,6 @@ optdepends=(
     'rclone: mount remotes'
     )
 makedepends=(git gcc libreadline-devel ncurses-devel)
-provides=(nnn)
-conflicts=(nnn)
 source=("git+${url}.git")
 md5sums=('SKIP')
 


### PR DESCRIPTION
Adding this to MSYS2-packages since one of the deps is only packaged here (ncurses-devel), plus vifm is also here, which is comparable. Both are terminal-based productivity tools to make it easier to develop in the terminal.