### PR TITLE
gdb: add support for guile and minor fix for ModuleNotFoundError

### DIFF
--- a/gdb/PKGBUILD
+++ b/gdb/PKGBUILD
@@ -2,15 +2,15 @@
 
 pkgname=gdb
 pkgver=11.1
-pkgrel=2
-_gcc_ver=11.2.0
+pkgrel=3
+_gcc_ver=11.3.0
 pkgdesc="GNU Debugger (MSYS2 version)"
 arch=('i686' 'x86_64')
 license=('GPL3')
 url="https://www.gnu.org/software/gdb/"
-depends=("libiconv" "zlib" "expat" "python" "libexpat" "libreadline" "mpfr" "xxhash")
+depends=('libiconv' 'zlib' 'expat' 'python' 'libexpat' 'libreadline' 'mpfr' 'xxhash' 'libguile')
 #checkdepends=('dejagnu' 'bc')
-makedepends=("libiconv-devel" "zlib-devel" "ncurses-devel" "liblzma-devel" "mpfr-devel" "libexpat-devel" "libreadline-devel" "python-devel" 'autotools' 'gcc')
+makedepends=('libiconv-devel' 'zlib-devel' 'ncurses-devel' 'liblzma-devel' 'mpfr-devel' 'libexpat-devel' 'libreadline-devel' 'python-devel' 'autotools' 'gcc' 'guile' 'libguile-devel')
 options=('staticlibs' '!distcc' '!ccache')
 source=("https://ftp.gnu.org/gnu/gdb/gdb-${pkgver}.tar.xz"{,.sig}
         'gdbinit'
@@ -58,7 +58,7 @@ build() {
     --with-python=/usr/bin/python3 \
     --without-tcl \
     --without-tk \
-    --without-guile \
+    --with-guile \
     --with-expat \
     --with-lzma \
     --with-mpfr \


### PR DESCRIPTION
Now gdb guile extension also with auto-loading is working. This simplifies debugging guile code.

Fix for ModuleNotFoundError: No module named 'libstdcxx' with updated gcc_ver=11.3.0