### PR TITLE
guile: fix auto-load filename for gdb

### DIFF
--- a/guile/PKGBUILD
+++ b/guile/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=guile
 pkgname=("${pkgbase}" "lib${pkgbase}" "lib${pkgbase}-devel")
 pkgver=3.0.8
-pkgrel=1
+pkgrel=2
 pkgdesc="a portable, embeddable Scheme implementation written in C"
 url="https://www.gnu.org/software/guile/"
 arch=(i686 x86_64)
@@ -106,8 +106,8 @@ package_libguile() {
   depends=('gmp'
            'libcrypt'
            'libffi'
-           'libreadline'
            'libgc'
+           'libreadline'
            'libunistring')
   groups=('libraries')
 
@@ -123,7 +123,7 @@ package_libguile() {
   mkdir -p ${pkgdir}/usr/share/gdb/auto-load/usr/bin
   install -Dm644 ${srcdir}/dest/usr/lib/*.scm \
                  ${pkgdir}/usr/share/gdb/auto-load/usr/bin/$(dlltool \
-                   -I /usr/lib/libguile-3.0.dll.a)-gdb.scm
+                   -I ${srcdir}/dest/usr/lib/libguile-*.dll.a)-gdb.scm
 }
 
 package_libguile-devel() {


### PR DESCRIPTION
Fix path and generalize filename for dlltool