### PR TITLE
makepkg: set _FORTIFY_SOURCE=2 by default

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.0.1
-pkgrel=20
+pkgrel=21
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -70,7 +70,7 @@ validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@a
 sha256sums=('SKIP'
             '26d141ead0b586e29ab6c49ffa45cf60eb2689f53f8e90c885ccd6d117e9ab67'
             'c12da01ede663a4924d0817a0d1bd6082b1380383cfb74cc1cea08f9d73e4902'
-            '41ab08fad3c24c4a426010f8634cdf2bca2cec8d7b3ef6fadf2d4793c6c91f0b'
+            '7bacd39772c7a3986eae7e4aa800ef139817c9774aacb5faee14fc5d3eddc655'
             '98198e1f0f252eae0560d271bee4b9149e127399dd0d3fd5d8d24579d9e0550f'
             '04ac67a8f458a9daea532f87cedbab76f028ccf437069e3d24a583457603e61d'
             '6904ea154e451115c14246ded57737a5ab6c1151d1ac818c37dc849b70a5275f'

--- a/pacman/makepkg_mingw.conf
+++ b/pacman/makepkg_mingw.conf
@@ -42,7 +42,7 @@ if [[ "$MSYSTEM" == "MINGW64" ]]; then
   CC="gcc"
   CXX="g++"
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
-  CFLAGS="-march=core2 -mno-ssse3 -mtune=generic -O2 -pipe"
+  CFLAGS="-march=core2 -mno-ssse3 -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2"
   CXXFLAGS="-march=core2 -mno-ssse3 -mtune=generic -O2 -pipe"
   LDFLAGS="-pipe"
 elif [[ "$MSYSTEM" == "MINGW32" ]]; then
@@ -54,7 +54,7 @@ elif [[ "$MSYSTEM" == "MINGW32" ]]; then
   CC="gcc"
   CXX="g++"
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
-  CFLAGS="-march=pentium4 -mtune=generic -O2 -pipe"
+  CFLAGS="-march=pentium4 -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2"
   CXXFLAGS="-march=pentium4 -mtune=generic -O2 -pipe"
   LDFLAGS="-pipe -Wl,--no-seh"
 elif [[ "$MSYSTEM" == "CLANG64" ]]; then
@@ -66,7 +66,7 @@ elif [[ "$MSYSTEM" == "CLANG64" ]]; then
   CC="clang"
   CXX="clang++"
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
-  CFLAGS="-march=core2 -mno-ssse3 -mtune=generic -O2 -pipe"
+  CFLAGS="-march=core2 -mno-ssse3 -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2"
   CXXFLAGS="-march=core2 -mno-ssse3 -mtune=generic -O2 -pipe"
   LDFLAGS="-pipe"
 elif [[ "$MSYSTEM" == "CLANG32" ]]; then
@@ -78,7 +78,7 @@ elif [[ "$MSYSTEM" == "CLANG32" ]]; then
   CC="clang"
   CXX="clang++"
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
-  CFLAGS="-march=pentium4 -mtune=generic -O2 -pipe"
+  CFLAGS="-march=pentium4 -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2"
   CXXFLAGS="-march=pentium4 -mtune=generic -O2 -pipe"
   LDFLAGS="-pipe -Wl,--no-seh"
 elif [[ "$MSYSTEM" == "CLANGARM64" ]]; then
@@ -90,7 +90,7 @@ elif [[ "$MSYSTEM" == "CLANGARM64" ]]; then
   CC="clang"
   CXX="clang++"
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
-  CFLAGS="-O2 -pipe"
+  CFLAGS="-O2 -pipe -Wp,-D_FORTIFY_SOURCE=2"
   CXXFLAGS="-O2 -pipe"
   LDFLAGS="-pipe"
 elif [[ "$MSYSTEM" == "UCRT64" ]]; then
@@ -102,7 +102,7 @@ elif [[ "$MSYSTEM" == "UCRT64" ]]; then
   CC="gcc"
   CXX="g++"
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
-  CFLAGS="-march=core2 -mno-ssse3 -mtune=generic -O2 -pipe"
+  CFLAGS="-march=core2 -mno-ssse3 -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2"
   CXXFLAGS="-march=core2 -mno-ssse3 -mtune=generic -O2 -pipe"
   LDFLAGS="-pipe"
 else


### PR DESCRIPTION
This follows what Arch Linux does by default, see
https://github.com/archlinux/svntogit-packages/blob/091c8714716b40241f4259c8e6fdf99508944a2f/trunk/makepkg.conf#L42

This is now possible after https://github.com/msys2/MINGW-packages/issues/13401