### PR TITLE
libgpg-error: Install gpg-error-config script explicitly

### DIFF
--- a/libgpg-error/PKGBUILD
+++ b/libgpg-error/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=libgpg-error
 pkgname=('libgpg-error' 'libgpg-error-devel') # 'gpg-error'
 pkgver=1.46
-pkgrel=1
+pkgrel=2
 pkgdesc="Support library for libgcrypt"
 arch=('i686' 'x86_64')
 url="https://gnupg.org"
@@ -41,6 +41,7 @@ build() {
     --build=${CYGWIN_CHOST} \
     --without-libiconv-prefix \
     --without-libintl-prefix \
+    --enable-install-gpg-error-config \
     --enable-shared \
     --enable-static
 


### PR DESCRIPTION
This is for backward compatibility.