### PR TITLE
gnupg: Update to 2.2.40

### DIFF
--- a/gnupg/PKGBUILD
+++ b/gnupg/PKGBUILD
@@ -50,12 +50,14 @@ depends=('bzip2'
 source=("https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2"{,.sig}
         'avoid-beta-warning.patch'
         '0001-gnupg-2.2.8-msys2.patch'
-        '0002-fix-pcsc_io_request_s-layout-for-SCardTransmit-in-64.patch')
+        '0002-fix-pcsc_io_request_s-layout-for-SCardTransmit-in-64.patch'
+        'ldap.patch::https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=patch;h=7011286ce6e1;hp=edf3b8aa53f7c451c84a537f1416761a8a77f15f')
 sha256sums=('1164b29a75e8ab93ea15033300149e1872a7ef6bdda3d7c78229a735f8204c28'
             'SKIP'
             '22fdf9490fad477f225e731c417867d9e7571ac654944e8be63a1fbaccd5c62d'
             '902563c91c72ed9222343de3482f4ca7b141775235625af5ad790f3d86419370'
-            '8c28135361d628296aff5e51facabb2f0dd99b93488a7b417f2e70296d63eded')
+            '8c28135361d628296aff5e51facabb2f0dd99b93488a7b417f2e70296d63eded'
+            '8aca85b110d6788e24f52d18c7316d51c66dba49bac61740bd50f6037cb8a011')
 validpgpkeys=(
   '5B80C5754298F0CB55D8ED6ABCEF7E294B092E28' # Andre Heinecke (Release Signing Key)
   '6DAA6E64A76D2840571B4902528897B826403ADA' # Werner Koch (dist signing 2020)
@@ -71,6 +73,8 @@ prepare() {
   patch -p1 -i ${srcdir}/0001-gnupg-2.2.8-msys2.patch
   # https://dev.gnupg.org/T4454
   patch -p1 -i ${srcdir}/0002-fix-pcsc_io_request_s-layout-for-SCardTransmit-in-64.patch
+  # https://dev.gnupg.org/T6239
+  patch -p1 -i ${srcdir}/ldap.patch
   
   ./autogen.sh --force
 }

--- a/gnupg/PKGBUILD
+++ b/gnupg/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=gnupg
-pkgver=2.2.39
+pkgver=2.2.40
 pkgrel=1
 pkgdesc='Complete and free implementation of the OpenPGP standard'
 provides=('dirmngr' "gnupg2=${pkgver}")
@@ -51,7 +51,7 @@ source=("https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2"{,
         'avoid-beta-warning.patch'
         '0001-gnupg-2.2.8-msys2.patch'
         '0002-fix-pcsc_io_request_s-layout-for-SCardTransmit-in-64.patch')
-sha256sums=('ab74db6685f026d7c0a10b527ecddecd608606a1691d15fda5d0a7f7d27e4c2f'
+sha256sums=('1164b29a75e8ab93ea15033300149e1872a7ef6bdda3d7c78229a735f8204c28'
             'SKIP'
             '22fdf9490fad477f225e731c417867d9e7571ac654944e8be63a1fbaccd5c62d'
             '902563c91c72ed9222343de3482f4ca7b141775235625af5ad790f3d86419370'


### PR DESCRIPTION
fails due to a missing ldap check, I'm waiting for my upstream account being confirmed so I can file a bug.

edit: was already filed https://dev.gnupg.org/T6239