### PR TITLE
pacman: Set default arch to `x86-64-v2`

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.0.1
-pkgrel=18
+pkgrel=19
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -70,7 +70,7 @@ validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@a
 sha256sums=('SKIP'
             '26d141ead0b586e29ab6c49ffa45cf60eb2689f53f8e90c885ccd6d117e9ab67'
             'c12da01ede663a4924d0817a0d1bd6082b1380383cfb74cc1cea08f9d73e4902'
-            '1b8033d17f23eb00c17b6303d854c4c6eae17cb2f59542f37ddfb83528437d6b'
+            'bf9d1e0133b023fc28be291a1c5520c50cb0064cabc18d6ee95db7710873de7c'
             '98198e1f0f252eae0560d271bee4b9149e127399dd0d3fd5d8d24579d9e0550f'
             '04ac67a8f458a9daea532f87cedbab76f028ccf437069e3d24a583457603e61d'
             '6904ea154e451115c14246ded57737a5ab6c1151d1ac818c37dc849b70a5275f'

--- a/pacman/makepkg_mingw.conf
+++ b/pacman/makepkg_mingw.conf
@@ -42,8 +42,8 @@ if [[ "$MSYSTEM" == "MINGW64" ]]; then
   CC="gcc"
   CXX="g++"
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
-  CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe"
-  CXXFLAGS="-march=x86-64 -mtune=generic -O2 -pipe"
+  CFLAGS="-march=core2 -mtune=generic -O2 -pipe"
+  CXXFLAGS="-march=core2 -mtune=generic -O2 -pipe"
   LDFLAGS="-pipe"
 elif [[ "$MSYSTEM" == "MINGW32" ]]; then
   CARCH="i686"
@@ -66,8 +66,8 @@ elif [[ "$MSYSTEM" == "CLANG64" ]]; then
   CC="clang"
   CXX="clang++"
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
-  CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe"
-  CXXFLAGS="-march=x86-64 -mtune=generic -O2 -pipe"
+  CFLAGS="-march=core2 -mtune=generic -O2 -pipe"
+  CXXFLAGS="-march=core2 -mtune=generic -O2 -pipe"
   LDFLAGS="-pipe"
 elif [[ "$MSYSTEM" == "CLANG32" ]]; then
   CARCH="i686"
@@ -102,8 +102,8 @@ elif [[ "$MSYSTEM" == "UCRT64" ]]; then
   CC="gcc"
   CXX="g++"
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
-  CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe"
-  CXXFLAGS="-march=x86-64 -mtune=generic -O2 -pipe"
+  CFLAGS="-march=core2 -mtune=generic -O2 -pipe"
+  CXXFLAGS="-march=core2 -mtune=generic -O2 -pipe"
   LDFLAGS="-pipe"
 else
   echo "Unsupported MSYSTEM: $MSYSTEM"


### PR DESCRIPTION
This allows SSE4.2 and CMPXCHG16, the same with RHEL 9.

Reference: https://developers.redhat.com/blog/2021/01/05/building-red-hat-enterprise-linux-9-for-the-x86-64-v2-microarchitecture-level
Signed-off-by: LIU Hao <lh_mouse@126.com>