### PR TITLE
pacman: Do strip all symbols from EXEs and DLLs

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.0.1
-pkgrel=19
+pkgrel=20
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -70,7 +70,7 @@ validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@a
 sha256sums=('SKIP'
             '26d141ead0b586e29ab6c49ffa45cf60eb2689f53f8e90c885ccd6d117e9ab67'
             'c12da01ede663a4924d0817a0d1bd6082b1380383cfb74cc1cea08f9d73e4902'
-            'bf9d1e0133b023fc28be291a1c5520c50cb0064cabc18d6ee95db7710873de7c'
+            'e775e49380631ab06fc3c8e4e3af31c6339e9d6a5dcc1bf6001a68227c8ccaf4'
             '98198e1f0f252eae0560d271bee4b9149e127399dd0d3fd5d8d24579d9e0550f'
             '04ac67a8f458a9daea532f87cedbab76f028ccf437069e3d24a583457603e61d'
             '6904ea154e451115c14246ded57737a5ab6c1151d1ac818c37dc849b70a5275f'

--- a/pacman/makepkg_mingw.conf
+++ b/pacman/makepkg_mingw.conf
@@ -169,7 +169,7 @@ INTEGRITY_CHECK=(sha256)
 #-- Options to be used when stripping binaries. See `man strip' for details.
 STRIP_BINARIES="--strip-all"
 #-- Options to be used when stripping shared libraries. See `man strip' for details.
-STRIP_SHARED="--strip-unneeded"
+STRIP_SHARED="--strip-all"
 #-- Options to be used when stripping static libraries. See `man strip' for details.
 STRIP_STATIC="--strip-debug"
 #-- Manual (man and info) directories to compress (if zipman is specified)


### PR DESCRIPTION
This has the effect of passing `--strip-all` instead of `--strip-unneeded` to `strip`, which can make installed executables a bit smaller.

For example, stripping all symbols from `/mingw64/bin/gcc.exe` can reduce its size from 2,351,500 to 2,344,448 (-7,052).

Microsoft documentation also suggests that there should be no symbol in PE files; see references about `PointerToSymbolTable` and `NumberOfSymbols`.

Reference: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format
Signed-off-by: LIU Hao <lh_mouse@126.com>