### PR TITLE
binutils: fix dynamicbase being set for 32bit binaries

### DIFF
--- a/binutils/0100-binutils-2.37-msys2.patch
+++ b/binutils/0100-binutils-2.37-msys2.patch
@@ -1291,10 +1291,18 @@ diff -Naur binutils-2.37-orig/ld/configure.tgt binutils-2.37/ld/configure.tgt
  *-*-linux*)
    ;;
  
-diff -Naur binutils-2.37-orig/ld/emultempl/pe.em binutils-2.37/ld/emultempl/pe.em
---- binutils-2.37-orig/ld/emultempl/pe.em	2021-11-30 08:19:29.913382800 +0100
-+++ binutils-2.37/ld/emultempl/pe.em	2021-11-30 09:07:25.784743500 +0100
-@@ -176,7 +176,7 @@
+--- binutils-2.39/ld/emultempl/pe.em.orig	2022-07-08 11:46:48.000000000 +0200
++++ binutils-2.39/ld/emultempl/pe.em	2022-10-18 20:19:55.104221000 +0200
+@@ -7,7 +7,7 @@
+ fi
+ 
+ case ${target} in
+-  *-*-cygwin*)
++  *-*-cygwin* | *-*-msys*)
+     cygwin_behavior=1
+     ;;
+   *)
+@@ -188,7 +188,7 @@
  # merge_rdata defaults to 0 for cygwin:
  #  http://cygwin.com/ml/cygwin-apps/2013-04/msg00187.html
  case ${target} in

--- a/binutils/PKGBUILD
+++ b/binutils/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=binutils
 pkgver=2.39
-pkgrel=1
+pkgrel=2
 pkgdesc="A set of programs to assemble and manipulate binary and object files"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/binutils/"
@@ -18,7 +18,7 @@ source=(https://ftp.gnu.org/gnu/binutils/binutils-${pkgver}.tar.xz{,.sig}
 sha256sums=('645c25f563b8adc0a81dbd6a41cffbf4d37083a382e02d5d3df4f65c09516d00'
             'SKIP'
             '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18'
-            'bb5fa45ae9116c8aafaf63130ac93caefba915e3fa8aab86e30585abd4a04eda'
+            '532f5864978a43ed0dd38b5aa2d40446b81532adcf9304ea1b762c30969a3b07'
             '57478b9971183d430c93701b1d533e3724dab5334bbf44db924777e4a93c1063')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')


### PR DESCRIPTION
I missed one target check when rebasing the patches. This only affects 32bit, so I didn't notice.