### PR TITLE
makepkg: don't use "-mno-*" in CFLAGS

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.0.1
-pkgrel=21
+pkgrel=22
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -70,7 +70,7 @@ validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@a
 sha256sums=('SKIP'
             '26d141ead0b586e29ab6c49ffa45cf60eb2689f53f8e90c885ccd6d117e9ab67'
             'c12da01ede663a4924d0817a0d1bd6082b1380383cfb74cc1cea08f9d73e4902'
-            '7bacd39772c7a3986eae7e4aa800ef139817c9774aacb5faee14fc5d3eddc655'
+            '73a718e81a1556ddd8a0ee93fbe3f85b3fcdbd9fd574f7deb99bccf0833143b2'
             '98198e1f0f252eae0560d271bee4b9149e127399dd0d3fd5d8d24579d9e0550f'
             '04ac67a8f458a9daea532f87cedbab76f028ccf437069e3d24a583457603e61d'
             '6904ea154e451115c14246ded57737a5ab6c1151d1ac818c37dc849b70a5275f'

--- a/pacman/makepkg_mingw.conf
+++ b/pacman/makepkg_mingw.conf
@@ -42,8 +42,8 @@ if [[ "$MSYSTEM" == "MINGW64" ]]; then
   CC="gcc"
   CXX="g++"
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
-  CFLAGS="-march=core2 -mno-ssse3 -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2"
-  CXXFLAGS="-march=core2 -mno-ssse3 -mtune=generic -O2 -pipe"
+  CFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2"
+  CXXFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe"
   LDFLAGS="-pipe"
 elif [[ "$MSYSTEM" == "MINGW32" ]]; then
   CARCH="i686"
@@ -66,8 +66,8 @@ elif [[ "$MSYSTEM" == "CLANG64" ]]; then
   CC="clang"
   CXX="clang++"
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
-  CFLAGS="-march=core2 -mno-ssse3 -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2"
-  CXXFLAGS="-march=core2 -mno-ssse3 -mtune=generic -O2 -pipe"
+  CFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2"
+  CXXFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe"
   LDFLAGS="-pipe"
 elif [[ "$MSYSTEM" == "CLANG32" ]]; then
   CARCH="i686"
@@ -102,8 +102,8 @@ elif [[ "$MSYSTEM" == "UCRT64" ]]; then
   CC="gcc"
   CXX="g++"
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
-  CFLAGS="-march=core2 -mno-ssse3 -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2"
-  CXXFLAGS="-march=core2 -mno-ssse3 -mtune=generic -O2 -pipe"
+  CFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2"
+  CXXFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe"
   LDFLAGS="-pipe"
 else
   echo "Unsupported MSYSTEM: $MSYSTEM"


### PR DESCRIPTION
In case a package has a configure check for say -mssse3 and then enables it if the compiler supports it it would be passed to the compiler before our CFLAGS, which currently has -mno-ssse3 (which seems to also disable sse4 and above while at it). The code then assumes it's available but the compiler fails.

While one could argue that we try to prevent ssse3+ being used in packages, there
are always exceptions like building sse4 code which dynamically gets executed.

So it's better we only enable machine options in CFLAGS and never disable them

Replace "-march=core2 -mno-ssse3" with the equivalent "-march=nocona -msahf". Note that the GCC docs wrongly state that "nocona" doesn't include "CX16", while it does.

See https://github.com/msys2/MINGW-packages/pull/13651