### PR TITLE
tzcode: Update to 2022f

### DIFF
--- a/tzcode/PKGBUILD
+++ b/tzcode/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=tzcode
-pkgver=2022e
+pkgver=2022f
 pkgrel=1
 pkgdesc="Sources for time zone and daylight saving time data"
 arch=('i686' 'x86_64')
@@ -15,9 +15,9 @@ source=(
         https://www.iana.org/time-zones/repository/releases/${pkgname}${pkgver}.tar.gz{,.asc}
         tzcode-makefile.patch
         tzcode-makefile-exe-extensions.patch)
-sha256sums=('8de4c2686dce3d1aae9030719e6814931c216a2d5e891ec3d332e6f6516aeccd'
+sha256sums=('9990d71f675d212567b931fe8aae1cab7027f89fefb8a79d808a6933a67af000'
             'SKIP'
-            'd40280253980e89168e6be4275a852bf9521524d47684de3135b9a5ca387710b'
+            'e4543e90f84f91fa82809ea98930052fdbc13880c8a623ee3a4eaa42f8a64c15'
             'SKIP'
             'a118e7b535bd21d494b9f3837a13939a0c826c0c6859dd8702a5256b898ad51a'
             'faf73eb5f07c56b019b540005f4262f33927a4ff2acf3752a055e8530decd749')
@@ -35,7 +35,7 @@ prepare() {
 
 build() {
  cd ${srcdir}
- make CFLAGS="${CFLAGS} -std=gnu99"
+ make CFLAGS="${CFLAGS} -std=gnu99 -DHAVE_GETTEXT=0"
 }
 
 package() {


### PR DESCRIPTION
don't fail if gettext is detected by explicitely disabling it