### PR TITLE
mosh: update sha256sum

### DIFF
--- a/mosh/PKGBUILD
+++ b/mosh/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=mosh
 pkgver=1.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Mobile shell, surviving disconnects with local echo and line editing"
 arch=('i686' 'x86_64')
 url='https://mosh.mit.edu/'
@@ -11,7 +11,7 @@ license=('GPL3')
 depends=('protobuf' 'ncurses' 'zlib' 'libopenssl' 'openssh' 'perl')
 makedepends=('protobuf-devel' 'ncurses-devel' 'zlib-devel' 'openssl-devel' 'bash-completion' 'autotools' 'gcc' 'perl-doc')
 source=("https://github.com/mobile-shell/mosh/releases/download/mosh-${pkgver}/mosh-${pkgver}.tar.gz")
-sha256sums=('d93ec9b2b0a012f59c4b8d5902b8a70b45db01e32c7c1ef7e5acd84ecebbb95f')
+sha256sums=('872e4b134e5df29c8933dff12350785054d2fd2839b5ae6b5587b14db1465ddd')
 options=(!emptydirs)
 
 build() {


### PR DESCRIPTION
Diffing the extracted .tar.gz files, it seems they regenerated the autotools files with newer versions, and replaced the file on the github release.

https://github.com/msys2/MSYS2-packages/pull/3263#issuecomment-1297921581