### PR TITLE
makepkg: default to -Wl,--large-address-aware

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.0.1
-pkgrel=24
+pkgrel=25
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -71,7 +71,7 @@ validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@a
 sha256sums=('SKIP'
             '26d141ead0b586e29ab6c49ffa45cf60eb2689f53f8e90c885ccd6d117e9ab67'
             'c12da01ede663a4924d0817a0d1bd6082b1380383cfb74cc1cea08f9d73e4902'
-            '0409c769b799085f066425c7fe2b4215a3b78d4be5630b4687a026a17f591ae5'
+            '8cb6b244d39107afc6cff74d919708ffc58b903c42f82d050d1d49bbf31208ab'
             '98198e1f0f252eae0560d271bee4b9149e127399dd0d3fd5d8d24579d9e0550f'
             '5951434296d1ea551941db408bac367e4b014add1b77ab5eb5d249deb81f777b'
             '1975fb6d1a0d4cc3c54caefb80b719b471b8cf797d4850a082a8d03aa2ba6278'

--- a/pacman/makepkg_mingw.conf
+++ b/pacman/makepkg_mingw.conf
@@ -56,7 +56,7 @@ elif [[ "$MSYSTEM" == "MINGW32" ]]; then
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
   CFLAGS="-march=pentium4 -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong"
   CXXFLAGS="-march=pentium4 -mtune=generic -O2 -pipe"
-  LDFLAGS="-pipe -Wl,--no-seh"
+  LDFLAGS="-pipe -Wl,--no-seh -Wl,--large-address-aware"
 elif [[ "$MSYSTEM" == "CLANG64" ]]; then
   CARCH="x86_64"
   CHOST="x86_64-w64-mingw32"
@@ -80,7 +80,7 @@ elif [[ "$MSYSTEM" == "CLANG32" ]]; then
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
   CFLAGS="-march=pentium4 -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong"
   CXXFLAGS="-march=pentium4 -mtune=generic -O2 -pipe"
-  LDFLAGS="-pipe -Wl,--no-seh"
+  LDFLAGS="-pipe -Wl,--no-seh -Wl,--large-address-aware"
 elif [[ "$MSYSTEM" == "CLANGARM64" ]]; then
   CARCH="aarch64"
   CHOST="aarch64-w64-mingw32"


### PR DESCRIPTION
There are many cases where the extra memory is helpful and with the type of software we package this hopefully shouldn't lead to any problems.

Fixes #3283