### PR TITLE
libunistring: remove old DLL again

### DIFF
--- a/libunistring/PKGBUILD
+++ b/libunistring/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('libunistring' 'libunistring-devel')
 pkgver=1.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for manipulating Unicode strings and C strings."
 url="https://www.gnu.org/software/libunistring/"
 arch=('i686' 'x86_64')
@@ -10,22 +10,14 @@ license=('spdx:LGPL-3.0-or-later OR GPL-2.0-or-later')
 depends=('libiconv')
 makedepends=('libiconv-devel' 'autotools' 'gcc')
 source=(https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz{,.sig}
-        https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-1.0.tar.xz{,.sig}
         libunistring-0.9.3-2.src.patch)
 sha256sums=('827c1eb9cb6e7c738b171745dac0888aa58c5924df2e59239318383de0729b98'
-            'SKIP'
-            '5bab55b49f75d77ed26b257997e919b693f29fd4a1bc22e0e6e024c246c72741'
             'SKIP'
             'a30d2733981e001e60992d188f145831cd1578bf3cd44bcfe46feaba415abd2b')
 validpgpkeys=('462225C3B46F34879FC8496CD605848ED7E69871'  # Daiki Ueno <ueno@unixuser.org>
               '9001B85AF9E1B83DF1BDA942F5BE8B267C6A406D') # Bruno Haible (Open Source Development) <bruno@clisp.org>
 
 prepare() {
-  cd "${srcdir}/${pkgname}-1.0"
-  patch -p1 -i ${srcdir}/libunistring-0.9.3-2.src.patch
-
-  autoreconf -fi
-
   cd "${srcdir}/${pkgname}-${pkgver}"
   patch -p1 -i ${srcdir}/libunistring-0.9.3-2.src.patch
 
@@ -33,17 +25,6 @@ prepare() {
 }
 
 build() {
-  cd "${srcdir}/${pkgname}-1.0"
-
-  export gl_cv_have_weak=no
-  local CYGWIN_CHOST="${CHOST/-msys/-cygwin}"
-  ./configure \
-    --build=${CYGWIN_CHOST} \
-    --prefix=/usr
-
-  make
-  make DESTDIR="${srcdir}/dest1.0" install
-
   cd "${srcdir}/${pkgname}-${pkgver}"
 
   export gl_cv_have_weak=no
@@ -60,7 +41,6 @@ package_libunistring() {
   groups=('libraries')
 
   mkdir -p ${pkgdir}/usr
-  cp -rf ${srcdir}/dest1.0/usr/bin ${pkgdir}/usr/
   cp -rf ${srcdir}/dest/usr/bin ${pkgdir}/usr/
   cp -rf ${srcdir}/dest/usr/share ${pkgdir}/usr/
 }


### PR DESCRIPTION
rebuilds are through and in the repo, so we can drop the 1.0 dll now