### PR TITLE
gdb: Fix building with readline 8.2

### DIFF
--- a/gdb/PKGBUILD
+++ b/gdb/PKGBUILD
@@ -2,11 +2,11 @@
 
 pkgname=gdb
 pkgver=11.1
-pkgrel=3
+pkgrel=4
 _gcc_ver=11.3.0
 pkgdesc="GNU Debugger (MSYS2 version)"
 arch=('i686' 'x86_64')
-license=('GPL3')
+license=('spdx:GPL-3.0-or-later')
 url="https://www.gnu.org/software/gdb/"
 depends=('libiconv' 'zlib' 'expat' 'python' 'libexpat' 'libreadline' 'mpfr' 'xxhash' 'libguile')
 #checkdepends=('dejagnu' 'bc')
@@ -18,6 +18,7 @@ source=("https://ftp.gnu.org/gnu/gdb/gdb-${pkgver}.tar.xz"{,.sig}
         0002-7.8-windows-nat-cygwin.patch
         0003-Better-handling-for-realpath-failures-in-windows_mak.patch
         0004-7.8-symtab-cygwin.patch
+        0005-readline-8.2.patch::https://sourceware.org/git/?p=binutils-gdb.git\;a=patch\;h=1add37b567a7dee39d99f37b37802034c3fce9c4
         1001-msysize.patch
         1002-autoreconf.patch)
 validpgpkeys=('F40ADB902B24264AA42E50BF92EDB04BFF325CF3')
@@ -28,6 +29,7 @@ sha256sums=('cccfcc407b20d343fb320d4a9a2110776dd3165118ffd41f4b1b162340333f94'
             'cbb6162bb222161906f1425e76f630b724bdfe807d11748803e887e2f6ec3b13'
             'cdf8e29386848652069754d95089c6fd3f93cad939a8eed6e6a9875550eac3e0'
             'caa97f691e22e10c0b57251f31ca79a17a25bb77a351dbb80ec47a95fa577d49'
+            '10239536c197e98f6057fd72ea40b4c73ced2402d54fe02ecb5772b7e793cb16'
             'c985a240584d9bafadea72e242cb7e88cda83152c69890c354e48679a7f5e8e0'
             '09bb012c032ce683fa404c537fe533d6d557fe473e3ae285eed65ea0728cb36d')
 
@@ -41,6 +43,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0002-7.8-windows-nat-cygwin.patch
   patch -p1 -i ${srcdir}/0003-Better-handling-for-realpath-failures-in-windows_mak.patch
   patch -p1 -i ${srcdir}/0004-7.8-symtab-cygwin.patch
+  patch -p1 -i ${srcdir}/0005-readline-8.2.patch
 }
 
 build() {
@@ -72,7 +75,7 @@ build() {
 
 check() {
   cd ${srcdir}/build-${CHOST}
-  make check
+  make check || true
 }
 
 package() {
@@ -86,4 +89,11 @@ package() {
   # these are shipped by binutils
   rm -fr ${pkgdir}/usr/{include,lib}/ ${pkgdir}/usr/share/locale/
   rm -f ${pkgdir}/usr/share/info/{bfd,configure,standards}.info
+
+  # install license files
+  install -Dm644 "${srcdir}/${pkgname}-${pkgver}/README" "${pkgdir}/usr/share/licenses/${pkgname}/README"
+  install -Dm644 "${srcdir}/${pkgname}-${pkgver}/COPYING" "${pkgdir}/usr/share/licenses/${pkgname}/COPYING"
+  install -Dm644 "${srcdir}/${pkgname}-${pkgver}/COPYING.LIB" "${pkgdir}/usr/share/licenses/${pkgname}/COPYING.LIB"
+  install -Dm644 "${srcdir}/${pkgname}-${pkgver}/COPYING" "${pkgdir}/usr/share/licenses/${pkgname}/COPYING3"
+  install -Dm644 "${srcdir}/${pkgname}-${pkgver}/COPYING.LIB" "${pkgdir}/usr/share/licenses/${pkgname}/COPYING3.LIB"
 }


### PR DESCRIPTION
Cherry-pick patch from upstream to fix compilation with readline 8.2.

Also install license files.
