### PR TITLE
nano: Update to 7.0

### DIFF
--- a/nano/PKGBUILD
+++ b/nano/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=nano
-pkgver=6.4
+pkgver=7.0
 pkgrel=1
 pkgdesc="Pico editor clone with enhancements"
 arch=('i686' 'x86_64')
@@ -15,12 +15,11 @@ makedepends=('autotools'
              'libiconv-devel'
              'gettext-devel')
 backup=('etc/nanorc')
-source=(https://www.nano-editor.org/dist/v6/${pkgname}-${pkgver}.tar.xz{,.asc})
-sha256sums=('4199ae8ca78a7796de56de1a41b821dc47912c0307e9816b56cc317df34661c0'
+source=(https://www.nano-editor.org/dist/v7/${pkgname}-${pkgver}.tar.xz{,.asc})
+sha256sums=('8dd6eac38b2b8786d82681f0e1afd84f6b75210d17391b6443c437e451552149'
             'SKIP')
-validpgpkeys=('8DA6FE7BFA7A418AB3CB2354BCB356DF91009FA7' # "Chris Allegretta <chrisa@asty.org>"
-              'A7F6A64A67DA09EF92782DD79DF4862AF1175C5B' # "Benno Schulenberg <bensberg@justemail.net>"
-              'BFD009061E535052AD0DF2150D28D4D2A0ACE884' # "Benno Schulenberg <bensberg@telfort.nl>"
+validpgpkeys=(
+  '168E6F4297BFD7A79AFD4496514BBE2EB8E1961F' # Benno Schulenberg <bensberg@telfort.nl>
 )
 
 prepare() {
@@ -31,8 +30,6 @@ prepare() {
 
 build() {
   cd ${srcdir}/${pkgname}-${pkgver}
-
-  export gl_cv_have_weak=no
 
   local CYGWIN_CHOST="${CHOST/-msys/-cygwin}"
   ./configure --build=${CYGWIN_CHOST} \


### PR DESCRIPTION
* gnulib was updated, so we can remove the weak symbol workaround
* the signing key changed, see https://lists.gnu.org/archive/html/info-gnu/2022-11/msg00005.html