### PR TITLE
msys2-runtime: apply workaround for missing trailing slashes with path_conv

### DIFF
--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.3.6
-pkgrel=4
+pkgrel=5
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -25,6 +25,7 @@ makedepends=('cocom'
 # re zipman: https://github.com/msys2/MSYS2-packages/pull/2687#issuecomment-965714874
 options=('!zipman')
 source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-${pkgver//./_}-release
+        https://patch-diff.githubusercontent.com/raw/msys2/msys2-runtime/pull/117.patch
         0001-Add-MSYS2-triplet.patch
         0002-Fix-msys-library-name-in-import-libraries.patch
         0003-Rename-dll-from-cygwin-to-msys.patch
@@ -70,6 +71,7 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0043-When-converting-to-a-Unix-path-avoid-double-trailing.patch
         0044-amend-Special-case-for-converting-root-directory-to-.patch)
 sha256sums=('SKIP'
+            '77a4cb681404750c518cec37cdc7b332a663b6106fc54df7cf102d945aa903d3'
             'c375315e58181ee5589b7966101aa095de3f864a579c3c3f0f0683595d4e428d'
             '01ea2b131cf5a3b27fdbc458019eac14e45a36782ce3ce33e62328eefcd2d02e'
             '475ddea4d86605ab097f98ec764951a9d647ea3100dea0e1620f57044ea4a114'
@@ -195,6 +197,8 @@ prepare() {
   0042-ci-avoid-using-Node.js-12-Actions.patch \
   0043-When-converting-to-a-Unix-path-avoid-double-trailing.patch \
   0044-amend-Special-case-for-converting-root-directory-to-.patch
+
+  git apply "${srcdir}/117.patch"
 }
 
 build() {


### PR DESCRIPTION
See https://github.com/msys2/msys2-runtime/pull/117