### PR TITLE
libxml2: remove indirect dependencies

### DIFF
--- a/libxml2/PKGBUILD
+++ b/libxml2/PKGBUILD
@@ -3,12 +3,12 @@
 pkgbase=libxml2
 pkgname=('libxml2' 'libxml2-devel' 'libxml2-python')
 pkgver=2.10.3
-pkgrel=1
+pkgrel=2
 pkgdesc="XML parsing library, version 2"
 arch=(i686 x86_64)
 license=('spdx:MIT')
 makedepends=('gcc' 'python-devel' 'libcrypt-devel' 'libreadline-devel'
-             'ncurses-devel' 'liblzma-devel' 'zlib-devel' 'autotools')
+             'liblzma-devel' 'zlib-devel' 'autotools')
 url="https://gitlab.gnome.org/GNOME/libxml2/-/wikis/"
 source=("https://download.gnome.org/sources/libxml2/${pkgver%.*}/${pkgbase}-${pkgver}.tar.xz"
         https://www.w3.org/XML/Test/xmlts20130923.tar.gz
@@ -53,7 +53,7 @@ prepare() {
   apply_patch_with_msg \
     libxml2-2.9.1-msys2.patch
 
-  autoreconf -fi
+  autoreconf -vfi
 }
 
 build() {
@@ -90,7 +90,7 @@ check() {
 }
 
 package_libxml2() {
-  depends=('coreutils' 'liblzma' 'libreadline' 'ncurses' 'zlib')
+  depends=('coreutils' 'liblzma' 'libreadline' 'zlib')
   groups=('libraries')
   install=libxml2.install
 
@@ -106,7 +106,7 @@ package_libxml2-devel() {
   pkgdesc="Libxml2 headers and libraries"
   groups=('development')
   options=('staticlibs')
-  depends=("libxml2=${pkgver}" 'libreadline-devel' 'ncurses-devel' 'liblzma-devel' 'zlib-devel')
+  depends=("libxml2=${pkgver}" 'libreadline-devel' 'liblzma-devel' 'zlib-devel')
 
   PYTHON_SITELIB="$(python -c 'import site, sys; sys.stdout.write(site.getsitepackages()[0])')"
   mkdir -p ${pkgdir}/usr/{bin,share}


### PR DESCRIPTION
* libxml2/PKGBUILD:
  - remove the libraries 'ncurses' and 'ncurses-devel' from depends and makedepends, resp., since they are indirect dependencies to libxml2.
  - make autoreconf be verbose
  - remove trailing spaces