### PR TITLE
libtool: fix license file location

### DIFF
--- a/libtool/PKGBUILD
+++ b/libtool/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=('libtool' 'libltdl')
 pkgver=2.4.7
 _gccver=11.2.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A generic library support script"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/libtool/"
@@ -99,5 +99,5 @@ package_libltdl() {
   make DESTDIR=${pkgdir} install-libLTLIBRARIES install-includeHEADERS \
                          install-ltdlincludeHEADERS
 
-  install -Dm644 "${srcdir}/${pkgbase}-${pkgver}/COPYING" "${pkgdir}/share/licenses/${pkgbase}/COPYING"
+  install -Dm644 "${srcdir}/${pkgbase}-${pkgver}/COPYING" "${pkgdir}/usr/share/licenses/${pkgbase}/COPYING"
 }


### PR DESCRIPTION
missing usr