### PR TITLE
tmate: don't makedep on ruby

### DIFF
--- a/tmate/PKGBUILD
+++ b/tmate/PKGBUILD
@@ -1,12 +1,12 @@
 pkgname=tmate
 pkgver=2.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Instant Terminal Sharing http://tmate.io/"
 arch=('i686' 'x86_64')
 license=('ISC')
 url="http://tmate.io/"
 depends=('libevent' 'ncurses' 'libopenssl' 'libssh' 'zlib' 'msgpack-c')
-makedepends=('libevent-devel' 'ncurses-devel' 'openssl-devel' 'libssh-devel' 'zlib-devel' 'ruby' 'msgpack-c-devel' 'autotools' 'gcc')
+makedepends=('libevent-devel' 'ncurses-devel' 'openssl-devel' 'libssh-devel' 'zlib-devel' 'msgpack-c-devel' 'autotools' 'gcc')
 
 source=("$pkgname"::"git+https://github.com/tmate-io/tmate.git#tag=$pkgver"
         "0001-tmux-Inherit-MSYSTEM-variable.patch"


### PR DESCRIPTION
doesn't seem to be used anymore