### PR TITLE
libtool: Allow spaces in program paths

### DIFF
--- a/libtool/0015-Allow-spaces-in-program-paths.patch
+++ b/libtool/0015-Allow-spaces-in-program-paths.patch
@@ -1,0 +1,60 @@
+diff -u a/bootstrap b/bootstrap
+--- a/bootstrap	2022-07-24 00:19:04.972571900 -0700
++++ b/bootstrap	2022-07-24 00:20:09.875444300 -0700
+@@ -369,8 +369,8 @@
+           _G_path_prog=$_G_dir/$_G_prog_name$_exeext
+           func_executable_p "$_G_path_prog" || continue
+           case `"$_G_path_prog" --version 2>&1` in
+-            *GNU*) func_path_progs_result=$_G_path_prog _G_path_prog_found=: ;;
+-            *)     $_G_check_func $_G_path_prog
++            *GNU*) func_path_progs_result="$_G_path_prog" _G_path_prog_found=: ;;
++            *)     $_G_check_func "$_G_path_prog"
+ 		   func_path_progs_result=$func_check_prog_result
+ 		   ;;
+           esac
+@@ -418,7 +418,7 @@
+       _G_count=`expr $_G_count + 1`
+       if test "$_G_count" -gt "$_G_path_prog_max"; then
+         # Best one so far, save it but keep looking for a better one
+-        func_check_prog_result=$_G_path_prog
++        func_check_prog_result="$_G_path_prog"
+         _G_path_prog_max=$_G_count
+       fi
+       # 10*(2^10) chars as input seems more than enough
+@@ -454,7 +454,7 @@
+       _G_count=`expr $_G_count + 1`
+       if test "$_G_count" -gt "$_G_path_prog_max"; then
+         # Best one so far, save it but keep looking for a better one
+-        func_check_prog_result=$_G_path_prog
++        func_check_prog_result="$_G_path_prog"
+         _G_path_prog_max=$_G_count
+       fi
+       # 10*(2^10) chars as input seems more than enough
+@@ -2503,15 +2503,15 @@
+ 	  IFS=$_G_find_tool_save_IFS
+ 	  _G_progpath=$_G_dir/$_G_prog
+           test -r "$_G_progpath" && {
+-            _G_curver=`func_tool_version_number $_G_progpath`
++            _G_curver=`func_tool_version_number "$_G_progpath"`
+ 	    case $_G_bestver,$_G_curver in
+ 	    ,)
+ 	      # first non--version responsive prog sticks!
+-              test -n "$_G_progpath" || _G_find_tool_res=$_G_progpath
++              test -n "$_G_progpath" || _G_find_tool_res="$_G_progpath"
+               ;;
+             ,*)
+ 	      # first --version responsive prog beats non--version responsive!
+-	      _G_find_tool_res=$_G_progpath
++	      _G_find_tool_res="$_G_progpath"
+ 	      _G_bestver=$_G_curver
+ 	      ;;
+ 	    *,*)
+@@ -2519,7 +2519,7 @@
+ 	      test "x$_G_curver" = "x$_G_bestver" \
+ 		|| func_lt_ver "$_G_curver" "$_G_bestver" \
+ 		|| {
+-		     _G_find_tool_res=$_G_progpath
++		     _G_find_tool_res="$_G_progpath"
+ 		     _G_bestver=$_G_curver
+ 	           }
+ 	      ;;

--- a/libtool/PKGBUILD
+++ b/libtool/PKGBUILD
@@ -22,7 +22,8 @@ source=(https://ftp.gnu.org/pub/gnu/libtool/${pkgname}-${pkgver}.tar.xz{,.sig}
         0011-Pick-up-clang_rt-static-archives-compiler-internal-l.patch
         0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
         0013-Allow-statically-linking-compiler-support-libraries-.patch
-        0014-Support-llvm-objdump-f-output.patch)
+        0014-Support-llvm-objdump-f-output.patch
+        0015-Allow-spaces-in-program-paths.patch)
 sha256sums=('7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f'
             'SKIP'
             'fe8b80efd34f9385220ebc90aaec945e44de8c343c75719d6ac0d4e472a6eed5'
@@ -35,7 +36,8 @@ sha256sums=('7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f'
             'c727b2b017163cfdeca60820d3cff2dac8968c5630745602b150f92b159af313'
             'c95a65e890b1ae6362807abc66809e72cf81aeea5f9f556e38f9752f974bf435'
             '8069e887aeeab7491f15e00547fa66d9b9e86407f5a23f37a6d8c7d165de752e'
-            'db16cd322e0ebc578c906e94b0788810af17ce617c700a50db2e3c598dbbed7e')
+            'db16cd322e0ebc578c906e94b0788810af17ce617c700a50db2e3c598dbbed7e'
+            '622f89a936979747a1f4e59279ca957a8d6f1dd92aa968e35258fc6c83b655ca')
 
  validpgpkeys=('CFE2BE707B538E8B26757D84151308092983D606') #Gary Vaughan (Free Software Developer) <gary@vaughan.pe>
 
@@ -54,6 +56,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0012-Prefer-response-files-over-linker-scripts-for-mingw-.patch
   patch -p1 -i ${srcdir}/0013-Allow-statically-linking-compiler-support-libraries-.patch
   patch -p1 -i ${srcdir}/0014-Support-llvm-objdump-f-output.patch
+  patch -p1 -i ${srcdir}/0015-Allow-spaces-in-program-paths.patch
 
 }
 


### PR DESCRIPTION
This makes `libtool` more Windows-friendly.  Sometimes, `libtool` will find tools like _C:\Program Files (x86)\Git\bin\ld_ that it subsequently cannot handle.