### PR TITLE
Add msys2-runtime-3.3

### DIFF
--- a/.ci/ci-dont-install-list.txt
+++ b/.ci/ci-dont-install-list.txt
@@ -1,2 +1,3 @@
 msys2-runtime
+msys2-runtime-3.3
 bash

--- a/msys2-runtime-3.3/0001-Add-MSYS2-triplet.patch
+++ b/msys2-runtime-3.3/0001-Add-MSYS2-triplet.patch
@@ -1,0 +1,2710 @@
+From 1e32c73dcc76fdb430cebdca8e790a2486dcef56 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=90=D0=BB=D0=B5=D0=BA=D1=81=D0=B5=D0=B8=CC=86=20=D0=9F?=
+ =?UTF-8?q?=D0=B0=D0=B2=D0=BB=D0=BE=D0=B2?= <alexey.pawlow@gmail.com>
+Date: Sun, 14 Apr 2019 20:40:45 +0300
+Subject: [PATCH 01/N] Add MSYS2 triplet
+
+---
+ compile                                       |  4 +-
+ config.guess                                  |  3 ++
+ config.rpath                                  |  8 +--
+ config/dfp.m4                                 |  3 +-
+ config/elf.m4                                 |  2 +-
+ config/lthostflags.m4                         |  2 +-
+ config/mmap.m4                                |  4 +-
+ config/picflag.m4                             |  2 +
+ config/tcl.m4                                 |  4 +-
+ configure                                     | 22 ++++----
+ configure.ac                                  | 20 +++----
+ libtool.m4                                    | 36 +++++++------
+ ltmain.sh                                     | 52 +++++++++----------
+ ltoptions.m4                                  |  2 +-
+ newlib/configure                              | 30 ++++++-----
+ newlib/configure.host                         |  8 +--
+ newlib/iconvdata/configure                    | 30 ++++++-----
+ newlib/libc/configure                         | 30 ++++++-----
+ newlib/libc/machine/configure                 | 30 ++++++-----
+ newlib/libc/machine/i386/configure            | 30 ++++++-----
+ newlib/libc/sys/configure                     | 30 ++++++-----
+ newlib/libc/sys/linux/configure               | 30 ++++++-----
+ newlib/libc/sys/linux/linuxthreads/configure  | 30 ++++++-----
+ .../sys/linux/linuxthreads/machine/configure  | 30 ++++++-----
+ .../linux/linuxthreads/machine/i386/configure | 30 ++++++-----
+ newlib/libc/sys/linux/machine/configure       | 30 ++++++-----
+ newlib/libc/sys/linux/machine/i386/configure  | 30 ++++++-----
+ newlib/libm/configure                         | 30 ++++++-----
+ newlib/libm/machine/configure                 | 30 ++++++-----
+ newlib/libm/machine/i386/configure            | 30 ++++++-----
+ 30 files changed, 362 insertions(+), 260 deletions(-)
+
+diff --git a/compile b/compile
+index a85b723..a4ecdb2 100755
+--- a/compile
++++ b/compile
+@@ -53,7 +53,7 @@ func_file_conv ()
+ 	  MINGW*)
+ 	    file_conv=mingw
+ 	    ;;
+-	  CYGWIN*)
++	  CYGWIN*|MSYS*)
+ 	    file_conv=cygwin
+ 	    ;;
+ 	  *)
+@@ -67,7 +67,7 @@ func_file_conv ()
+ 	mingw/*)
+ 	  file=`cmd //C echo "$file " | sed -e 's/"\(.*\) " *$/\1/'`
+ 	  ;;
+-	cygwin/*)
++	cygwin/*|msys/*)
+ 	  file=`cygpath -m "$file" || echo "$file"`
+ 	  ;;
+ 	wine/*)
+diff --git a/config.guess b/config.guess
+index 1972fda..a922fa3 100755
+--- a/config.guess
++++ b/config.guess
+@@ -914,6 +914,9 @@ EOF
+     amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
+ 	echo x86_64-pc-cygwin
+ 	exit ;;
++    amd64:MSYS*:*:* | x86_64:MSYS*:*:*)
++	echo x86_64-unknown-msys
++	exit ;;
+     prep*:SunOS:5.*:*)
+ 	echo powerpcle-unknown-solaris2"$(echo "$UNAME_RELEASE"|sed -e 's/[^.]*//')"
+ 	exit ;;
+diff --git a/config.rpath b/config.rpath
+index 4dea759..4f12c27 100755
+--- a/config.rpath
++++ b/config.rpath
+@@ -109,7 +109,7 @@ hardcode_direct=no
+ hardcode_minus_L=no
+ 
+ case "$host_os" in
+-  cygwin* | mingw* | pw32*)
++  cygwin* | msys* | mingw* | pw32*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -149,7 +149,7 @@ if test "$with_gnu_ld" = yes; then
+         ld_shlibs=no
+       fi
+       ;;
+-    cygwin* | mingw* | pw32*)
++    cygwin* | msys* | mingw* | pw32*)
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+       # no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -268,7 +268,7 @@ else
+       ;;
+     bsdi4*)
+       ;;
+-    cygwin* | mingw* | pw32*)
++    cygwin* | msys* | mingw* | pw32*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -437,7 +437,7 @@ case "$host_os" in
+     ;;
+   bsdi4*)
+     ;;
+-  cygwin* | mingw* | pw32*)
++  cygwin* | msys* | mingw* | pw32*)
+     shrext=.dll
+     ;;
+   darwin* | rhapsody*)
+diff --git a/config/dfp.m4 b/config/dfp.m4
+index 5b29089..b03bcf0 100644
+--- a/config/dfp.m4
++++ b/config/dfp.m4
+@@ -23,7 +23,8 @@ Valid choices are 'yes', 'bid', 'dpd', and 'no'.]) ;;
+     powerpc*-*-linux* | i?86*-*-linux* | x86_64*-*-linux* | s390*-*-linux* | \
+     i?86*-*-elfiamcu | i?86*-*-gnu* | \
+     i?86*-*-mingw* | x86_64*-*-mingw* | \
+-    i?86*-*-cygwin* | x86_64*-*-cygwin*)
++    i?86*-*-cygwin* | x86_64*-*-cygwin* | \
++    i?86*-*-msys* | x86_64*-*-msys*)
+       enable_decimal_float=yes
+       ;;
+     *)
+diff --git a/config/elf.m4 b/config/elf.m4
+index 5f5cd88..b8491de 100644
+--- a/config/elf.m4
++++ b/config/elf.m4
+@@ -15,7 +15,7 @@ AC_REQUIRE([AC_CANONICAL_TARGET])
+ 
+ target_elf=no
+ case $target in
+-  *-darwin* | *-aix* | *-cygwin* | *-mingw* | *-aout* | *-*coff* | \
++  *-darwin* | *-aix* | *-cygwin* | *-msys* | *-mingw* | *-aout* | *-*coff* | \
+   *-msdosdjgpp* | *-vms* | *-wince* | *-*-pe* | \
+   alpha*-dec-osf* | hppa[[12]]*-*-hpux* | \
+   nvptx-*-none)
+diff --git a/config/lthostflags.m4 b/config/lthostflags.m4
+index bc0f59e..ad977d4 100644
+--- a/config/lthostflags.m4
++++ b/config/lthostflags.m4
+@@ -13,7 +13,7 @@ AC_DEFUN([ACX_LT_HOST_FLAGS], [
+ AC_REQUIRE([AC_CANONICAL_SYSTEM])
+ 
+ case $host in
+-  *-cygwin* | *-mingw*)
++  *-cygwin* | *-msys* | *-mingw*)
+     # 'host' will be top-level target in the case of a target lib,
+     # we must compare to with_cross_host to decide if this is a native
+     # or cross-compiler and select where to install dlls appropriately.
+diff --git a/config/mmap.m4 b/config/mmap.m4
+index fba0d9d..df2c778 100644
+--- a/config/mmap.m4
++++ b/config/mmap.m4
+@@ -42,7 +42,7 @@ else
+    # Systems known to be in this category are Windows (all variants),
+    # VMS, and Darwin.
+    case "$host_os" in
+-     *vms* | cygwin* | pe | mingw* | darwin* | ultrix* | hpux10* | hpux11.00)
++     *vms* | cygwin* | msys* | pe | mingw* | darwin* | ultrix* | hpux10* | hpux11.00)
+         gcc_cv_func_mmap_dev_zero=no ;;
+      *)
+         gcc_cv_func_mmap_dev_zero=yes;;
+@@ -74,7 +74,7 @@ else
+    # above for use of /dev/zero.
+    # Systems known to be in this category are Windows, VMS, and SCO Unix.
+    case "$host_os" in
+-     *vms* | cygwin* | pe | mingw* | sco* | udk* )
++     *vms* | cygwin* | msys* | pe | mingw* | sco* | udk* )
+         gcc_cv_func_mmap_anon=no ;;
+      *)
+         gcc_cv_func_mmap_anon=yes;;
+diff --git a/config/picflag.m4 b/config/picflag.m4
+index 614421d..9d507ba 100644
+--- a/config/picflag.m4
++++ b/config/picflag.m4
+@@ -25,6 +25,8 @@ case "${$2}" in
+ 	;;
+     i[[34567]]86-*-cygwin* | x86_64-*-cygwin*)
+ 	;;
++    i[[34567]]86-*-msys* | x86_64-*-msys*)
++	;;
+     i[[34567]]86-*-mingw* | x86_64-*-mingw*)
+ 	;;
+     i[[34567]]86-*-nto-qnx*)
+diff --git a/config/tcl.m4 b/config/tcl.m4
+index 4542a4b..209bd8d 100644
+--- a/config/tcl.m4
++++ b/config/tcl.m4
+@@ -33,7 +33,7 @@ AC_DEFUN([SC_PATH_TCLCONFIG], [
+ 
+ 	    # First check to see if --with-tcl was specified.
+ 	    case "${host}" in
+-		*-*-cygwin*) platDir="win" ;;
++		*-*-cygwin* | *-*-msys*) platDir="win" ;;
+ 		*) platDir="unix" ;;
+ 	    esac
+ 	    if test x"${with_tclconfig}" != x ; then
+@@ -165,7 +165,7 @@ AC_DEFUN([SC_PATH_TKCONFIG], [
+ 
+ 	    # then check for a private Tk library
+ 	    case "${host}" in
+-		*-*-cygwin*) platDir="win" ;;
++		*-*-cygwin* | *-*-msys*) platDir="win" ;;
+ 		*) platDir="unix" ;;
+ 	    esac
+ 	    if test x"${ac_cv_c_tkconfig}" = x ; then
+diff --git a/configure b/configure
+index 5db5270..ad2739d 100755
+--- a/configure
++++ b/configure
+@@ -3036,7 +3036,7 @@ fi
+ # Configure extra directories which are host specific
+ 
+ case "${host}" in
+-  *-cygwin*)
++  *-cygwin* | *-msys*)
+     configdirs="$configdirs libtermcap" ;;
+ esac
+ 
+@@ -3557,7 +3557,7 @@ esac
+ # Disable the go frontend on systems where it is known to not work. Please keep
+ # this in sync with contrib/config-list.mk.
+ case "${target}" in
+-*-*-darwin* | *-*-cygwin* | *-*-mingw* | *-*-aix*)
++*-*-darwin* | *-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-aix*)
+     unsupported_languages="$unsupported_languages go"
+     ;;
+ esac
+@@ -3570,7 +3570,7 @@ if test x$enable_libgo = x; then
+ 	# PR 46986
+ 	noconfigdirs="$noconfigdirs target-libgo"
+ 	;;
+-    *-*-cygwin* | *-*-mingw*)
++    *-*-cygwin* | *-*-msys* | *-*-mingw*)
+ 	noconfigdirs="$noconfigdirs target-libgo"
+ 	;;
+     *-*-aix*)
+@@ -3842,7 +3842,7 @@ case "${target}" in
+   i[3456789]86-*-mingw*)
+     target_configdirs="$target_configdirs target-winsup"
+     ;;
+-  *-*-cygwin*)
++  *-*-cygwin* | *-*-msys*)
+     target_configdirs="$target_configdirs target-libtermcap target-winsup"
+     noconfigdirs="$noconfigdirs target-libgloss"
+     # always build newlib if winsup directory is present.
+@@ -3986,7 +3986,7 @@ case "${host}" in
+   i[3456789]86-*-msdosdjgpp*)
+     host_makefile_frag="config/mh-djgpp"
+     ;;
+-  *-cygwin*)
++  *-cygwin* | *-msys*)
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking to see if cat works as expected" >&5
+ $as_echo_n "checking to see if cat works as expected... " >&6; }
+@@ -6130,7 +6130,7 @@ fi
+ 
+ target_elf=no
+ case $target in
+-  *-darwin* | *-aix* | *-cygwin* | *-mingw* | *-aout* | *-*coff* | \
++  *-darwin* | *-aix* | *-cygwin* | *-msys* | *-mingw* | *-aout* | *-*coff* | \
+   *-msdosdjgpp* | *-vms* | *-wince* | *-*-pe* | \
+   alpha*-dec-osf* | hppa[12]*-*-hpux* | \
+   nvptx-*-none)
+@@ -6148,7 +6148,7 @@ if test $target_elf = yes; then :
+ else
+   if test x"$default_enable_lto" = x"yes" ; then
+     case $target in
+-      *-apple-darwin9* | *-cygwin* | *-mingw* | *djgpp*) ;;
++      *-apple-darwin9* | *-cygwin* | *-msys* | *-mingw* | *djgpp*) ;;
+       # On other non-ELF platforms, LTO has yet to be validated.
+       *) enable_lto=no ;;
+     esac
+@@ -6159,7 +6159,7 @@ else
+   # warn during gcc/ subconfigure; unless you're bootstrapping with
+   # -flto it won't be needed until after installation anyway.
+     case $target in
+-      *-cygwin* | *-mingw* | *-apple-darwin* | *djgpp*) ;;
++      *-cygwin* | *-msys* | *-mingw* | *-apple-darwin* | *djgpp*) ;;
+       *) if test x"$enable_lto" = x"yes"; then
+ 	as_fn_error "LTO support is not enabled for this target." "$LINENO" 5
+         fi
+@@ -6169,7 +6169,7 @@ else
+   # Among non-ELF, only Windows platforms support the lto-plugin so far.
+   # Build it unless LTO was explicitly disabled.
+   case $target in
+-    *-cygwin* | *-mingw*) build_lto_plugin=$enable_lto ;;
++    *-cygwin* | *-msys* | *-mingw*) build_lto_plugin=$enable_lto ;;
+     *) ;;
+   esac
+ 
+@@ -7040,7 +7040,7 @@ rm -f conftest*
+ case "${host}" in
+   *-*-hpux*) RPATH_ENVVAR=SHLIB_PATH ;;
+   *-*-darwin*) RPATH_ENVVAR=DYLD_LIBRARY_PATH ;;
+-  *-*-mingw* | *-*-cygwin ) RPATH_ENVVAR=PATH ;;
++  *-*-mingw* | *-*-cygwin | *-msys ) RPATH_ENVVAR=PATH ;;
+   *) RPATH_ENVVAR=LD_LIBRARY_PATH ;;
+ esac
+ 
+@@ -7558,7 +7558,7 @@ case " $target_configdirs " in
+   case " $target_configargs " in
+   *" --with-newlib "*)
+    case "$target" in
+-    *-cygwin*)
++    *-cygwin* | *-msys*)
+       FLAGS_FOR_TARGET=$FLAGS_FOR_TARGET' -L$$r/$(TARGET_SUBDIR)/winsup/cygwin -isystem $$s/winsup/cygwin/include'
+       ;;
+    esac
+diff --git a/configure.ac b/configure.ac
+index cf856e5..cb23f21 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -409,7 +409,7 @@ AC_ARG_ENABLE(compressed_debug_sections,
+ # Configure extra directories which are host specific
+ 
+ case "${host}" in
+-  *-cygwin*)
++  *-cygwin* | *-msys*)
+     configdirs="$configdirs libtermcap" ;;
+ esac
+ 
+@@ -893,7 +893,7 @@ esac
+ # Disable the go frontend on systems where it is known to not work. Please keep
+ # this in sync with contrib/config-list.mk.
+ case "${target}" in
+-*-*-darwin* | *-*-cygwin* | *-*-mingw* | *-*-aix*)
++*-*-darwin* | *-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-aix*)
+     unsupported_languages="$unsupported_languages go"
+     ;;
+ esac
+@@ -906,7 +906,7 @@ if test x$enable_libgo = x; then
+ 	# PR 46986
+ 	noconfigdirs="$noconfigdirs target-libgo"
+ 	;;
+-    *-*-cygwin* | *-*-mingw*)
++    *-*-cygwin* | *-*-msys* | *-*-mingw*)
+ 	noconfigdirs="$noconfigdirs target-libgo"
+ 	;;
+     *-*-aix*)
+@@ -1178,7 +1178,7 @@ case "${target}" in
+   i[[3456789]]86-*-mingw*)
+     target_configdirs="$target_configdirs target-winsup"
+     ;;
+-  *-*-cygwin*)
++  *-*-cygwin* | *-*-msys*)
+     target_configdirs="$target_configdirs target-libtermcap target-winsup"
+     noconfigdirs="$noconfigdirs target-libgloss"
+     # always build newlib if winsup directory is present.
+@@ -1322,7 +1322,7 @@ case "${host}" in
+   i[[3456789]]86-*-msdosdjgpp*)
+     host_makefile_frag="config/mh-djgpp"
+     ;;
+-  *-cygwin*)
++  *-cygwin* | *-msys*)
+     ACX_CHECK_CYGWIN_CAT_WORKS
+     host_makefile_frag="config/mh-cygwin"
+     ;;
+@@ -1809,7 +1809,7 @@ ACX_ELF_TARGET_IFELSE([# ELF platforms build the lto-plugin always.
+   build_lto_plugin=yes
+ ],[if test x"$default_enable_lto" = x"yes" ; then
+     case $target in
+-      *-apple-darwin9* | *-cygwin* | *-mingw* | *djgpp*) ;;
++      *-apple-darwin9* | *-cygwin* | *-msys* | *-mingw* | *djgpp*) ;;
+       # On other non-ELF platforms, LTO has yet to be validated.
+       *) enable_lto=no ;;
+     esac
+@@ -1820,7 +1820,7 @@ ACX_ELF_TARGET_IFELSE([# ELF platforms build the lto-plugin always.
+   # warn during gcc/ subconfigure; unless you're bootstrapping with
+   # -flto it won't be needed until after installation anyway.
+     case $target in
+-      *-cygwin* | *-mingw* | *-apple-darwin* | *djgpp*) ;;
++      *-cygwin*  | *-msys*| *-mingw* | *-apple-darwin* | *djgpp*) ;;
+       *) if test x"$enable_lto" = x"yes"; then
+ 	AC_MSG_ERROR([LTO support is not enabled for this target.])
+         fi
+@@ -1830,7 +1830,7 @@ ACX_ELF_TARGET_IFELSE([# ELF platforms build the lto-plugin always.
+   # Among non-ELF, only Windows platforms support the lto-plugin so far.
+   # Build it unless LTO was explicitly disabled.
+   case $target in
+-    *-cygwin* | *-mingw*) build_lto_plugin=$enable_lto ;;
++    *-cygwin* | *-msys* | *-mingw*) build_lto_plugin=$enable_lto ;;
+     *) ;;
+   esac
+ ])
+@@ -2644,7 +2644,7 @@ rm -f conftest*
+ case "${host}" in
+   *-*-hpux*) RPATH_ENVVAR=SHLIB_PATH ;;
+   *-*-darwin*) RPATH_ENVVAR=DYLD_LIBRARY_PATH ;;
+-  *-*-mingw* | *-*-cygwin ) RPATH_ENVVAR=PATH ;;
++  *-*-mingw* | *-*-cygwin | *-*-msys ) RPATH_ENVVAR=PATH ;;
+   *) RPATH_ENVVAR=LD_LIBRARY_PATH ;;
+ esac
+ 
+@@ -3157,7 +3157,7 @@ case " $target_configdirs " in
+   case " $target_configargs " in
+   *" --with-newlib "*)
+    case "$target" in
+-    *-cygwin*)
++    *-cygwin* | *-msys*)
+       FLAGS_FOR_TARGET=$FLAGS_FOR_TARGET' -L$$r/$(TARGET_SUBDIR)/winsup/cygwin -isystem $$s/winsup/cygwin/include'
+       ;;
+    esac
+diff --git a/libtool.m4 b/libtool.m4
+index 24d13f3..9a37fd7 100644
+--- a/libtool.m4
++++ b/libtool.m4
+@@ -1491,7 +1491,7 @@ AC_CACHE_VAL([lt_cv_sys_max_cmd_len], [dnl
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -1733,7 +1733,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+@@ -2204,14 +2204,14 @@ bsdi[[45]]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -2232,6 +2232,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+     cygwin*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[[.]]/-/g'`${versuffix}${shared_ext}'
++m4_if([$1], [],[
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"])
++      ;;
++    msys*)
++      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[[.]]/-/g'`${versuffix}${shared_ext}'
+ m4_if([$1], [],[
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"])
+       ;;
+@@ -3001,7 +3007,7 @@ bsdi[[45]]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -3285,7 +3291,7 @@ AC_DEFUN([LT_LIB_M],
+ [AC_REQUIRE([AC_CANONICAL_HOST])dnl
+ LIBM=
+ case $host in
+-*-*-beos* | *-*-cegcc* | *-*-cygwin* | *-*-haiku* | *-*-pw32* | *-*-darwin*)
++*-*-beos* | *-*-cegcc* | *-*-cygwin* | *-*-msys* | *-*-haiku* | *-*-pw32* | *-*-darwin*)
+   # These system don't have libm, or don't need it
+   ;;
+ *-ncr-sysv4.3*)
+@@ -3360,7 +3366,7 @@ case $host_os in
+ aix*)
+   symcode='[[BCDT]]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[[ABCDGISTW]]'
+   ;;
+ hpux*)
+@@ -3607,7 +3613,7 @@ m4_if([$1], [CXX], [
+     beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
+       # PIC is the default for these OSes.
+       ;;
+-    mingw* | cygwin* | os2* | pw32* | cegcc*)
++    mingw* | cygwin* | msys* | os2* | pw32* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -3920,7 +3926,7 @@ m4_if([$1], [CXX], [
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -4003,7 +4009,7 @@ m4_if([$1], [CXX], [
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       m4_if([$1], [GCJ], [],
+@@ -4236,7 +4242,7 @@ m4_if([$1], [CXX], [
+   pw32*)
+     _LT_TAGVAR(export_symbols_cmds, $1)="$ltdll_cmds"
+   ;;
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     _LT_TAGVAR(export_symbols_cmds, $1)='$NM $libobjs $convenience | $global_symbol_pipe | $SED -e '\''/^[[BCDGRS]][[ ]]/s/.*[[ ]]\([[^ ]]*\)/\1 DATA/;/^.*[[ ]]__nm__/s/^.*[[ ]]__nm__\([[^ ]]*\)[[ ]][[^ ]]*/\1 DATA/;/^I[[ ]]/d;/^[[AITW]][[ ]]/s/.* //'\'' | sort | uniq > $export_symbols'
+   ;;
+   *)
+@@ -4288,7 +4294,7 @@ dnl Note also adjust exclude_expsyms for C++ above.
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -4403,7 +4409,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, $1) is actually meaningless,
+       # as there is no search path for DLLs.
+       _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
+@@ -4776,7 +4782,7 @@ _LT_EOF
+       _LT_TAGVAR(export_dynamic_flag_spec, $1)=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -5720,7 +5726,7 @@ if test "$_lt_caught_CXX_error" != yes; then
+         esac
+         ;;
+ 
+-      cygwin* | mingw* | pw32* | cegcc*)
++      cygwin* | msys* | mingw* | pw32* | cegcc*)
+         # _LT_TAGVAR(hardcode_libdir_flag_spec, $1) is actually meaningless,
+         # as there is no search path for DLLs.
+         _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
+diff --git a/ltmain.sh b/ltmain.sh
+index 9503ec8..307a339 100644
+--- a/ltmain.sh
++++ b/ltmain.sh
+@@ -976,7 +976,7 @@ func_enable_tag ()
+ 
+ 
+   case $host in
+-    *cygwin* | *mingw* | *pw32* | *cegcc* | *solaris2* )
++    *cygwin* | *msys* | *mingw* | *pw32* | *cegcc* | *solaris2* )
+       # don't eliminate duplications in $postdeps and $predeps
+       opt_duplicate_compiler_generated_deps=:
+       ;;
+@@ -1453,7 +1453,7 @@ func_mode_compile ()
+ 
+     # On Cygwin there's no "real" PIC flag so we must build both object types
+     case $host_os in
+-    cygwin* | mingw* | pw32* | os2* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | os2* | cegcc*)
+       pic_mode=default
+       ;;
+     esac
+@@ -2279,7 +2279,7 @@ func_mode_install ()
+ 	      'exit $?'
+ 	  tstripme="$stripme"
+ 	  case $host_os in
+-	  cygwin* | mingw* | pw32* | cegcc*)
++	  cygwin* | msys* | mingw* | pw32* | cegcc*)
+ 	    case $realname in
+ 	    *.dll.a)
+ 	      tstripme=""
+@@ -2385,7 +2385,7 @@ func_mode_install ()
+ 
+ 	# Do a test to see if this is really a libtool program.
+ 	case $host in
+-	*cygwin* | *mingw*)
++	*cygwin* | *msys* | *mingw*)
+ 	    if func_ltwrapper_executable_p "$file"; then
+ 	      func_ltwrapper_scriptname "$file"
+ 	      wrapper=$func_ltwrapper_scriptname_result
+@@ -2460,7 +2460,7 @@ func_mode_install ()
+ 	# remove .exe since cygwin /usr/bin/install will append another
+ 	# one anyway
+ 	case $install_prog,$host in
+-	*/usr/bin/install*,*cygwin*)
++	*/usr/bin/install*,*cygwin*|*/usr/bin/install*,*msys*)
+ 	  case $file:$destfile in
+ 	  *.exe:*.exe)
+ 	    # this is ok
+@@ -2595,7 +2595,7 @@ extern \"C\" {
+ 	      $RM $export_symbols
+ 	      ${SED} -n -e '/^: @PROGRAM@ $/d' -e 's/^.* \(.*\)$/\1/p' < "$nlist" > "$export_symbols"
+ 	      case $host in
+-	      *cygwin* | *mingw* | *cegcc* )
++	      *cygwin* | *msys* | *mingw* | *cegcc* )
+                 echo EXPORTS > "$output_objdir/$outputname.def"
+                 cat "$export_symbols" >> "$output_objdir/$outputname.def"
+ 	        ;;
+@@ -2607,7 +2607,7 @@ extern \"C\" {
+ 	      $GREP -f "$output_objdir/$outputname.exp" < "$nlist" > "$nlist"T
+ 	      $MV "$nlist"T "$nlist"
+ 	      case $host in
+-	        *cygwin* | *mingw* | *cegcc* )
++	        *cygwin* | *msys* | *mingw* | *cegcc* )
+ 	          echo EXPORTS > "$output_objdir/$outputname.def"
+ 	          cat "$nlist" >> "$output_objdir/$outputname.def"
+ 	          ;;
+@@ -2663,7 +2663,7 @@ typedef struct {
+ } lt_dlsymlist;
+ "
+ 	  case $host in
+-	  *cygwin* | *mingw* | *cegcc* )
++	  *cygwin* | *msys* | *mingw* | *cegcc* )
+ 	    echo >> "$output_objdir/$my_dlsyms" "\
+ /* DATA imports from DLLs on WIN32 con't be const, because
+    runtime relocations are performed -- see ld's documentation
+@@ -2749,7 +2749,7 @@ static const void *lt_preloaded_setup() {
+ 	# Transform the symbol file into the correct name.
+ 	symfileobj="$output_objdir/${my_outputname}S.$objext"
+ 	case $host in
+-	*cygwin* | *mingw* | *cegcc* )
++	*cygwin* | *msys* | *mingw* | *cegcc* )
+ 	  if test -f "$output_objdir/$my_outputname.def"; then
+ 	    compile_command=`$ECHO "$compile_command" | $SED "s%@SYMFILE@%$output_objdir/$my_outputname.def $symfileobj%"`
+ 	    finalize_command=`$ECHO "$finalize_command" | $SED "s%@SYMFILE@%$output_objdir/$my_outputname.def $symfileobj%"`
+@@ -3192,7 +3192,7 @@ func_to_host_path ()
+             func_to_host_path_result=`( cmd //c echo "$1" ) 2>/dev/null |
+               $SED -e 's/[ ]*$//' -e "$lt_sed_naive_backslashify"`
+             ;;
+-          *cygwin* )
++          *cygwin* | *msys* )
+             func_to_host_path_result=`cygpath -w "$1" |
+ 	      $SED -e "$lt_sed_naive_backslashify"`
+             ;;
+@@ -3265,7 +3265,7 @@ func_to_host_pathlist ()
+ 	      ( cmd //c echo "$func_to_host_pathlist_tmp1" ) 2>/dev/null |
+ 	      $SED -e 's/[ ]*$//' -e "$lt_sed_naive_backslashify"`
+             ;;
+-          *cygwin* )
++          *cygwin* | *msys* )
+             func_to_host_pathlist_result=`cygpath -w -p "$func_to_host_pathlist_tmp1" |
+               $SED -e "$lt_sed_naive_backslashify"`
+             ;;
+@@ -3571,7 +3571,7 @@ main (int argc, char *argv[])
+ 	{
+ EOF
+ 	    case "$host" in
+-	      *mingw* | *cygwin* )
++	      *mingw* | *cygwin* | *msys* )
+ 		# make stdout use "unix" line endings
+ 		echo "          setmode(1,_O_BINARY);"
+ 		;;
+@@ -4233,7 +4233,7 @@ func_mode_link ()
+ {
+     $opt_debug
+     case $host in
+-    *-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-os2* | *-cegcc*)
++    *-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-os2* | *-cegcc*)
+       # It is impossible to link a dll without this setting, and
+       # we shouldn't force the makefile maintainer to figure out
+       # which system we are compiling for in order to pass an extra
+@@ -4713,7 +4713,7 @@ func_mode_link ()
+ 	  ;;
+ 	esac
+ 	case $host in
+-	*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-os2* | *-cegcc*)
++	*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-os2* | *-cegcc*)
+ 	  testbindir=`$ECHO "$dir" | $SED 's*/lib$*/bin*'`
+ 	  case :$dllsearchpath: in
+ 	  *":$dir:"*) ;;
+@@ -4733,7 +4733,7 @@ func_mode_link ()
+       -l*)
+ 	if test "X$arg" = "X-lc" || test "X$arg" = "X-lm"; then
+ 	  case $host in
+-	  *-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-beos* | *-cegcc* | *-*-haiku*)
++	  *-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-beos* | *-cegcc* | *-*-haiku*)
+ 	    # These systems don't actually have a C or math library (as such)
+ 	    continue
+ 	    ;;
+@@ -4813,7 +4813,7 @@ func_mode_link ()
+ 
+       -no-install)
+ 	case $host in
+-	*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-os2* | *-*-darwin* | *-cegcc*)
++	*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-os2* | *-*-darwin* | *-cegcc*)
+ 	  # The PATH hackery in wrapper scripts is required on Windows
+ 	  # and Darwin in order for the loader to find any dlls it needs.
+ 	  func_warning "\`-no-install' is ignored for $host"
+@@ -5772,7 +5772,7 @@ func_mode_link ()
+ 	if test -n "$library_names" &&
+ 	   { test "$use_static_libs" = no || test -z "$old_library"; }; then
+ 	  case $host in
+-	  *cygwin* | *mingw* | *cegcc*)
++	  *cygwin* | *msys* | *mingw* | *cegcc*)
+ 	      # No point in relinking DLLs because paths are not encoded
+ 	      notinst_deplibs="$notinst_deplibs $lib"
+ 	      need_relink=no
+@@ -5842,7 +5842,7 @@ func_mode_link ()
+ 	    elif test -n "$soname_spec"; then
+ 	      # bleh windows
+ 	      case $host in
+-	      *cygwin* | mingw* | *cegcc*)
++	      *cygwin* | msys* | mingw* | *cegcc*)
+ 	        func_arith $current - $age
+ 		major=$func_arith_result
+ 		versuffix="-$major"
+@@ -6693,7 +6693,7 @@ func_mode_link ()
+       if test "$build_libtool_libs" = yes; then
+ 	if test -n "$rpath"; then
+ 	  case $host in
+-	  *-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-os2* | *-*-beos* | *-cegcc* | *-*-haiku*)
++	  *-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-os2* | *-*-beos* | *-cegcc* | *-*-haiku*)
+ 	    # these systems don't actually have a c library (as such)!
+ 	    ;;
+ 	  *-*-rhapsody* | *-*-darwin1.[012])
+@@ -7194,7 +7194,7 @@ EOF
+ 
+ 	orig_export_symbols=
+ 	case $host_os in
+-	cygwin* | mingw* | cegcc*)
++	cygwin* | msys* | mingw* | cegcc*)
+ 	  if test -n "$export_symbols" && test -z "$export_symbols_regex"; then
+ 	    # exporting using user supplied symfile
+ 	    if test "x`$SED 1q $export_symbols`" != xEXPORTS; then
+@@ -7710,7 +7710,7 @@ EOF
+ 
+     prog)
+       case $host in
+-	*cygwin*) func_stripname '' '.exe' "$output"
++	*cygwin* | *msys*) func_stripname '' '.exe' "$output"
+ 	          output=$func_stripname_result.exe;;
+       esac
+       test -n "$vinfo" && \
+@@ -7823,7 +7823,7 @@ EOF
+ 	  esac
+ 	fi
+ 	case $host in
+-	*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-os2* | *-cegcc*)
++	*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-os2* | *-cegcc*)
+ 	  testbindir=`${ECHO} "$libdir" | ${SED} -e 's*/lib$*/bin*'`
+ 	  case :$dllsearchpath: in
+ 	  *":$libdir:"*) ;;
+@@ -7901,7 +7901,7 @@ EOF
+         # Disable wrappers for cegcc and mingw32ce hosts, we are cross compiling anyway.
+         wrappers_required=no
+         ;;
+-      *cygwin* | *mingw* )
++      *cygwin* | *msys* | *mingw* )
+         if test "$build_libtool_libs" != yes; then
+           wrappers_required=no
+         fi
+@@ -8029,14 +8029,14 @@ EOF
+ 	esac
+ 	# test for cygwin because mv fails w/o .exe extensions
+ 	case $host in
+-	  *cygwin*)
++	  *cygwin* | *msys*)
+ 	    exeext=.exe
+ 	    func_stripname '' '.exe' "$outputname"
+ 	    outputname=$func_stripname_result ;;
+ 	  *) exeext= ;;
+ 	esac
+ 	case $host in
+-	  *cygwin* | *mingw* )
++	  *cygwin* | *msys* | *mingw* )
+ 	    func_dirname_and_basename "$output" "" "."
+ 	    output_name=$func_basename_result
+ 	    output_path=$func_dirname_result
+@@ -8343,7 +8343,7 @@ EOF
+ 	  # tests/bindir.at for full details.
+ 	  tdlname=$dlname
+ 	  case $host,$output,$installed,$module,$dlname in
+-	    *cygwin*,*lai,yes,no,*.dll | *mingw*,*lai,yes,no,*.dll | *cegcc*,*lai,yes,no,*.dll)
++	    *cygwin*,*lai,yes,no,*.dll | *msys*,*lai,yes,no,*.dll | *mingw*,*lai,yes,no,*.dll | *cegcc*,*lai,yes,no,*.dll)
+ 	      # If a -bindir argument was supplied, place the dll there.
+ 	      if test "x$bindir" != x ;
+ 	      then
+diff --git a/ltoptions.m4 b/ltoptions.m4
+index 5ef12ce..5e7bc34 100644
+--- a/ltoptions.m4
++++ b/ltoptions.m4
+@@ -126,7 +126,7 @@ LT_OPTION_DEFINE([LT_INIT], [win32-dll],
+ [enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   AC_CHECK_TOOL(AS, as, false)
+   AC_CHECK_TOOL(DLLTOOL, dlltool, false)
+   AC_CHECK_TOOL(OBJDUMP, objdump, false)
+diff --git a/newlib/configure b/newlib/configure
+index 2771fa2..ea3740b 100755
+--- a/newlib/configure
++++ b/newlib/configure
+@@ -4304,7 +4304,7 @@ if test "${use_libtool}" = "yes"; then
+ enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}as; ac_word=$2
+@@ -6130,7 +6130,7 @@ else
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6469,7 +6469,7 @@ bsdi[45]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -7049,7 +7049,7 @@ case $host_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8930,7 +8930,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -9012,7 +9012,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9474,7 +9474,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9589,7 +9589,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -10020,7 +10020,7 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10921,14 +10921,14 @@ bsdi[45]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10950,6 +10950,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+ 
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
++    msys*)
++      # MSYS DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+@@ -11588,7 +11594,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+diff --git a/newlib/configure.host b/newlib/configure.host
+index ef481ff..7dbf48f 100644
+--- a/newlib/configure.host
++++ b/newlib/configure.host
+@@ -201,7 +201,7 @@ case "${host_cpu}" in
+ 	shared_machine_dir=shared_x86
+ 	# Don't use for these since they provide their own setjmp.
+ 	case ${host} in
+-	*-*-sco* | *-*-cygwin*) 
++	*-*-sco* | *-*-cygwin* | *-*-msys*) 
+ 		;;
+ 	*) 
+ 		mach_add_setjmp=true
+@@ -406,7 +406,7 @@ fi
+ 
+ if [ "x${newlib_mb}" = "x" ]; then
+ 	case "${host}" in
+-  	  i[34567]86-pc-linux-*|*-*-cygwin*)
++  	  i[34567]86-pc-linux-*|*-*-cygwin*|*-*-msys*)
+ 		newlib_mb=yes
+ 	  	;;
+ 	esac
+@@ -440,7 +440,7 @@ esac
+ # THIS TABLE IS ALPHA SORTED.  KEEP IT THAT WAY.
+ 
+ case "${host}" in
+-  *-*-cygwin*)
++  *-*-cygwin* | *-*-msys*)
+ 	posix_dir=posix
+ 	stdio64_dir=stdio64
+ 	xdr_dir=xdr
+@@ -644,7 +644,7 @@ esac
+ # THIS TABLE IS ALPHA SORTED.  KEEP IT THAT WAY.
+ 
+ case "${host}" in
+-  *-*-cygwin*)
++  *-*-cygwin* | *-*-msys*)
+ 	test -z "$cygwin_srcdir" && cygwin_srcdir=`cd ${srcdir}/../winsup/cygwin; pwd`
+ 	export cygwin_srcdir
+ 	default_newlib_io_c99_formats="yes"
+diff --git a/newlib/iconvdata/configure b/newlib/iconvdata/configure
+index aaadeb8..f60bf17 100755
+--- a/newlib/iconvdata/configure
++++ b/newlib/iconvdata/configure
+@@ -3892,7 +3892,7 @@ if test "${use_libtool}" = "yes"; then
+ enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}as; ac_word=$2
+@@ -5718,7 +5718,7 @@ else
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6057,7 +6057,7 @@ bsdi[45]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -6637,7 +6637,7 @@ case $host_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8518,7 +8518,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8600,7 +8600,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9062,7 +9062,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9177,7 +9177,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9608,7 +9608,7 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10509,14 +10509,14 @@ bsdi[45]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10538,6 +10538,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+ 
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
++    msys*)
++      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+@@ -11176,7 +11182,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+diff --git a/newlib/libc/configure b/newlib/libc/configure
+index 7367964..e169c18 100755
+--- a/newlib/libc/configure
++++ b/newlib/libc/configure
+@@ -4018,7 +4018,7 @@ if test "${use_libtool}" = "yes"; then
+ enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}as; ac_word=$2
+@@ -5844,7 +5844,7 @@ else
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6183,7 +6183,7 @@ bsdi[45]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -6763,7 +6763,7 @@ case $host_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8644,7 +8644,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | msys* | cygwin* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8726,7 +8726,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | msys* | cygwin* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9188,7 +9188,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9303,7 +9303,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9734,7 +9734,7 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10635,14 +10635,14 @@ bsdi[45]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10664,6 +10664,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+ 
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
++    msys*)
++      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+@@ -11302,7 +11308,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+diff --git a/newlib/libc/machine/configure b/newlib/libc/machine/configure
+index 58d8726..b1c2f35 100755
+--- a/newlib/libc/machine/configure
++++ b/newlib/libc/machine/configure
+@@ -3954,7 +3954,7 @@ if test "${use_libtool}" = "yes"; then
+ enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}as; ac_word=$2
+@@ -5780,7 +5780,7 @@ else
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6119,7 +6119,7 @@ bsdi[45]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -6699,7 +6699,7 @@ case $host_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8580,7 +8580,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8662,7 +8662,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9124,7 +9124,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9239,7 +9239,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9670,7 +9670,7 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10571,14 +10571,14 @@ bsdi[45]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10600,6 +10600,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+ 
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
++    msys*)
++      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+@@ -11238,7 +11244,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+diff --git a/newlib/libc/machine/i386/configure b/newlib/libc/machine/i386/configure
+index 215f983..c9d0862 100755
+--- a/newlib/libc/machine/i386/configure
++++ b/newlib/libc/machine/i386/configure
+@@ -3894,7 +3894,7 @@ if test "${use_libtool}" = "yes"; then
+ enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}as; ac_word=$2
+@@ -5720,7 +5720,7 @@ else
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6059,7 +6059,7 @@ bsdi[45]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -6639,7 +6639,7 @@ case $host_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8520,7 +8520,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8602,7 +8602,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9064,7 +9064,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9179,7 +9179,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9610,7 +9610,7 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10511,14 +10511,14 @@ bsdi[45]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10540,6 +10540,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+ 
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
++    msys*)
++      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+@@ -11178,7 +11184,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+diff --git a/newlib/libc/sys/configure b/newlib/libc/sys/configure
+index e41f1cd..69bb7a5 100755
+--- a/newlib/libc/sys/configure
++++ b/newlib/libc/sys/configure
+@@ -3924,7 +3924,7 @@ if test "${use_libtool}" = "yes"; then
+ enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}as; ac_word=$2
+@@ -5750,7 +5750,7 @@ else
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6089,7 +6089,7 @@ bsdi[45]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -6669,7 +6669,7 @@ case $host_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8550,7 +8550,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8632,7 +8632,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9094,7 +9094,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9209,7 +9209,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9640,7 +9640,7 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10541,14 +10541,14 @@ bsdi[45]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10570,6 +10570,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+ 
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
++    msys*)
++      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+@@ -11208,7 +11214,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+diff --git a/newlib/libc/sys/linux/configure b/newlib/libc/sys/linux/configure
+index d62b93b..debe952 100755
+--- a/newlib/libc/sys/linux/configure
++++ b/newlib/libc/sys/linux/configure
+@@ -3940,7 +3940,7 @@ if test "${use_libtool}" = "yes"; then
+ enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}as; ac_word=$2
+@@ -5766,7 +5766,7 @@ else
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6105,7 +6105,7 @@ bsdi[45]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -6685,7 +6685,7 @@ case $host_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8566,7 +8566,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | msys* | cygwin* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8648,7 +8648,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | msys* | cygwin* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9110,7 +9110,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9225,7 +9225,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9656,7 +9656,7 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10557,14 +10557,14 @@ bsdi[45]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10586,6 +10586,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+ 
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
++    msys*)
++      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+@@ -11224,7 +11230,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+diff --git a/newlib/libc/sys/linux/linuxthreads/configure b/newlib/libc/sys/linux/linuxthreads/configure
+index dd08d43..f5e182b 100755
+--- a/newlib/libc/sys/linux/linuxthreads/configure
++++ b/newlib/libc/sys/linux/linuxthreads/configure
+@@ -3938,7 +3938,7 @@ if test "${use_libtool}" = "yes"; then
+ enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}as; ac_word=$2
+@@ -5764,7 +5764,7 @@ else
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6103,7 +6103,7 @@ bsdi[45]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -6683,7 +6683,7 @@ case $host_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8564,7 +8564,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8646,7 +8646,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9108,7 +9108,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9223,7 +9223,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9654,7 +9654,7 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10555,14 +10555,14 @@ bsdi[45]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10584,6 +10584,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+ 
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
++    msys*)
++      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+@@ -11222,7 +11228,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+diff --git a/newlib/libc/sys/linux/linuxthreads/machine/configure b/newlib/libc/sys/linux/linuxthreads/machine/configure
+index b0ef17c..93a2a92 100755
+--- a/newlib/libc/sys/linux/linuxthreads/machine/configure
++++ b/newlib/libc/sys/linux/linuxthreads/machine/configure
+@@ -3896,7 +3896,7 @@ if test "${use_libtool}" = "yes"; then
+ enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}as; ac_word=$2
+@@ -5722,7 +5722,7 @@ else
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6061,7 +6061,7 @@ bsdi[45]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -6641,7 +6641,7 @@ case $host_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8522,7 +8522,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8604,7 +8604,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9066,7 +9066,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9181,7 +9181,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9612,7 +9612,7 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10513,14 +10513,14 @@ bsdi[45]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10542,6 +10542,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+ 
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
++    msys*)
++      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+@@ -11180,7 +11186,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+diff --git a/newlib/libc/sys/linux/linuxthreads/machine/i386/configure b/newlib/libc/sys/linux/linuxthreads/machine/i386/configure
+index 238ddad..245726f 100755
+--- a/newlib/libc/sys/linux/linuxthreads/machine/i386/configure
++++ b/newlib/libc/sys/linux/linuxthreads/machine/i386/configure
+@@ -3934,7 +3934,7 @@ if test "${use_libtool}" = "yes"; then
+ enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}as; ac_word=$2
+@@ -5760,7 +5760,7 @@ else
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6099,7 +6099,7 @@ bsdi[45]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -6679,7 +6679,7 @@ case $host_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8560,7 +8560,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8642,7 +8642,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9104,7 +9104,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9219,7 +9219,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9650,7 +9650,7 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10551,14 +10551,14 @@ bsdi[45]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10580,6 +10580,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+ 
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
++    msys*)
++      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+@@ -11218,7 +11224,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+diff --git a/newlib/libc/sys/linux/machine/configure b/newlib/libc/sys/linux/machine/configure
+index 75d4794..3e624ec 100755
+--- a/newlib/libc/sys/linux/machine/configure
++++ b/newlib/libc/sys/linux/machine/configure
+@@ -3897,7 +3897,7 @@ if test "${use_libtool}" = "yes"; then
+ enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}as; ac_word=$2
+@@ -5723,7 +5723,7 @@ else
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6062,7 +6062,7 @@ bsdi[45]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -6642,7 +6642,7 @@ case $host_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8523,7 +8523,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8605,7 +8605,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9067,7 +9067,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9182,7 +9182,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9613,7 +9613,7 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10514,14 +10514,14 @@ bsdi[45]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10543,6 +10543,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+ 
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
++    msys*)
++      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+@@ -11181,7 +11187,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+diff --git a/newlib/libc/sys/linux/machine/i386/configure b/newlib/libc/sys/linux/machine/i386/configure
+index 7c5de77..ab10fc4 100755
+--- a/newlib/libc/sys/linux/machine/i386/configure
++++ b/newlib/libc/sys/linux/machine/i386/configure
+@@ -3934,7 +3934,7 @@ if test "${use_libtool}" = "yes"; then
+ enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}as; ac_word=$2
+@@ -5760,7 +5760,7 @@ else
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6099,7 +6099,7 @@ bsdi[45]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -6679,7 +6679,7 @@ case $host_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8560,7 +8560,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8642,7 +8642,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9104,7 +9104,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9219,7 +9219,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9650,7 +9650,7 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10551,14 +10551,14 @@ bsdi[45]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10580,6 +10580,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+ 
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
++    msys*)
++      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+@@ -11218,7 +11224,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+diff --git a/newlib/libm/configure b/newlib/libm/configure
+index 0c79bb2..06f7042 100755
+--- a/newlib/libm/configure
++++ b/newlib/libm/configure
+@@ -3958,7 +3958,7 @@ if test "${use_libtool}" = "yes"; then
+ enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}as; ac_word=$2
+@@ -5784,7 +5784,7 @@ else
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6123,7 +6123,7 @@ bsdi[45]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -6703,7 +6703,7 @@ case $host_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8584,7 +8584,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8666,7 +8666,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9128,7 +9128,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9243,7 +9243,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9674,7 +9674,7 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10575,14 +10575,14 @@ bsdi[45]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10604,6 +10604,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+ 
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
++    msys*)
++      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+@@ -11242,7 +11248,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+diff --git a/newlib/libm/machine/configure b/newlib/libm/machine/configure
+index 9380947..c74835e 100755
+--- a/newlib/libm/machine/configure
++++ b/newlib/libm/machine/configure
+@@ -3907,7 +3907,7 @@ if test "${use_libtool}" = "yes"; then
+ enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}as; ac_word=$2
+@@ -5733,7 +5733,7 @@ else
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6072,7 +6072,7 @@ bsdi[45]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -6652,7 +6652,7 @@ case $host_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8533,7 +8533,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8615,7 +8615,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9077,7 +9077,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9192,7 +9192,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9623,7 +9623,7 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10524,14 +10524,14 @@ bsdi[45]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10553,6 +10553,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+ 
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
++    msys*)
++      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+@@ -11191,7 +11197,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;
+diff --git a/newlib/libm/machine/i386/configure b/newlib/libm/machine/i386/configure
+index eb2a870..3bf9d9f 100755
+--- a/newlib/libm/machine/i386/configure
++++ b/newlib/libm/machine/i386/configure
+@@ -3892,7 +3892,7 @@ if test "${use_libtool}" = "yes"; then
+ enable_win32_dll=yes
+ 
+ case $host in
+-*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++*-*-cygwin* | *-*-msys* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
+   if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}as", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}as; ac_word=$2
+@@ -5718,7 +5718,7 @@ else
+     lt_cv_sys_max_cmd_len=-1;
+     ;;
+ 
+-  cygwin* | mingw* | cegcc*)
++  cygwin* | msys* | mingw* | cegcc*)
+     # On Win9x/ME, this test blows up -- it succeeds, but takes
+     # about 5 minutes as the teststring grows exponentially.
+     # Worse, since 9x/ME are not pre-emptively multitasking,
+@@ -6057,7 +6057,7 @@ bsdi[45]*)
+   lt_cv_file_magic_test_file=/shlib/libc.so
+   ;;
+ 
+-cygwin*)
++cygwin* | msys*)
+   # func_win32_libid is a shell function defined in ltmain.sh
+   lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+   lt_cv_file_magic_cmd='func_win32_libid'
+@@ -6637,7 +6637,7 @@ case $host_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+@@ -8518,7 +8518,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       # PIC is the default for these OSes.
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+@@ -8600,7 +8600,7 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       fi
+       ;;
+ 
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+@@ -9062,7 +9062,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   extract_expsyms_cmds=
+ 
+   case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -9177,7 +9177,7 @@ _LT_EOF
+       fi
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -9608,7 +9608,7 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+       export_dynamic_flag_spec=-rdynamic
+       ;;
+ 
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -10509,14 +10509,14 @@ bsdi[45]*)
+   # libtool to hard-code these into programs
+   ;;
+ 
+-cygwin* | mingw* | pw32* | cegcc*)
++cygwin* | msys* | mingw* | pw32* | cegcc*)
+   version_type=windows
+   shrext_cmds=".dll"
+   need_version=no
+   need_lib_prefix=no
+ 
+   case $GCC,$host_os in
+-  yes,cygwin* | yes,mingw* | yes,pw32* | yes,cegcc*)
++  yes,cygwin* | yes,msys* | yes,mingw* | yes,pw32* | yes,cegcc*)
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+     postinstall_cmds='base_file=`basename \${file}`~
+@@ -10538,6 +10538,12 @@ cygwin* | mingw* | pw32* | cegcc*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+ 
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
++      ;;
++    msys*)
++      # Msys DLLs use 'msys-' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/msys-/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+@@ -11176,7 +11182,7 @@ else
+     lt_cv_dlopen_libs=
+     ;;
+ 
+-  cygwin*)
++  cygwin* | msys*)
+     lt_cv_dlopen="dlopen"
+     lt_cv_dlopen_libs=
+     ;;

--- a/msys2-runtime-3.3/0002-Fix-msys-library-name-in-import-libraries.patch
+++ b/msys2-runtime-3.3/0002-Fix-msys-library-name-in-import-libraries.patch
@@ -1,0 +1,26 @@
+From e78e1440c29bc5340ef5403af120a3101e11361d Mon Sep 17 00:00:00 2001
+From: Kaleb Barrett <dev.ktbarrett@gmail.com>
+Date: Sun, 14 Mar 2021 18:58:55 -0500
+Subject: [PATCH 02/N] Fix msys library name in import libraries
+
+Cygwin's speclib doesn't handle dashes or dots. However, we are about to
+rename the output file name from `cygwin1.dll` to `msys-2.0.dll`.
+
+Let's preemptively fix up all the import libraries that would link
+against `msys_2_0.dll` to correctly link against `msys-2.0.dll` instead.
+---
+ winsup/cygwin/speclib | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/winsup/cygwin/speclib b/winsup/cygwin/speclib
+index b900960..617a9c2 100755
+--- a/winsup/cygwin/speclib
++++ b/winsup/cygwin/speclib
+@@ -37,6 +37,7 @@ while (<$nm_fd>) {
+     study;
+     if (/ I _?(.*)_dll_iname/o) {
+ 	$dllname = $1;
++	$dllname =~ s/_2_0/-2.0/;
+     } else {
+ 	my ($file, $member, $symbol) = m%^([^:]*):([^:]*(?=:))?.* T (.*)%o;
+ 	next if !defined($symbol) || $symbol =~ $exclude_regex;

--- a/msys2-runtime-3.3/0003-Rename-dll-from-cygwin-to-msys.patch
+++ b/msys2-runtime-3.3/0003-Rename-dll-from-cygwin-to-msys.patch
@@ -1,0 +1,1443 @@
+From 27982ff1c2d32b2734328483dfed44ed0293825a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=90=D0=BB=D0=B5=D0=BA=D1=81=D0=B5=D0=B8=CC=86=20=D0=9F?=
+ =?UTF-8?q?=D0=B0=D0=B2=D0=BB=D0=BE=D0=B2?= <alexey.pawlow@gmail.com>
+Date: Sun, 14 Apr 2019 21:09:17 +0300
+Subject: [PATCH 03/N] Rename dll from cygwin to msys
+
+---
+ winsup/Makefile.am                        |  2 +-
+ winsup/cygserver/Makefile.am              |  2 +-
+ winsup/cygserver/transport_pipes.h        |  4 +++
+ winsup/cygwin/Makefile.am                 | 40 +++++++++++----------
+ winsup/cygwin/common.din                  |  4 +--
+ winsup/cygwin/crt0.c                      |  8 +++++
+ winsup/cygwin/cyglsa.h                    |  4 +++
+ winsup/cygwin/cygserver_setpwd.h          |  4 +++
+ winsup/cygwin/cygthread.cc                |  2 +-
+ winsup/cygwin/cygwin.sc.in                | 21 +++++++----
+ winsup/cygwin/dcrt0.cc                    | 20 ++++++-----
+ winsup/cygwin/dlfcn.cc                    |  5 +++
+ winsup/cygwin/dll_init.cc                 |  8 +++++
+ winsup/cygwin/dtable.cc                   |  6 ++++
+ winsup/cygwin/exceptions.cc               |  4 +--
+ winsup/cygwin/fhandler_pipe.cc            |  4 +++
+ winsup/cygwin/fhandler_tty.cc             | 20 +++++++++++
+ winsup/cygwin/fork.cc                     |  2 +-
+ winsup/cygwin/hookapi.cc                  |  4 +++
+ winsup/cygwin/i686.din                    |  6 ++--
+ winsup/cygwin/include/cygwin/cygwin_dll.h | 14 ++++----
+ winsup/cygwin/include/cygwin/version.h    |  8 +++++
+ winsup/cygwin/lib/_cygwin_crt0_common.cc  |  4 +++
+ winsup/cygwin/lib/crt0.h                  |  4 +++
+ winsup/cygwin/lib/cygwin_attach_dll.c     |  8 +++++
+ winsup/cygwin/lib/cygwin_crt0.c           |  8 +++++
+ winsup/cygwin/mkvers.sh                   |  6 ++--
+ winsup/cygwin/pinfo.cc                    |  2 +-
+ winsup/cygwin/pseudo-reloc.cc             |  2 +-
+ winsup/cygwin/sec_auth.cc                 | 16 ++++-----
+ winsup/cygwin/syscalls.cc                 |  4 +--
+ winsup/cygwin/syslog.cc                   |  4 +++
+ winsup/cygwin/winsup.h                    |  4 +++
+ winsup/cygwin/winver.rc                   |  2 +-
+ winsup/cygwin/x86_64.din                  |  2 +-
+ winsup/testsuite/config/default.exp       |  8 ++---
+ winsup/testsuite/cygrun.c                 |  6 ++--
+ winsup/testsuite/winsup.api/cygload.cc    | 12 +++----
+ winsup/testsuite/winsup.api/cygload.exp   |  2 +-
+ winsup/testsuite/winsup.api/cygload.h     |  2 +-
+ winsup/testsuite/winsup.api/winsup.exp    |  2 +-
+ winsup/utils/ldd.cc                       |  2 +-
+ winsup/utils/loadlib.h                    |  6 ++--
+ winsup/utils/mingw/cygcheck.cc            | 43 +++++++++++------------
+ winsup/utils/mingw/strace.cc              | 11 +++---
+ winsup/utils/path.cc                      | 12 +++----
+ winsup/utils/ssp.c                        |  8 ++---
+ 47 files changed, 246 insertions(+), 126 deletions(-)
+
+diff --git a/winsup/Makefile.am b/winsup/Makefile.am
+index 067f746..932882a 100644
+--- a/winsup/Makefile.am
++++ b/winsup/Makefile.am
+@@ -8,7 +8,7 @@
+ 
+ # This makefile requires GNU make.
+ 
+-cygdocdir = $(datarootdir)/doc/Cygwin
++cygdocdir = $(datarootdir)/doc/Msys
+ 
+ cygdoc_DATA = \
+ 	CYGWIN_LICENSE \
+diff --git a/winsup/cygserver/Makefile.am b/winsup/cygserver/Makefile.am
+index ec7a622..b0d5735 100644
+--- a/winsup/cygserver/Makefile.am
++++ b/winsup/cygserver/Makefile.am
+@@ -46,7 +46,7 @@ libcygserver_a_SOURCES = \
+ 
+ libcygserver_a_CXXFLAGS = $(cygserver_flags)
+ 
+-cygdocdir = $(datarootdir)/doc/Cygwin
++cygdocdir = $(datarootdir)/doc/Msys
+ 
+ install-data-local:
+ 	@$(MKDIR_P) $(DESTDIR)$(cygdocdir)
+diff --git a/winsup/cygserver/transport_pipes.h b/winsup/cygserver/transport_pipes.h
+index e101623..66272bc 100644
+--- a/winsup/cygserver/transport_pipes.h
++++ b/winsup/cygserver/transport_pipes.h
+@@ -11,7 +11,11 @@ details. */
+ #ifndef _TRANSPORT_PIPES_H
+ #define _TRANSPORT_PIPES_H
+ 
++#ifdef __MSYS__
++#define PIPE_NAME_PREFIX	L"\\\\.\\pipe\\msys-"
++#else
+ #define PIPE_NAME_PREFIX	L"\\\\.\\pipe\\cygwin-"
++#endif
+ #define PIPE_NAME_SUFFIX	L"-lpc"
+ 
+ /* Named pipes based transport, for security on NT */
+diff --git a/winsup/cygwin/Makefile.am b/winsup/cygwin/Makefile.am
+index ca499bc..72471ea 100644
+--- a/winsup/cygwin/Makefile.am
++++ b/winsup/cygwin/Makefile.am
+@@ -37,15 +37,15 @@ newlib_build=$(target_builddir)/newlib
+ toollibdir=$(tooldir)/lib
+ toolincludedir=$(tooldir)/include
+ 
+-# Parameters used in building the cygwin.dll.
++# Parameters used in building the msys-2.0.dll.
+ 
+-DLL_NAME=cygwin1.dll
+-TEST_DLL_NAME=cygwin0.dll
++DLL_NAME=msys-2.0.dll
++TEST_DLL_NAME=msys0.dll
+ DIN_FILE=@DIN_FILE@
+-DEF_FILE=cygwin.def
++DEF_FILE=msys.def
+ TLSOFFSETS_H=@TLSOFFSETS_H@
+-LIB_NAME=libcygwin.a
+-TEST_LIB_NAME=libcygwin0.a
++LIB_NAME=libmsys-2.0.a
++TEST_LIB_NAME=libmsys0.a
+ 
+ #
+ # sources
+@@ -613,33 +613,33 @@ LIBSERVER = $(cygserver_blddir)/libcygserver.a
+ $(LIBSERVER):
+ 	$(MAKE) -C $(cygserver_blddir) libcygserver.a
+ 
+-# We build as cygwin0.dll and rename at install time to overcome native
++# We build as msys-2.0.dll and rename at install time to overcome native
+ # rebuilding issues (we don't want the build tools to see a partially built
+-# cygwin.dll and attempt to use it instead of the old one).
++# msys-2.0.dll and attempt to use it instead of the old one).
+ 
+ # linker script
+ LDSCRIPT=cygwin.sc
+ $(LDSCRIPT): $(LDSCRIPT).in
+ 	$(CC) -E - -P < $^ -o $@
+ 
+-# cygwin dll
++# msys-2.0 dll
+ $(TEST_DLL_NAME): $(LDSCRIPT) dllfixdbg libdll.a $(VERSION_OFILES) $(LIBSERVER)\
+ 		  $(newlib_build)/libm/libm.a $(newlib_build)/libc/libc.a
+ 	$(CXX) $(CXXFLAGS) \
+ 	-mno-use-libstdc-wrappers \
+ 	-Wl,--gc-sections -nostdlib -Wl,-T$(LDSCRIPT) -static \
+-	-Wl,--heap=0 -Wl,--out-implib,cygdll.a -shared -o $@ \
++	-Wl,--heap=0 -Wl,--out-implib,msysdll.a -shared -o $@ \
+ 	-e @DLL_ENTRY@ $(DEF_FILE) \
+ 	-Wl,-whole-archive libdll.a -Wl,-no-whole-archive \
+ 	$(VERSION_OFILES) \
+ 	$(LIBSERVER) \
+ 	$(newlib_build)/libm/libm.a \
+ 	$(newlib_build)/libc/libc.a \
+-	-lgcc -lkernel32 -lntdll -Wl,-Map,cygwin.map
+-	$(srcdir)/dllfixdbg $(OBJDUMP) $(OBJCOPY) $@ cygwin1.dbg
+-	@ln -f $@ new-cygwin1.dll
++	-lgcc -lkernel32 -lntdll -Wl,-Map,msys.map
++	$(srcdir)/dllfixdbg $(OBJDUMP) $(OBJCOPY) $@ msys-2.0.dbg
++	@ln -f $@ new-msys-2.0.dll
+ 
+-# cygwin import library
++# msys-2.0 import library
+ toolopts=--cpu=@target_cpu@ --ar=@AR@ --as=@AS@ --nm=@NM@ --objcopy=@OBJCOPY@
+ 
+ $(DEF_FILE): gendef $(srcdir)/$(TLSOFFSETS_H) $(DIN_FILE) common.din
+@@ -652,17 +652,18 @@ sigfe.s: $(DEF_FILE)
+ 
+ LIBCOS=$(addsuffix .o,$(basename $(LIB_FILES)))
+ $(LIB_NAME): $(DEF_FILE) $(LIBCOS) | $(TEST_DLL_NAME)
+-	$(srcdir)/mkimport $(toolopts) $(NEW_FUNCTIONS) $@ cygdll.a $(wordlist 2,99,$^)
++	$(srcdir)/mkimport $(toolopts) $(NEW_FUNCTIONS) $@ msysdll.a $(wordlist 2,99,$^)
+ 
+-# cygwin import library used by testsuite
++# msys-2.0 import library used by testsuite
+ $(TEST_LIB_NAME): $(LIB_NAME)
+-	perl -p -e 'BEGIN{binmode(STDIN); binmode(STDOUT);}; s/cygwin1/cygwin0/g' < $? > $@
++	perl -p -e 'BEGIN{binmode(STDIN); binmode(STDOUT);}; s/msys-2.0/msys0/g' < $? > $@
+ 
+ # sublibs
+ # import libraries for some subset of symbols indicated by given objects
+ speclib=\
+ 	$(srcdir)/speclib $(toolopts) \
+ 	--exclude='cygwin' \
++	--exclude='msys' \
+ 	--exclude='(?i:dll)' \
+ 	--exclude='reloc' \
+ 	--exclude='^main$$' \
+@@ -709,7 +710,7 @@ all-local: $(LIB_NAME) $(TEST_LIB_NAME) $(SUBLIBS)
+ clean-local:
+ 	-rm -f $(BUILT_SOURCES)
+ 	-rm -f $(DEF_FILE) sigfe.s
+-	-rm -f cygwin.sc cygdll.a cygwin.map $(TEST_DLL_NAME) cygwin1.dbg new-cygwin1.dll
++	-rm -f cygwin.sc msysdll.a msys.map $(TEST_DLL_NAME) msys-2.0.dbg new-msys-2.0.dll
+ 	-rm -f $(LIB_NAME) $(TEST_LIB_NAME) $(SUBLIBS)
+ 	-rm -f version.cc
+ 
+@@ -729,6 +730,7 @@ install-libs:
+ 	@$(MKDIR_P) $(DESTDIR)$(bindir)
+ 	$(INSTALL_PROGRAM) $(TEST_DLL_NAME) $(DESTDIR)$(bindir)/$(DLL_NAME)
+ 	@$(MKDIR_P) $(DESTDIR)$(toollibdir)
++	$(INSTALL_DATA) msys-2.0.dbg $(DESTDIR)$(bindir)/msys-2.0.dbg
+ 	(cd $(DESTDIR)$(toollibdir) && ln -sf $(LIB_NAME) libg.a)
+ 
+ install-headers:
+@@ -751,7 +753,7 @@ install-ldif:
+ uninstall-hook: uninstall-headers uninstall-ldif uninstall-libs
+ 
+ uninstall-libs:
+-	rm -f $(DESTDIR)$(bindir)/cygwin1.dll
++	rm -f $(DESTDIR)$(bindir)/msys-2.0.dll
+ 	rm -f $(DESTDIR)$(toollibdir)/libg.a
+ 
+ uninstall-headers:
+diff --git a/winsup/cygwin/common.din b/winsup/cygwin/common.din
+index 63fa09a..41d3041 100644
+--- a/winsup/cygwin/common.din
++++ b/winsup/cygwin/common.din
+@@ -390,8 +390,8 @@ cygwin_attach_handle_to_fd SIGFE
+ cygwin_conv_path SIGFE
+ cygwin_conv_path_list SIGFE
+ cygwin_create_path SIGFE
+-cygwin_detach_dll SIGFE_MAYBE
+-cygwin_dll_init NOSIGFE
++msys_detach_dll SIGFE_MAYBE
++msys_dll_init NOSIGFE
+ cygwin_internal NOSIGFE
+ cygwin_logon_user SIGFE
+ cygwin_posix_path_list_p NOSIGFE
+diff --git a/winsup/cygwin/crt0.c b/winsup/cygwin/crt0.c
+index ec7959a..cf74961 100644
+--- a/winsup/cygwin/crt0.c
++++ b/winsup/cygwin/crt0.c
+@@ -14,7 +14,11 @@ details. */
+ 
+ extern int main (int argc, char **argv);
+ 
++#ifdef __MSYS__
++void msys_crt0 (int (*main) (int, char **));
++#else
+ void cygwin_crt0 (int (*main) (int, char **));
++#endif
+ 
+ #ifdef __i386__
+ __attribute__ ((force_align_arg_pointer))
+@@ -22,7 +26,11 @@ __attribute__ ((force_align_arg_pointer))
+ void
+ mainCRTStartup ()
+ {
++#ifdef __MSYS__
++  msys_crt0 (main);
++#else
+   cygwin_crt0 (main);
++#endif
+ 
+   /* These are never actually called.  They are just here to force the inclusion
+      of things like -lbinmode.  */
+diff --git a/winsup/cygwin/cyglsa.h b/winsup/cygwin/cyglsa.h
+index f9da707..120c0a9 100644
+--- a/winsup/cygwin/cyglsa.h
++++ b/winsup/cygwin/cyglsa.h
+@@ -14,7 +14,11 @@ Cygwin license.  Please consult the file "CYGWIN_LICENSE" for details. */
+ extern "C" {
+ #endif
+ 
++#ifdef __MSYS__
++#define CYG_LSA_PKGNAME "MSYSLsa"
++#else
+ #define CYG_LSA_PKGNAME "CygwinLsa"
++#endif
+ 
+ #define CYG_LSA_MAGIC_OLD1 0x0379f014LU
+ /* First change to cyglsa_t.
+diff --git a/winsup/cygwin/cygserver_setpwd.h b/winsup/cygwin/cygserver_setpwd.h
+index fc1576b..b297511 100644
+--- a/winsup/cygwin/cygserver_setpwd.h
++++ b/winsup/cygwin/cygserver_setpwd.h
+@@ -12,7 +12,11 @@ details. */
+ #include <sys/types.h>
+ #include "cygserver.h"
+ 
++#ifdef __MSYS__
++#define CYGWIN_LSA_KEY_PREFIX	L"L$MSYS_"
++#else
+ #define CYGWIN_LSA_KEY_PREFIX	L"L$CYGWIN_"
++#endif
+ 
+ #ifndef __INSIDE_CYGWIN__
+ class transport_layer_base;
+diff --git a/winsup/cygwin/cygthread.cc b/winsup/cygwin/cygthread.cc
+index 66a3179..11c21d8 100644
+--- a/winsup/cygwin/cygthread.cc
++++ b/winsup/cygwin/cygthread.cc
+@@ -170,7 +170,7 @@ new (size_t)
+       }
+ 
+ #ifdef DEBUGGING
+-  if (!getenv ("CYGWIN_FREERANGE_NOCHECK"))
++  if (!getenv ("MSYS_FREERANGE_NOCHECK"))
+     api_fatal ("overflowed cygwin thread pool");
+   else
+     thread_printf ("overflowed cygwin thread pool");
+diff --git a/winsup/cygwin/cygwin.sc.in b/winsup/cygwin/cygwin.sc.in
+index 293d2ab..264e240 100644
+--- a/winsup/cygwin/cygwin.sc.in
++++ b/winsup/cygwin/cygwin.sc.in
+@@ -1,10 +1,18 @@
+ #ifdef __x86_64__
+ OUTPUT_FORMAT(pei-x86-64)
++# ifdef __MSYS__
++SEARCH_DIR("/usr/x86_64-pc-msys/lib/w32api"); SEARCH_DIR("=/usr/lib/w32api");
++# else
+ SEARCH_DIR("/usr/x86_64-pc-cygwin/lib/w32api"); SEARCH_DIR("=/usr/lib/w32api");
++# endif
+ #else
+ #undef i386
+ OUTPUT_FORMAT(pei-i386)
++# ifdef __MSYS__
++SEARCH_DIR("/usr/i686-pc-msys/lib/w32api"); SEARCH_DIR("=/usr/lib/w32api");
++# else
+ SEARCH_DIR("/usr/i686-pc-cygwin/lib/w32api"); SEARCH_DIR("=/usr/lib/w32api");
++# endif
+ #endif
+ #define __CONCAT1(a,b)	a##b
+ #define __CONCAT(a,b) __CONCAT1(a,b)
+@@ -115,13 +123,14 @@ SECTIONS
+   }
+   .gnu_debuglink_overlay ALIGN(__section_alignment__) (NOLOAD):
+   {
+-    BYTE(0)	/* c */
++    BYTE(0)	/* m */
++    BYTE(0)	/* s */
+     BYTE(0)	/* y */
+-    BYTE(0)	/* g */
+-    BYTE(0)	/* w */
+-    BYTE(0)	/* i */
+-    BYTE(0)	/* n */
+-    BYTE(0)	/* 1 */
++    BYTE(0)	/* s */
++    BYTE(0)	/* - */
++    BYTE(0)	/* 2 */
++    BYTE(0)	/* . */
++    BYTE(0)	/* 0 */
+     BYTE(0)	/* . */
+     BYTE(0)	/* d */
+     BYTE(0)	/* b */
+diff --git a/winsup/cygwin/dcrt0.cc b/winsup/cygwin/dcrt0.cc
+index 28b5146..ee75d3b 100644
+--- a/winsup/cygwin/dcrt0.cc
++++ b/winsup/cygwin/dcrt0.cc
+@@ -378,21 +378,21 @@ check_sanity_and_sync (per_process *p)
+ 
+   /* Complain if older than last incompatible change */
+   if (p->dll_major < CYGWIN_VERSION_DLL_EPOCH)
+-    api_fatal ("cygwin DLL and APP are out of sync -- DLL version mismatch %u < %u",
++    api_fatal ("msys DLL and APP are out of sync -- DLL version mismatch %u < %u",
+ 	       p->dll_major, CYGWIN_VERSION_DLL_EPOCH);
+ 
+   /* magic_biscuit != 0 if using the old style version numbering scheme.  */
+   if (p->magic_biscuit != SIZEOF_PER_PROCESS)
+-    api_fatal ("Incompatible cygwin .dll -- incompatible per_process info %u != %u",
++    api_fatal ("Incompatible msys .dll -- incompatible per_process info %u != %u",
+ 	       p->magic_biscuit, SIZEOF_PER_PROCESS);
+ 
+   /* Complain if incompatible API changes made */
+   if (p->api_major > cygwin_version.api_major)
+-    api_fatal ("cygwin DLL and APP are out of sync -- API version mismatch %u > %u",
++    api_fatal ("msys DLL and APP are out of sync -- API version mismatch %u > %u",
+ 	       p->api_major, cygwin_version.api_major);
+ 
+ #ifdef __i386__
+-  /* This is a kludge to work around a version of _cygwin_common_crt0
++  /* This is a kludge to work around a version of _msys_common_crt0
+      which overwrote the cxx_malloc field with the local DLL copy.
+      Hilarity ensues if the DLL is not loaded while the process
+      is forking. */
+@@ -491,12 +491,12 @@ break_here ()
+ static void
+ initial_env ()
+ {
+-  if (GetEnvironmentVariableA ("CYGWIN_TESTING", NULL, 0))
++  if (GetEnvironmentVariableA ("MSYS_TESTING", NULL, 0))
+     _cygwin_testing = 1;
+ 
+ #ifdef DEBUGGING
+   char buf[PATH_MAX];
+-  if (GetEnvironmentVariableA ("CYGWIN_DEBUG", buf, sizeof (buf) - 1))
++  if (GetEnvironmentVariableA ("MSYS_DEBUG", buf, sizeof (buf) - 1))
+     {
+       char buf1[PATH_MAX];
+       GetModuleFileName (NULL, buf1, PATH_MAX);
+@@ -1123,7 +1123,11 @@ dll_crt0 (per_process *uptr)
+    See winsup/testsuite/cygload for an example of how to use cygwin1.dll
+    from MSVC and non-cygwin MinGW applications.  */
+ extern "C" void
++#ifdef __MSYS__
++msys_dll_init ()
++#else
+ cygwin_dll_init ()
++#endif
+ {
+ #ifdef __i386__
+   static char **envp;
+@@ -1336,7 +1340,7 @@ multiple_cygwin_problem (const char *what, uintptr_t magic_version, uintptr_t ve
+       return;
+     }
+ 
+-  if (GetEnvironmentVariableA ("CYGWIN_MISMATCH_OK", NULL, 0))
++  if (GetEnvironmentVariableA ("MSYS_MISMATCH_OK", NULL, 0))
+     return;
+ 
+   if (CYGWIN_VERSION_MAGIC_VERSION (magic_version) == version)
+@@ -1356,7 +1360,7 @@ are unable to find another cygwin DLL.",
+ void __reg1
+ cygbench (const char *s)
+ {
+-  if (GetEnvironmentVariableA ("CYGWIN_BENCH", NULL, 0))
++  if (GetEnvironmentVariableA ("MSYS_BENCH", NULL, 0))
+     small_printf ("%05u ***** %s : %10d\n", GetCurrentProcessId (), s, strace.microseconds ());
+ }
+ #endif
+diff --git a/winsup/cygwin/dlfcn.cc b/winsup/cygwin/dlfcn.cc
+index 9a74728..b94117d 100644
+--- a/winsup/cygwin/dlfcn.cc
++++ b/winsup/cygwin/dlfcn.cc
+@@ -147,8 +147,13 @@ collect_basenames (pathfinder::basenamelist & basenames,
+   /* If the basename starts with "lib", ... */
+   if (!strncmp (basename, "lib", 3))
+     {
++#ifdef __MSYS__
++      /* ... replace "lib" with "msys-", before ... */
++      basenames.appendv ("msys-", 5, basename+3, baselen-3, ext, extlen, NULL);
++#else
+       /* ... replace "lib" with "cyg", before ... */
+       basenames.appendv ("cyg", 3, basename+3, baselen-3, ext, extlen, NULL);
++#endif
+     }
+   /* ... using original basename with new suffix. */
+   basenames.appendv (basename, baselen, ext, extlen, NULL);
+diff --git a/winsup/cygwin/dll_init.cc b/winsup/cygwin/dll_init.cc
+index 6a4ed26..6f69b60 100644
+--- a/winsup/cygwin/dll_init.cc
++++ b/winsup/cygwin/dll_init.cc
+@@ -889,14 +889,22 @@ dll_dllcrt0_1 (VOID *x)
+    future.  Cygwin can now handle being loaded from a noncygwin app
+    using the same entry point. */
+ extern "C" int
++#ifdef __MSYS__
++dll_nonmsys_dllcrt0 (HMODULE h, per_process *p)
++#else
+ dll_noncygwin_dllcrt0 (HMODULE h, per_process *p)
++#endif
+ {
+   return (int) dll_dllcrt0 (h, p);
+ }
+ #endif /* __i386__ */
+ 
+ extern "C" void
++#ifdef __MSYS__
++msys_detach_dll (dll *)
++#else
+ cygwin_detach_dll (dll *)
++#endif
+ {
+   HANDLE retaddr;
+   if (_my_tls.isinitialized ())
+diff --git a/winsup/cygwin/dtable.cc b/winsup/cygwin/dtable.cc
+index ce5f641..bad7bd1 100644
+--- a/winsup/cygwin/dtable.cc
++++ b/winsup/cygwin/dtable.cc
+@@ -981,9 +981,15 @@ handle_to_fn (HANDLE h, char *posix_fn)
+       if (wcsncasecmp (w32, DEV_NAMED_PIPE, DEV_NAMED_PIPE_LEN) == 0)
+ 	{
+ 	  w32 += DEV_NAMED_PIPE_LEN;
++#ifdef __MSYS__
++	  if (wcsncmp (w32, L"msys-", WCLEN (L"msys-")) != 0)
++	    return false;
++	  w32 += WCLEN (L"msys-");
++#else
+ 	  if (wcsncmp (w32, L"cygwin-", WCLEN (L"cygwin-")) != 0)
+ 	    return false;
+ 	  w32 += WCLEN (L"cygwin-");
++#endif
+ 	  /* Check for installation key and trailing dash. */
+ 	  w32len = cygheap->installation_key.Length / sizeof (WCHAR);
+ 	  if (w32len
+diff --git a/winsup/cygwin/exceptions.cc b/winsup/cygwin/exceptions.cc
+index f946bed..5fe6b4d 100644
+--- a/winsup/cygwin/exceptions.cc
++++ b/winsup/cygwin/exceptions.cc
+@@ -502,14 +502,14 @@ try_to_debug ()
+   PWCHAR rawenv = GetEnvironmentStringsW () ;
+   for (PWCHAR p = rawenv; *p != L'\0'; p = wcschr (p, L'\0') + 1)
+     {
+-      if (wcsncmp (p, L"CYGWIN=", wcslen (L"CYGWIN=")) == 0)
++      if (wcsncmp (p, L"MSYS=", wcslen (L"MSYS=")) == 0)
+ 	{
+ 	  PWCHAR q = wcsstr (p, L"error_start") ;
+ 	  /* replace 'error_start=...' with '_rror_start=...' */
+ 	  if (q)
+ 	    {
+ 	      *q = L'_' ;
+-	      SetEnvironmentVariableW (L"CYGWIN", p + wcslen (L"CYGWIN=")) ;
++	      SetEnvironmentVariableW (L"MSYS", p + wcslen (L"MSYS=")) ;
+ 	    }
+ 	  break;
+ 	}
+diff --git a/winsup/cygwin/fhandler_pipe.cc b/winsup/cygwin/fhandler_pipe.cc
+index 82c1ed3..89f7729 100644
+--- a/winsup/cygwin/fhandler_pipe.cc
++++ b/winsup/cygwin/fhandler_pipe.cc
+@@ -690,7 +690,11 @@ fhandler_pipe::close ()
+   return ret;
+ }
+ 
++#ifdef __MSYS__
++#define PIPE_INTRO "\\\\.\\pipe\\msys-"
++#else
+ #define PIPE_INTRO "\\\\.\\pipe\\cygwin-"
++#endif
+ 
+ /* Create a pipe, and return handles to the read and write ends,
+    just like CreatePipe, but ensure that the write end permits
+diff --git a/winsup/cygwin/fhandler_tty.cc b/winsup/cygwin/fhandler_tty.cc
+index 399b6ef..adc7dfe 100644
+--- a/winsup/cygwin/fhandler_tty.cc
++++ b/winsup/cygwin/fhandler_tty.cc
+@@ -925,7 +925,11 @@ fhandler_pty_slave::open (int flags, mode_t)
+       pipe_reply repl;
+       DWORD len;
+ 
++#ifdef __MSYS__
++      __small_sprintf (buf, "\\\\.\\pipe\\msys-%S-pty%d-master-ctl",
++#else
+       __small_sprintf (buf, "\\\\.\\pipe\\cygwin-%S-pty%d-master-ctl",
++#endif
+ 		       &cygheap->installation_key, get_minor ());
+       termios_printf ("dup handles via master control pipe %s", buf);
+       if (!CallNamedPipe (buf, &req, sizeof req, &repl, sizeof repl,
+@@ -1202,7 +1206,11 @@ fhandler_pty_slave::reset_switch_to_pcon (void)
+ 		    {
+ 		      char pipe[MAX_PATH];
+ 		      __small_sprintf (pipe,
++#ifdef __MSYS__
++			       "\\\\.\\pipe\\msys-%S-pty%d-master-ctl",
++#else
+ 			       "\\\\.\\pipe\\cygwin-%S-pty%d-master-ctl",
++#endif
+ 			       &cygheap->installation_key, get_minor ());
+ 		      pipe_request req = { GetCurrentProcessId () };
+ 		      pipe_reply repl;
+@@ -2156,7 +2164,11 @@ fhandler_pty_master::close ()
+ 	  pipe_reply repl;
+ 	  DWORD len;
+ 
++#ifdef __MSYS__
++	  __small_sprintf (buf, "\\\\.\\pipe\\msys-%S-pty%d-master-ctl",
++#else
+ 	  __small_sprintf (buf, "\\\\.\\pipe\\cygwin-%S-pty%d-master-ctl",
++#endif
+ 			   &cygheap->installation_key, get_minor ());
+ 	  acquire_output_mutex (mutex_timeout);
+ 	  if (master_ctl)
+@@ -3063,7 +3075,11 @@ fhandler_pty_master::setup ()
+ 
+   /* Create master control pipe which allows the master to duplicate
+      the pty pipe handles to processes which deserve it. */
++#ifdef __MSYS__
++  __small_sprintf (buf, "\\\\.\\pipe\\msys-%S-pty%d-master-ctl",
++#else
+   __small_sprintf (buf, "\\\\.\\pipe\\cygwin-%S-pty%d-master-ctl",
++#endif
+ 		   &cygheap->installation_key, unit);
+   master_ctl = CreateNamedPipe (buf, PIPE_ACCESS_DUPLEX
+ 				     | FILE_FLAG_FIRST_PIPE_INSTANCE,
+@@ -3968,7 +3984,11 @@ fhandler_pty_slave::transfer_input (tty::xfer_dir dir, HANDLE from, tty *ttyp,
+     {
+       char pipe[MAX_PATH];
+       __small_sprintf (pipe,
++#ifdef __MSYS__
++		       "\\\\.\\pipe\\msys-%S-pty%d-master-ctl",
++#else
+ 		       "\\\\.\\pipe\\cygwin-%S-pty%d-master-ctl",
++#endif
+ 		       &cygheap->installation_key, ttyp->get_minor ());
+       pipe_request req = { GetCurrentProcessId () };
+       pipe_reply repl;
+diff --git a/winsup/cygwin/fork.cc b/winsup/cygwin/fork.cc
+index 7192178..0fe112f 100644
+--- a/winsup/cygwin/fork.cc
++++ b/winsup/cygwin/fork.cc
+@@ -158,7 +158,7 @@ frok::child (volatile char * volatile here)
+   char buf[80];
+   /* This is useful for debugging fork problems.  Use gdb to attach to
+      the pid reported here. */
+-  if (GetEnvironmentVariableA ("CYGWIN_FORK_SLEEP", buf, sizeof (buf)))
++  if (GetEnvironmentVariableA ("MSYS_FORK_SLEEP", buf, sizeof (buf)))
+     {
+       small_printf ("Sleeping %d after fork, pid %u\n", atoi (buf), GetCurrentProcessId ());
+       Sleep (atoi (buf));
+diff --git a/winsup/cygwin/hookapi.cc b/winsup/cygwin/hookapi.cc
+index 1eb5fde..f15e6b4 100644
+--- a/winsup/cygwin/hookapi.cc
++++ b/winsup/cygwin/hookapi.cc
+@@ -401,7 +401,11 @@ hook_or_detect_cygwin (const char *name, const void *fn, WORD& subsys, HANDLE h)
+   for (PIMAGE_IMPORT_DESCRIPTOR pd = pdfirst; pd->FirstThunk; pd++)
+     {
+       if (!ascii_strcasematch (rva (PSTR, map ?: (char *) hm, pd->Name - delta),
++#ifdef __MSYS__
++			       "msys-2.0.dll"))
++#else
+ 			       "cygwin1.dll"))
++#endif
+ 	continue;
+       if (!fn)
+ 	{
+diff --git a/winsup/cygwin/i686.din b/winsup/cygwin/i686.din
+index 174e73d..b514a41 100644
+--- a/winsup/cygwin/i686.din
++++ b/winsup/cygwin/i686.din
+@@ -1,4 +1,4 @@
+-LIBRARY "cygwin1.dll" BASE=0x61000000
++LIBRARY "msys-2.0.dll" BASE=0x61000000
+ 
+ EXPORTS
+ #Exported variables
+@@ -595,7 +595,7 @@ cygwin32_conv_to_full_posix_path = cygwin_conv_to_full_posix_path SIGFE
+ cygwin32_conv_to_full_win32_path = cygwin_conv_to_full_win32_path SIGFE
+ cygwin32_conv_to_posix_path = cygwin_conv_to_posix_path SIGFE
+ cygwin32_conv_to_win32_path = cygwin_conv_to_win32_path SIGFE
+-cygwin32_detach_dll = cygwin_detach_dll SIGFE_MAYBE
++cygwin32_detach_dll = msys_detach_dll SIGFE_MAYBE
+ cygwin32_internal = cygwin_internal SIGFE
+ cygwin32_posix_path_list_p = cygwin_posix_path_list_p NOSIGFE
+ cygwin32_posix_to_win32_path_list = cygwin_posix_to_win32_path_list SIGFE
+@@ -613,7 +613,7 @@ cygwin_posix_to_win32_path_list_buf_size SIGFE
+ cygwin_win32_to_posix_path_list SIGFE
+ cygwin_win32_to_posix_path_list_buf_size SIGFE
+ dll_entry@12 NOSIGFE
+-dll_noncygwin_dllcrt0 NOSIGFE
++dll_nonmsys_dllcrt0 NOSIGFE
+ fcloseall_r = _fcloseall_r SIGFE
+ fscanf_r = _fscanf_r SIGFE
+ get_osfhandle = _get_osfhandle SIGFE
+diff --git a/winsup/cygwin/include/cygwin/cygwin_dll.h b/winsup/cygwin/include/cygwin/cygwin_dll.h
+index 56b4363..6bc948a 100644
+--- a/winsup/cygwin/include/cygwin/cygwin_dll.h
++++ b/winsup/cygwin/include/cygwin/cygwin_dll.h
+@@ -24,8 +24,8 @@ details. */
+ CDECL_BEGIN								      \
+   int WINAPI Entry (HINSTANCE h, DWORD reason, void *ptr);	              \
+   typedef int (*mainfunc) (int, char **, char **);			      \
+-  extern PVOID cygwin_attach_dll (HMODULE, mainfunc);			      \
+-  extern void cygwin_detach_dll (PVOID);				      \
++  extern PVOID msys_attach_dll (HMODULE, mainfunc);			      \
++  extern void msys_detach_dll (PVOID);				      \
+ CDECL_END								      \
+ 									      \
+ static HINSTANCE storedHandle;						      \
+@@ -42,7 +42,7 @@ static int __dllMain (int a __attribute__ ((__unused__)),		      \
+ 									      \
+ static PVOID dll_index;							      \
+ 									      \
+-int WINAPI _cygwin_dll_entry (HINSTANCE h, DWORD reason, void *ptr)	      \
++int WINAPI _msys_dll_entry (HINSTANCE h, DWORD reason, void *ptr)	      \
+ {									      \
+   int ret;								      \
+   ret = 1;								      \
+@@ -55,7 +55,7 @@ int WINAPI _cygwin_dll_entry (HINSTANCE h, DWORD reason, void *ptr)	      \
+       storedReason = reason;						      \
+       storedPtr = ptr;							      \
+       __dynamically_loaded = (ptr == NULL);				      \
+-      dll_index = cygwin_attach_dll (h, &__dllMain);			      \
++      dll_index = msys_attach_dll (h, &__dllMain);			      \
+       if (dll_index == (PVOID) -1)					      \
+ 	ret = 0;							      \
+     }									      \
+@@ -66,7 +66,7 @@ int WINAPI _cygwin_dll_entry (HINSTANCE h, DWORD reason, void *ptr)	      \
+       ret = Entry (h, reason, ptr);					      \
+       if (ret)								      \
+       {									      \
+-	cygwin_detach_dll (dll_index);					      \
++	msys_detach_dll (dll_index);					      \
+ 	dll_index = (PVOID) -1;						      \
+       }									      \
+     }									      \
+@@ -88,9 +88,9 @@ int WINAPI _cygwin_dll_entry (HINSTANCE h, DWORD reason, void *ptr)	      \
+ }									      \
+ 									      \
+ /* OBSOLETE: This is only provided for source level compatibility. */         \
+-int WINAPI _cygwin_noncygwin_dll_entry (HINSTANCE h, DWORD reason, void *ptr) \
++int WINAPI _msys_nonmsys_dll_entry (HINSTANCE h, DWORD reason, void *ptr) \
+ {									      \
+-  return _cygwin_dll_entry (h, reason, ptr);				      \
++  return _msys_dll_entry (h, reason, ptr);				      \
+ }									      \
+ 
+ #endif /* __CYGWIN_CYGWIN_DLL_H__ */
+diff --git a/winsup/cygwin/include/cygwin/version.h b/winsup/cygwin/include/cygwin/version.h
+index f901816..e6ae517 100644
+--- a/winsup/cygwin/include/cygwin/version.h
++++ b/winsup/cygwin/include/cygwin/version.h
+@@ -533,7 +533,11 @@ details. */
+    names include the CYGWIN_VERSION_SHARED_DATA version as well as this
+    identifier. */
+ 
++#ifdef __MSYS__
++#define CYGWIN_VERSION_DLL_IDENTIFIER	"msys-2.0"
++#else
+ #define CYGWIN_VERSION_DLL_IDENTIFIER	"cygwin1"
++#endif
+ 
+ /* The Cygwin mount table interface in the Win32 registry also has a version
+    number associated with it in case that is changed in a non-backwards
+@@ -549,7 +553,11 @@ details. */
+ 
+ /* Identifiers used in the Win32 registry. */
+ 
++#ifdef __MSYS__
++#define CYGWIN_INFO_CYGWIN_REGISTRY_NAME "MSYS"
++#else
+ #define CYGWIN_INFO_CYGWIN_REGISTRY_NAME "Cygwin"
++#endif
+ #define CYGWIN_INFO_INSTALLATIONS_NAME   "Installations"
+ 
+ /* The default cygdrive prefix. */
+diff --git a/winsup/cygwin/lib/_cygwin_crt0_common.cc b/winsup/cygwin/lib/_cygwin_crt0_common.cc
+index 025e2f2..aa5a85d 100644
+--- a/winsup/cygwin/lib/_cygwin_crt0_common.cc
++++ b/winsup/cygwin/lib/_cygwin_crt0_common.cc
+@@ -87,7 +87,11 @@ struct per_process_cxx_malloc __cygwin_cxx_malloc =
+    and then jump to the dll.  */
+ 
+ int __stdcall
++#ifdef __MSYS__
++_msys_crt0_common (MainFunc f, per_process *u)
++#else
+ _cygwin_crt0_common (MainFunc f, per_process *u)
++#endif
+ {
+   per_process *newu = (per_process *) cygwin_internal (CW_USER_DATA);
+   bool uwasnull;
+diff --git a/winsup/cygwin/lib/crt0.h b/winsup/cygwin/lib/crt0.h
+index c551de7..e901d91 100644
+--- a/winsup/cygwin/lib/crt0.h
++++ b/winsup/cygwin/lib/crt0.h
+@@ -13,7 +13,11 @@ extern "C" {
+ #include "winlean.h"
+ struct per_process;
+ typedef int (*MainFunc) (int argc, char *argv[], char **env);
++#ifdef __MSYS__
++int __stdcall _msys_crt0_common (MainFunc, struct per_process *);
++#else
+ int __stdcall _cygwin_crt0_common (MainFunc, struct per_process *);
++#endif
+ PVOID dll_dllcrt0 (HMODULE, struct per_process *);
+ 
+ #ifdef __cplusplus
+diff --git a/winsup/cygwin/lib/cygwin_attach_dll.c b/winsup/cygwin/lib/cygwin_attach_dll.c
+index 866bfd8..82679c4 100644
+--- a/winsup/cygwin/lib/cygwin_attach_dll.c
++++ b/winsup/cygwin/lib/cygwin_attach_dll.c
+@@ -15,10 +15,18 @@ details. */
+ 
+ /* for a loaded dll */
+ PVOID
++#ifdef __MSYS__
++msys_attach_dll (HMODULE h, MainFunc f)
++#else
+ cygwin_attach_dll (HMODULE h, MainFunc f)
++#endif
+ {
+   static struct per_process u;
++#ifdef __MSYS__
++  (void) _msys_crt0_common (f, &u);
++#else
+   (void) _cygwin_crt0_common (f, &u);
++#endif
+ 
+   /* jump into the dll. */
+   return dll_dllcrt0 (h, &u);
+diff --git a/winsup/cygwin/lib/cygwin_crt0.c b/winsup/cygwin/lib/cygwin_crt0.c
+index 776e7e8..3e1eda1 100644
+--- a/winsup/cygwin/lib/cygwin_crt0.c
++++ b/winsup/cygwin/lib/cygwin_crt0.c
+@@ -14,8 +14,16 @@ extern void __stdcall _dll_crt0 ()
+ 
+ /* for main module */
+ void
++#ifdef __MSYS__
++msys_crt0 (MainFunc f)
++#else
+ cygwin_crt0 (MainFunc f)
++#endif
+ {
++#ifdef __MSYS__
++  _msys_crt0_common (f, NULL);
++#else
+   _cygwin_crt0_common (f, NULL);
++#endif
+   _dll_crt0 ();	/* Jump into the dll, never to return */
+ }
+diff --git a/winsup/cygwin/mkvers.sh b/winsup/cygwin/mkvers.sh
+index b2db73c..ee99dd0 100755
+--- a/winsup/cygwin/mkvers.sh
++++ b/winsup/cygwin/mkvers.sh
+@@ -133,7 +133,7 @@ fi
+ ) | while read var; do
+     read val
+ cat <<EOF
+-  "%%% Cygwin $var: $val\n"
++  "%%% MSYS $var: $val\n"
+ EOF
+ done | tee /tmp/mkvers.$$ 1>&9
+ 
+@@ -152,9 +152,9 @@ fi
+ #
+ cat <<EOF 1>&9
+ #ifdef DEBUGGING
+-  "%%% Cygwin shared id: " CYGWIN_VERSION_DLL_IDENTIFIER "S" shared_data_version "-$builddate\n"
++  "%%% MSYS shared id: " CYGWIN_VERSION_DLL_IDENTIFIER "S" shared_data_version "-$builddate\n"
+ #else
+-  "%%% Cygwin shared id: " CYGWIN_VERSION_DLL_IDENTIFIER "S" shared_data_version "\n"
++  "%%% MSYS shared id: " CYGWIN_VERSION_DLL_IDENTIFIER "S" shared_data_version "\n"
+ #endif
+   "END_CYGWIN_VERSION_INFO\n\0";
+ cygwin_version_info cygwin_version =
+diff --git a/winsup/cygwin/pinfo.cc b/winsup/cygwin/pinfo.cc
+index a16e219..dcd0285 100644
+--- a/winsup/cygwin/pinfo.cc
++++ b/winsup/cygwin/pinfo.cc
+@@ -194,7 +194,7 @@ pinfo::maybe_set_exit_code_from_windows ()
+       GetExitCodeProcess (hProcess, &x);
+       set_exit_code (x);
+     }
+-  sigproc_printf ("pid %d, exit value - old %y, windows %y, cygwin %y",
++  sigproc_printf ("pid %d, exit value - old %y, windows %y, MSYS %y",
+ 		  self->pid, oexitcode, x, self->exitcode);
+ }
+ 
+diff --git a/winsup/cygwin/pseudo-reloc.cc b/winsup/cygwin/pseudo-reloc.cc
+index d015cc5..cd4dff8 100644
+--- a/winsup/cygwin/pseudo-reloc.cc
++++ b/winsup/cygwin/pseudo-reloc.cc
+@@ -85,7 +85,7 @@ __report_error (const char *msg, ...)
+   char buf[128];
+   char *posix_module = NULL;
+   static const char UNKNOWN_MODULE[] = "<unknown module>: ";
+-  static const char CYGWIN_FAILURE_MSG[] = "Cygwin runtime failure: ";
++  static const char CYGWIN_FAILURE_MSG[] = "MSYS runtime failure: ";
+   HANDLE errh = GetStdHandle (STD_ERROR_HANDLE);
+   va_list args;
+ 
+diff --git a/winsup/cygwin/sec_auth.cc b/winsup/cygwin/sec_auth.cc
+index e44b70b..2b94d03 100644
+--- a/winsup/cygwin/sec_auth.cc
++++ b/winsup/cygwin/sec_auth.cc
+@@ -848,7 +848,7 @@ verify_token (HANDLE token, cygsid &usersid, user_groups &groups, bool *pintern)
+       if (!NT_SUCCESS (status))
+ 	debug_printf ("NtQueryInformationToken(), %y", status);
+       else
+-	*pintern = intern = !memcmp (ts.SourceName, "Cygwin.1", 8);
++	*pintern = intern = !memcmp (ts.SourceName, "MSYS.2", 6);
+     }
+   /* Verify usersid */
+   cygsid tok_usersid (NO_SID);
+@@ -992,7 +992,7 @@ create_token (cygsid &usersid, user_groups &new_groups)
+   TOKEN_DEFAULT_DACL dacl = {};
+   TOKEN_SOURCE source;
+   TOKEN_STATISTICS stats;
+-  memcpy (source.SourceName, "Cygwin.1", 8);
++  memcpy (source.SourceName, "MSYS.2", 6);
+   source.SourceIdentifier.HighPart = 0;
+   source.SourceIdentifier.LowPart = 0x0101;
+ 
+@@ -1151,7 +1151,7 @@ lsaauth (cygsid &usersid, user_groups &new_groups)
+   push_self_privilege (SE_TCB_PRIVILEGE, true);
+ 
+   /* Register as logon process. */
+-  RtlInitAnsiString (&name, "Cygwin");
++  RtlInitAnsiString (&name, "MSYS");
+   status = LsaRegisterLogonProcess (&name, &lsa_hdl, &sec_mode);
+   if (status != STATUS_SUCCESS)
+     {
+@@ -1174,10 +1174,10 @@ lsaauth (cygsid &usersid, user_groups &new_groups)
+     goto out;
+ 
+   /* Create origin. */
+-  stpcpy (origin.buf, "Cygwin");
++  stpcpy (origin.buf, "MSYS");
+   RtlInitAnsiString (&origin.str, origin.buf);
+   /* Create token source. */
+-  memcpy (ts.SourceName, "Cygwin.1", 8);
++  memcpy (ts.SourceName, "MSYS.2", 6);
+   ts.SourceIdentifier.HighPart = 0;
+   ts.SourceIdentifier.LowPart = 0x0103;
+ 
+@@ -1529,7 +1529,7 @@ s4uauth (bool logon, PCWSTR domain, PCWSTR user, NTSTATUS &ret_status)
+     {
+       /* Register as logon process. */
+       debug_printf ("Impersonation requested");
+-      RtlInitAnsiString (&name, "Cygwin");
++      RtlInitAnsiString (&name, "MSYS");
+       status = LsaRegisterLogonProcess (&name, &lsa_hdl, &sec_mode);
+     }
+   else
+@@ -1568,11 +1568,11 @@ s4uauth (bool logon, PCWSTR domain, PCWSTR user, NTSTATUS &ret_status)
+     }
+ 
+   /* Create origin. */
+-  stpcpy (origin.buf, "Cygwin");
++  stpcpy (origin.buf, "MSYS");
+   RtlInitAnsiString (&origin.str, origin.buf);
+ 
+   /* Create token source. */
+-  memcpy (ts.SourceName, "Cygwin.1", 8);
++  memcpy (ts.SourceName, "MSYS.2", 6);
+   ts.SourceIdentifier.HighPart = 0;
+   ts.SourceIdentifier.LowPart = kerberos_auth ? 0x0105 : 0x0106;
+ 
+diff --git a/winsup/cygwin/syscalls.cc b/winsup/cygwin/syscalls.cc
+index 03fed03..0890390 100644
+--- a/winsup/cygwin/syscalls.cc
++++ b/winsup/cygwin/syscalls.cc
+@@ -325,7 +325,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, ACCESS_MASK access, ULONG flags)
+     }
+   else
+     {
+-      /* Create unique filename.  Start with a dot, followed by "cyg"
++      /* Create unique filename.  Start with a dot, followed by "msys"
+ 	 transposed into the Unicode low surrogate area (U+dc00) on file
+ 	 systems supporting Unicode (except Samba), followed by the inode
+ 	 number in hex, followed by a path hash in hex.  The combination
+@@ -333,7 +333,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, ACCESS_MASK access, ULONG flags)
+       RtlAppendUnicodeToString (&recycler,
+ 				(pc.fs_flags () & FILE_UNICODE_ON_DISK
+ 				 && !pc.fs_is_samba ())
+-				? L".\xdc63\xdc79\xdc67" : L".cyg");
++				? L".\xdc6d\xdc73\xdc79\xdc73" : L".msys");
+       pfii = (PFILE_INTERNAL_INFORMATION) infobuf;
+       status = NtQueryInformationFile (fh, &io, pfii, sizeof *pfii,
+ 				       FileInternalInformation);
+diff --git a/winsup/cygwin/syslog.cc b/winsup/cygwin/syslog.cc
+index 6a29550..431f9d2 100644
+--- a/winsup/cygwin/syslog.cc
++++ b/winsup/cygwin/syslog.cc
+@@ -26,7 +26,11 @@ details. */
+ #include "cygtls.h"
+ #include "tls_pbuf.h"
+ 
++#ifdef __MSYS__
++#define CYGWIN_LOG_NAME L"MSYS"
++#else
+ #define CYGWIN_LOG_NAME L"Cygwin"
++#endif
+ 
+ static struct
+ {
+diff --git a/winsup/cygwin/winsup.h b/winsup/cygwin/winsup.h
+index 1f265ec..4843f8c 100644
+--- a/winsup/cygwin/winsup.h
++++ b/winsup/cygwin/winsup.h
+@@ -166,7 +166,11 @@ extern "C" void _pei386_runtime_relocator (per_process *);
+ 
+ #ifdef __i386__
+ /* dynamically loaded dll initialization for non-cygwin apps */
++#ifdef __MSYS__
++extern "C" int dll_nonmsys_dllcrt0 (HMODULE, per_process *);
++#else
+ extern "C" int dll_noncygwin_dllcrt0 (HMODULE, per_process *);
++#endif
+ #endif /* __i386__ */
+ 
+ void __reg1 do_exit (int) __attribute__ ((noreturn));
+diff --git a/winsup/cygwin/winver.rc b/winsup/cygwin/winver.rc
+index 980d512..58878d4 100644
+--- a/winsup/cygwin/winver.rc
++++ b/winsup/cygwin/winver.rc
+@@ -35,7 +35,7 @@ BEGIN
+       VALUE "InternalName", CYGWIN_DLL_NAME
+       VALUE "LegalCopyright", "Copyright \251 Cygwin Authors 1996-" STRINGIFY(CYGWIN_BUILD_YEAR)
+       VALUE "OriginalFilename", CYGWIN_DLL_NAME
+-      VALUE "ProductName", "Cygwin"
++      VALUE "ProductName", "MSYS2"
+       VALUE "ProductVersion", STRINGIFY(CYGWIN_VERSION)
+       VALUE "APIVersion", CYGWIN_API_VERSION
+       VALUE "SharedMemoryVersion", STRINGIFY(CYGWIN_VERSION_SHARED_DATA)
+diff --git a/winsup/cygwin/x86_64.din b/winsup/cygwin/x86_64.din
+index e1896bf..38332c7 100644
+--- a/winsup/cygwin/x86_64.din
++++ b/winsup/cygwin/x86_64.din
+@@ -1,4 +1,4 @@
+-LIBRARY "cygwin1.dll" BASE=0x180040000
++LIBRARY "msys-2.0.dll" BASE=0x180040000
+ 
+ EXPORTS
+ #Exported variables
+diff --git a/winsup/testsuite/config/default.exp b/winsup/testsuite/config/default.exp
+index 7ef16ee..fd592c3 100644
+--- a/winsup/testsuite/config/default.exp
++++ b/winsup/testsuite/config/default.exp
+@@ -1,11 +1,11 @@
+ proc winsup_version {} {
+     global env
+     global runtime_root
+-    clone_output "\n[exec grep -a ^%%% $runtime_root/cygwin0.dll]\n"
+-    if { [info exists env(CYGWIN)] } {
+-        clone_output "CYGWIN=$env(CYGWIN)\n"
++    clone_output "\n[exec grep -a ^%%% $runtime_root/msys0.dll]\n"
++    if { [info exists env(MSYS)] } {
++        clone_output "MSYS=$env(MSYS)\n"
+     } else {
+-        clone_output "CYGWIN=\n"
++        clone_output "MSYS=\n"
+     }
+ }
+ 
+diff --git a/winsup/testsuite/cygrun.c b/winsup/testsuite/cygrun.c
+index 65d859d..616b043 100644
+--- a/winsup/testsuite/cygrun.c
++++ b/winsup/testsuite/cygrun.c
+@@ -32,8 +32,8 @@ main (int argc, char **argv)
+   if (argc >= 3)
+     SetEnvironmentVariable ("TDIRECTORY", argv[2]);
+ 
+-  SetEnvironmentVariable ("CYGWIN_TESTING", "1");
+-  if ((p = getenv ("CYGWIN")) == NULL || (strstr (p, "ntsec") == NULL))
++  SetEnvironmentVariable ("MSYS_TESTING", "1");
++  if ((p = getenv ("MSYS")) == NULL || (strstr (p, "ntsec") == NULL))
+     {
+       char buf[4096];
+       if (!p)
+@@ -47,7 +47,7 @@ main (int argc, char **argv)
+ 	  strcat (buf, " ");
+ 	}
+       strcat(buf, "ntsec");
+-      SetEnvironmentVariable ("CYGWIN", buf);
++      SetEnvironmentVariable ("MSYS", buf);
+     }
+ 
+   memset (&sa, 0, sizeof (sa));
+diff --git a/winsup/testsuite/winsup.api/cygload.cc b/winsup/testsuite/winsup.api/cygload.cc
+index ad45996..7a398dc 100644
+--- a/winsup/testsuite/winsup.api/cygload.cc
++++ b/winsup/testsuite/winsup.api/cygload.cc
+@@ -25,7 +25,7 @@
+ 		     save for errors.
+      -testinterrupts Pauses the program for 30 seconds so you can demonstrate
+ 		     that it handles ^C properly.
+-     -cygwin         Name of DLL to load.  Defaults to "cygwin1.dll". */
++     -cygwin         Name of DLL to load.  Defaults to "msys-2.0.dll". */
+ 
+ #include "cygload.h"
+ #include <iostream>
+@@ -136,15 +136,15 @@ cygwin::connector::connector (const char *dll)
+   if ((_library = LoadLibrary (dll)) == NULL)
+     throw windows_error ("LoadLibrary", dll);
+ 
+-  *out << "Initializing cygwin..." << endl;
++  *out << "Initializing msys..." << endl;
+ 
+-  // This calls dcrt0.cc:cygwin_dll_init(), which calls dll_crt0_1(),
++  // This calls dcrt0.cc:msys_dll_init(), which calls dll_crt0_1(),
+   // which will, among other things:
+   // * spawn the cygwin signal handling thread from sigproc_init()
+   // * initialize the thread-local storage for this thread and overwrite
+   //   the first 4K of the stack
+   void (*cyginit) ();
+-  get_symbol ("cygwin_dll_init", cyginit);
++  get_symbol ("msys_dll_init", cyginit);
+   (*cyginit) ();
+ 
+   *out << "Loading symbols..." << endl;
+@@ -210,7 +210,7 @@ cygwin::connector::~connector ()
+ 
+     // This should call init.cc:dll_entry() with DLL_PROCESS_DETACH.
+     if (!FreeLibrary (_library))
+-      throw windows_error ("FreeLibrary", "cygwin1.dll");
++      throw windows_error ("FreeLibrary", "msys-2.0.dll");
+   }
+   catch (std::exception &x)
+   {
+@@ -476,7 +476,7 @@ main (int argc, char *argv[])
+ 
+   std::ostringstream output;
+   bool verbose = false, testinterrupts = false;
+-  const char *dll = "cygwin1.dll";
++  const char *dll = "msys-2.0.dll";
+ 
+   out = &output;
+ 
+diff --git a/winsup/testsuite/winsup.api/cygload.exp b/winsup/testsuite/winsup.api/cygload.exp
+index e7b4395..c092d99 100644
+--- a/winsup/testsuite/winsup.api/cygload.exp
++++ b/winsup/testsuite/winsup.api/cygload.exp
+@@ -26,7 +26,7 @@ if { $rv != {0 {}} } {
+         set redirect_output /dev/null
+     }
+     set windows_runtime_root [exec cygpath -m $runtime_root]
+-    ws_spawn "./mingw-cygload.exe -cygwin $windows_runtime_root/cygwin0.dll > $redirect_output"
++    ws_spawn "./mingw-cygload.exe -cygwin $windows_runtime_root/msys0.dll > $redirect_output"
+     if { $rv != {0 {}} } {
+         verbose -log "cygload: $rv"
+         fail "cygload (execute)"
+diff --git a/winsup/testsuite/winsup.api/cygload.h b/winsup/testsuite/winsup.api/cygload.h
+index 8007fd5..ab4003b 100644
+--- a/winsup/testsuite/winsup.api/cygload.h
++++ b/winsup/testsuite/winsup.api/cygload.h
+@@ -76,7 +76,7 @@ namespace cygwin
+   // spawns a thread to let you receive signals from cygwin.
+   class connector {
+   public:
+-    connector (const char *dll = "cygwin1.dll");
++    connector (const char *dll = "msys-2.0.dll");
+     ~connector ();
+ 
+     // A wrapper around GetProcAddress() for fetching symbols from the
+diff --git a/winsup/testsuite/winsup.api/winsup.exp b/winsup/testsuite/winsup.api/winsup.exp
+index 584aa57..bc05713 100644
+--- a/winsup/testsuite/winsup.api/winsup.exp
++++ b/winsup/testsuite/winsup.api/winsup.exp
+@@ -61,7 +61,7 @@ foreach src [lsort [glob -nocomplain $srcdir/$subdir/*.c $srcdir/$subdir/*/*.{cc
+     if [ file exists "$srcdir/$subdir/$basename.exp" ] then {
+ 	source "$srcdir/$subdir/$basename.exp"
+     } else {
+-	ws_spawn "$CC -nodefaultlibs -mwin32 $CFLAGS $src $add_includes $add_libs $runtime_root/binmode.o -lgcc $runtime_root/libcygwin0.a -lkernel32 -luser32 -o $base.exe"
++	ws_spawn "$CC -nodefaultlibs -mwin32 $CFLAGS $src $add_includes $add_libs $runtime_root/binmode.o -lgcc $runtime_root/libmsys0.a -lkernel32 -luser32 -o $base.exe"
+ 	if { $rv } {
+ 	    fail "$testcase (compile)"
+ 	} else {
+diff --git a/winsup/utils/ldd.cc b/winsup/utils/ldd.cc
+index 0d073c2..a31c4c6 100644
+--- a/winsup/utils/ldd.cc
++++ b/winsup/utils/ldd.cc
+@@ -249,7 +249,7 @@ tocyg (wchar_t *win_fn)
+   return fn;
+ }
+ 
+-#define CYGWIN_DLL_LEN (wcslen (L"\\cygwin1.dll"))
++#define CYGWIN_DLL_LEN (wcslen (L"\\msys-2.0.dll"))
+ static int
+ print_dlls (dlls *dll, const wchar_t *dllfn, const wchar_t *process_fn)
+ {
+diff --git a/winsup/utils/loadlib.h b/winsup/utils/loadlib.h
+index c83b764..42ffbfd 100644
+--- a/winsup/utils/loadlib.h
++++ b/winsup/utils/loadlib.h
+@@ -13,7 +13,7 @@
+ #include <wchar.h>
+ 
+ /* Load all system libs from the windows system directory by prepending the
+-   full path.  This doesn't work for loadling cygwin1.dll.  For this case,
++   full path.  This doesn't work for loadling msys-2.0.dll.  For this case,
+    instead of prepending the path, make sure that the CWD is removed from
+    the DLL search path, if possible (XP SP1++, Vista++). */
+ static HMODULE _load_sys_library (const wchar_t *dll) __attribute__ ((used));
+@@ -45,8 +45,8 @@ _load_sys_library (const wchar_t *dll)
+       	set_dll_directory (L"");
+     }
+ 
+-  if (wcscmp (dll, L"cygwin1.dll") == 0)
+-    return LoadLibraryExW (L"cygwin1.dll", NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
++  if (wcscmp (dll, L"msys-2.0.dll") == 0)
++    return LoadLibraryExW (L"msys-2.0.dll", NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
+ 
+   wcscpy (dllpath, sysdir);
+   wcscpy (dllpath + sysdir_len, dll);
+diff --git a/winsup/utils/mingw/cygcheck.cc b/winsup/utils/mingw/cygcheck.cc
+index 288a718..7674e8e 100644
+--- a/winsup/utils/mingw/cygcheck.cc
++++ b/winsup/utils/mingw/cygcheck.cc
+@@ -66,8 +66,7 @@ static const char *known_env_vars[] = {
+   "c_include_path",
+   "compiler_path",
+   "cxx_include_path",
+-  "cygwin",
+-  "cygwin32",
++  "msys",
+   "dejagnu",
+   "expect",
+   "gcc_default_options",
+@@ -517,12 +516,12 @@ struct ImpDirectory
+ 
+ static bool track_down (const char *file, const char *suffix, int lvl);
+ 
+-#define CYGPREFIX (sizeof ("%%% Cygwin ") - 1)
++#define CYGPREFIX (sizeof ("%%% Msys ") - 1)
+ static void
+ cygwin_info (HANDLE h)
+ {
+   char *buf, *bufend, *buf_start = NULL;
+-  const char *hello = "    Cygwin DLL version info:\n";
++  const char *hello = "    Msys DLL version info:\n";
+   DWORD size = GetFileSize (h, NULL);
+   DWORD n;
+ 
+@@ -549,7 +548,7 @@ cygwin_info (HANDLE h)
+   while (buf < bufend)
+     if ((buf = (char *) memchr (buf, '%', bufend - buf)) == NULL)
+       break;
+-    else if (strncmp ("%%% Cygwin ", buf, CYGPREFIX) != 0)
++    else if (strncmp ("%%% Msys ", buf, CYGPREFIX) != 0)
+       buf++;
+     else
+       {
+@@ -748,7 +747,7 @@ dll_info (const char *path, HANDLE fh, int lvl, int recurse)
+ 	    }
+ 	}
+     }
+-  if (strstr (path, "\\cygwin1.dll"))
++  if (strstr (path, "\\msys-2.0.dll"))
+     cygwin_info (fh);
+ }
+ 
+@@ -995,7 +994,7 @@ scan_registry (RegInfo * prev, HKEY hKey, char *name, int cygwin, bool wow64)
+ 
+   char *cp;
+   for (cp = name; *cp; cp++)
+-    if (strncasecmp (cp, "Cygwin", 6) == 0)
++    if (strncasecmp (cp, "Msys", 4) == 0)
+       cygwin = 1;
+ 
+   DWORD num_subkeys, max_subkey_len, num_values;
+@@ -1259,7 +1258,7 @@ dump_sysinfo_services ()
+ 
+   /* inform the user if nothing found */
+   if (no_services)
+-    puts ("No Cygwin services found.\n");
++    puts ("No Msys services found.\n");
+ }
+ 
+ enum handle_reg_t
+@@ -1274,10 +1273,10 @@ handle_reg_installation (handle_reg_t what)
+   HKEY key;
+ 
+   if (what == PRINT_KEY)
+-    printf ("Cygwin installations found in the registry:\n");
++    printf ("Msys installations found in the registry:\n");
+   for (int i = 0; i < 2; ++i)
+     if (RegOpenKeyEx (i ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE,
+-		      "SOFTWARE\\Cygwin\\Installations", 0,
++		      "SOFTWARE\\Msys\\Installations", 0,
+ 		      what == DELETE_KEY ? KEY_READ | KEY_WRITE : KEY_READ,
+ 		      &key)
+ 	== ERROR_SUCCESS)
+@@ -1299,7 +1298,7 @@ handle_reg_installation (handle_reg_t what)
+ 	      if (what == PRINT_KEY)
+ 		printf ("  %s Key: %s Path: %s", i ? "User:  " : "System:",
+ 			name, path);
+-	      strcat (path, "\\bin\\cygwin1.dll");
++	      strcat (path, "\\bin\\msys-2.0.dll");
+ 	      if (what == PRINT_KEY)
+ 		printf ("%s\n", access (path, F_OK) ? " (ORPHANED)" : "");
+ 	      else if (access (path, F_OK))
+@@ -1373,7 +1372,7 @@ dump_sysinfo ()
+       _wputenv (comspec);
+     }
+ 
+-  printf ("\nCygwin Configuration Diagnostics\n");
++  printf ("\nMsys Configuration Diagnostics\n");
+   time (&now);
+   printf ("Current System Time: %s\n", ctime (&now));
+ 
+@@ -1663,7 +1662,7 @@ dump_sysinfo ()
+ 
+ 
+   if (givehelp)
+-    printf ("Here's some environment variables that may affect cygwin:\n");
++    printf ("Here's some environment variables that may affect msys:\n");
+   for (i = 0; environ[i]; i++)
+     {
+       char *eq = strchr (environ[i], '=');
+@@ -1713,7 +1712,7 @@ dump_sysinfo ()
+   if (registry)
+     {
+       if (givehelp)
+-	printf ("Scanning registry for keys with 'Cygwin' in them...\n");
++	printf ("Scanning registry for keys with 'Msys' in them...\n");
+       scan_registry (0, HKEY_CURRENT_USER,
+ 		     (char *) "HKEY_CURRENT_USER", 0, false);
+       scan_registry (0, HKEY_LOCAL_MACHINE,
+@@ -1891,7 +1890,7 @@ dump_sysinfo ()
+   printf ("\n");
+ 
+   if (givehelp)
+-    printf ("Looking for various Cygwin DLLs...  (-v gives version info)\n");
++    printf ("Looking for various Msys DLLs...  (-v gives version info)\n");
+   int cygwin_dll_count = 0;
+   char cygdll_path[32768];
+   for (pathlike *pth = paths; pth->dir; pth++)
+@@ -1908,10 +1907,10 @@ dump_sysinfo ()
+ 	  wcstombs (f, ffinfo.cFileName, sizeof f);
+ 	  if (strcasecmp (f + strlen (f) - 4, ".dll") == 0)
+ 	    {
+-	      if (strncasecmp (f, "cyg", 3) == 0)
++	      if (strncasecmp (f, "msys-", 5) == 0)
+ 		{
+ 		  sprintf (tmp, "%s%s", pth->dir, f);
+-		  if (strcasecmp (f, "cygwin1.dll") == 0)
++		  if (strcasecmp (f, "msys-2.0.dll") == 0)
+ 		    {
+ 		      if (!cygwin_dll_count)
+ 			strcpy (cygdll_path, pth->dir);
+@@ -1935,9 +1934,9 @@ dump_sysinfo ()
+       FindClose (ff);
+     }
+   if (cygwin_dll_count > 1)
+-    puts ("Warning: There are multiple cygwin1.dlls on your path");
++    puts ("Warning: There are multiple msys-2.0.dlls on your path");
+   if (!cygwin_dll_count)
+-    puts ("Warning: cygwin1.dll not found on your path");
++    puts ("Warning: msys-2.0.dll not found on your path");
+ 
+   dump_dodgy_apps (verbose);
+ 
+@@ -2184,8 +2183,8 @@ static char opts[] = "cdsrvkflphV";
+ static void
+ print_version ()
+ {
+-  printf ("cygcheck (cygwin) %d.%d.%d\n"
+-	  "System Checker for Cygwin\n"
++  printf ("cygcheck (msys) %d.%d.%d\n"
++	  "System Checker for Msys\n"
+ 	  "Copyright (C) 1998 - %s Cygwin Authors\n"
+ 	  "This is free software; see the source for copying conditions.  "
+ 	  "There is NO\n"
+@@ -2217,7 +2216,7 @@ load_cygwin (int& argc, char **&argv)
+ {
+   HMODULE h;
+ 
+-  if (!(h = LoadLibrary ("cygwin1.dll")))
++  if (!(h = LoadLibrary ("msys-2.0.dll")))
+     return;
+   GetModuleFileNameW (h, cygwin_dll_path, 32768);
+   if ((cygwin_internal = (uintptr_t (*) (int, ...))
+diff --git a/winsup/utils/mingw/strace.cc b/winsup/utils/mingw/strace.cc
+index d8a095f..de4abc4 100644
+--- a/winsup/utils/mingw/strace.cc
++++ b/winsup/utils/mingw/strace.cc
+@@ -284,7 +284,7 @@ load_cygwin ()
+   if (h)
+     return 0;
+ 
+-  if (!(h = LoadLibrary ("cygwin1.dll")))
++  if (!(h = LoadLibrary ("msys-2.0.dll")))
+     {
+       errno = ENOENT;
+       return 0;
+@@ -354,17 +354,16 @@ create_child (char **argv)
+   make_command_line (one_line, argv);
+ 
+   SetConsoleCtrlHandler (NULL, 0);
+-
+-  const char *cygwin_env = getenv ("CYGWIN");
++  const char *cygwin_env = getenv ("MSYS");
+   const char *space;
+ 
+   if (cygwin_env && strlen (cygwin_env) <= 256) /* sanity check */
+     space = " ";
+   else
+     space = cygwin_env = "";
+-  char *newenv = (char *) malloc (sizeof ("CYGWIN=noglob")
++  char *newenv = (char *) malloc (sizeof ("MSYS=noglob")
+ 				  + strlen (space) + strlen (cygwin_env));
+-  sprintf (newenv, "CYGWIN=noglob%s%s", space, cygwin_env);
++  sprintf (newenv, "MSYS=noglob%s%s", space, cygwin_env);
+   _putenv (newenv);
+   ret = CreateProcess (0, one_line.buf,	/* command line */
+ 		       NULL,	/* Security */
+@@ -825,7 +824,7 @@ dotoggle (pid_t pid)
+   child_pid = (DWORD) cygwin_internal (CW_CYGWIN_PID_TO_WINPID, pid);
+   if (!child_pid)
+     {
+-      warn (0, "no such cygwin pid - %d", pid);
++      warn (0, "no such msys pid - %d", pid);
+       child_pid = pid;
+     }
+   if (cygwin_internal (CW_STRACE_TOGGLE, child_pid))
+diff --git a/winsup/utils/path.cc b/winsup/utils/path.cc
+index df0037c..2445655 100644
+--- a/winsup/utils/path.cc
++++ b/winsup/utils/path.cc
+@@ -586,14 +586,14 @@ read_mounts ()
+     }
+   max_mount_entry = 0;
+ 
+-  /* First fetch the cygwin1.dll path from the LoadLibrary call in load_cygwin.
+-     This utilizes the DLL search order to find a matching cygwin1.dll and to
++  /* First fetch the msys-2.0.dll path from the LoadLibrary call in load_cygwin.
++     This utilizes the DLL search order to find a matching msys-2.0.dll and to
+      compute the installation path from that DLL's path. */
+   if (cygwin_dll_path[0])
+     wcscpy (path, cygwin_dll_path);
+-  /* If we can't load cygwin1.dll, check where cygcheck is living itself and
+-     try to fetch installation path from here.  Does cygwin1.dll exist in the
+-     same path?  This should only kick in if the cygwin1.dll in the same path
++  /* If we can't load msys-2.0.dll, check where cygcheck is living itself and
++     try to fetch installation path from here.  Does msys-2.0.dll exist in the
++     same path?  This should only kick in if the msys-2.0.dll in the same path
+      has been made non-executable for the current user accidentally. */
+   else if (!GetModuleFileNameW (NULL, path, 32768))
+     return;
+@@ -602,7 +602,7 @@ read_mounts ()
+     {
+       if (!cygwin_dll_path[0])
+ 	{
+-	  wcscpy (path_end, L"\\cygwin1.dll");
++	  wcscpy (path_end, L"\\msys-2.0.dll");
+ 	  DWORD attr = GetFileAttributesW (path);
+ 	  if (attr == (DWORD) -1
+ 	      || (attr & (FILE_ATTRIBUTE_DIRECTORY
+diff --git a/winsup/utils/ssp.c b/winsup/utils/ssp.c
+index 4c98eef..ad35d23 100644
+--- a/winsup/utils/ssp.c
++++ b/winsup/utils/ssp.c
+@@ -718,15 +718,15 @@ usage (FILE * stream)
+     "You must specify the range of memory addresses to keep track of\n"
+     "manually, but it's not hard to figure out what to specify.  Use the\n"
+     "\"objdump\" program to determine the bounds of the target's \".text\"\n"
+-    "section.  Let's say we're profiling cygwin1.dll.  Make sure you've\n"
++    "section.  Let's say we're profiling msys-2.0.dll.  Make sure you've\n"
+     "built it with debug symbols (else gprof won't run) and run objdump\n"
+     "like this:\n"
+     "\n"
+-    "	objdump -h cygwin1.dll\n"
++    "	objdump -h msys-2.0.dll\n"
+     "\n"
+     "It will print a report like this:\n"
+     "\n"
+-    "cygwin1.dll:     file format pei-i386\n"
++    "msys-2.0.dll:     file format pei-i386\n"
+     "\n"
+     "Sections:\n"
+     "Idx Name          Size      VMA       LMA       File off  Algn\n"
+@@ -757,7 +757,7 @@ usage (FILE * stream)
+     "\"gmon.out\".  You can turn this data file into a readable report with\n"
+     "gprof:\n"
+     "\n"
+-    "	gprof -b cygwin1.dll\n"
++    "	gprof -b msys-2.0.dll\n"
+     "\n"
+     "The \"-b\" means 'skip the help pages'.  You can omit this until you're\n"
+     "familiar with the report layout.  The gprof documentation explains\n"

--- a/msys2-runtime-3.3/0004-Add-functionality-for-converting-UNIX-paths-in-argum.patch
+++ b/msys2-runtime-3.3/0004-Add-functionality-for-converting-UNIX-paths-in-argum.patch
@@ -1,0 +1,1095 @@
+From eec753278b54a8ad5e5371dfe1b4c3023408fed4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=90=D0=BB=D0=B5=D0=BA=D1=81=D0=B5=D0=B8=CC=86=20=D0=9F?=
+ =?UTF-8?q?=D0=B0=D0=B2=D0=BB=D0=BE=D0=B2?= <alexey.pawlow@gmail.com>
+Date: Sun, 14 Apr 2019 21:17:46 +0300
+Subject: [PATCH 04/N] Add functionality for converting UNIX paths in
+ arguments and environment variables to Windows form for native Win32
+ applications.
+
+---
+ winsup/cygwin/Makefile.am          |   1 +
+ winsup/cygwin/environ.cc           |  24 +-
+ winsup/cygwin/environ.h            |   2 +-
+ winsup/cygwin/external.cc          |   2 +-
+ winsup/cygwin/include/sys/cygwin.h |   6 +
+ winsup/cygwin/msys2_path_conv.cc   | 639 +++++++++++++++++++++++++++++
+ winsup/cygwin/msys2_path_conv.h    | 147 +++++++
+ winsup/cygwin/path.cc              |  69 ++++
+ winsup/cygwin/spawn.cc             |  42 +-
+ winsup/cygwin/winf.h               |   4 +
+ 10 files changed, 930 insertions(+), 6 deletions(-)
+ create mode 100644 winsup/cygwin/msys2_path_conv.cc
+ create mode 100644 winsup/cygwin/msys2_path_conv.h
+
+diff --git a/winsup/cygwin/Makefile.am b/winsup/cygwin/Makefile.am
+index 72471ea..23a3c23 100644
+--- a/winsup/cygwin/Makefile.am
++++ b/winsup/cygwin/Makefile.am
+@@ -283,6 +283,7 @@ DLL_FILES= \
+ 	mmap.cc \
+ 	mmap_alloc.cc \
+ 	msg.cc \
++	msys2_path_conv.cc \
+ 	mount.cc \
+ 	net.cc \
+ 	netdb.cc \
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index 03f8277..8ad1026 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -1058,7 +1058,7 @@ env_compare (const void *key, const void *memb)
+    to the child. */
+ char ** __reg3
+ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
+-	   bool no_envblock, HANDLE new_token)
++	   bool no_envblock, HANDLE new_token, bool keep_posix)
+ {
+   PWCHAR cwinenv = NULL;
+   size_t winnum = 0;
+@@ -1151,6 +1151,19 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
+   for (srcp = envp, dstp = newenv, pass_dstp = pass_env; *srcp; srcp++)
+     {
+       bool calc_tl = !no_envblock;
++#ifdef __MSYS__
++      /* Don't pass timezone environment to non-msys applications */
++      if (!keep_posix && ascii_strncasematch(*srcp, "TZ=", 3))
++        {
++          const char *v = *srcp + 3;
++          if (*v == ':')
++            goto next1;
++          for (; *v; v++)
++            if (!isalpha(*v) && !isdigit(*v) &&
++                *v != '-' && *v != '+' && *v != ':')
++              goto next1;
++        }
++#endif
+       /* Look for entries that require special attention */
+       for (unsigned i = 0; i < SPENVS_SIZE; i++)
+ 	if (!saw_spenv[i] && (*dstp = spenvs[i].retrieve (no_envblock, *srcp)))
+@@ -1271,6 +1284,15 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
+ 		  saw_PATH = true;
+ 		}
+ 	    }
++#ifdef __MSYS__
++	  else if (!keep_posix) {
++	    char *win_arg = arg_heuristic(*srcp);
++	    debug_printf("WIN32_PATH is %s", win_arg);
++	    p = cstrdup1(win_arg);
++	    if (win_arg != *srcp)
++	      free (win_arg);
++	  }
++#endif
+ 	  else
+ 	    p = *srcp;		/* Don't worry about it */
+ 
+diff --git a/winsup/cygwin/environ.h b/winsup/cygwin/environ.h
+index 269591a..71c3f22 100644
+--- a/winsup/cygwin/environ.h
++++ b/winsup/cygwin/environ.h
+@@ -43,7 +43,7 @@ extern "C" char **__cygwin_environ, ***main_environ;
+ extern "C" char __stdcall **cur_environ ();
+ #endif
+ char ** __reg3 build_env (const char * const *envp, PWCHAR &envblock,
+-			  int &envc, bool need_envblock, HANDLE new_token);
++			  int &envc, bool need_envblock, HANDLE new_token, bool keep_posix);
+ 
+ char ** __reg2 win32env_to_cygenv (PWCHAR rawenv, bool posify);
+ 
+diff --git a/winsup/cygwin/external.cc b/winsup/cygwin/external.cc
+index 74413a8..6adf620 100644
+--- a/winsup/cygwin/external.cc
++++ b/winsup/cygwin/external.cc
+@@ -141,7 +141,7 @@ create_winenv (const char * const *env)
+   int unused_envc;
+   PWCHAR envblock = NULL;
+   char **envp = build_env (env ?: cur_environ (), envblock, unused_envc, false,
+-			   NULL);
++			   NULL, true);
+   PWCHAR p = envblock;
+ 
+   if (envp)
+diff --git a/winsup/cygwin/include/sys/cygwin.h b/winsup/cygwin/include/sys/cygwin.h
+index c9d4599..70fd3e7 100644
+--- a/winsup/cygwin/include/sys/cygwin.h
++++ b/winsup/cygwin/include/sys/cygwin.h
+@@ -83,6 +83,12 @@ extern ssize_t cygwin_conv_path_list (cygwin_conv_path_t what, const void *from,
+    to one of the above values, or to ENOMEM if malloc fails. */
+ extern void *cygwin_create_path (cygwin_conv_path_t what, const void *from);
+ 
++extern char * arg_heuristic_with_exclusions (char const * const arg,
++					     char const * exclusions,
++					     size_t exclusions_count);
++
++extern char * arg_heuristic (char const * const);
++
+ extern pid_t cygwin_winpid_to_pid (int);
+ extern int cygwin_posix_path_list_p (const char *);
+ extern void cygwin_split_path (const char *, char *, char *);
+diff --git a/winsup/cygwin/msys2_path_conv.cc b/winsup/cygwin/msys2_path_conv.cc
+new file mode 100644
+index 0000000..2d401ca
+--- /dev/null
++++ b/winsup/cygwin/msys2_path_conv.cc
+@@ -0,0 +1,639 @@
++/*
++  The MSYS2 Path conversion source code is licensed under:
++  
++  CC0 1.0 Universal
++  
++  Official translations of this legal tool are available
++  
++  CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
++  LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
++  ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
++  INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
++  REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
++  PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
++  THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
++  HEREUNDER.
++  
++  Statement of Purpose
++  
++  The laws of most jurisdictions throughout the world automatically
++  confer exclusive Copyright and Related Rights (defined below) upon the
++  creator and subsequent owner(s) (each and all, an "owner") of an
++  original work of authorship and/or a database (each, a "Work").
++  
++  Certain owners wish to permanently relinquish those rights to a Work
++  for the purpose of contributing to a commons of creative, cultural and
++  scientific works ("Commons") that the public can reliably and without
++  fear of later claims of infringement build upon, modify, incorporate
++  in other works, reuse and redistribute as freely as possible in any
++  form whatsoever and for any purposes, including without limitation
++  commercial purposes. These owners may contribute to the Commons to
++  promote the ideal of a free culture and the further production of
++  creative, cultural and scientific works, or to gain reputation or
++  greater distribution for their Work in part through the use and
++  efforts of others.
++  
++  For these and/or other purposes and motivations, and without any
++  expectation of additional consideration or compensation, the person
++  associating CC0 with a Work (the "Affirmer"), to the extent that he or
++  she is an owner of Copyright and Related Rights in the Work,
++  voluntarily elects to apply CC0 to the Work and publicly distribute
++  the Work under its terms, with knowledge of his or her Copyright and
++  Related Rights in the Work and the meaning and intended legal effect
++  of CC0 on those rights.
++  
++  1. Copyright and Related Rights. A Work made available under CC0 may
++  be protected by copyright and related or neighboring rights
++  ("Copyright and Related Rights"). Copyright and Related Rights
++  include, but are not limited to, the following:
++  
++  the right to reproduce, adapt, distribute, perform, display,
++  communicate, and translate a Work;
++  moral rights retained by the original author(s) and/or performer(s);
++  publicity and privacy rights pertaining to a person's image or
++  likeness depicted in a Work;
++  rights protecting against unfair competition in regards to a Work,
++  subject to the limitations in paragraph 4(a), below;
++  rights protecting the extraction, dissemination, use and reuse of data
++  in a Work;
++  database rights (such as those arising under Directive 96/9/EC of the
++  European Parliament and of the Council of 11 March 1996 on the legal
++  protection of databases, and under any national implementation
++  thereof, including any amended or successor version of such
++  directive); and
++  other similar, equivalent or corresponding rights throughout the world
++  based on applicable law or treaty, and any national implementations
++  thereof.
++  
++  2. Waiver. To the greatest extent permitted by, but not in
++  contravention of, applicable law, Affirmer hereby overtly, fully,
++  permanently, irrevocably and unconditionally waives, abandons, and
++  surrenders all of Affirmer's Copyright and Related Rights and
++  associated claims and causes of action, whether now known or unknown
++  (including existing as well as future claims and causes of action), in
++  the Work (i) in all territories worldwide, (ii) for the maximum
++  duration provided by applicable law or treaty (including future time
++  extensions), (iii) in any current or future medium and for any number
++  of copies, and (iv) for any purpose whatsoever, including without
++  limitation commercial, advertising or promotional purposes (the
++  "Waiver"). Affirmer makes the Waiver for the benefit of each member of
++  the public at large and to the detriment of Affirmer's heirs and
++  successors, fully intending that such Waiver shall not be subject to
++  revocation, rescission, cancellation, termination, or any other legal
++  or equitable action to disrupt the quiet enjoyment of the Work by the
++  public as contemplated by Affirmer's express Statement of Purpose.
++  
++  3. Public License Fallback. Should any part of the Waiver for any
++  reason be judged legally invalid or ineffective under applicable law,
++  then the Waiver shall be preserved to the maximum extent permitted
++  taking into account Affirmer's express Statement of Purpose. In
++  addition, to the extent the Waiver is so judged Affirmer hereby grants
++  to each affected person a royalty-free, non transferable, non
++  sublicensable, non exclusive, irrevocable and unconditional license to
++  exercise Affirmer's Copyright and Related Rights in the Work (i) in
++  all territories worldwide, (ii) for the maximum duration provided by
++  applicable law or treaty (including future time extensions), (iii) in
++  any current or future medium and for any number of copies, and (iv)
++  for any purpose whatsoever, including without limitation commercial,
++  advertising or promotional purposes (the "License"). The License shall
++  be deemed effective as of the date CC0 was applied by Affirmer to the
++  Work. Should any part of the License for any reason be judged legally
++  invalid or ineffective under applicable law, such partial invalidity
++  or ineffectiveness shall not invalidate the remainder of the License,
++  and in such case Affirmer hereby affirms that he or she will not (i)
++  exercise any of his or her remaining Copyright and Related Rights in
++  the Work or (ii) assert any associated claims and causes of action
++  with respect to the Work, in either case contrary to Affirmer's
++  express Statement of Purpose.
++  
++  4. Limitations and Disclaimers.
++  
++  No trademark or patent rights held by Affirmer are waived, abandoned,
++  surrendered, licensed or otherwise affected by this document.
++  Affirmer offers the Work as-is and makes no representations or
++  warranties of any kind concerning the Work, express, implied,
++  statutory or otherwise, including without limitation warranties of
++  title, merchantability, fitness for a particular purpose, non
++  infringement, or the absence of latent or other defects, accuracy, or
++  the present or absence of errors, whether or not discoverable, all to
++  the greatest extent permissible under applicable law.
++  Affirmer disclaims responsibility for clearing rights of other persons
++  that may apply to the Work or any use thereof, including without
++  limitation any person's Copyright and Related Rights in the Work.
++  Further, Affirmer disclaims responsibility for obtaining any necessary
++  consents, permissions or other rights required for any use of the
++  Work.
++  Affirmer understands and acknowledges that Creative Commons is not a
++  party to this document and has no duty or obligation with respect to
++  this CC0 or use of the Work.
++
++  Contributions thanks to:
++    niXman <i.nixman@autistici.org>
++    Ely Arzhannikov <iarzhannikov@gmail.com>
++    Alexey Pavlov <alexpux@gmail.com>
++    Ray Donnelly <mingw.android@gmail.com>
++    Johannes Schindelin <johannes.schindelin@gmx.de>
++  
++*/
++
++#include "winsup.h"
++#include "miscfuncs.h"
++#include <ctype.h>
++#include <winioctl.h>
++#include <shlobj.h>
++#include <sys/param.h>
++#include <sys/cygwin.h>
++#include "cygerrno.h"
++#include "security.h"
++#include "path.h"
++#include "fhandler.h"
++#include "dtable.h"
++#include "cygheap.h"
++#include "shared_info.h"
++#include "cygtls.h"
++#include "tls_pbuf.h"
++#include "environ.h"
++#include <assert.h>
++#include <ntdll.h>
++#include <wchar.h>
++#include <wctype.h>
++
++#include "msys2_path_conv.h"
++
++typedef enum PATH_TYPE_E {
++    NONE = 0,
++    SIMPLE_WINDOWS_PATH,
++    ESCAPE_WINDOWS_PATH,
++    WINDOWS_PATH_LIST,
++    UNC,
++    ESCAPED_PATH,
++    ROOTED_PATH,
++    POSIX_PATH_LIST,
++    RELATIVE_PATH,
++    URL
++} path_type;
++
++int is_special_posix_path(const char* from, const char* to, char** dst, const char* dstend);
++void posix_to_win32_path(const char* from, const char* to, char** dst, const char* dstend);
++
++
++path_type find_path_start_and_type(const char** src, int recurse, const char* end);
++void copy_to_dst(const char* from, const char* to, char** dst, const char* dstend);
++void convert_path(const char** from, const char* to, path_type type, char** dst, const char* dstend);
++
++//Transformations
++//SIMPLE_WINDOWS_PATH converter. Copy as is. Hold C:\Something\like\this
++void swp_convert(const char** from, const char* to, char** dst, const char* dstend);
++//ESCAPE_WINDOWS_PATH converter. Turn backslashes to slashes and skip first /. Hold /C:\Somethind\like\this
++void ewp_convert(const char** from, const char* to, char** dst, const char* dstend);
++//WINDOWS_PATH_LIST converter. Copy as is. Hold /something/like/this;
++void wpl_convert(const char** from, const char* to, char** dst, const char* dstend);
++//UNC convert converter. Copy as is. Hold //somethig/like/this
++void unc_convert(const char** from, const char* to, char** dst, const char* dstend);
++//ESCAPED_PATH converter. Turn backslashes to slashes and skip first /. Hold //something\like\this
++void ep_convert(const char** from, const char* to, char** dst, const char* dstend);
++//ROOTED_PATH converter. Prepend root dir to front. Hold /something/like/this
++void rp_convert(const char** from, const char* to, char** dst, const char* dstend);
++//URL converter. Copy as is.
++void url_convert(const char** from, const char* to, char** dst, const char* dstend);
++//POSIX_PATH_LIST. Hold x::x/y:z
++void ppl_convert(const char** from, const char* to, char** dst, const char* dstend);
++
++
++void find_end_of_posix_list(const char** to, int* in_string) {
++    for (; **to != '\0' && (in_string ? (**to != *in_string) : **to != ' '); ++*to) {
++    }
++
++    if (**to == *in_string) {
++        *in_string = 0;
++    }
++}
++
++void find_end_of_rooted_path(const char** from, const char** to, int* in_string) {
++    for (const char* it = *from; *it != '\0' && it != *to; ++it)
++        if (*it == '.' && *(it + 1) == '.' && *(it - 1) == '/') {
++            *to = it - 1;
++            return;
++        }
++
++    for (; **to != '\0'; ++*to) {
++        if (*in_string == 0 && **to == ' ') {
++            return;
++        }
++
++        if (**to == *in_string) {
++            *in_string = 0;
++            return;
++        }
++
++        if (**to == '/') {
++            if (*(*to - 1) == ' ') {
++                *to -= 1;
++                return;
++            }
++        }
++    }
++}
++
++void sub_convert(const char** from, const char** to, char** dst, const char* dstend, int* in_string) {
++    const char* copy_from = *from;
++    path_type type = find_path_start_and_type(from, false, *to);
++
++    if (type == POSIX_PATH_LIST) {
++        find_end_of_posix_list(to, in_string);
++    }
++
++    if (type == ROOTED_PATH) {
++        find_end_of_rooted_path(from, to, in_string);
++    }
++
++    copy_to_dst(copy_from, *from, dst, dstend);
++
++    if (type != NONE) {
++        convert_path(from, *to, type, dst, dstend);
++    }
++
++    if (*dst != dstend) {
++        **dst = **to;
++        *dst += 1;
++    }
++}
++
++const char* convert(char *dst, size_t dstlen, const char *src) {
++    if (dst == NULL || dstlen == 0 || src == NULL) {
++        return dst;
++    }
++
++    int need_convert = false;
++    for (const char* it = src; *it != '\0'; ++it) {
++        if (*it == '\\' || *it == '/') {
++            need_convert = true;
++            break;
++        }
++        if (isspace(*it)) {
++            need_convert = false;
++            break;
++        }
++    }
++
++    char* dstit = dst;
++    char* dstend = dst + dstlen;
++    if (!need_convert) {
++        copy_to_dst(src, NULL, &dstit, dstend);
++        *dstit = '\0';
++        return dst;
++    }
++    *dstend = '\0';
++
++    const char* srcit = src;
++    const char* srcbeg = src;
++
++    int in_string = false;
++
++    for (; *srcit != '\0'; ++srcit) {
++        if (*srcit == '\'' || *srcit == '"') {
++            if (in_string == *srcit) {
++                if (*(srcit + 1) != in_string) {
++                    in_string = 0;
++                }
++            } else {
++                in_string = *srcit;
++            }
++            continue;
++        }
++
++        if (isspace(*srcit)) {
++            //sub_convert(&srcbeg, &srcit, &dstit, dstend, &in_string);
++            //srcbeg = srcit + 1;
++            break;
++        }
++    }
++
++    sub_convert(&srcbeg, &srcit, &dstit, dstend, &in_string);
++    if (!*srcit) {
++      *dstit = '\0';
++      return dst;
++    }
++    srcbeg = srcit + 1;
++    for (; *srcit != '\0'; ++srcit) {
++      continue;
++    }
++    copy_to_dst(srcbeg, srcit, &dstit, dstend);
++    *dstit = '\0';
++
++    /*if (dstit - dst < 2) {
++        dstit = dst;
++        copy_to_dst(src, NULL, &dstit, dstend);
++        *dstit = '\0';
++    }*/
++
++    return dst;
++}
++
++void copy_to_dst(const char* from, const char* to, char** dst, const char* dstend) {
++    for (; (*from != '\0') && (from != to) && (*dst != dstend); ++from, ++(*dst)) {
++        **dst = *from;
++    }
++}
++
++const char** move(const char** p, int count) {
++    *p += count;
++    return p;
++}
++
++path_type find_path_start_and_type(const char** src, int recurse, const char* end) {
++    const char* it = *src;
++
++    if (*it == '\0' || it == end) return NONE;
++
++    if (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
++        return find_path_start_and_type(move(src, 1), true, end);
++    }
++
++    path_type result = NONE;
++
++    if (isalpha(*it) && *(it + 1) == ':') {
++        if (*(it + 2) == '\\') {
++            return SIMPLE_WINDOWS_PATH;
++        }
++
++        if (*(it + 2) == '/' && memchr(it + 2, ':', end - (it + 2)) == NULL) {
++            return SIMPLE_WINDOWS_PATH;
++        }
++
++        if (*(it + 2) == '/' && memchr(it + 2, ';', end - (it + 2))) {
++            return WINDOWS_PATH_LIST;
++        }
++    }
++
++    if (*it == '.' && (*(it + 1) == '.' || *(it + 1) == '/') && memchr(it + 2, ':', end - (it + 2)) == NULL) {
++        return RELATIVE_PATH;
++    }
++
++    if (*it == '/') {
++        it += 1;
++
++        if (isalpha(*it) && *(it + 1) == ':') {
++            return ESCAPE_WINDOWS_PATH;
++        }
++
++        if (*it == '.' && *(it + 1) == '.') {
++            return SIMPLE_WINDOWS_PATH;
++        }
++
++        if (*it == '/') {
++            it += 1;
++            switch(*it) {
++              case ':': return URL;
++              case '/': return ESCAPED_PATH;
++            }
++            if (memchr(it, '/', end - it))
++              return UNC;
++            else
++              return ESCAPED_PATH;
++        }
++
++        for (; *it != '\0' && it != end; ++it) {
++            switch(*it) {
++                case ':': {char ch = *(it + 1); if (ch == '/' || ch == ':' || ch == '.') return POSIX_PATH_LIST;} return WINDOWS_PATH_LIST;
++                case ';': return WINDOWS_PATH_LIST;
++            }
++        }
++
++        if (result != NONE) {
++            return result;
++        }
++
++        return ROOTED_PATH;
++    }
++
++    int starts_with_minus = 0;
++    int starts_with_minus_alpha = 0;
++    if (*it == '-') {
++      starts_with_minus = 1;
++      it += 1;
++      if (isalpha(*it)) {
++        it += 1;
++        starts_with_minus_alpha = 1;
++        if (memchr(it, ';', end - it)) {
++        	return WINDOWS_PATH_LIST;
++        }
++      }
++    }
++
++    for (const char* it2 = it; *it2 != '\0' && it2 != end; ++it2) {
++        char ch = *it2;
++        if (starts_with_minus_alpha) {
++            if (isalpha(ch) && (*(it2+1) == ':') && (*(it2+2) == '/')) {
++                return SIMPLE_WINDOWS_PATH;
++            }
++            if (ch == '/'&& memchr(it2, ',', end - it) == NULL) {
++                *src = it2;
++                return find_path_start_and_type(src, true, end);
++            }
++            starts_with_minus_alpha = 0;
++        }
++        if (ch == '\'' || ch == '"')
++            starts_with_minus = false;
++        if ((ch == '=') || (ch == ':' && starts_with_minus) || ((ch == '\'' || ch == '"') && result == NONE)) {
++            *src = it2 + 1;
++            return find_path_start_and_type(src, true, end);
++        }
++
++        if (ch == ',' && starts_with_minus) {
++            *src = it2 + 1;
++            return find_path_start_and_type(src, true, end);
++        }
++
++        if (ch == ':' && it2 + 1 != end) {
++            it2 += 1;
++            ch = *it2;
++            if (ch == '/' || ch == ':' || ch == '.') {
++                if (ch == '/' && *(it2 + 1) == '/') {
++                    return URL;
++                } else {
++                    return POSIX_PATH_LIST;
++                }
++            } else if (memchr(it2, '=', end - it) == NULL) {
++                return SIMPLE_WINDOWS_PATH;
++            }
++        }
++    }
++
++    if (result != NONE) {
++        *src = it;
++        return result;
++    }
++
++    return SIMPLE_WINDOWS_PATH;
++}
++
++void convert_path(const char** from, const char* to, path_type type, char** dst, const char* dstend) {
++    switch(type) {
++        case SIMPLE_WINDOWS_PATH: swp_convert(from, to, dst, dstend); break;
++        case ESCAPE_WINDOWS_PATH: ewp_convert(from, to, dst, dstend); break;
++        case WINDOWS_PATH_LIST: wpl_convert(from, to, dst, dstend); break;
++        case RELATIVE_PATH: swp_convert(from, to, dst, dstend); break;
++        case UNC: unc_convert(from, to, dst, dstend); break;
++        case ESCAPED_PATH: ep_convert(from, to, dst, dstend); break;
++        case ROOTED_PATH: rp_convert(from, to, dst, dstend); break;
++        case URL: url_convert(from, to, dst, dstend); break;
++        case POSIX_PATH_LIST: ppl_convert(from, to, dst, dstend); break;
++        case NONE: // prevent warnings;
++        default:
++                return;
++    }
++}
++
++void swp_convert(const char** from, const char* to, char** dst, const char* dstend) {
++    copy_to_dst(*from, to, dst, dstend);
++}
++
++void ewp_convert(const char** from, const char* to, char** dst, const char* dstend) {
++    *from += 1;
++    unc_convert(from, to, dst, dstend);
++}
++
++void wpl_convert(const char** from, const char* to, char** dst, const char* dstend) {
++    swp_convert(from, to, dst, dstend);
++}
++
++void unc_convert(const char** from, const char* to, char** dst, const char* dstend) {
++    const char* it = *from;
++    for (; (*it != '\0' && it != to) && (*dst != dstend); ++it, ++(*dst)) {
++        if (*it == '\\') {
++            **dst = '/';
++        } else {
++            **dst = *it;
++        }
++    }
++}
++
++void ep_convert(const char** from, const char* to, char** dst, const char* dstend) {
++    ewp_convert(from, to, dst, dstend);
++}
++
++void rp_convert(const char** from, const char* to, char** dst, const char* dstend) {
++    const char* it = *from;
++    const char* real_to = to;
++
++    if (*real_to == '\0')  {
++        real_to -= 1;
++        if (*real_to != '\'' && *real_to != '"') {
++            real_to += 1;
++        }
++    }
++
++    if (!is_special_posix_path(*from, real_to, dst, dstend)) {
++        posix_to_win32_path(it, real_to, dst, dstend);
++    }
++
++    if (*dst != dstend && real_to != to) {
++        **dst = *real_to;
++        *dst += 1;
++    }
++}
++
++void url_convert(const char** from, const char* to, char** dst, const char* dstend) {
++    unc_convert(from, to, dst, dstend);
++}
++
++void subp_convert(const char** from, const char* end, int is_url, char** dst, const char* dstend) {
++    const char* begin = *from;
++    path_type type = is_url ? URL : find_path_start_and_type(from, 0, end);
++    copy_to_dst(begin, *from, dst, dstend);
++
++    if (type == NONE) {
++        return;
++    }
++
++    char* start = *dst;
++    convert_path(from, end, type, dst, dstend);
++
++    if (!is_url) {
++        for (; start != *dst; ++start) {
++            if (*start == '/') {
++                *start = '\\';
++            }
++        }
++    }
++}
++
++void ppl_convert(const char** from, const char* to, char** dst, const char* dstend) {
++    const char *orig_dst = *dst;
++    const char* it = *from;
++    const char* beg = it;
++    int prev_was_simc = 0;
++    int is_url = 0;
++    for (; (*it != '\0' && it != to) && (*dst != dstend); ++it) {
++        if (*it == ':') {
++            if (prev_was_simc) {
++                continue;
++            }
++            if (*(it + 1) == '/' && *(it + 2) == '/' && isalpha(*beg)) {
++                is_url = 1;
++                /* double-check: protocol must be alnum (or +) */
++                for (const char *p = beg; p != it; ++p)
++                    if (!isalnum(*p) && *p != '+') {
++                        is_url = 0;
++                        break;
++                    }
++                if (is_url)
++                    continue;
++            }
++            prev_was_simc = 1;
++            subp_convert(&beg, it, is_url, dst, dstend);
++            is_url = 0;
++
++            if (*dst == dstend) {
++                system_printf("Path cut off during conversion: %s\n", orig_dst);
++                break;
++            }
++
++            **dst = ';';
++            *dst += 1;
++        }
++
++        if (*it != ':' && prev_was_simc) {
++            prev_was_simc = 0;
++            beg = it;
++        }
++    }
++
++    if (!prev_was_simc) {
++        subp_convert(&beg, it, is_url, dst, dstend);
++    }
++}
++
++int is_special_posix_path(const char* from, const char* to, char** dst, const char* dstend) {
++    const char dev_null[] = "/dev/null";
++
++    if ((to - from) == (sizeof(dev_null) - 1) && strncmp(from, "/dev/null", to - from) == 0) {
++        copy_to_dst("nul", NULL, dst, dstend);
++        return true;
++    }
++    return false;
++}
++
++void posix_to_win32_path(const char* from, const char* to, char** dst, const char* dstend) {
++    if ( from != to ) {
++        tmp_pathbuf tp;
++        char *one_path = tp.c_get();
++        strncpy(one_path, from, to-from);
++        one_path[to-from] = '\0';
++
++        path_conv conv (one_path, 0);
++        if (conv.error)
++        {
++          set_errno(conv.error);
++          copy_to_dst(one_path, NULL, dst, dstend);
++        } else {
++          char* win32_path = tp.c_get();
++          stpcpy (win32_path, conv.get_win32 ());
++          for (; (*win32_path != '\0') && (*dst != dstend); ++win32_path, ++(*dst)) {
++             **dst = (*win32_path == '\\') ? '/' : *win32_path;
++          }
++        }
++    }
++}
++
+diff --git a/winsup/cygwin/msys2_path_conv.h b/winsup/cygwin/msys2_path_conv.h
+new file mode 100644
+index 0000000..67d85ec
+--- /dev/null
++++ b/winsup/cygwin/msys2_path_conv.h
+@@ -0,0 +1,147 @@
++/*
++  The MSYS2 Path conversion source code is licensed under:
++  
++  CC0 1.0 Universal
++  
++  Official translations of this legal tool are available
++  
++  CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
++  LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
++  ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
++  INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
++  REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
++  PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
++  THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
++  HEREUNDER.
++  
++  Statement of Purpose
++  
++  The laws of most jurisdictions throughout the world automatically
++  confer exclusive Copyright and Related Rights (defined below) upon the
++  creator and subsequent owner(s) (each and all, an "owner") of an
++  original work of authorship and/or a database (each, a "Work").
++  
++  Certain owners wish to permanently relinquish those rights to a Work
++  for the purpose of contributing to a commons of creative, cultural and
++  scientific works ("Commons") that the public can reliably and without
++  fear of later claims of infringement build upon, modify, incorporate
++  in other works, reuse and redistribute as freely as possible in any
++  form whatsoever and for any purposes, including without limitation
++  commercial purposes. These owners may contribute to the Commons to
++  promote the ideal of a free culture and the further production of
++  creative, cultural and scientific works, or to gain reputation or
++  greater distribution for their Work in part through the use and
++  efforts of others.
++  
++  For these and/or other purposes and motivations, and without any
++  expectation of additional consideration or compensation, the person
++  associating CC0 with a Work (the "Affirmer"), to the extent that he or
++  she is an owner of Copyright and Related Rights in the Work,
++  voluntarily elects to apply CC0 to the Work and publicly distribute
++  the Work under its terms, with knowledge of his or her Copyright and
++  Related Rights in the Work and the meaning and intended legal effect
++  of CC0 on those rights.
++  
++  1. Copyright and Related Rights. A Work made available under CC0 may
++  be protected by copyright and related or neighboring rights
++  ("Copyright and Related Rights"). Copyright and Related Rights
++  include, but are not limited to, the following:
++  
++  the right to reproduce, adapt, distribute, perform, display,
++  communicate, and translate a Work;
++  moral rights retained by the original author(s) and/or performer(s);
++  publicity and privacy rights pertaining to a person's image or
++  likeness depicted in a Work;
++  rights protecting against unfair competition in regards to a Work,
++  subject to the limitations in paragraph 4(a), below;
++  rights protecting the extraction, dissemination, use and reuse of data
++  in a Work;
++  database rights (such as those arising under Directive 96/9/EC of the
++  European Parliament and of the Council of 11 March 1996 on the legal
++  protection of databases, and under any national implementation
++  thereof, including any amended or successor version of such
++  directive); and
++  other similar, equivalent or corresponding rights throughout the world
++  based on applicable law or treaty, and any national implementations
++  thereof.
++  
++  2. Waiver. To the greatest extent permitted by, but not in
++  contravention of, applicable law, Affirmer hereby overtly, fully,
++  permanently, irrevocably and unconditionally waives, abandons, and
++  surrenders all of Affirmer's Copyright and Related Rights and
++  associated claims and causes of action, whether now known or unknown
++  (including existing as well as future claims and causes of action), in
++  the Work (i) in all territories worldwide, (ii) for the maximum
++  duration provided by applicable law or treaty (including future time
++  extensions), (iii) in any current or future medium and for any number
++  of copies, and (iv) for any purpose whatsoever, including without
++  limitation commercial, advertising or promotional purposes (the
++  "Waiver"). Affirmer makes the Waiver for the benefit of each member of
++  the public at large and to the detriment of Affirmer's heirs and
++  successors, fully intending that such Waiver shall not be subject to
++  revocation, rescission, cancellation, termination, or any other legal
++  or equitable action to disrupt the quiet enjoyment of the Work by the
++  public as contemplated by Affirmer's express Statement of Purpose.
++  
++  3. Public License Fallback. Should any part of the Waiver for any
++  reason be judged legally invalid or ineffective under applicable law,
++  then the Waiver shall be preserved to the maximum extent permitted
++  taking into account Affirmer's express Statement of Purpose. In
++  addition, to the extent the Waiver is so judged Affirmer hereby grants
++  to each affected person a royalty-free, non transferable, non
++  sublicensable, non exclusive, irrevocable and unconditional license to
++  exercise Affirmer's Copyright and Related Rights in the Work (i) in
++  all territories worldwide, (ii) for the maximum duration provided by
++  applicable law or treaty (including future time extensions), (iii) in
++  any current or future medium and for any number of copies, and (iv)
++  for any purpose whatsoever, including without limitation commercial,
++  advertising or promotional purposes (the "License"). The License shall
++  be deemed effective as of the date CC0 was applied by Affirmer to the
++  Work. Should any part of the License for any reason be judged legally
++  invalid or ineffective under applicable law, such partial invalidity
++  or ineffectiveness shall not invalidate the remainder of the License,
++  and in such case Affirmer hereby affirms that he or she will not (i)
++  exercise any of his or her remaining Copyright and Related Rights in
++  the Work or (ii) assert any associated claims and causes of action
++  with respect to the Work, in either case contrary to Affirmer's
++  express Statement of Purpose.
++  
++  4. Limitations and Disclaimers.
++  
++  No trademark or patent rights held by Affirmer are waived, abandoned,
++  surrendered, licensed or otherwise affected by this document.
++  Affirmer offers the Work as-is and makes no representations or
++  warranties of any kind concerning the Work, express, implied,
++  statutory or otherwise, including without limitation warranties of
++  title, merchantability, fitness for a particular purpose, non
++  infringement, or the absence of latent or other defects, accuracy, or
++  the present or absence of errors, whether or not discoverable, all to
++  the greatest extent permissible under applicable law.
++  Affirmer disclaims responsibility for clearing rights of other persons
++  that may apply to the Work or any use thereof, including without
++  limitation any person's Copyright and Related Rights in the Work.
++  Further, Affirmer disclaims responsibility for obtaining any necessary
++  consents, permissions or other rights required for any use of the
++  Work.
++  Affirmer understands and acknowledges that Creative Commons is not a
++  party to this document and has no duty or obligation with respect to
++  this CC0 or use of the Work.
++
++  Contributions thanks to:
++    niXman <i.nixman@autistici.org>
++    Ely Arzhannikov <iarzhannikov@gmail.com>
++    Alexey Pavlov <alexpux@gmail.com>
++    Ray Donnelly <mingw.android@gmail.com>
++    Johannes Schindelin <johannes.schindelin@gmx.de>
++  
++*/
++
++#ifndef PATH_CONV_H_DB4IQBH3
++#define PATH_CONV_H_DB4IQBH3
++
++#include <stdlib.h>
++
++const char* convert(char *dst, size_t dstlen, const char *src);
++
++#endif /* end of include guard: PATH_CONV_H_DB4IQBH3 */
++
+diff --git a/winsup/cygwin/path.cc b/winsup/cygwin/path.cc
+index 8caa019..a430d98 100644
+--- a/winsup/cygwin/path.cc
++++ b/winsup/cygwin/path.cc
+@@ -66,6 +66,7 @@
+ #include "shared_info.h"
+ #include "tls_pbuf.h"
+ #include "environ.h"
++#include "msys2_path_conv.h"
+ #undef basename
+ 
+ suffix_info stat_suffixes[] =
+@@ -3834,6 +3835,74 @@ fchdir (int fd)
+   return res;
+ }
+ 
++//
++// Important: If returned pointer == arg, then this function
++//            did not malloc that pointer; otherwise free it.
++//
++extern "C" char *
++arg_heuristic_with_exclusions (char const * const arg, char const * exclusions, size_t exclusions_count)
++{
++  char *arg_result;
++
++  // Must return something ..
++  size_t arglen = (arg ? strlen (arg): 0);
++  
++  if (arglen == 0 || !arg)
++  {
++    arg_result = (char *)malloc (sizeof (char));
++    arg_result[0] = '\0';
++    return arg_result;
++  }
++
++  debug_printf("Input value: (%s)", arg);
++  for (size_t excl = 0; excl < exclusions_count; ++excl)
++    {
++      /* Since we've got regex linked we should maybe switch to that, but
++         running regexes for every argument could be too slow. */
++      if ( strcmp (exclusions, "*") == 0 || (strlen (exclusions) && strstr (arg, exclusions) == arg) )
++        return (char*)arg;
++      exclusions += strlen (exclusions) + 1;
++    }
++
++  // Leave enough room for at least 16 path elements; we might be converting
++  // a path list.
++  size_t stack_len = arglen + 16 * MAX_PATH;
++  char * stack_path = (char *)malloc (stack_len);
++  if (!stack_path)
++    {
++      debug_printf ("out of stack space?");
++      return (char *)arg;
++    }
++  memset (stack_path, 0, MAX_PATH);
++  convert (stack_path, stack_len - 1, arg);
++  debug_printf ("convert()'ed: %s (length %d)\n.....->: %s", arg, arglen, stack_path);
++  // Don't allocate memory if no conversion happened.
++  if (!strcmp (arg, stack_path))
++    {
++      if (arg != stack_path)
++        {
++          free (stack_path);
++        }
++      return ((char *)arg);
++    }
++  arg_result = (char *)realloc (stack_path, strlen (stack_path)+1);
++  // Windows doesn't like empty entries in PATH env. variables (;;)
++  char* semisemi = strstr(arg_result, ";;");
++  while (semisemi)
++    {
++      memmove(semisemi, semisemi+1, strlen(semisemi));
++      semisemi = strstr(semisemi, ";;");
++    }
++  return arg_result;
++}
++
++extern "C" char *
++arg_heuristic (char const * const arg)
++{
++  return arg_heuristic_with_exclusions (arg, NULL, 0);
++}
++
++
+ /******************** Exported Path Routines *********************/
+ 
+ /* Cover functions to the path conversion routines.
+diff --git a/winsup/cygwin/spawn.cc b/winsup/cygwin/spawn.cc
+index d9d7716..283041a 100644
+--- a/winsup/cygwin/spawn.cc
++++ b/winsup/cygwin/spawn.cc
+@@ -288,6 +288,27 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
+   bool rc;
+   int res = -1;
+ 
++  /* Environment variable MSYS2_ARG_CONV_EXCL contains a list
++     of ';' separated argument prefixes to pass un-modified..
++     It isn't applied to env. variables; only spawn arguments.
++     A value of * means don't convert any arguments. */
++  char* msys2_arg_conv_excl_env = getenv("MSYS2_ARG_CONV_EXCL");
++  char* msys2_arg_conv_excl = NULL;
++  size_t msys2_arg_conv_excl_count = 0;
++  if (msys2_arg_conv_excl_env)
++    {
++      msys2_arg_conv_excl = (char*)alloca (strlen(msys2_arg_conv_excl_env)+1);
++      strcpy (msys2_arg_conv_excl, msys2_arg_conv_excl_env);
++      msys2_arg_conv_excl_count = 1;
++      msys2_arg_conv_excl_env = strchr ( msys2_arg_conv_excl, ';' );
++      while (msys2_arg_conv_excl_env)
++        {
++          *msys2_arg_conv_excl_env = '\0';
++          ++msys2_arg_conv_excl_count;
++          msys2_arg_conv_excl_env = strchr ( msys2_arg_conv_excl_env + 1, ';' );
++        }
++    }
++
+   /* Check if we have been called from exec{lv}p or spawn{lv}p and mask
+      mode to keep only the spawn mode. */
+   bool p_type_exec = !!(mode & _P_PATH_TYPE_EXEC);
+@@ -402,9 +423,23 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
+ 	      moreinfo->argc = newargv.argc;
+ 	      moreinfo->argv = newargv;
+ 	    }
++	  else
++	    {
++	      for (int i = 0; i < newargv.argc; i++)
++	        {
++	          //convert argv to win32
++	          int newargvlen = strlen (newargv[i]);
++	          char *tmpbuf = (char *)malloc (newargvlen + 1);
++	          memcpy (tmpbuf, newargv[i], newargvlen + 1);
++	          tmpbuf = arg_heuristic_with_exclusions(tmpbuf, msys2_arg_conv_excl, msys2_arg_conv_excl_count);
++	          debug_printf("newargv[%d] = %s", i, newargv[i]);
++	          newargv.replace (i, tmpbuf);
++	          free (tmpbuf);
++	        }
++	    }
+ 	  if ((wincmdln || !real_path.iscygexec ())
+-	       && !cmd.fromargv (newargv, real_path.get_win32 (),
+-				 real_path.iscygexec ()))
++	        && !cmd.fromargv (newargv, real_path.get_win32 (),
++		    real_path.iscygexec ()))
+ 	    {
+ 	      res = -1;
+ 	      __leave;
+@@ -538,7 +573,8 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
+       moreinfo->envp = build_env (envp, envblock, moreinfo->envc,
+ 				  real_path.iscygexec (),
+ 				  switch_user ? ::cygheap->user.primary_token ()
+-					      : NULL);
++					      : NULL,
++				  real_path.iscygexec ());
+       if (!moreinfo->envp || !envblock)
+ 	{
+ 	  set_errno (E2BIG);
+diff --git a/winsup/cygwin/winf.h b/winsup/cygwin/winf.h
+index e3a65f8..1aeec8d 100644
+--- a/winsup/cygwin/winf.h
++++ b/winsup/cygwin/winf.h
+@@ -51,6 +51,10 @@ class av
+ 	calloced = 1;
+       }
+   }
++  void replace (int i, const char *arg)
++  {
++    argv[i] = cstrdup1 (arg);
++  }
+   void dup_all ()
+   {
+     for (int i = calloced; i < argc; i++)

--- a/msys2-runtime-3.3/0005-Add-functionality-for-changing-OS-name-via-MSYSTEM-e.patch
+++ b/msys2-runtime-3.3/0005-Add-functionality-for-changing-OS-name-via-MSYSTEM-e.patch
@@ -1,0 +1,192 @@
+From 4282d492159c1a52fbc161ff48ef906d154b23b5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=90=D0=BB=D0=B5=D0=BA=D1=81=D0=B5=D0=B8=CC=86=20=D0=9F?=
+ =?UTF-8?q?=D0=B0=D0=B2=D0=BB=D0=BE=D0=B2?= <alexey.pawlow@gmail.com>
+Date: Sun, 14 Apr 2019 21:29:01 +0300
+Subject: [PATCH 05/N] Add functionality for changing OS name via MSYSTEM
+ environment variables.
+
+---
+ winsup/cygserver/cygserver-config   |  4 ++--
+ winsup/cygwin/environ.cc            | 36 +++++++++++++++++++++++++----
+ winsup/cygwin/include/sys/utsname.h |  2 +-
+ winsup/cygwin/uname.cc              | 17 ++++++++++++--
+ 4 files changed, 50 insertions(+), 9 deletions(-)
+
+diff --git a/winsup/cygserver/cygserver-config b/winsup/cygserver/cygserver-config
+index 373bfd2..c902857 100755
+--- a/winsup/cygserver/cygserver-config
++++ b/winsup/cygserver/cygserver-config
+@@ -86,7 +86,7 @@ done
+ 
+ # Check if running on NT
+ _sys="`uname`"
+-_nt=`expr "${_sys}" : "CYGWIN_NT"`
++_nt=`expr "${_sys}" : "MSYS_NT"`
+ 
+ # Check for running cygserver processes first.
+ if ps -ef | grep -v grep | grep -q ${service_name}
+@@ -178,7 +178,7 @@ then
+     echo "Do you want to install cygserver as service?"
+     if request "(Say \"no\" if it's already installed as service)"
+     then
+-      if ! cygrunsrv -I ${service_name} -d "CYGWIN cygserver" -p /usr/sbin/cygserver
++      if ! cygrunsrv -I ${service_name} -d "MSYS cygserver" -p /usr/sbin/cygserver
+       then
+         echo
+ 	echo "Installation of cygserver as service failed.  Please check the"
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index 8ad1026..f746841 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -191,7 +191,11 @@ parse_options (const char *inbuf)
+       if (export_settings)
+ 	{
+ 	  debug_printf ("%s", newbuf + 1);
++#ifdef __MSYS__
++	  setenv ("MSYS", newbuf + 1, 1);
++#else
+ 	  setenv ("CYGWIN", newbuf + 1, 1);
++#endif
+ 	}
+       return;
+     }
+@@ -655,7 +659,7 @@ _addenv (const char *name, const char *value, int overwrite)
+   win_env *spenv;
+   if ((spenv = getwinenv (envhere)))
+     spenv->add_cache (value);
+-  if (strcmp (name, "CYGWIN") == 0)
++  if (strcmp (name, "MSYS") == 0)
+     parse_options (value);
+ 
+   return 0;
+@@ -759,6 +763,9 @@ static struct renv {
+ } renv_arr[] = {
+ 	{ NL("COMMONPROGRAMFILES=") },		// 0
+ 	{ NL("COMSPEC=") },
++#ifdef __MSYS__
++	{ NL("MSYSTEM=") },			// 2
++#endif /* __MSYS__ */
+ 	{ NL("PATH=") },			// 2
+ 	{ NL("PROGRAMFILES=") },
+ 	{ NL("SYSTEMDRIVE=") },			// 4
+@@ -770,10 +777,21 @@ static struct renv {
+ #define RENV_SIZE (sizeof (renv_arr) / sizeof (renv_arr[0]))
+ 
+ /* Set of first characters of the above list of variables. */
+-static const char idx_arr[] = "CPSTW";
++static const char idx_arr[] =
++#ifdef __MSYS__
++	"CMPSTW";
++#else
++	"CPSTW";
++#endif
+ /* Index into renv_arr at which the variables with this specific character
+    starts. */
+-static const int start_at[] = { 0, 2, 4, 6, 8 };
++static const int start_at[] = {
++#ifdef __MSYS__
++				0, 2, 3, 5, 7, 9
++#else
++				0, 2, 4, 6, 8
++#endif
++								};
+ 
+ /* Turn environment variable part of a=b string into uppercase - for some
+    environment variables only. */
+@@ -848,7 +866,11 @@ environ_init (char **envp, int envc)
+       update_envptrs ();
+       if (envp_passed_in)
+ 	{
++#ifdef __MSYS__
++	  p = getenv ("MSYS");
++#else
+ 	  p = getenv ("CYGWIN");
++#endif
+ 	  if (p)
+ 	    parse_options (p);
+ 	}
+@@ -895,8 +917,13 @@ win32env_to_cygenv (PWCHAR rawenv, bool posify)
+       ucenv (newp, eq);    /* uppercase env vars which need it */
+       if (*newp == 'T' && strncmp (newp, "TERM=", 5) == 0)
+         sawTERM = 1;
++#ifdef __MSYS__
++      else if (*newp == 'M' && strncmp (newp, "MSYS=", 5) == 0)
++        parse_options (newp + 5);
++#else
+       else if (*newp == 'C' && strncmp (newp, "CYGWIN=", 7) == 0)
+         parse_options (newp + 7);
++#endif
+       if (*eq && posify)
+         posify_maybe (envp + i, *++eq ? eq : --eq, tmpbuf);
+       debug_printf ("%p: %s", envp[i], envp[i]);
+@@ -965,12 +992,13 @@ struct spenv
+ static NO_COPY spenv spenvs[] =
+ {
+ #ifdef DEBUGGING
+-  {NL ("CYGWIN_DEBUG="), false, true, NULL},
++  {NL ("MSYS_DEBUG="), false, true, NULL},
+ #endif
+   {NL ("HOMEDRIVE="), false, false, &cygheap_user::env_homedrive},
+   {NL ("HOMEPATH="), false, false, &cygheap_user::env_homepath},
+   {NL ("LOGONSERVER="), false, false, &cygheap_user::env_logsrv},
+   {NL ("PATH="), false, true, NULL},
++  {NL ("MSYSTEM="), true, true, NULL},
+   {NL ("SYSTEMDRIVE="), false, true, NULL},
+   {NL ("SYSTEMROOT="), true, true, &cygheap_user::env_systemroot},
+   {NL ("USERDOMAIN="), false, false, &cygheap_user::env_domain},
+diff --git a/winsup/cygwin/include/sys/utsname.h b/winsup/cygwin/include/sys/utsname.h
+index d6b3be9..730cb73 100644
+--- a/winsup/cygwin/include/sys/utsname.h
++++ b/winsup/cygwin/include/sys/utsname.h
+@@ -17,7 +17,7 @@ extern "C" {
+ 
+ struct utsname
+ {
+-  char sysname[_UTSNAME_LENGTH];
++  char sysname[_UTSNAME_LENGTH + 1];
+   char nodename[_UTSNAME_LENGTH];
+   char release[_UTSNAME_LENGTH];
+   char version[_UTSNAME_LENGTH];
+diff --git a/winsup/cygwin/uname.cc b/winsup/cygwin/uname.cc
+index 3502166..daed73f 100644
+--- a/winsup/cygwin/uname.cc
++++ b/winsup/cygwin/uname.cc
+@@ -36,7 +36,12 @@ uname_x (struct utsname *name)
+ 
+       memset (name, 0, sizeof (*name));
+       /* sysname */
+-      __small_sprintf (name->sysname, "CYGWIN_%s-%u%s",
++      char* msystem = getenv("MSYSTEM");
++      const char* msystem_sysname = "MSYS";
++      if (msystem != NULL && *msystem && strcmp(msystem, "MSYS") != 0)
++        msystem_sysname = (strstr(msystem, "32") != NULL) ? "MINGW32" : "MINGW64";;
++      __small_sprintf (name->sysname, "%s_%s-%u%s",
++		       msystem_sysname,
+ 		       wincap.osname (), wincap.build_number (),
+ 		       wincap.is_wow64 () ? "-WOW64" : "");
+       /* nodename */
+@@ -82,7 +87,7 @@ uname_x (struct utsname *name)
+ /* Old entrypoint for applications up to API 334 */
+ struct old_utsname
+ {
+-  char sysname[20];
++  char sysname[21];
+   char nodename[20];
+   char release[20];
+   char version[20];
+@@ -98,7 +103,15 @@ uname (struct utsname *in_name)
+       char *snp = strstr  (cygwin_version.dll_build_date, "SNP");
+ 
+       memset (name, 0, sizeof (*name));
++#ifdef __MSYS__
++      char* msystem = getenv("MSYSTEM");
++      const char* msystem_sysname = "MSYS";
++      if (msystem != NULL && *msystem && strcmp(msystem, "MSYS") != 0)
++        msystem_sysname = (strstr(msystem, "32") != NULL) ? "MINGW32" : "MINGW64";
++      __small_sprintf (name->sysname, "%s_%s", msystem_sysname, wincap.osname ());
++#else
+       __small_sprintf (name->sysname, "CYGWIN_%s", wincap.osname ());
++#endif
+ 
+       /* Add a hint to the sysname, that we're running under WOW64.  This might
+ 	 give an early clue if somebody encounters problems. */

--- a/msys2-runtime-3.3/0006-Move-root-to-usr.-Change-sorting-mount-points.-By-de.patch
+++ b/msys2-runtime-3.3/0006-Move-root-to-usr.-Change-sorting-mount-points.-By-de.patch
@@ -1,0 +1,398 @@
+From 7794a2ab74e5e7474356c6a356bdccd0482d4dee Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=90=D0=BB=D0=B5=D0=BA=D1=81=D0=B5=D0=B8=CC=86=20=D0=9F?=
+ =?UTF-8?q?=D0=B0=D0=B2=D0=BB=D0=BE=D0=B2?= <alexey.pawlow@gmail.com>
+Date: Sun, 14 Apr 2019 21:45:06 +0300
+Subject: [PATCH 06/N] - Move root to /usr. - Change sorting mount points. -
+ By default mount without ACLs. - Can read /etc/fstab with short mount point
+ format.
+
+---
+ winsup/cygwin/cygheap.cc |  12 ++-
+ winsup/cygwin/mount.cc   | 185 +++++++++++++++++++++++++++++++++------
+ winsup/cygwin/mount.h    |   3 +-
+ winsup/cygwin/uinfo.cc   |   2 +-
+ 4 files changed, 174 insertions(+), 28 deletions(-)
+
+diff --git a/winsup/cygwin/cygheap.cc b/winsup/cygwin/cygheap.cc
+index 79300a3..4ccd1a8 100644
+--- a/winsup/cygwin/cygheap.cc
++++ b/winsup/cygwin/cygheap.cc
+@@ -197,14 +197,22 @@ init_cygheap::init_installation_root ()
+ 
+   /* Strip off last path component ("\\cygwin1.dll") */
+   PWCHAR w = wcsrchr (installation_root_buf, L'\\');
++#ifdef __MSYS__
++  /* Back two folders to get root as we have all stuff in usr subfolder */
++  for (int i=1; i >=0; --i)
++  {
++#endif
+   if (w)
+     {
+       *w = L'\0';
+       w = wcsrchr (installation_root_buf, L'\\');
+     }
+   if (!w)
+-    api_fatal ("Can't initialize Cygwin installation root dir.\n"
++    api_fatal ("Can't initialize MSYS2 installation root dir.\n"
+ 	       "Invalid DLL path");
++#ifdef __MSYS__
++  }
++#endif
+ 
+   /* Copy result into installation_dir before stripping off "bin" dir and
+      revert to Win32 path.  This path is added to the Windows environment
+@@ -229,6 +237,7 @@ init_cygheap::init_installation_root ()
+   RtlInitUnicodeString (&installation_root, installation_root_buf);
+   RtlInitUnicodeString (&installation_dir, installation_dir_buf);
+ 
++#ifndef __MSYS__
+   for (int i = 1; i >= 0; --i)
+     {
+       reg_key r (i, KEY_WRITE, _WIDE (CYGWIN_INFO_INSTALLATIONS_NAME),
+@@ -237,6 +246,7 @@ init_cygheap::init_installation_root ()
+ 				    installation_root_buf)))
+ 	break;
+     }
++#endif
+ }
+ 
+ void __stdcall
+diff --git a/winsup/cygwin/mount.cc b/winsup/cygwin/mount.cc
+index 5eb0289..22d7b31 100644
+--- a/winsup/cygwin/mount.cc
++++ b/winsup/cygwin/mount.cc
+@@ -39,7 +39,6 @@ details. */
+   (path_prefix_p (proc, (path), proc_len, false))
+ 
+ bool NO_COPY mount_info::got_usr_bin;
+-bool NO_COPY mount_info::got_usr_lib;
+ int NO_COPY mount_info::root_idx = -1;
+ 
+ /* is_unc_share: Return non-zero if PATH begins with //server/share
+@@ -332,7 +331,6 @@ fs_info::update (PUNICODE_STRING upath, HANDLE in_vol)
+ #define MINIMAL_WIN_NTFS_FLAGS (FILE_CASE_SENSITIVE_SEARCH \
+ 				| FILE_CASE_PRESERVED_NAMES \
+ 				| FILE_UNICODE_ON_DISK \
+-				| FILE_PERSISTENT_ACLS \
+ 				| FILE_FILE_COMPRESSION \
+ 				| FILE_VOLUME_QUOTAS \
+ 				| FILE_SUPPORTS_SPARSE_FILES \
+@@ -473,13 +471,13 @@ mount_info::create_root_entry (const PWCHAR root)
+   sys_wcstombs (native_root, PATH_MAX, root);
+   assert (*native_root != '\0');
+   if (add_item (native_root, "/",
+-		MOUNT_SYSTEM | MOUNT_IMMUTABLE | MOUNT_AUTOMATIC)
++		MOUNT_SYSTEM | MOUNT_IMMUTABLE | MOUNT_AUTOMATIC | MOUNT_NOACL)
+       < 0)
+     api_fatal ("add_item (\"%s\", \"/\", ...) failed, errno %d", native_root, errno);
+   /* Create a default cygdrive entry.  Note that this is a user entry.
+      This allows to override it with mount, unless the sysadmin created
+      a cygdrive entry in /etc/fstab. */
+-  cygdrive_flags = MOUNT_NOPOSIX | MOUNT_CYGDRIVE;
++  cygdrive_flags = MOUNT_NOPOSIX | MOUNT_CYGDRIVE | MOUNT_NOACL;
+   strcpy (cygdrive, CYGWIN_INFO_CYGDRIVE_DEFAULT_PREFIX "/");
+   cygdrive_len = strlen (cygdrive);
+ }
+@@ -499,22 +497,14 @@ mount_info::init (bool user_init)
+   pathend = wcpcpy (pathend, L"\\etc\\fstab");
+   from_fstab (user_init, path, pathend);
+ 
+-  if (!user_init && (!got_usr_bin || !got_usr_lib))
++  if (!user_init && !got_usr_bin)
+     {
+       char native[PATH_MAX];
+       if (root_idx < 0)
+-	api_fatal ("root_idx %d, user_shared magic %y, nmounts %d", root_idx, user_shared->version, nmounts);
++        api_fatal ("root_idx %d, user_shared magic %y, nmounts %d", root_idx, user_shared->version, nmounts);
+       char *p = stpcpy (native, mount[root_idx].native_path);
+-      if (!got_usr_bin)
+-      {
+-	stpcpy (p, "\\bin");
+-	add_item (native, "/usr/bin", MOUNT_SYSTEM | MOUNT_AUTOMATIC);
+-      }
+-      if (!got_usr_lib)
+-      {
+-	stpcpy (p, "\\lib");
+-	add_item (native, "/usr/lib", MOUNT_SYSTEM | MOUNT_AUTOMATIC);
+-      }
++      stpcpy (p, "\\usr\\bin");
++      add_item (native, "/bin", MOUNT_SYSTEM | MOUNT_AUTOMATIC | MOUNT_NOACL);
+     }
+ }
+ 
+@@ -595,6 +585,7 @@ mount_info::conv_to_win32_path (const char *src_path, char *dst, device& dev,
+   /* See if this is a cygwin "device" */
+   if (win32_device_name (src_path, dst, dev))
+     {
++      debug_printf ("win32_device_name (%s)", src_path);
+       *flags = 0;
+       rc = 0;
+       goto out_no_chroot_check;
+@@ -625,6 +616,7 @@ mount_info::conv_to_win32_path (const char *src_path, char *dst, device& dev,
+     }
+   if (isproc (src_path))
+     {
++      debug_printf ("isproc (%s)", src_path);
+       dev = *proc_dev;
+       dev = fhandler_proc::get_proc_fhandler (src_path);
+       if (dev == FH_NADA)
+@@ -646,6 +638,7 @@ mount_info::conv_to_win32_path (const char *src_path, char *dst, device& dev,
+      off the prefix and transform it into an MS-DOS path. */
+   else if (iscygdrive (src_path))
+     {
++      debug_printf ("iscygdrive (%s) mount_table->cygdrive %s", src_path, mount_table->cygdrive);
+       int n = mount_table->cygdrive_len - 1;
+       int unit;
+ 
+@@ -657,11 +650,15 @@ mount_info::conv_to_win32_path (const char *src_path, char *dst, device& dev,
+ 	}
+       else if (cygdrive_win32_path (src_path, dst, unit))
+ 	{
++	  debug_printf ("cygdrive_win32_path (%s)", src_path);
+ 	  *flags = cygdrive_flags;
+ 	  goto out;
+ 	}
+       else if (mount_table->cygdrive_len > 1)
+-	return ENOENT;
++      {
++		debug_printf ("mount_table->cygdrive_len > 1 (%s)", src_path);
++		return ENOENT;
++      }
+     }
+ 
+   int chroot_pathlen;
+@@ -672,7 +669,9 @@ mount_info::conv_to_win32_path (const char *src_path, char *dst, device& dev,
+       const char *path;
+       int len;
+ 
+-      mi = mount + posix_sorted[i];
++      mi = mount + shortest_native_sorted[i];
++      debug_printf (" mount[%d] .. checking %s -> %s ", i, mi->posix_path, mi->native_path);
++
+       if (!cygheap->root.exists ()
+ 	  || (mi->posix_pathlen == 1 && mi->posix_path[0] == '/'))
+ 	{
+@@ -903,7 +902,8 @@ mount_info::conv_to_posix_path (const char *src_path, char *posix_path,
+   int pathbuflen = tail - pathbuf;
+   for (int i = 0; i < nmounts; ++i)
+     {
+-      mount_item &mi = mount[native_sorted[i]];
++      mount_item &mi = mount[longest_posix_sorted[i]];
++      debug_printf (" mount[%d] .. checking %s -> %s ", i, mi.posix_path, mi.native_path);
+       if (!path_prefix_p (mi.native_path, pathbuf, mi.native_pathlen,
+ 			  mi.flags & MOUNT_NOPOSIX))
+ 	continue;
+@@ -1116,8 +1116,17 @@ mount_info::from_fstab_line (char *line, bool user)
+   if (!*c)
+     return true;
+   cend = find_ws (c);
+-  *cend = '\0';
+   posix_path = conv_fstab_spaces (c);
++  if (!*cend)
++   {
++     unsigned mount_flags = MOUNT_SYSTEM | MOUNT_NOPOSIX | MOUNT_NOACL;
++
++     int res = mount_table->add_item (native_path, posix_path, mount_flags);
++     if (res && get_errno () == EMFILE)
++       return false;
++     return true;
++   }
++  *cend = '\0';
+   /* Third field: FS type. */
+   c = skip_ws (cend + 1);
+   if (!*c)
+@@ -1346,16 +1355,145 @@ sort_by_native_name (const void *a, const void *b)
+   return res;
+ }
+ 
++/* sort_by_longest_posix_name: qsort callback to sort the mount entries.
++   Sort user mounts ahead of system mounts to the same POSIX path. */
++/* FIXME: should the user should be able to choose whether to
++   prefer user or system mounts??? */
++static int
++sort_by_longest_posix_name (const void *a, const void *b)
++{
++  mount_item *ap = mounts_for_sort + (*((int*) a));
++  mount_item *bp = mounts_for_sort + (*((int*) b));
++
++  /* Base weighting on the conversion that would give the longest
++     posix path. */
++  ssize_t alen = (ssize_t) strlen (ap->posix_path) - (ssize_t) strlen (ap->native_path);
++  ssize_t blen = (ssize_t) strlen (bp->posix_path) - (ssize_t) strlen (bp->native_path);
++
++  int res = blen - alen;
++
++  if (res)
++    return res;		/* Path lengths differed */
++
++  /* The two paths were the same length, so just determine normal
++     lexical sorted order. */
++  res = strcmp (ap->posix_path, bp->posix_path);
++
++  if (res == 0)
++   {
++     /* need to select between user and system mount to same POSIX path */
++     if (!(bp->flags & MOUNT_SYSTEM))	/* user mount */
++      return 1;
++     else
++      return -1;
++   }
++
++  return res;
++}
++
++/* sort_by_shortest_native_name: qsort callback to sort the mount entries.
++   Sort user mounts ahead of system mounts to the same POSIX path. */
++/* FIXME: should the user should be able to choose whether to
++   prefer user or system mounts??? */
++static int
++sort_by_shortest_native_name (const void *a, const void *b)
++{
++  mount_item *ap = mounts_for_sort + (*((int*) a));
++  mount_item *bp = mounts_for_sort + (*((int*) b));
++
++  /* Base weighting on the conversion that would give the shortest
++     native path. */
++  ssize_t alen = (ssize_t) strlen (ap->native_path);
++  ssize_t blen = (ssize_t) strlen (bp->native_path);
++
++  int res = alen - blen;
++
++  if (res)
++    return res;		/* Path lengths differed */
++
++  /* The two paths were the same length, so just determine normal
++     lexical sorted order. */
++  res = strcmp (ap->native_path, bp->native_path);
++
++  if (res == 0)
++   {
++     /* need to select between user and system mount to same POSIX path */
++     if (!(bp->flags & MOUNT_SYSTEM))	/* user mount */
++      return 1;
++     else
++      return -1;
++   }
++
++  return res;
++}
++
++static int
++sort_posix_subdirs_before_parents (const void *a, const void *b)
++{
++    mount_item *ap = mounts_for_sort + (*((int*) a));
++    mount_item *bp = mounts_for_sort + (*((int*) b));
++
++    if (ap->posix_pathlen > bp->posix_pathlen)
++    {
++        if (!memcmp (bp->posix_path, ap->posix_path, bp->posix_pathlen))
++        {
++            // bp is a subdir of ap (bp must be moved in-front)
++            return -1;
++        }
++    }
++    else if (ap->posix_pathlen < bp->posix_pathlen)
++    {
++        if (!memcmp (ap->posix_path, bp->posix_path, ap->posix_pathlen))
++        {
++            // ap is a subdir of bp (good as we are)
++            return 1;
++        }
++    }
++    return 0;
++}
++
++#define DISABLE_NEW_STUFF 0
++#define ONLY_USE_NEW_STUFF 1
++
+ void
+ mount_info::sort ()
+ {
+   for (int i = 0; i < nmounts; i++)
+-    native_sorted[i] = posix_sorted[i] = i;
++    native_sorted[i] = posix_sorted[i] = shortest_native_sorted[i] = longest_posix_sorted[i] = i;
+   /* Sort them into reverse length order, otherwise we won't
+      be able to look for /foo in /.  */
+   mounts_for_sort = mount;	/* ouch. */
+   qsort (posix_sorted, nmounts, sizeof (posix_sorted[0]), sort_by_posix_name);
+   qsort (native_sorted, nmounts, sizeof (native_sorted[0]), sort_by_native_name);
++  qsort (longest_posix_sorted, nmounts, sizeof (longest_posix_sorted[0]), sort_by_longest_posix_name);
++  qsort (shortest_native_sorted, nmounts, sizeof (shortest_native_sorted[0]), sort_by_shortest_native_name);
++  qsort (shortest_native_sorted, nmounts, sizeof (shortest_native_sorted[0]), sort_posix_subdirs_before_parents);
++  /* Disabling my new crap. */
++  #if DISABLE_NEW_STUFF
++  for (int i = 0; i < nmounts; i++)
++  {
++      longest_posix_sorted[i] = native_sorted[i];
++      shortest_native_sorted[i] = posix_sorted[i];
++  }
++  #else
++  #if ONLY_USE_NEW_STUFF
++  for (int i = 0; i < nmounts; i++)
++  {
++      native_sorted[i] = longest_posix_sorted[i];
++      posix_sorted[i] = shortest_native_sorted[i];
++  }
++  #endif
++  #endif
++  for (int i = 0; i < nmounts; i++)
++  {
++      mount_item *mi = mount + shortest_native_sorted[i];
++      debug_printf ("shortest_native_sorted (subdirs before parents)[%d] %12s       %12s", i, mi->native_path, mi->posix_path);
++  }
++  for (int i = 0; i < nmounts; i++)
++  {
++      mount_item *mi = mount + longest_posix_sorted[i];
++      debug_printf ("longest_posix_sorted[%d] %12s       %12s", i, mi->native_path, mi->posix_path);
++  }
+ }
+ 
+ /* Add an entry to the mount table.
+@@ -1446,12 +1584,9 @@ mount_info::add_item (const char *native, const char *posix,
+   if (i == nmounts)
+     nmounts++;
+ 
+-  if (strcmp (posixtmp, "/usr/bin") == 0)
++  if (strcmp (posixtmp, "/bin") == 0)
+     got_usr_bin = true;
+ 
+-  if (strcmp (posixtmp, "/usr/lib") == 0)
+-    got_usr_lib = true;
+-
+   if (posixtmp[0] == '/' && posixtmp[1] == '\0' && !(mountflags & MOUNT_CYGDRIVE))
+     root_idx = i;
+ 
+diff --git a/winsup/cygwin/mount.h b/winsup/cygwin/mount.h
+index 122a679..c447381 100644
+--- a/winsup/cygwin/mount.h
++++ b/winsup/cygwin/mount.h
+@@ -171,7 +171,6 @@ class mount_info
+   mount_item mount[MAX_MOUNTS];
+ 
+   static bool got_usr_bin;
+-  static bool got_usr_lib;
+   static int root_idx;
+ 
+   /* cygdrive_prefix is used as the root of the path automatically
+@@ -183,6 +182,8 @@ class mount_info
+  private:
+   int posix_sorted[MAX_MOUNTS];
+   int native_sorted[MAX_MOUNTS];
++  int longest_posix_sorted[MAX_MOUNTS];
++  int shortest_native_sorted[MAX_MOUNTS];
+ 
+  public:
+   void init (bool);
+diff --git a/winsup/cygwin/uinfo.cc b/winsup/cygwin/uinfo.cc
+index 6aae33c..5736ffb 100644
+--- a/winsup/cygwin/uinfo.cc
++++ b/winsup/cygwin/uinfo.cc
+@@ -2772,7 +2772,7 @@ pwdgrp::fetch_account_from_windows (fetch_user_arg_t &arg, cyg_ldap *pldap)
+ 		     dom, name,
+ 		     sid.string ((char *) sidstr),
+ 		     home ?: "/home/", home ? L"" : name,
+-		     shell ?: "/bin/bash");
++		     shell ?: "/usr/bin/bash");
+   if (gecos)
+     free (gecos);
+   if (home)

--- a/msys2-runtime-3.3/0007-Instead-of-creating-Cygwin-symlinks-use-deep-copy-by.patch
+++ b/msys2-runtime-3.3/0007-Instead-of-creating-Cygwin-symlinks-use-deep-copy-by.patch
@@ -1,0 +1,234 @@
+From bb01dd41c6717f478c94f3790b90138c2a7c2660 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=90=D0=BB=D0=B5=D0=BA=D1=81=D0=B5=D0=B8=CC=86=20=D0=9F?=
+ =?UTF-8?q?=D0=B0=D0=B2=D0=BB=D0=BE=D0=B2?= <alexey.pawlow@gmail.com>
+Date: Sun, 14 Apr 2019 21:47:21 +0300
+Subject: [PATCH 07/N] Instead of creating Cygwin symlinks, use deep copy by
+ default
+
+The new `winsymlinks` mode `deepcopy` (which is made the default) lets
+calls to `symlink()` create (deep) copies of the source file/directory.
+
+This is necessary because unlike Cygwin, MSYS2 does not try to be its
+own little ecosystem that lives its life separate from regular Win32
+programs: the latter have _no idea_ about Cygwin-emulated symbolic links
+(i.e. system files whose contents start with `!<symlink>\xff\xfe` and
+the remainder consists of the NUL-terminated, UTF-16LE-encoded symlink
+target).
+
+To support Cygwin-style symlinks, the new mode `sysfile` is introduced.
+
+Co-authored-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/environ.cc |   4 +
+ winsup/cygwin/globals.cc |   3 +-
+ winsup/cygwin/path.cc    | 154 +++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 160 insertions(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index f746841..296c890 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -88,6 +88,10 @@ set_winsymlinks (const char *buf)
+   else if (ascii_strncasematch (buf, "native", 6))
+     allow_winsymlinks = ascii_strcasematch (buf + 6, "strict")
+ 			? WSYM_nativestrict : WSYM_native;
++  else if (ascii_strncasematch (buf, "deepcopy", 8))
++    allow_winsymlinks = WSYM_deepcopy;
++  else
++    allow_winsymlinks = WSYM_sysfile;
+ }
+ 
+ /* The structure below is used to set up an array which is used to
+diff --git a/winsup/cygwin/globals.cc b/winsup/cygwin/globals.cc
+index 5687a1e..1b8d8e2 100644
+--- a/winsup/cygwin/globals.cc
++++ b/winsup/cygwin/globals.cc
+@@ -59,6 +59,7 @@ enum winsym_t
+   WSYM_nativestrict,
+   WSYM_nfs,
+   WSYM_sysfile,
++  WSYM_deepcopy
+ };
+ 
+ exit_states NO_COPY exit_state;
+@@ -72,7 +73,7 @@ bool ignore_case_with_glob;
+ bool pipe_byte;
+ bool reset_com;
+ bool wincmdln;
+-winsym_t allow_winsymlinks = WSYM_default;
++winsym_t allow_winsymlinks = WSYM_deepcopy;
+ bool disable_pcon;
+ 
+ bool NO_COPY in_forkee;
+diff --git a/winsup/cygwin/path.cc b/winsup/cygwin/path.cc
+index a430d98..17646a8 100644
+--- a/winsup/cygwin/path.cc
++++ b/winsup/cygwin/path.cc
+@@ -1682,6 +1682,89 @@ conv_path_list (const char *src, char *dst, size_t size,
+ 
+ /********************** Symbolic Link Support **************************/
+ 
++/*
++  Create a deep copy of src as dst, while avoiding descending in origpath.
++*/
++static int
++recursiveCopy (char * src, char * dst, const char * origpath)
++{
++  WIN32_FIND_DATA dHfile;
++  HANDLE dH = INVALID_HANDLE_VALUE;
++  BOOL findfiles;
++  int srcpos = strlen (src);
++  int dstpos = strlen (dst);
++  int res = -1;
++
++  debug_printf("recursiveCopy (%s, %s)", src, dst);
++
++  /* Create the destination directory */
++  if (!CreateDirectoryEx (src, dst, NULL))
++    {
++      debug_printf("CreateDirectoryEx(%s, %s, 0) failed", src, dst);
++      __seterrno ();
++      goto done;
++    }
++  /* Descend into the source directory */
++  if (srcpos + 2 >= MAX_PATH || dstpos + 1 >= MAX_PATH)
++    {
++      set_errno (ENAMETOOLONG);
++      goto done;
++    }
++  strcat (src, "\\*");
++  strcat (dst, "\\");
++  dH = FindFirstFile (src, &dHfile);
++  debug_printf("dHfile(1): %s", dHfile.cFileName);
++  findfiles = FindNextFile (dH, &dHfile);
++  debug_printf("dHfile(2): %s", dHfile.cFileName);
++  findfiles = FindNextFile (dH, &dHfile);
++  while (findfiles)
++    {
++      /* Append the directory item filename to both source and destination */
++      int filelen = strlen (dHfile.cFileName);
++      debug_printf("dHfile(3): %s", dHfile.cFileName);
++      if (srcpos + 1 + filelen >= MAX_PATH ||
++          dstpos + 1 + filelen >= MAX_PATH)
++        {
++          set_errno (ENAMETOOLONG);
++          goto done;
++        }
++      strcpy (&src[srcpos+1], dHfile.cFileName);
++      strcpy (&dst[dstpos+1], dHfile.cFileName);
++      debug_printf("%s -> %s", src, dst);
++      if (dHfile.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
++        {
++          /* Recurse into the child directory */
++          debug_printf("%s <-> %s", src, origpath);
++          if (strcmp (src, origpath)) // avoids endless recursion
++            if (recursiveCopy (src, dst, origpath))
++              goto done;
++        }
++      else
++        {
++          /* Just copy the file */
++          if (!CopyFile (src, dst, FALSE))
++            {
++              __seterrno ();
++              goto done;
++            }
++        }
++      findfiles = FindNextFile (dH, &dHfile);
++    }
++  if (GetLastError() != ERROR_NO_MORE_FILES)
++    {
++      __seterrno ();
++      goto done;
++    }
++  res = 0;
++
++done:
++
++  if (dH != INVALID_HANDLE_VALUE)
++    FindClose (dH);
++
++  return res;
++}
++
+ /* Create a symlink from FROMPATH to TOPATH. */
+ 
+ extern "C" int
+@@ -2219,6 +2302,77 @@ symlink_worker (const char *oldpath, path_conv &win32_newpath, bool isdevice)
+ 	}
+       else /* wsym_type == WSYM_sysfile */
+ 	{
++          if (wsym_type == WSYM_deepcopy)
++	    {
++	      path_conv src_path;
++	      src_path.check (oldpath, PC_SYM_NOFOLLOW, stat_suffixes);
++	      if (src_path.error)
++		{
++		  set_errno (src_path.error);
++		  __leave;
++		}
++	      if (!src_path.isdevice () && !src_path.is_fs_special ())
++	        {
++		  /* MSYS copy file instead make symlink */
++
++		  char * real_oldpath;
++		  if (isabspath (oldpath))
++		    strcpy (real_oldpath = tp.c_get (), oldpath);
++		  else
++		    /* Find the real source path, relative
++		       to the directory of the destination */
++		    {
++		      /* Determine the character position of the last path component */
++		      const char *newpath = win32_newpath.get_posix();
++		      int pos = strlen (newpath);
++		      while (--pos >= 0)
++			if (isdirsep (newpath[pos]))
++			  break;
++		      /* Append the source path to the directory
++			 component of the destination */
++		      if (pos+1+strlen(oldpath) >= MAX_PATH)
++			{
++			  set_errno(ENAMETOOLONG);
++			  __leave;
++			}
++		      strcpy (real_oldpath = tp.c_get (), newpath);
++		      strcpy (&real_oldpath[pos+1], oldpath);
++		    }
++
++		  /* As a MSYS limitation, the source path must exist. */
++		  path_conv win32_oldpath;
++		  win32_oldpath.check (real_oldpath, PC_SYM_NOFOLLOW, stat_suffixes);
++		  if (!win32_oldpath.exists ())
++		    {
++		      set_errno (ENOENT);
++		      __leave;
++		    }
++
++		  char *w_newpath;
++		  char *w_oldpath;
++		  stpcpy (w_newpath = tp.c_get (), win32_newpath.get_win32());
++		  stpcpy (w_oldpath = tp.c_get (), win32_oldpath.get_win32());
++		  if (win32_oldpath.isdir())
++		    {
++		      char *origpath;
++		      strcpy (origpath = tp.c_get (), w_oldpath);
++		      res = recursiveCopy (w_oldpath, w_newpath, origpath);
++		    }
++		  else
++		    {
++		      if (!CopyFile (w_oldpath, w_newpath, FALSE))
++			{
++			  __seterrno ();
++			}
++		      else
++			{
++			  res = 0;
++			}
++		    }
++		  __leave;
++		}
++	    }
++
+ 	  /* Default technique creating a symlink. */
+ 	  buf = tp.t_get ();
+ 	  cp = stpcpy (buf, SYMLINK_COOKIE);

--- a/msys2-runtime-3.3/0008-Automatically-rewrite-TERM-msys-to-TERM-cygwin-With-.patch
+++ b/msys2-runtime-3.3/0008-Automatically-rewrite-TERM-msys-to-TERM-cygwin-With-.patch
@@ -1,0 +1,36 @@
+From 6f8d01098eab4130afa8e9a7aa69cc6189f31da4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=90=D0=BB=D0=B5=D0=BA=D1=81=D0=B5=D0=B8=CC=86=20=D0=9F?=
+ =?UTF-8?q?=D0=B0=D0=B2=D0=BB=D0=BE=D0=B2?= <alexey.pawlow@gmail.com>
+Date: Sun, 14 Apr 2019 21:48:54 +0300
+Subject: [PATCH 08/N] Automatically rewrite TERM=msys to TERM=cygwin With
+ MSys1, it was necessary to set the TERM variable to "msys". To allow for a
+ smooth transition from MSys1 to MSys2, let's simply handle TERM=msys as if
+ the user had not specified TERM at all and wanted us to use our preferred
+ TERM value.
+
+---
+ winsup/cygwin/environ.cc | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index 296c890..2e290a8 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -920,7 +920,16 @@ win32env_to_cygenv (PWCHAR rawenv, bool posify)
+       char *eq = strchrnul (newp, '=');
+       ucenv (newp, eq);    /* uppercase env vars which need it */
+       if (*newp == 'T' && strncmp (newp, "TERM=", 5) == 0)
+-        sawTERM = 1;
++	    {
++	      /* backwards compatibility: override TERM=msys by TERM=cygwin */
++	      if (strcmp (newp + 5, "msys") == 0)
++		{
++		  free(newp);
++		  i--;
++		  continue;
++		}
++	      sawTERM = 1;
++	    }
+ #ifdef __MSYS__
+       else if (*newp == 'M' && strncmp (newp, "MSYS=", 5) == 0)
+         parse_options (newp + 5);

--- a/msys2-runtime-3.3/0009-Do-not-convert-environment-for-strace.patch
+++ b/msys2-runtime-3.3/0009-Do-not-convert-environment-for-strace.patch
@@ -1,0 +1,30 @@
+From 528620587ae370a0019218428b5af74a79186841 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=90=D0=BB=D0=B5=D0=BA=D1=81=D0=B5=D0=B8=CC=86=20=D0=9F?=
+ =?UTF-8?q?=D0=B0=D0=B2=D0=BB=D0=BE=D0=B2?= <alexey.pawlow@gmail.com>
+Date: Sun, 14 Apr 2019 21:50:55 +0300
+Subject: [PATCH 09/N] Do not convert environment for strace
+
+Strace is a Windows program so MSYS2 will convert all arguments and environment vars and that makes debugging msys2 software with strace very tricky.
+---
+ winsup/cygwin/spawn.cc | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/spawn.cc b/winsup/cygwin/spawn.cc
+index 283041a..49cd941 100644
+--- a/winsup/cygwin/spawn.cc
++++ b/winsup/cygwin/spawn.cc
+@@ -570,11 +570,13 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
+       bool switch_user = ::cygheap->user.issetuid ()
+ 			 && (::cygheap->user.saved_uid
+ 			     != ::cygheap->user.real_uid);
++      bool keep_posix = (iscmd (argv[0], "strace.exe")
++			|| iscmd (argv[0], "strace")) ? true : real_path.iscygexec ();
+       moreinfo->envp = build_env (envp, envblock, moreinfo->envc,
+ 				  real_path.iscygexec (),
+ 				  switch_user ? ::cygheap->user.primary_token ()
+ 					      : NULL,
+-				  real_path.iscygexec ());
++				  keep_posix);
+       if (!moreinfo->envp || !envblock)
+ 	{
+ 	  set_errno (E2BIG);

--- a/msys2-runtime-3.3/0010-Special-case-for-converting-root-directory-to-have-t.patch
+++ b/msys2-runtime-3.3/0010-Special-case-for-converting-root-directory-to-have-t.patch
@@ -1,0 +1,55 @@
+From 4676ec44f24a0bfa208e6f0c79b0b059c88f6b1a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=90=D0=BB=D0=B5=D0=BA=D1=81=D0=B5=D0=B8=CC=86=20=D0=9F?=
+ =?UTF-8?q?=D0=B0=D0=B2=D0=BB=D0=BE=D0=B2?= <alexey.pawlow@gmail.com>
+Date: Sun, 14 Apr 2019 22:13:51 +0300
+Subject: [PATCH 10/N] Special case for converting root directory to have
+ training slash
+
+---
+ winsup/cygwin/path.cc | 25 ++++++++++++++++---------
+ 1 file changed, 16 insertions(+), 9 deletions(-)
+
+diff --git a/winsup/cygwin/path.cc b/winsup/cygwin/path.cc
+index 17646a8..77480aa 100644
+--- a/winsup/cygwin/path.cc
++++ b/winsup/cygwin/path.cc
+@@ -709,6 +709,12 @@ path_conv::check (const char *src, unsigned opt,
+ 	      need_directory = 1;
+ 	      *--tail = '\0';
+ 	    }
++	  /* Special case for "/" must set need_directory, without removing
++	     trailing slash */
++	  else if (tail == path_copy + 1 && isslash (tail[-1]))
++	    {
++	      need_directory = 1;
++	    }
+ 	  path_end = tail;
+ 
+ 	  /* Scan path_copy from right to left looking either for a symlink
+@@ -1248,16 +1254,17 @@ path_conv::check (const char *src, unsigned opt,
+ 		cfree (wide_path);
+ 	      wide_path = NULL;
+ 	    }
+-	  if (need_directory)
++	}
++
++      if (need_directory)
++	{
++	  size_t n = strlen (this->path);
++	  /* Do not add trailing \ to UNC device names like \\.\a: */
++	  if (this->path[n - 1] != '\\' &&
++	      (strncmp (this->path, "\\\\.\\", 4) != 0))
+ 	    {
+-	      size_t n = strlen (this->path);
+-	      /* Do not add trailing \ to UNC device names like \\.\a: */
+-	      if (this->path[n - 1] != '\\' &&
+-		  (strncmp (this->path, "\\\\.\\", 4) != 0))
+-		{
+-		  this->modifiable_path ()[n] = '\\';
+-		  this->modifiable_path ()[n + 1] = '\0';
+-		}
++	      this->modifiable_path ()[n] = '\\';
++	      this->modifiable_path ()[n + 1] = '\0';
+ 	    }
+ 	}
+ 

--- a/msys2-runtime-3.3/0011-dcrt0.cc-Untangle-allow_glob-from-winshell.patch
+++ b/msys2-runtime-3.3/0011-dcrt0.cc-Untangle-allow_glob-from-winshell.patch
@@ -1,0 +1,77 @@
+From afe78f32340340ed57185049ad2dbb2bbb297eca Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Fri, 21 Aug 2015 12:52:09 +0100
+Subject: [PATCH 11/N] dcrt0.cc: Untangle allow_glob from winshell
+
+Otherwise if globbing is allowed and we get called from a
+Windows program, build_argv thinks we've been called from
+a Cygwin program.
+---
+ winsup/cygwin/dcrt0.cc | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/winsup/cygwin/dcrt0.cc b/winsup/cygwin/dcrt0.cc
+index ee75d3b..d652b32 100644
+--- a/winsup/cygwin/dcrt0.cc
++++ b/winsup/cygwin/dcrt0.cc
+@@ -154,12 +154,12 @@ isquote (char c)
+ 
+ /* Step over a run of characters delimited by quotes */
+ static /*__inline*/ char *
+-quoted (char *cmd, int winshell)
++quoted (char *cmd, int winshell, int glob)
+ {
+   char *p;
+   char quote = *cmd;
+ 
+-  if (!winshell)
++  if (!winshell || !glob)
+     {
+       char *p;
+       strcpy (cmd, cmd + 1);
+@@ -169,8 +169,8 @@ quoted (char *cmd, int winshell)
+     }
+ 
+   const char *s = quote == '\'' ? "'" : "\\\"";
+-  /* This must have been run from a Windows shell, so preserve
+-     quotes for globify to play with later. */
++  /* This must have been run from a Windows shell and globbing is enabled,
++     so preserve quotes for globify to play with later. */
+   while (*cmd && *++cmd)
+     if ((p = strpbrk (cmd, s)) == NULL)
+       {
+@@ -291,7 +291,7 @@ globify (char *word, char **&argv, int &argc, int &argvlen)
+ /* Build argv, argc from string passed from Windows.  */
+ 
+ static void __stdcall
+-build_argv (char *cmd, char **&argv, int &argc, int winshell)
++build_argv (char *cmd, char **&argv, int &argc, int winshell, int glob)
+ {
+   int argvlen = 0;
+   int nesting = 0;		// monitor "nesting" from insert_file
+@@ -325,7 +325,7 @@ build_argv (char *cmd, char **&argv, int &argc, int winshell)
+ 		 a Cygwin process, or if the word starts with a '@'.
+ 		 In this case, the insert_file function needs an unquoted
+ 		 DOS filename and globbing isn't performed anyway. */
+-	      cmd = quoted (cmd, winshell && argc > 0 && *word != '@');
++	      cmd = quoted (cmd, winshell && argc > 0 && *word != '@', glob);
+ 	    }
+ 	  if (issep (*cmd))	// End of argument if space
+ 	    break;
+@@ -351,7 +351,7 @@ build_argv (char *cmd, char **&argv, int &argc, int winshell)
+ 	}
+ 
+       /* Add word to argv file after (optional) wildcard expansion. */
+-      if (!winshell || !argc || !globify (word, argv, argc, argvlen))
++      if (!glob || !argc || !globify (word, argv, argc, argvlen))
+ 	{
+ 	  debug_printf ("argv[%d] = '%s'", argc, word);
+ 	  argv[argc++] = word;
+@@ -952,6 +952,7 @@ dll_crt0_1 (void *)
+       /* Scan the command line and build argv.  Expand wildcards if not
+ 	 called from another cygwin process. */
+       build_argv (line, __argv, __argc,
++		  NOTSTATE (myself, PID_CYGPARENT),
+ 		  NOTSTATE (myself, PID_CYGPARENT) && allow_glob);
+ 
+       /* Convert argv[0] to posix rules if it's currently blatantly

--- a/msys2-runtime-3.3/0012-dcrt0.cc-globify-Don-t-quote-literal-strings-differe.patch
+++ b/msys2-runtime-3.3/0012-dcrt0.cc-globify-Don-t-quote-literal-strings-differe.patch
@@ -1,0 +1,57 @@
+From 8cbda4bfc8f6ac7075a294498d62f803f6a141b5 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Mon, 24 Aug 2015 00:48:06 +0100
+Subject: [PATCH 12/N] dcrt0.cc (globify): Don't quote literal strings
+ differently when dos_spec
+
+Reverts 25ba8f306f3099caf8397859019e936b90510e8d. I can't figure out what
+the intention was. I'm sure I'll find out soon enough when everything breaks.
+
+This change means that input of:
+  '"C:/test.exe SOME_VAR=\"literal quotes\""'
+
+becomes:
+  'C:/test.exe SOME_VAR="literal quotes"'
+
+instead of:
+  'C:/test.exe SOME_VAR=\literal quotes\'
+
+.. which is at least consistent with the result for:
+  '"no_drive_or_colon SOME_VAR=\"literal quotes\""'
+
+The old result of course resulted in the quoted string being split into
+two arguments at the space which is clearly not intended.
+
+I *guess* backslashes in dos paths may have been the issue here?
+If so I don't care since we should not use them, ever, esp. not at
+the expense of sensible forward-slash-containing input.
+---
+ winsup/cygwin/dcrt0.cc | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/dcrt0.cc b/winsup/cygwin/dcrt0.cc
+index d652b32..f75ba5f 100644
+--- a/winsup/cygwin/dcrt0.cc
++++ b/winsup/cygwin/dcrt0.cc
+@@ -236,10 +236,20 @@ globify (char *word, char **&argv, int &argc, int &argvlen)
+ 	char quote = *s;
+ 	while (*++s && *s != quote)
+ 	  {
++	    /* This used to be:
+ 	    if (dos_spec || *s != '\\')
+-	      /* nothing */;
++	      // nothing
+ 	    else if (s[1] == quote || s[1] == '\\')
+ 	      s++;
++	    With commit message:
++	       dcrt0.cc (globify): Don't use \ quoting when apparently quoting a DOS path
++	       spec, even within a quoted string.
++	    But that breaks the "literal quotes" part of '"C:/test.exe SOME_VAR=\"literal quotes\""'
++	    giving:    'C:/test.exe SOME_VAR=\literal quotes\' (with \'s between each character)
++	    instead of 'C:/test.exe SOME_VAR="literal quotes"' (with \'s between each character)
++	    */
++	    if (*s == '\\' && (s[1] == quote || s[1] == '\\'))
++	      s++;
+ 	    *p++ = '\\';
+ 	    size_t cnt = isascii (*s) ? 1 : mbtowc (NULL, s, MB_CUR_MAX);
+ 	    if (cnt <= 1 || cnt == (size_t)-1)

--- a/msys2-runtime-3.3/0013-strace.cc-Don-t-set-MSYS-noglob.patch
+++ b/msys2-runtime-3.3/0013-strace.cc-Don-t-set-MSYS-noglob.patch
@@ -1,0 +1,69 @@
+From 93909972c22cc7b1d2e4e9528037d03041730697 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Sun, 23 Aug 2015 20:47:30 +0100
+Subject: [PATCH 13/N] strace.cc: Don't set MSYS=noglob
+
+Commit message for this code was:
+
+* strace.cc (create_child): Set CYGWIN=noglob when starting new process so that
+
+  Cygwin will leave already-parsed the command line alonw."
+
+I can see no reason for it and it badly breaks the ability to use
+strace.exe to investigate calling a Cygwin program from a Windows
+program, for example:
+strace mingw32-make.exe
+.. where mingw32-make.exe finds sh.exe and uses it as the shell.
+The reason it badly breaks this use-case is because dcrt0.cc depends
+on globbing to happen to parse commandlines from Windows programs;
+irrespective of whether they contain any glob patterns or not.
+
+See quoted () comment:
+"This must have been run from a Windows shell, so preserve
+ quotes for globify to play with later."
+---
+ winsup/utils/mingw/strace.cc | 21 ++++++++++++++++++++-
+ 1 file changed, 20 insertions(+), 1 deletion(-)
+
+diff --git a/winsup/utils/mingw/strace.cc b/winsup/utils/mingw/strace.cc
+index de4abc4..3dbce3b 100644
+--- a/winsup/utils/mingw/strace.cc
++++ b/winsup/utils/mingw/strace.cc
+@@ -354,10 +354,28 @@ create_child (char **argv)
+   make_command_line (one_line, argv);
+ 
+   SetConsoleCtrlHandler (NULL, 0);
++/* Commit message for this code was:
++"* strace.cc (create_child): Set CYGWIN=noglob when starting new process so that
++
++  Cygwin will leave already-parsed the command line alonw."
++
++  I can see no reason for it and it badly breaks the ability to use
++  strace.exe to investigate calling a Cygwin program from a Windows
++  program, for example:
++  strace mingw32-make.exe
++  .. where mingw32-make.exe finds sh.exe and uses it as the shell.
++  The reason it badly breaks this use-case is because dcrt0.cc depends
++  on globbing to happen to parse commandlines from Windows programs;
++  irrespective of whether they contain any glob patterns or not.
++  
++  See quoted () comment:
++  "This must have been run from a Windows shell, so preserve
++     quotes for globify to play with later."
++
+   const char *cygwin_env = getenv ("MSYS");
+   const char *space;
+ 
+-  if (cygwin_env && strlen (cygwin_env) <= 256) /* sanity check */
++  if (cygwin_env && strlen (cygwin_env) <= 256) // sanity check
+     space = " ";
+   else
+     space = cygwin_env = "";
+@@ -365,6 +383,7 @@ create_child (char **argv)
+ 				  + strlen (space) + strlen (cygwin_env));
+   sprintf (newenv, "MSYS=noglob%s%s", space, cygwin_env);
+   _putenv (newenv);
++*/
+   ret = CreateProcess (0, one_line.buf,	/* command line */
+ 		       NULL,	/* Security */
+ 		       NULL,	/* thread */

--- a/msys2-runtime-3.3/0014-Add-debugging-for-build_argv.patch
+++ b/msys2-runtime-3.3/0014-Add-debugging-for-build_argv.patch
@@ -1,0 +1,22 @@
+From 5a00c6b3403e644f59c5dac3c7051aa277612feb Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Fri, 21 Aug 2015 12:18:52 +0100
+Subject: [PATCH 14/N] Add debugging for build_argv
+
+---
+ winsup/cygwin/dcrt0.cc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/winsup/cygwin/dcrt0.cc b/winsup/cygwin/dcrt0.cc
+index f75ba5f..4dc8be8 100644
+--- a/winsup/cygwin/dcrt0.cc
++++ b/winsup/cygwin/dcrt0.cc
+@@ -310,6 +310,8 @@ build_argv (char *cmd, char **&argv, int &argc, int winshell, int glob)
+   argvlen = 0;
+   argv = NULL;
+ 
++  debug_printf ("cmd = '%s', winshell = %d, glob = %d", cmd, winshell, glob);
++
+   /* Scan command line until there is nothing left. */
+   while (*cmd)
+     {

--- a/msys2-runtime-3.3/0015-Add-debugging-for-strace-make_command_line.patch
+++ b/msys2-runtime-3.3/0015-Add-debugging-for-strace-make_command_line.patch
@@ -1,0 +1,21 @@
+From aaadd113642fa4989550b57e506e7f1648b2bf3d Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Fri, 21 Aug 2015 09:52:47 +0100
+Subject: [PATCH 15/N] Add debugging for strace make_command_line
+
+---
+ winsup/utils/mingw/strace.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/winsup/utils/mingw/strace.cc b/winsup/utils/mingw/strace.cc
+index 3dbce3b..4e5d24c 100644
+--- a/winsup/utils/mingw/strace.cc
++++ b/winsup/utils/mingw/strace.cc
+@@ -352,6 +352,7 @@ create_child (char **argv)
+     flags |= CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP;
+ 
+   make_command_line (one_line, argv);
++  printf ("create_child: %s\n", one_line.buf);
+ 
+   SetConsoleCtrlHandler (NULL, 0);
+ /* Commit message for this code was:

--- a/msys2-runtime-3.3/0016-environ.cc-New-facility-environment-variable-MSYS2_E.patch
+++ b/msys2-runtime-3.3/0016-environ.cc-New-facility-environment-variable-MSYS2_E.patch
@@ -1,0 +1,173 @@
+From 9559773cc4474eeaad7dabb061d909ad5e0aa3c9 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Sun, 10 Apr 2016 21:47:41 +0100
+Subject: [PATCH 16/N] environ.cc: New facility/environment variable
+ MSYS2_ENV_CONV_EXCL
+
+Works very much like MSYS2_ARG_CONV_EXCL. In fact it uses the same
+function, arg_heuristic_with_exclusions (). Also refactors parsing
+the env. variables to use new function, string_split_delimited ().
+
+The env. that is searched through is the merged (POSIX + Windows)
+one. It remains to be seen if this should be made an option or not.
+
+This feature was prompted because the R language (Windows exe) calls
+bash to run configure.win, which then calls back into R to read its
+config variables (LOCAL_SOFT) and when this happens, msys2-runtime
+converts R_ARCH from "/x64" to an absolute Windows path and appends
+it to another absolute path, R_HOME, forming an invalid path.
+---
+ winsup/cygwin/environ.cc   | 34 ++++++++++++++++++++++++----------
+ winsup/cygwin/miscfuncs.cc | 21 +++++++++++++++++++++
+ winsup/cygwin/miscfuncs.h  |  2 ++
+ winsup/cygwin/path.cc      |  1 -
+ winsup/cygwin/spawn.cc     | 12 ++----------
+ 5 files changed, 49 insertions(+), 21 deletions(-)
+
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index 2e290a8..49631d6 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -1185,6 +1185,10 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
+ 
+   int tl = 0;
+   char **pass_dstp;
++#ifdef __MSYS__
++  char *msys2_env_conv_excl_env = NULL;
++  size_t msys2_env_conv_excl_count = 0;
++#endif
+   char **pass_env = (char **) alloca (sizeof (char *)
+ 				      * (n + winnum + SPENVS_SIZE + 1));
+   /* Iterate over input list, generating a new environment list and refreshing
+@@ -1193,16 +1197,25 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
+     {
+       bool calc_tl = !no_envblock;
+ #ifdef __MSYS__
+-      /* Don't pass timezone environment to non-msys applications */
+-      if (!keep_posix && ascii_strncasematch(*srcp, "TZ=", 3))
++      if (!keep_posix)
+         {
+-          const char *v = *srcp + 3;
+-          if (*v == ':')
+-            goto next1;
+-          for (; *v; v++)
+-            if (!isalpha(*v) && !isdigit(*v) &&
+-                *v != '-' && *v != '+' && *v != ':')
+-              goto next1;
++          /* Don't pass timezone environment to non-msys applications */
++          if (ascii_strncasematch(*srcp, "TZ=", 3))
++            {
++              const char *v = *srcp + 3;
++              if (*v == ':')
++                goto next1;
++              for (; *v; v++)
++                if (!isalpha(*v) && !isdigit(*v) &&
++                    *v != '-' && *v != '+' && *v != ':')
++                  goto next1;
++            }
++          else if (ascii_strncasematch(*srcp, "MSYS2_ENV_CONV_EXCL=", 20))
++            {
++              msys2_env_conv_excl_env = (char*)alloca (strlen(&(*srcp)[20])+1);
++              strcpy (msys2_env_conv_excl_env, &(*srcp)[20]);
++              msys2_env_conv_excl_count = string_split_delimited (msys2_env_conv_excl_env, ';');
++            }
+         }
+ #endif
+       /* Look for entries that require special attention */
+@@ -1327,7 +1340,8 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
+ 	    }
+ #ifdef __MSYS__
+ 	  else if (!keep_posix) {
+-	    char *win_arg = arg_heuristic(*srcp);
++	    char *win_arg = arg_heuristic_with_exclusions
++		   (*srcp, msys2_env_conv_excl_env, msys2_env_conv_excl_count);
+ 	    debug_printf("WIN32_PATH is %s", win_arg);
+ 	    p = cstrdup1(win_arg);
+ 	    if (win_arg != *srcp)
+diff --git a/winsup/cygwin/miscfuncs.cc b/winsup/cygwin/miscfuncs.cc
+index adf9a3d..55c8518 100644
+--- a/winsup/cygwin/miscfuncs.cc
++++ b/winsup/cygwin/miscfuncs.cc
+@@ -325,6 +325,27 @@ NT_readline::gets ()
+     }
+ }
+ 
++/* Searches through string for delimiter replacing each instance with '\0'
++   and returning the number of such delimited substrings. This function
++   Will return 0 for the NULL string and at least 1 otherwise. */
++
++size_t
++string_split_delimited (char * string, char delimiter)
++{
++  if ( string == NULL )
++      return 0;
++  size_t count = 1;
++  string = strchr ( string, delimiter );
++  while (string)
++    {
++      *string = '\0';
++      ++count;
++      string = strchr ( string + 1, delimiter );
++    }
++  return count;
++}
++
++
+ /* Return an address from the import jmp table of main program.  */
+ void * __reg1
+ __import_address (void *imp)
+diff --git a/winsup/cygwin/miscfuncs.h b/winsup/cygwin/miscfuncs.h
+index 47cef6f..b3d1a6b 100644
+--- a/winsup/cygwin/miscfuncs.h
++++ b/winsup/cygwin/miscfuncs.h
+@@ -88,6 +88,8 @@ void backslashify (const char *, char *, bool);
+ void slashify (const char *, char *, bool);
+ #define isslash(c) ((c) == '/')
+ 
++size_t string_split_delimited (char * string, char delimiter);
++
+ extern void transform_chars (PWCHAR, PWCHAR);
+ extern inline void
+ transform_chars (PUNICODE_STRING upath, USHORT start_idx)
+diff --git a/winsup/cygwin/path.cc b/winsup/cygwin/path.cc
+index 77480aa..9edd949 100644
+--- a/winsup/cygwin/path.cc
++++ b/winsup/cygwin/path.cc
+@@ -4015,7 +4015,6 @@ arg_heuristic_with_exclusions (char const * const arg, char const * exclusions,
+     return arg_result;
+   }
+ 
+-  debug_printf("Input value: (%s)", arg);
+   for (size_t excl = 0; excl < exclusions_count; ++excl)
+     {
+       /* Since we've got regex linked we should maybe switch to that, but
+diff --git a/winsup/cygwin/spawn.cc b/winsup/cygwin/spawn.cc
+index 49cd941..8359f12 100644
+--- a/winsup/cygwin/spawn.cc
++++ b/winsup/cygwin/spawn.cc
+@@ -289,8 +289,7 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
+   int res = -1;
+ 
+   /* Environment variable MSYS2_ARG_CONV_EXCL contains a list
+-     of ';' separated argument prefixes to pass un-modified..
+-     It isn't applied to env. variables; only spawn arguments.
++     of ';' separated argument prefixes to pass un-modified.
+      A value of * means don't convert any arguments. */
+   char* msys2_arg_conv_excl_env = getenv("MSYS2_ARG_CONV_EXCL");
+   char* msys2_arg_conv_excl = NULL;
+@@ -299,14 +298,7 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
+     {
+       msys2_arg_conv_excl = (char*)alloca (strlen(msys2_arg_conv_excl_env)+1);
+       strcpy (msys2_arg_conv_excl, msys2_arg_conv_excl_env);
+-      msys2_arg_conv_excl_count = 1;
+-      msys2_arg_conv_excl_env = strchr ( msys2_arg_conv_excl, ';' );
+-      while (msys2_arg_conv_excl_env)
+-        {
+-          *msys2_arg_conv_excl_env = '\0';
+-          ++msys2_arg_conv_excl_count;
+-          msys2_arg_conv_excl_env = strchr ( msys2_arg_conv_excl_env + 1, ';' );
+-        }
++      msys2_arg_conv_excl_count = string_split_delimited (msys2_arg_conv_excl, ';');
+     }
+ 
+   /* Check if we have been called from exec{lv}p or spawn{lv}p and mask

--- a/msys2-runtime-3.3/0017-Fix-native-symbolic-link-spawn-passing-wrong-arg0.patch
+++ b/msys2-runtime-3.3/0017-Fix-native-symbolic-link-spawn-passing-wrong-arg0.patch
@@ -1,0 +1,22 @@
+From 3578452c55a3754bb64f8bfd19b4e194f6bf2ef2 Mon Sep 17 00:00:00 2001
+From: SquallATF <squallatf@gmail.com>
+Date: Mon, 10 Sep 2018 11:32:18 +0300
+Subject: [PATCH 17/N] Fix native symbolic link spawn passing wrong arg0
+
+---
+ winsup/cygwin/spawn.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/spawn.cc b/winsup/cygwin/spawn.cc
+index 8359f12..4f28335 100644
+--- a/winsup/cygwin/spawn.cc
++++ b/winsup/cygwin/spawn.cc
+@@ -51,7 +51,7 @@ perhaps_suffix (const char *prog, path_conv& buf, int& err, unsigned opt)
+ 
+   err = 0;
+   debug_printf ("prog '%s'", prog);
+-  buf.check (prog, PC_SYM_FOLLOW | PC_NULLEMPTY | PC_POSIX,
++  buf.check (prog, PC_SYM_FOLLOW | PC_SYM_NOFOLLOW_REP | PC_NULLEMPTY | PC_POSIX,
+ 	     (opt & FE_DLL) ? stat_suffixes : exe_suffixes);
+ 
+   if (buf.isdir ())

--- a/msys2-runtime-3.3/0018-QueryUnbiasedInterruptTime-must-be-load-from-kernel3.patch
+++ b/msys2-runtime-3.3/0018-QueryUnbiasedInterruptTime-must-be-load-from-kernel3.patch
@@ -1,0 +1,23 @@
+From b0485d48b3e82ba2c37fb2aa294458c0c79eeafe Mon Sep 17 00:00:00 2001
+From: Alexey Pavlov <alexpux@gmail.com>
+Date: Fri, 24 May 2019 13:41:47 +0300
+Subject: [PATCH 18/N] QueryUnbiasedInterruptTime must be load from
+ kernel32.dll
+
+---
+ winsup/cygwin/autoload.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/autoload.cc b/winsup/cygwin/autoload.cc
+index e254397..2a03ac1 100644
+--- a/winsup/cygwin/autoload.cc
++++ b/winsup/cygwin/autoload.cc
+@@ -596,7 +596,7 @@ LoadDLLfunc (SetThreadGroupAffinity, 12, kernel32)
+    available via KernelBase.dll. */
+ LoadDLLfunc (QueryInterruptTime, 4, KernelBase)
+ LoadDLLfunc (QueryInterruptTimePrecise, 4, KernelBase)
+-LoadDLLfunc (QueryUnbiasedInterruptTime, 4, KernelBase)
++LoadDLLfunc (QueryUnbiasedInterruptTime, 4, kernel32)
+ LoadDLLfunc (QueryUnbiasedInterruptTimePrecise, 4, KernelBase)
+ LoadDLLfunc (VirtualAlloc2, 28, KernelBase)
+ 

--- a/msys2-runtime-3.3/0019-strace-quiet-be-really-quiet.patch
+++ b/msys2-runtime-3.3/0019-strace-quiet-be-really-quiet.patch
@@ -1,0 +1,37 @@
+From 09db143dac95e1f4e06756a9819c7ef76e1a6841 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 17 May 2017 18:13:32 +0200
+Subject: [PATCH 19/N] strace --quiet: be *really* quiet
+
+The biggest problem with strace spitting out `create_child: ...` despite
+being asked to be real quiet is that its output can very well interfere
+with scripts' operations.
+
+For example, when running any of Git for Windows' shell scripts with
+`GIT_STRACE_COMMANDS=/path/to/logfile` (which is sadly an often needed
+debugging technique while trying to address the many MSYS2 issues Git for
+Windows faces), any time the output of any command is redirected into a
+variable, it will include that `create_child: ...` line, wreaking havoc
+with Git's expectations.
+
+So let's just really be quiet when we're asked to be quiet.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/utils/mingw/strace.cc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/winsup/utils/mingw/strace.cc b/winsup/utils/mingw/strace.cc
+index 4e5d24c..a4713a2 100644
+--- a/winsup/utils/mingw/strace.cc
++++ b/winsup/utils/mingw/strace.cc
+@@ -352,7 +352,8 @@ create_child (char **argv)
+     flags |= CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP;
+ 
+   make_command_line (one_line, argv);
+-  printf ("create_child: %s\n", one_line.buf);
++  if (!quiet)
++    printf ("create_child: %s\n", one_line.buf);
+ 
+   SetConsoleCtrlHandler (NULL, 0);
+ /* Commit message for this code was:

--- a/msys2-runtime-3.3/0020-Default-to-disable_pcon.patch
+++ b/msys2-runtime-3.3/0020-Default-to-disable_pcon.patch
@@ -1,0 +1,51 @@
+From 8e89fffcfb0884da1398dd55f0d0cc57294549ec Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 19 May 2020 13:24:55 +0200
+Subject: [PATCH 20/N] Default to `disable_pcon`
+
+The pseudo console support is just a bit too buggy still:
+
+- When typing anything in an interactive Bash session before the prompt
+  is shown, frequently the keystrokes are then replayed _twice_ when the
+  prompt is active.
+
+  Even worse: it seems that under certain circumstances (e.g. when
+  spawning `less.exe` from a MINGW process), keystrokes are recorded
+  while a process is active that wants to consume them but those
+  recorded keystrokes are then replayed once the process finished (e.g.
+  the `q` keystroke to exit `less.exe` will then be misinterpreted for
+  interactive input in the Bash session).
+
+- When `vim` is called from a MINGW process, it seems that the terminal
+  loses the `onlcr` property after the `vim` process finished, i.e.
+  subsequently printed lines do not start at the beginning of the line
+  anymore, but precisely where the previous line ended.
+
+- In `vim`, when selecting text visually (via the `v` keystroke), it
+  seems that the selection is frequently reset while navigating with the
+  arrow keys.
+
+There are probably quite a few more rough edges in the pseudo console
+feature, unfortunately.
+
+In light of these issues, it makes most sense to disable the pseudo
+console support and make it opt-in rather than opt-out.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/globals.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/globals.cc b/winsup/cygwin/globals.cc
+index 1b8d8e2..29ca896 100644
+--- a/winsup/cygwin/globals.cc
++++ b/winsup/cygwin/globals.cc
+@@ -74,7 +74,7 @@ bool pipe_byte;
+ bool reset_com;
+ bool wincmdln;
+ winsym_t allow_winsymlinks = WSYM_deepcopy;
+-bool disable_pcon;
++bool disable_pcon = true;
+ 
+ bool NO_COPY in_forkee;
+ 

--- a/msys2-runtime-3.3/0021-Introduce-the-enable_pcon-value-for-MSYS.patch
+++ b/msys2-runtime-3.3/0021-Introduce-the-enable_pcon-value-for-MSYS.patch
@@ -1,0 +1,54 @@
+From a4a2aebc21843483387198cdb20db3a1eeb99362 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 19 May 2020 13:49:37 +0200
+Subject: [PATCH 21/N] Introduce the `enable_pcon` value for `MSYS`
+
+It is simply the negation of `disable_pcon`, i.e. `MSYS=enable_pcon` is
+equivalent to `MSYS=nodisable_pcon` (the former is slightly more
+intuitive than the latter) and likewise `MSYS=noenable_pcon` is
+equivalent to `MSYS=disable_pcon` (here, the latter is definitely more
+intuitive than the former).
+
+This is needed because we just demoted the pseudo console feature to be
+opt-in instead of opt-out, and it would be awkward to recommend to users
+to use "nodisable_pcon"... "nodisable" is not even a verb.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/environ.cc | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index 49631d6..daaa1ec 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -42,6 +42,7 @@ enum settings
+     isfunc,
+     setdword,
+     setbool,
++    setnegbool,
+     setbit
+   };
+ 
+@@ -126,6 +127,7 @@ static struct parse_thing
+   {"wincmdln", {&wincmdln}, setbool, NULL, {{false}, {true}}},
+   {"winsymlinks", {func: set_winsymlinks}, isfunc, NULL, {{0}, {0}}},
+   {"disable_pcon", {&disable_pcon}, setbool, NULL, {{false}, {true}}},
++  {"enable_pcon", {&disable_pcon}, setnegbool, NULL, {{true}, {false}}},
+   {NULL, {0}, setdword, 0, {{0}, {0}}}
+ };
+ 
+@@ -243,6 +245,13 @@ parse_options (const char *inbuf)
+ 		  *k->setting.b = !!strtol (eq, NULL, 0);
+ 		debug_printf ("%s%s", *k->setting.b ? "" : "no", k->name);
+ 		break;
++	      case setnegbool:
++		if (!istrue || !eq)
++		  *k->setting.b = k->values[istrue].i;
++		else
++		  *k->setting.b = !strtol (eq, NULL, 0);
++		debug_printf ("%s%s", !*k->setting.b ? "" : "no", k->name);
++		break;
+ 	      case setbit:
+ 		*k->setting.x &= ~k->values[istrue].i;
+ 		if (istrue || (eq && strtol (eq, NULL, 0)))

--- a/msys2-runtime-3.3/0022-popen-call-usr-bin-sh-instead-of-bin-sh.patch
+++ b/msys2-runtime-3.3/0022-popen-call-usr-bin-sh-instead-of-bin-sh.patch
@@ -1,0 +1,31 @@
+From f9b94aa83675ae1d080c23c270fab083a99f6413 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Fri, 5 Jun 2020 20:09:11 +0200
+Subject: [PATCH 22/N] popen: call /usr/bin/sh instead of /bin/sh
+
+We mount /usr/bin to /bin, but in a chroot this is broken and we
+have no /bin, so try to use the real path.
+
+chroot is used by pacman to run install scripts when called with --root
+and this broke programs in install scripts calling popen()
+(install-info from texinfo for example)
+
+There are more paths hardcoded to /bin in cygwin which might also be broken
+in this scenario, so this maybe should be extended to all of them.
+---
+ winsup/cygwin/syscalls.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/syscalls.cc b/winsup/cygwin/syscalls.cc
+index 0890390..f6ffb1c 100644
+--- a/winsup/cygwin/syscalls.cc
++++ b/winsup/cygwin/syscalls.cc
+@@ -4614,7 +4614,7 @@ popen (const char *command, const char *in_type)
+       fcntl64 (stdchild, F_SETFD, stdchild_state | FD_CLOEXEC);
+ 
+       /* Start a shell process to run the given command without forking. */
+-      pid_t pid = ch_spawn.worker ("/bin/sh", argv, cur_environ (), _P_NOWAIT,
++      pid_t pid = ch_spawn.worker ("/usr/bin/sh", argv, cur_environ (), _P_NOWAIT,
+ 				   __std[0], __std[1]);
+ 
+       /* Reinstate the close-on-exec state */

--- a/msys2-runtime-3.3/0023-CI-add-a-GHA-for-doing-a-basic-build-test.patch
+++ b/msys2-runtime-3.3/0023-CI-add-a-GHA-for-doing-a-basic-build-test.patch
@@ -1,0 +1,52 @@
+From 69029b18df8090e071eb8a8c1446a532c0c71d0b Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Sun, 9 Aug 2020 14:02:51 +0200
+Subject: [PATCH 23/N] CI: add a GHA for doing a basic build test
+
+---
+ .github/workflows/build.yaml | 36 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 36 insertions(+)
+ create mode 100644 .github/workflows/build.yaml
+
+diff --git a/.github/workflows/build.yaml b/.github/workflows/build.yaml
+new file mode 100644
+index 0000000..4e1d498
+--- /dev/null
++++ b/.github/workflows/build.yaml
+@@ -0,0 +1,36 @@
++name: build
++
++on: [push, pull_request]
++
++jobs:
++  build:
++    runs-on: windows-latest
++
++    steps:
++      - name: Checkout code
++        uses: actions/checkout@v2
++
++      - name: setup-msys2
++        uses: msys2/setup-msys2@v2
++        with:
++          msystem: MSYS
++          update: true
++          install: msys2-devel base-devel autotools cocom diffutils gcc gettext-devel libiconv-devel make mingw-w64-cross-crt mingw-w64-cross-gcc mingw-w64-cross-zlib perl zlib-devel xmlto docbook-xsl
++
++      - name: Build
++        shell: msys2 {0}
++        run: |
++          (cd winsup && ./autogen.sh)
++          ./configure
++          make -j8
++
++      - name: Install
++        shell: msys2 {0}
++        run: |
++          make DESTDIR="$(pwd)"/_dest install
++
++      - name: Upload
++        uses: actions/upload-artifact@v2
++        with:
++          name: install
++          path: _dest/

--- a/msys2-runtime-3.3/0024-Set-up-a-GitHub-Action-to-keep-in-sync-with-Cygwin.patch
+++ b/msys2-runtime-3.3/0024-Set-up-a-GitHub-Action-to-keep-in-sync-with-Cygwin.patch
@@ -1,0 +1,43 @@
+From 51766aba40e36ad9527442410693a0fa282a5e77 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Fri, 22 Nov 2019 11:20:22 +0100
+Subject: [PATCH 24/N] Set up a GitHub Action to keep in sync with Cygwin
+
+This will help us by automating an otherwise tedious task.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ .github/workflows/sync-with-cygwin.yml | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+ create mode 100644 .github/workflows/sync-with-cygwin.yml
+
+diff --git a/.github/workflows/sync-with-cygwin.yml b/.github/workflows/sync-with-cygwin.yml
+new file mode 100644
+index 0000000..57bd30e
+--- /dev/null
++++ b/.github/workflows/sync-with-cygwin.yml
+@@ -0,0 +1,24 @@
++name: sync-with-cygwin
++
++# File: .github/workflows/repo-sync.yml
++
++on:
++  workflow_dispatch:
++  schedule:
++  - cron:  "42 * * * *"
++jobs:
++  repo-sync:
++    runs-on: ubuntu-latest
++    permissions:
++      contents: write
++    steps:
++    - name: Fetch Cygwin's latest master and tags
++      run: |
++        git init --bare
++        # Potentially use git://sourceware.org/git/newlib-cygwin.git directly, but GitHub seems more reliable
++        git fetch https://github.com/cygwin/cygwin master:refs/heads/cygwin/master 'refs/tags/*:refs/tags/*'
++    - name: Push to our fork
++      env:
++        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
++      run: |
++        git push https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY refs/heads/cygwin/master 'refs/tags/*:refs/tags/*'

--- a/msys2-runtime-3.3/0025-Expose-full-command-lines-to-other-Win32-processes-b.patch
+++ b/msys2-runtime-3.3/0025-Expose-full-command-lines-to-other-Win32-processes-b.patch
@@ -1,0 +1,53 @@
+From b37c67a23018d626b4a4228f71c8eda2f6d96f77 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 12 Aug 2020 12:22:38 +0200
+Subject: [PATCH 25/N] Expose full command-lines to other Win32 processes by
+ default
+
+In the Cygwin project, it was decided that the command-line of Cygwin
+processes, as shown in the output of `wmic process list`, would suffer
+from being truncated to 32k (and is transmitted to the child process via
+a different mechanism, anyway), and therefore only the absolute path of
+the executable is shown by default.
+
+Users who would like to see the full command-line (even if it is
+truncated) are expected to set `CYGWIN=wincmdln` (or, in MSYS2's case,
+`MSYS=wincmdln`).
+
+Seeing as MSYS2 tries to integrate much better with the surrounding
+Win32 ecosystem than Cygwin, it makes sense to turn this on by default.
+
+Users who wish to suppress it can still set `MSYS=nowincmdln`.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/globals.cc | 2 +-
+ winsup/doc/cygwinenv.xml | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/winsup/cygwin/globals.cc b/winsup/cygwin/globals.cc
+index 29ca896..b4a0c87 100644
+--- a/winsup/cygwin/globals.cc
++++ b/winsup/cygwin/globals.cc
+@@ -72,7 +72,7 @@ bool allow_glob = true;
+ bool ignore_case_with_glob;
+ bool pipe_byte;
+ bool reset_com;
+-bool wincmdln;
++bool wincmdln = true;
+ winsym_t allow_winsymlinks = WSYM_deepcopy;
+ bool disable_pcon = true;
+ 
+diff --git a/winsup/doc/cygwinenv.xml b/winsup/doc/cygwinenv.xml
+index 649084d..28056e6 100644
+--- a/winsup/doc/cygwinenv.xml
++++ b/winsup/doc/cygwinenv.xml
+@@ -72,7 +72,7 @@ time and when handles are inherited.  Defaults to set.</para>
+ <listitem>
+ <para><envar>(no)wincmdln</envar> - if set, the windows complete command
+ line (truncated to ~32K) will be passed on any processes that it creates
+-in addition to the normal UNIX argv list.  Defaults to not set.</para>
++in addition to the normal UNIX argv list.  Defaults to set.</para>
+ </listitem>
+ 
+ <listitem>

--- a/msys2-runtime-3.3/0026-Disable-the-cygwin-GitHub-workflow.patch
+++ b/msys2-runtime-3.3/0026-Disable-the-cygwin-GitHub-workflow.patch
@@ -1,0 +1,32 @@
+From 991789ad7a8e0dd65c2969c677a889cede8b37fe Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 17 Mar 2021 17:41:02 +0100
+Subject: [PATCH 26/N] Disable the 'cygwin' GitHub workflow
+
+It does not work at all. For example, `rpm -E %fedora` says that there
+should be version 33 of rpmsphere at
+https://github.com/rpmsphere/noarch/tree/master/r, but there is only
+version 32.
+
+Another thing that is broken: Cygwin now assumes that a recent
+mingw-w64-headers version is available, but Fedora apparently only
+offers v7.0.0, which is definitely too old to accommodate for the
+expectation of https://github.com/cygwin/cygwin/commit/c1f7c4d1b6d7.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ .github/workflows/cygwin.yml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/.github/workflows/cygwin.yml b/.github/workflows/cygwin.yml
+index f9a9a7a..4b541a8 100644
+--- a/.github/workflows/cygwin.yml
++++ b/.github/workflows/cygwin.yml
+@@ -1,6 +1,6 @@
+ name: cygwin
+ 
+-on: push
++on: workflow_dispatch
+ 
+ jobs:
+   fedora-build:

--- a/msys2-runtime-3.3/0027-Do-not-show-Error-dialogs-by-default.patch
+++ b/msys2-runtime-3.3/0027-Do-not-show-Error-dialogs-by-default.patch
@@ -1,0 +1,65 @@
+From c20ec3a443668ab7047a383958e1b2d9f687bbf0 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 31 Mar 2021 11:38:41 +0200
+Subject: [PATCH 27/N] Do not show Error dialogs by default
+
+In https://github.com/msys2/msys2-runtime/pull/18, we discussed a change
+that would allow default Windows error handling of spawned processes to
+kick in (such as registered JIT debuggers). We even agreed that it would
+make sense to hide this functionality behind a flag, `winjitdebug`.
+
+However, when this got upstreamed as 21ec498d7f (cygwin: use
+CREATE_DEFAULT_ERROR_MODE in spawn, 2020-12-09), that flag was deemed
+unnecessary.
+
+But it would appear that it _is_ necessary: As reported in
+https://github.com/msys2/MSYS2-packages/pull/2414#issuecomment-810841296
+this new behavior is pretty disruptive e.g. in CI scenarios.
+
+So let's introduce that `winjitdebug` flag (settable via the environment
+variable `MSYS`) at long last.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/environ.cc | 1 +
+ winsup/cygwin/globals.cc | 1 +
+ winsup/cygwin/spawn.cc   | 2 +-
+ 3 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index daaa1ec..f4e2c68 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -128,6 +128,7 @@ static struct parse_thing
+   {"winsymlinks", {func: set_winsymlinks}, isfunc, NULL, {{0}, {0}}},
+   {"disable_pcon", {&disable_pcon}, setbool, NULL, {{false}, {true}}},
+   {"enable_pcon", {&disable_pcon}, setnegbool, NULL, {{true}, {false}}},
++  {"winjitdebug", {&winjitdebug}, setbool, NULL, {{false}, {true}}},
+   {NULL, {0}, setdword, 0, {{0}, {0}}}
+ };
+ 
+diff --git a/winsup/cygwin/globals.cc b/winsup/cygwin/globals.cc
+index b4a0c87..5c111ab 100644
+--- a/winsup/cygwin/globals.cc
++++ b/winsup/cygwin/globals.cc
+@@ -75,6 +75,7 @@ bool reset_com;
+ bool wincmdln = true;
+ winsym_t allow_winsymlinks = WSYM_deepcopy;
+ bool disable_pcon = true;
++bool winjitdebug = false;
+ 
+ bool NO_COPY in_forkee;
+ 
+diff --git a/winsup/cygwin/spawn.cc b/winsup/cygwin/spawn.cc
+index 4f28335..bc9dc5a 100644
+--- a/winsup/cygwin/spawn.cc
++++ b/winsup/cygwin/spawn.cc
+@@ -460,7 +460,7 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
+ 	 get the default error mode instead of inheriting the mode Cygwin
+ 	 uses.  This allows things like Windows Error Reporting/JIT debugging
+ 	 to work with processes launched from a Cygwin shell. */
+-      if (!real_path.iscygexec ())
++      if (winjitdebug && !real_path.iscygexec ())
+ 	c_flags |= CREATE_DEFAULT_ERROR_MODE;
+ 
+       /* We're adding the CREATE_BREAKAWAY_FROM_JOB flag here to workaround

--- a/msys2-runtime-3.3/0028-Add-a-helper-to-obtain-a-function-s-address-in-kerne.patch
+++ b/msys2-runtime-3.3/0028-Add-a-helper-to-obtain-a-function-s-address-in-kerne.patch
@@ -1,0 +1,382 @@
+From 22f77091e940c4d404dd5478c31823745effe5a9 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 16 Apr 2018 14:59:39 +0200
+Subject: [PATCH 28/N] Add a helper to obtain a function's address in
+ kernel32.dll
+
+In particular, we are interested in the address of the CtrlRoutine
+and the ExitProcess functions. Since kernel32.dll is loaded first thing,
+the addresses will be the same for all processes (matching the
+CPU architecture, of course).
+
+This will help us with emulating SIGINT properly (by not sending signals
+to *all* processes attached to the same Console, as
+GenerateConsoleCtrlEvent() would do).
+
+Co-authored-by: Naveen M K <naveen@syrusdark.website>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/configure.ac              |   5 +
+ winsup/utils/mingw/Makefile.am   |  15 ++
+ winsup/utils/mingw/getprocaddr.c | 310 +++++++++++++++++++++++++++++++
+ 3 files changed, 330 insertions(+)
+ create mode 100644 winsup/utils/mingw/getprocaddr.c
+
+diff --git a/winsup/configure.ac b/winsup/configure.ac
+index 9a11411..5eb3273 100644
+--- a/winsup/configure.ac
++++ b/winsup/configure.ac
+@@ -95,6 +95,11 @@ if test "x$with_cross_bootstrap" != "xyes"; then
+     test -n "$MINGW_CXX" || AC_MSG_ERROR([no acceptable MinGW g++ found in \$PATH])
+     AC_CHECK_PROGS(MINGW_CC, ${target_cpu}-w64-mingw32-gcc)
+     test -n "$MINGW_CC" || AC_MSG_ERROR([no acceptable MinGW gcc found in \$PATH])
++
++    AC_CHECK_PROGS(MINGW32_CC, i686-w64-mingw32-gcc)
++    test -n "$MINGW32_CC" || AC_MSG_ERROR([no acceptable mingw32 gcc found in \$PATH])
++    AC_CHECK_PROGS(MINGW64_CC, x86_64-w64-mingw32-gcc)
++    test -n "$MINGW64_CC" || AC_MSG_ERROR([no acceptable mingw64 gcc found in \$PATH])
+ fi
+ AM_CONDITIONAL(CROSS_BOOTSTRAP, [test "x$with_cross_bootstrap" != "xyes"])
+ 
+diff --git a/winsup/utils/mingw/Makefile.am b/winsup/utils/mingw/Makefile.am
+index 46d8213..0e4218a 100644
+--- a/winsup/utils/mingw/Makefile.am
++++ b/winsup/utils/mingw/Makefile.am
+@@ -26,6 +26,21 @@ bin_PROGRAMS = \
+ 	ldh \
+ 	strace
+ 
++libexec_PROGRAMS = getprocaddr32 getprocaddr64
++
++# Must *not* use -O2 here, as it screws up the stack backtrace
++getprocaddr32.o: %32.o: %.c
++	$(MINGW32_CC) -c -o $@ $<
++
++getprocaddr32.exe: %.exe: %.o
++	$(MINGW32_CC) -o $@ $^ -static -ldbghelp
++
++getprocaddr64.o: %64.o: %.c
++	$(MINGW64_CC) -c -o $@ $<
++
++getprocaddr64.exe: %.exe: %.o
++	$(MINGW64_CC) -o $@ $^ -static -ldbghelp
++
+ cygcheck_SOURCES = \
+ 	bloda.cc \
+ 	cygcheck.cc \
+diff --git a/winsup/utils/mingw/getprocaddr.c b/winsup/utils/mingw/getprocaddr.c
+new file mode 100644
+index 0000000..25814c7
+--- /dev/null
++++ b/winsup/utils/mingw/getprocaddr.c
+@@ -0,0 +1,310 @@
++/* getprocaddr.c
++
++This program is a helper for getting the pointers for the
++functions in kernel32 module, and optionally injects a remote
++thread that runs those functions given a pid and exit code.
++
++We use dbghelp.dll to get the pointer to kernel32!CtrlRoutine
++because it isn't exported. For that, we try to generate console
++event (Ctrl+Break) ourselves, to find the pointer, and it is
++printed if asked to, or a remote thread is injected to run the
++given function.
++
++This software is a copyrighted work licensed under the terms of the
++Cygwin license.  Please consult the file "CYGWIN_LICENSE" for
++details. */
++
++#include <stdio.h>
++#include <windows.h>
++
++/* Include dbghelp.h after windows.h */
++#include <dbghelp.h>
++
++static DWORD pid;
++static uintptr_t exit_code;
++static HANDLE CtrlEvent;
++
++static int
++inject_remote_thread_into_process (HANDLE process,
++                                   LPTHREAD_START_ROUTINE address,
++                                   uintptr_t exit_code,
++                                   DWORD *thread_return)
++{
++  int res = -1;
++
++  if (!address)
++    return res;
++  DWORD thread_id;
++  HANDLE thread = CreateRemoteThread (process, NULL, 1024 * 1024, address,
++                                      (PVOID)exit_code, 0, &thread_id);
++  if (thread)
++    {
++      /*
++       * Wait up to 10 seconds (arbitrary constant) for the thread to finish;
++       * Maybe we should wait forever? I have seen Cmd does so, but well...
++       */
++      if (WaitForSingleObject (thread, 10000) == WAIT_OBJECT_0)
++        res = 0;
++      /*
++      According to the docs at MSDN for GetExitCodeThread, it will
++      get the return value from the function, here CtrlRoutine. So, this
++      checks if the Ctrl Event is handled correctly by the process.
++
++      By some testing I could see CtrlRoutine returns 0 in case where
++      CtrlEvent set by SetConsoleCtrlHandler is handled correctly, in all
++      other cases it returns something non-zero(not sure what it that).
++      */
++      if (thread_return != NULL)
++        GetExitCodeThread (thread, thread_return);
++
++      CloseHandle (thread);
++    }
++
++  return res;
++}
++
++/* Here, we send a CtrlEvent to the current process for the
++ * sole purpose of capturing the address of the CtrlRoutine
++ * function, by looking the stack trace.
++ *
++ * This hack is needed because we cannot use GetProcAddress()
++ * as we do for ExitProcess(), because CtrlRoutine is not
++ * exported (although the .pdb files ensure that we can see
++ * it in a debugger).
++ */
++static WINAPI BOOL
++ctrl_handler (DWORD ctrl_type)
++{
++  unsigned short count;
++  void *address;
++  HANDLE process;
++  PSYMBOL_INFOW info;
++  DWORD64 displacement;
++  DWORD thread_return = 0;
++
++  count = CaptureStackBackTrace (1l /* skip this function */,
++                                 1l /* return only one trace item */, &address,
++                                 NULL);
++  if (count != 1)
++    {
++      fprintf (stderr, "Could not capture backtrace\n");
++      return FALSE;
++    }
++
++  process = GetCurrentProcess ();
++  if (!SymInitialize (process, NULL, TRUE))
++    {
++      fprintf (stderr, "Could not initialize symbols\n");
++      return FALSE;
++    }
++
++  info = (PSYMBOL_INFOW)malloc (sizeof (*info)
++                                + MAX_SYM_NAME * sizeof (wchar_t));
++  if (!info)
++    {
++      fprintf (stderr, "Could not allocate symbol info structure\n");
++      return FALSE;
++    }
++  info->SizeOfStruct = sizeof (*info);
++  info->MaxNameLen = MAX_SYM_NAME;
++
++  if (!SymFromAddrW (process, (DWORD64) (intptr_t)address, &displacement,
++                     info))
++    {
++      fprintf (stderr, "Could not get symbol info\n");
++      SymCleanup (process);
++      return FALSE;
++    }
++
++  if (pid == 0)
++    {
++      printf ("%p\n", (void *)(intptr_t)info->Address);
++    }
++  else
++    {
++      LPTHREAD_START_ROUTINE address =
++        (LPTHREAD_START_ROUTINE) (intptr_t)info->Address;
++      HANDLE h = OpenProcess (PROCESS_CREATE_THREAD |
++                              PROCESS_QUERY_INFORMATION |
++                              PROCESS_VM_OPERATION |
++                              PROCESS_VM_WRITE |
++                              PROCESS_VM_READ, FALSE, pid);
++      if (h == NULL)
++        {
++          fprintf (stderr, "OpenProcess failed: %ld\n", GetLastError ());
++          return 1;
++        }
++      /* Inject the remote thread only when asked to */
++      if (inject_remote_thread_into_process (h, address, exit_code,
++                                             &thread_return) < 0)
++        {
++          fprintf (stderr,
++                   "Error while injecting remote thread for pid(%lu)\n", pid);
++          exit (1); /*We should exit immediately or else there will a 10s hang
++                       waiting for the event to happen.*/
++        }
++      if (thread_return)
++        fprintf (stderr,
++                 "Injected remote thread for pid(%lu) returned %lu\n", pid,
++                 thread_return);
++    }
++  SymCleanup (process);
++  if (!SetEvent (CtrlEvent))
++    {
++      fprintf (stderr, "SetEvent failed (%ld)\n", GetLastError ());
++      return 1;
++    }
++  exit (thread_return != 0);
++}
++
++/* The easy route for finding the address of CtrlRoutine
++ * would be use GetProcAddress() but this isn't viable
++ * here because that symbol isn't exported.
++ */
++static int
++find_ctrl_routine_the_hard_way ()
++{
++  /*
++   * Avoid terminating all processes attached to the current console;
++   * This would happen if we used the same console as the caller, though,
++   * because we are sending a CtrlEvent on purpose (which _is_ sent to
++   * all processes connected to the same console, and the other processes
++   * are most likely unprepared for that CTRL_BREAK_EVENT and would be
++   * terminated as a consequence, _including the caller_).
++   *
++   * In case we get only one result from GetConsoleProcessList(), we don't
++   * need to create and allocate a new console, and it could avoid a console
++   * window popping up.
++   */
++  DWORD proc_lists;
++  if (GetConsoleProcessList (&proc_lists, 5) > 1)
++    {
++      if (!FreeConsole () && GetLastError () != ERROR_INVALID_PARAMETER)
++        {
++          fprintf (stderr, "Could not detach from current Console: %ld\n",
++                   GetLastError ());
++          return 1;
++        }
++      if (!AllocConsole ())
++        {
++          fprintf (stderr, "Could not allocate a new Console\n");
++          return 1;
++        }
++    }
++
++  CtrlEvent = CreateEvent (NULL,  // default security attributes
++                           TRUE,  // manual-reset event
++                           FALSE, // initial state is nonsignaled
++                           NULL   // object name
++  );
++
++  if (CtrlEvent == NULL)
++    {
++      fprintf (stderr, "CreateEvent failed (%ld)\n", GetLastError ());
++      return 1;
++    }
++
++
++  if (!SetConsoleCtrlHandler (ctrl_handler, TRUE))
++    {
++      fprintf (stderr, "Could not register Ctrl handler\n");
++      return 1;
++    }
++
++  if (!GenerateConsoleCtrlEvent (CTRL_BREAK_EVENT, 0))
++    {
++      fprintf (stderr, "Could not simulate Ctrl+Break\n");
++      return 1;
++    }
++
++  if (WaitForSingleObject (CtrlEvent, 10000 /* 10 seconds*/) != WAIT_OBJECT_0)
++    {
++      fprintf (stderr, "WaitForSingleObject failed (%ld)\n", GetLastError ());
++      return 1;
++    }
++  return 0;
++}
++
++static void *
++get_proc_addr (const char * module_name, const char * function_name)
++{
++      HMODULE module = GetModuleHandle (module_name);
++      if (!module)
++        return NULL;
++      return (void *)GetProcAddress (module, function_name);
++}
++
++int
++main (int argc, char **argv)
++{
++  char *end;
++  void *address;
++  BOOL is_ctrl_routine;
++  DWORD thread_return = 0;
++
++  if (argc == 4)
++    {
++      exit_code = atoi (argv[2]);
++      pid = strtoul (argv[3], NULL, 0);
++    }
++  else if (argc == 2)
++    {
++      pid = 0;
++    }
++  else
++    {
++      fprintf (stderr, "Need a function name, exit code and pid\n"
++               "Or needs a function name.\n");
++      return 1;
++    }
++
++  is_ctrl_routine = strcmp (argv[1], "CtrlRoutine") == 0;
++  address = get_proc_addr ("kernel32", argv[1]);
++  if (is_ctrl_routine && !address)
++    {
++      /* CtrlRoutine is undocumented, and has been seen in both
++       * kernel32 and kernelbase
++       */
++      address = get_proc_addr ("kernelbase", argv[1]);
++      if (!address)
++        return find_ctrl_routine_the_hard_way ();
++    }
++
++  if (!address)
++    {
++      fprintf (stderr, "Could not get proc address\n");
++      return 1;
++    }
++
++  if (pid == 0)
++    {
++      printf ("%p\n", address);
++      fflush (stdout);
++      return 0;
++    }
++  HANDLE h = OpenProcess (PROCESS_CREATE_THREAD |
++                          PROCESS_QUERY_INFORMATION | PROCESS_VM_OPERATION |
++                          PROCESS_VM_WRITE | PROCESS_VM_READ, FALSE, pid);
++  if (h == NULL)
++    {
++      fprintf (stderr, "OpenProcess failed: %ld\n", GetLastError ());
++      return 1;
++    }
++  /* Inject the remote thread */
++  if (inject_remote_thread_into_process (h, (LPTHREAD_START_ROUTINE)address,
++                                         exit_code, &thread_return) < 0)
++    {
++      fprintf (stderr, "Could not inject thread into process %lu\n", pid);
++      return 1;
++    }
++
++  if (is_ctrl_routine && thread_return)
++    {
++      fprintf (stderr,
++               "Injected remote thread for pid %lu returned %lu\n", pid,
++               thread_return);
++      return 1;
++    }
++
++  return 0;
++}

--- a/msys2-runtime-3.3/0029-Emulate-GenerateConsoleCtrlEvent-upon-Ctrl-C.patch
+++ b/msys2-runtime-3.3/0029-Emulate-GenerateConsoleCtrlEvent-upon-Ctrl-C.patch
@@ -1,0 +1,506 @@
+From be43d1330988ee93aa837c3f4610ef35a04349e8 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Fri, 20 Mar 2015 09:56:28 +0000
+Subject: [PATCH 29/N] Emulate GenerateConsoleCtrlEvent() upon Ctrl+C
+
+This patch is heavily inspired by the Git for Windows' strategy in
+handling Ctrl+C.
+
+When a process is terminated via TerminateProcess(), it has no chance to
+do anything in the way of cleaning up. This is particularly noticeable
+when a lengthy Git for Windows process tries to update Git's index file
+and leaves behind an index.lock file. Git's idea is to remove the stale
+index.lock file in that case, using the signal and atexit handlers
+available in Linux. But those signal handlers never run.
+
+Note: this is not an issue for MSYS2 processes because MSYS2 emulates
+Unix' signal system accurately, both for the process sending the kill
+signal and the process receiving it. Win32 processes do not have such a
+signal handler, though, instead MSYS2 shuts them down via
+`TerminateProcess()`.
+
+For a while, Git for Windows tried to use a gentler method, described in
+the Dr Dobb's article "A Safer Alternative to TerminateProcess()" by
+Andrew Tucker (July 1, 1999),
+http://www.drdobbs.com/a-safer-alternative-to-terminateprocess/184416547
+
+Essentially, we injected a new thread into the running process that does
+nothing else than running the ExitProcess() function.
+
+However, this was still not in line with the way CMD handles Ctrl+C: it
+gives processes a chance to do something upon Ctrl+C by calling
+SetConsoleCtrlHandler(), and ExitProcess() simply never calls that
+handler.
+
+So for a while we tried to handle SIGINT/SIGTERM by attaching to the
+console of the command to interrupt, and generating the very same event
+as CMD does via GenerateConsoleCtrlEvent().
+
+This method *still* was not correct, though, as it would interrupt
+*every* process attached to that Console, not just the process (and its
+children) that we wanted to signal. A symptom was that hitting Ctrl+C
+while `git log` was shown in the pager would interrupt *the pager*.
+
+The method we settled on is to emulate what GenerateConsoleCtrlEvent()
+does, but on a process by process basis: inject a remote thread and call
+the (private) function kernel32!CtrlRoutine.
+
+To obtain said function's address, we use the dbghelp API to generate a
+stack trace from a handler configured via SetConsoleCtrlHandler() and
+triggered via GenerateConsoleCtrlEvent(). To avoid killing each and all
+processes attached to the same Console as the MSYS2 runtime, we modify
+the cygwin-console-helper to optionally print the address of
+kernel32!CtrlRoutine to stdout, and then spawn it with a new Console.
+
+Note that this also opens the door to handling 32-bit process from a
+64-bit MSYS2 runtime and vice versa, by letting the MSYS2 runtime look
+for the cygwin-console-helper.exe of the "other architecture" in a
+specific place (we choose /usr/libexec/, as it seems to be the
+convention for helper .exe files that are not intended for public
+consumption).
+
+The 32-bit helper implicitly links to libgcc_s_dw2.dll and
+libwinpthread-1.dll, so to avoid cluttering /usr/libexec/, we look for
+the helped of the "other" architecture in the corresponding mingw32/ or
+mingw64/ subdirectory.
+
+Among other bugs, this strategy to handle Ctrl+C fixes the MSYS2 side of
+the bug where interrupting `git clone https://...` would send the
+spawned-off `git remote-https` process into the background instead of
+interrupting it, i.e. the clone would continue and its progress would be
+reported mercilessly to the console window without the user being able
+to do anything about it (short of firing up the task manager and killing
+the appropriate task manually).
+
+Note that this special-handling is only necessary when *MSYS2* handles
+the Ctrl+C event, e.g. when interrupting a process started from within
+MinTTY or any other non-cmd-based terminal emulator. If the process was
+started from within `cmd.exe`'s terminal window, child processes are
+already killed appropriately upon Ctrl+C, by `cmd.exe` itself.
+
+Also, we can't trust the processes to end it's subprocesses upon receiving
+Ctrl+C. For example, `pip.exe` from `python-pip` doesn't kill the python
+it lauches (it tries to but fails), and I noticed that in cmd it kills python
+also correctly, which mean we should kill all the process using
+`exit_process_tree`.
+
+Co-authored-by: Naveen M K <naveen@syrusdark.website>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/exceptions.cc                 |  24 +-
+ winsup/cygwin/include/cygwin/exit_process.h | 364 ++++++++++++++++++++
+ 2 files changed, 384 insertions(+), 4 deletions(-)
+ create mode 100644 winsup/cygwin/include/cygwin/exit_process.h
+
+diff --git a/winsup/cygwin/exceptions.cc b/winsup/cygwin/exceptions.cc
+index 5fe6b4d..ed4b427 100644
+--- a/winsup/cygwin/exceptions.cc
++++ b/winsup/cygwin/exceptions.cc
+@@ -29,6 +29,7 @@ details. */
+ #include "exception.h"
+ #include "posix_timer.h"
+ #include "gcc_seh.h"
++#include "cygwin/exit_process.h"
+ 
+ /* Definitions for code simplification */
+ #ifdef __x86_64__
+@@ -1580,10 +1581,25 @@ exit_sig:
+ dosig:
+   if (have_execed)
+     {
+-      sigproc_printf ("terminating captive process");
+-      if (::cygheap->ctty)
+-	::cygheap->ctty->cleanup_before_exit ();
+-      TerminateProcess (ch_spawn, sigExeced = si.si_signo);
++      switch (si.si_signo)
++        {
++        case SIGUSR1:
++        case SIGUSR2:
++        case SIGCONT:
++        case SIGSTOP:
++        case SIGTSTP:
++        case SIGTTIN:
++        case SIGTTOU:
++          system_printf ("Suppressing signal %d to win32 process (pid %u)",
++              (int)si.si_signo, (unsigned int)GetProcessId(ch_spawn));
++          goto done;
++        default:
++          sigproc_printf ("terminating captive process");
++          if (::cygheap->ctty)
++	    ::cygheap->ctty->cleanup_before_exit ();
++          rc = exit_process_tree (ch_spawn, 128 + (sigExeced = si.si_signo));
++          goto done;
++        }
+     }
+   /* Dispatch to the appropriate function. */
+   sigproc_printf ("signal %d, signal handler %p", si.si_signo, handler);
+diff --git a/winsup/cygwin/include/cygwin/exit_process.h b/winsup/cygwin/include/cygwin/exit_process.h
+new file mode 100644
+index 0000000..0486a0c
+--- /dev/null
++++ b/winsup/cygwin/include/cygwin/exit_process.h
+@@ -0,0 +1,364 @@
++#ifndef EXIT_PROCESS_H
++#define EXIT_PROCESS_H
++
++/*
++ * This file contains functions to terminate a Win32 process, as gently as
++ * possible.
++ *
++ * If appropriate, we will attempt to emulate a console Ctrl event for the
++ * process. Otherwise we will fall back to terminating the process.
++ *
++ * As we do not want to export this function in the MSYS2 runtime, these
++ * functions are marked as file-local.
++ *
++ * The idea is to inject a thread into the given process that runs either
++ * kernel32!CtrlRoutine() (i.e. the work horse of GenerateConsoleCtrlEvent())
++ * for SIGINT (Ctrl+C) and SIGQUIT (Ctrl+Break), or ExitProcess() for SIGTERM.
++ * This is handled through the console helpers.
++ *
++ * For SIGKILL, we run TerminateProcess() without injecting anything, and this
++ * is also the fall-back when the previous methods are unavailable.
++ *
++ * Note: as kernel32.dll is loaded before any process, the other process and
++ * this process will have ExitProcess() at the same address. The same holds
++ * true for kernel32!CtrlRoutine(), of course, but it is an internal API
++ * function, so we cannot look it up directly. Instead, we launch
++ * getprocaddr.exe to find out and inject the remote thread.
++ *
++ * This function expects the process handle to have the access rights for
++ * CreateRemoteThread(): PROCESS_CREATE_THREAD, PROCESS_QUERY_INFORMATION,
++ * PROCESS_VM_OPERATION, PROCESS_VM_WRITE, and PROCESS_VM_READ.
++ *
++ * The idea for the injected remote thread comes from the Dr Dobb's article "A
++ * Safer Alternative to TerminateProcess()" by Andrew Tucker (July 1, 1999),
++ * http://www.drdobbs.com/a-safer-alternative-to-terminateprocess/184416547.
++ *
++ * The idea to use kernel32!CtrlRoutine for the other signals comes from
++ * SendSignal (https://github.com/AutoSQA/SendSignal/ and
++ * http://stanislavs.org/stopping-command-line-applications-programatically-with-ctrl-c-events-from-net/).
++ */
++
++#include <math.h>
++#include <wchar.h>
++
++#ifndef __INSIDE_CYGWIN__
++/* To help debugging via kill.exe */
++#define small_printf(...) fprintf (stderr, __VA_ARGS__)
++#endif
++
++static BOOL get_wow (HANDLE process, BOOL &is_wow, USHORT &process_arch);
++static int exit_process_tree (HANDLE main_process, int exit_code);
++
++static BOOL
++kill_via_console_helper (HANDLE process, wchar_t *function_name, int exit_code,
++                         DWORD pid)
++{
++  BOOL is_wow;
++  USHORT process_arch;
++  if (!get_wow (process, is_wow, process_arch))
++    {
++      return FALSE;
++    }
++
++  const char *name;
++  switch (process_arch)
++  {
++    case IMAGE_FILE_MACHINE_I386:
++      name = "/usr/libexec/getprocaddr32.exe";
++      break;
++    case IMAGE_FILE_MACHINE_AMD64:
++      name = "/usr/libexec/getprocaddr64.exe";
++      break;
++    /* TODO: provide exes for these */
++    case IMAGE_FILE_MACHINE_ARMNT:
++      name = "/usr/libexec/getprocaddrarm32.exe";
++      break;
++    case IMAGE_FILE_MACHINE_ARM64:
++      name = "/usr/libexec/getprocaddrarm64.exe";
++      break;
++    default:
++      return FALSE; /* what?!? */
++  }
++  wchar_t wbuf[PATH_MAX];
++
++  if (cygwin_conv_path (CCP_POSIX_TO_WIN_W, name, wbuf, PATH_MAX)
++      || GetFileAttributesW (wbuf) == INVALID_FILE_ATTRIBUTES)
++    return FALSE;
++
++  STARTUPINFOW si = {};
++  PROCESS_INFORMATION pi;
++  size_t len = wcslen (wbuf) + 1 /* space */ + wcslen (function_name)
++               + 1 /* space */ + 3 /* exit code */ + 1 /* space */
++               + 10 /* process ID, i.e. DWORD */ + 1 /* NUL */;
++  WCHAR cmd[len + 1];
++  WCHAR title[] = L"cygwin-console-helper";
++  DWORD process_exit;
++
++  swprintf (cmd, len + 1, L"%S %S %d %u", wbuf, function_name, exit_code,
++            pid);
++
++  si.cb = sizeof (si);
++  si.dwFlags = STARTF_USESHOWWINDOW | STARTF_USESTDHANDLES;
++  si.wShowWindow = SW_HIDE;
++  si.lpTitle = title;
++  si.hStdInput = si.hStdError = si.hStdOutput = INVALID_HANDLE_VALUE;
++
++  /* Create a new hidden process. */
++  if (!CreateProcessW (NULL, cmd, NULL, NULL, TRUE,
++                       CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP, NULL, NULL,
++                       &si, &pi))
++    {
++      return FALSE;
++    }
++  else
++    {
++      /* Wait for the process to complete for 10 seconds */
++      WaitForSingleObject (pi.hProcess, 10000);
++    }
++
++  if (!GetExitCodeProcess (pi.hProcess, &process_exit))
++    process_exit = -1;
++
++  CloseHandle (pi.hThread);
++  CloseHandle (pi.hProcess);
++
++  return process_exit == 0 ? TRUE : FALSE;
++}
++
++static int current_is_wow = -1;
++static int is_32_bit_os = -1;
++
++typedef BOOL (WINAPI * IsWow64Process2_t) (HANDLE, USHORT *, USHORT *);
++static bool wow64process2initialized = false;
++static IsWow64Process2_t pIsWow64Process2 /* = NULL */;
++
++typedef BOOL (WINAPI * GetProcessInformation_t) (HANDLE,
++                                                 PROCESS_INFORMATION_CLASS,
++                                                 LPVOID, DWORD);
++static bool getprocessinfoinitialized = false;
++static GetProcessInformation_t pGetProcessInformation /* = NULL */;
++
++static BOOL
++get_wow (HANDLE process, BOOL &is_wow, USHORT &process_arch)
++{
++  USHORT native_arch = IMAGE_FILE_MACHINE_UNKNOWN;
++  if (!wow64process2initialized)
++    {
++      pIsWow64Process2 = (IsWow64Process2_t)
++              GetProcAddress (GetModuleHandle ("KERNEL32"),
++                              "IsWow64Process2");
++      MemoryBarrier ();
++      wow64process2initialized = true;
++    }
++  if (!pIsWow64Process2)
++    {
++      if (is_32_bit_os == -1)
++        {
++          SYSTEM_INFO info;
++
++          GetNativeSystemInfo (&info);
++          if (info.wProcessorArchitecture == 0)
++            is_32_bit_os = 1;
++          else if (info.wProcessorArchitecture == 9)
++            is_32_bit_os = 0;
++          else
++            is_32_bit_os = -2;
++        }
++
++      if (current_is_wow == -1
++          && !IsWow64Process (GetCurrentProcess (), &current_is_wow))
++        current_is_wow = -2;
++
++      if (is_32_bit_os == -2 || current_is_wow == -2)
++        return FALSE;
++
++      if (!IsWow64Process (process, &is_wow))
++        return FALSE;
++
++      process_arch = is_32_bit_os || is_wow ? IMAGE_FILE_MACHINE_I386 :
++                                      IMAGE_FILE_MACHINE_AMD64;
++      return TRUE;
++    }
++
++  if (!pIsWow64Process2 (process, &process_arch, &native_arch))
++    return FALSE;
++
++  /* The value will be IMAGE_FILE_MACHINE_UNKNOWN if the target process
++   * is not a WOW64 process
++   */
++  if (process_arch == IMAGE_FILE_MACHINE_UNKNOWN)
++    {
++      struct /* _PROCESS_MACHINE_INFORMATION */
++        {
++          /* 0x0000 */ USHORT ProcessMachine;
++          /* 0x0002 */ USHORT Res0;
++          /* 0x0004 */ DWORD MachineAttributes;
++        } /* size: 0x0008 */ process_machine_info;
++
++      is_wow = FALSE;
++      /* However, x86_64 on ARM64 claims not to be WOW64, so we have to
++       * dig harder... */
++      if (!getprocessinfoinitialized)
++        {
++          pGetProcessInformation = (GetProcessInformation_t)
++                  GetProcAddress (GetModuleHandle ("KERNEL32"),
++                                  "GetProcessInformation");
++          MemoryBarrier ();
++          getprocessinfoinitialized = true;
++        }
++      /*#define ProcessMachineTypeInfo 9*/
++      if (pGetProcessInformation &&
++          pGetProcessInformation (process, (PROCESS_INFORMATION_CLASS)9,
++            &process_machine_info, sizeof (process_machine_info)))
++        process_arch = process_machine_info.ProcessMachine;
++      else
++        process_arch = native_arch;
++    }
++  else
++    {
++      is_wow = TRUE;
++    }
++  return TRUE;
++}
++
++/**
++ * Terminates the process corresponding to the process ID
++ *
++ * This way of terminating the processes is not gentle: the process gets
++ * no chance of cleaning up after itself (closing file handles, removing
++ * .lock files, terminating spawned processes (if any), etc).
++ */
++static int
++exit_process (HANDLE process, int exit_code)
++{
++  LPTHREAD_START_ROUTINE address = NULL;
++  DWORD pid = GetProcessId (process), code;
++  int signo = exit_code & 0x7f;
++  switch (signo)
++    {
++    case SIGINT:
++    case SIGQUIT:
++      /* We are not going to kill them but simply say that Ctrl+C
++      is pressed. If the processes want they can exit or else
++      just wait.*/
++      if (kill_via_console_helper (
++              process, L"CtrlRoutine",
++              signo == SIGINT ? CTRL_C_EVENT : CTRL_BREAK_EVENT, pid))
++        return 0;
++      /* fall-through */
++    case SIGTERM:
++      if (kill_via_console_helper (process, L"ExitProcess", exit_code, pid))
++        return 0;
++      break;
++    default:
++      break;
++    }
++
++  return int (TerminateProcess (process, exit_code));
++}
++
++#include <tlhelp32.h>
++#include <unistd.h>
++
++/**
++ * Terminates the process corresponding to the process ID and all of its
++ * directly and indirectly spawned subprocesses using the
++ * TerminateProcess() function.
++ */
++static int
++exit_process_tree (HANDLE main_process, int exit_code)
++{
++  HANDLE snapshot = CreateToolhelp32Snapshot (TH32CS_SNAPPROCESS, 0);
++  PROCESSENTRY32 entry;
++  DWORD pids[16384];
++  int max_len = sizeof (pids) / sizeof (*pids), i, len, ret = 0;
++  DWORD pid = GetProcessId (main_process);
++  int signo = exit_code & 0x7f;
++
++  pids[0] = pid;
++  len = 1;
++
++  /*
++   * Even if Process32First()/Process32Next() seem to traverse the
++   * processes in topological order (i.e. parent processes before
++   * child processes), there is nothing in the Win32 API documentation
++   * suggesting that this is guaranteed.
++   *
++   * Therefore, run through them at least twice and stop when no more
++   * process IDs were added to the list.
++   */
++  for (;;)
++    {
++      memset (&entry, 0, sizeof (entry));
++      entry.dwSize = sizeof (entry);
++
++      if (!Process32First (snapshot, &entry))
++        break;
++
++      int orig_len = len;
++      do
++        {
++          /**
++           * Look for the parent process ID in the list of pids to kill, and if
++           * found, add it to the list.
++           */
++          for (i = len - 1; i >= 0; i--)
++            {
++              if (pids[i] == entry.th32ProcessID)
++                break;
++              if (pids[i] != entry.th32ParentProcessID)
++                continue;
++
++              /* We found a process to kill; is it an MSYS2 process? */
++              pid_t cyg_pid = cygwin_winpid_to_pid (entry.th32ProcessID);
++              if (cyg_pid > -1)
++                {
++                  if (cyg_pid == getpgid (cyg_pid))
++                    kill (cyg_pid, signo);
++                  break;
++                }
++              pids[len++] = entry.th32ProcessID;
++              break;
++            }
++        }
++      while (len < max_len && Process32Next (snapshot, &entry));
++
++      if (orig_len == len || len >= max_len)
++        break;
++    }
++
++  CloseHandle (snapshot);
++
++  for (i = len - 1; i >= 0; i--)
++    {
++      HANDLE process;
++
++      if (!i)
++        process = main_process;
++      else
++        {
++          process = OpenProcess (
++              PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION
++                  | PROCESS_VM_OPERATION | PROCESS_VM_WRITE | PROCESS_VM_READ,
++              FALSE, pids[i]);
++          if (!process)
++            process = OpenProcess (
++                PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE,
++                FALSE, pids[i]);
++        }
++      DWORD code;
++
++      if (process
++          && (!GetExitCodeProcess (process, &code) || code == STILL_ACTIVE))
++        {
++          if (!exit_process (process, exit_code))
++            ret = -1;
++        }
++      if (process && process != main_process)
++        CloseHandle (process);
++    }
++
++  return ret;
++}
++
++#endif

--- a/msys2-runtime-3.3/0030-kill-kill-Win32-processes-more-gently.patch
+++ b/msys2-runtime-3.3/0030-kill-kill-Win32-processes-more-gently.patch
@@ -1,0 +1,51 @@
+From 486c7601503c313c3fc3d84b1144064067754f2f Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Fri, 20 Mar 2015 10:01:50 +0000
+Subject: [PATCH 30/N] kill: kill Win32 processes more gently
+
+This change is the equivalent to the change to the Ctrl+C handling we
+just made.
+
+Co-authored-by: Naveen M K <naveen@syrusdark.website>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/utils/kill.cc | 19 +++++++++++++++----
+ 1 file changed, 15 insertions(+), 4 deletions(-)
+
+diff --git a/winsup/utils/kill.cc b/winsup/utils/kill.cc
+index d0fb547..ad718c3 100644
+--- a/winsup/utils/kill.cc
++++ b/winsup/utils/kill.cc
+@@ -17,6 +17,7 @@ details. */
+ #include <cygwin/version.h>
+ #include <getopt.h>
+ #include <limits.h>
++#include <cygwin/exit_process.h>
+ 
+ static char *prog_name;
+ 
+@@ -186,10 +187,20 @@ forcekill (pid_t pid, DWORD winpid, int sig, int wait)
+       return;
+     }
+   if (!wait || WaitForSingleObject (h, 200) != WAIT_OBJECT_0)
+-    if (sig && !TerminateProcess (h, sig << 8)
+-	&& WaitForSingleObject (h, 200) != WAIT_OBJECT_0)
+-      fprintf (stderr, "%s: couldn't kill pid %u, %u\n",
+-	       prog_name, (unsigned int) dwpid, (unsigned int) GetLastError ());
++    {
++      HANDLE cur = GetCurrentProcess (), h2;
++      /* duplicate handle with access rights required for exit_process_tree() */
++      if (DuplicateHandle (cur, h, cur, &h2, PROCESS_CREATE_THREAD |
++			      PROCESS_QUERY_INFORMATION |
++			      PROCESS_VM_OPERATION |
++			      PROCESS_VM_WRITE | PROCESS_VM_READ |
++			      PROCESS_TERMINATE, FALSE, 0))
++      {
++        CloseHandle(h);
++        h = h2;
++      }
++      exit_process_tree (h, 128 + sig);
++    }
+   CloseHandle (h);
+ }
+ 

--- a/msys2-runtime-3.3/0031-Cygwin-make-option-for-native-inner-link-handling.patch
+++ b/msys2-runtime-3.3/0031-Cygwin-make-option-for-native-inner-link-handling.patch
@@ -1,0 +1,52 @@
+From aa9dbc9c9fc47ae4371d5847b358122eb1f54750 Mon Sep 17 00:00:00 2001
+From: Jeremy Drake <github@jdrake.com>
+Date: Thu, 22 Jul 2021 11:59:16 -0700
+Subject: [PATCH 31/N] Cygwin: make option for native inner link handling.
+
+This code has been causing issues with SUBST and mapped network drives,
+so add an option (defaulted to on) which can be used to disable it where
+needed.  MSYS=nonativeinnerlinks
+---
+ winsup/cygwin/environ.cc | 1 +
+ winsup/cygwin/globals.cc | 1 +
+ winsup/cygwin/path.cc    | 3 ++-
+ 3 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index f4e2c68..18c37ee 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -129,6 +129,7 @@ static struct parse_thing
+   {"disable_pcon", {&disable_pcon}, setbool, NULL, {{false}, {true}}},
+   {"enable_pcon", {&disable_pcon}, setnegbool, NULL, {{true}, {false}}},
+   {"winjitdebug", {&winjitdebug}, setbool, NULL, {{false}, {true}}},
++  {"nativeinnerlinks", {&nativeinnerlinks}, setbool, NULL, {{false}, {true}}},
+   {NULL, {0}, setdword, 0, {{0}, {0}}}
+ };
+ 
+diff --git a/winsup/cygwin/globals.cc b/winsup/cygwin/globals.cc
+index 5c111ab..6c15138 100644
+--- a/winsup/cygwin/globals.cc
++++ b/winsup/cygwin/globals.cc
+@@ -76,6 +76,7 @@ bool wincmdln = true;
+ winsym_t allow_winsymlinks = WSYM_deepcopy;
+ bool disable_pcon = true;
+ bool winjitdebug = false;
++bool nativeinnerlinks = true;
+ 
+ bool NO_COPY in_forkee;
+ 
+diff --git a/winsup/cygwin/path.cc b/winsup/cygwin/path.cc
+index 9edd949..9a3ad7a 100644
+--- a/winsup/cygwin/path.cc
++++ b/winsup/cygwin/path.cc
+@@ -3645,7 +3645,8 @@ restart:
+ 	    goto file_not_symlink;
+ 	}
+ #endif /* __i386__ */
+-      if ((pc_flags & (PC_SYM_FOLLOW | PC_SYM_NOFOLLOW_REP)) == PC_SYM_FOLLOW)
++      if (nativeinnerlinks
++	  && (pc_flags & (PC_SYM_FOLLOW | PC_SYM_NOFOLLOW_REP)) == PC_SYM_FOLLOW)
+ 	{
+ 	  PWCHAR fpbuf = tp.w_get ();
+ 	  DWORD ret;

--- a/msys2-runtime-3.3/0032-docs-skip-building-texinfo-and-PDF-files.patch
+++ b/msys2-runtime-3.3/0032-docs-skip-building-texinfo-and-PDF-files.patch
@@ -1,0 +1,46 @@
+From 20f59b414ff39195eb42bca7751ee3b4ae33f870 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 8 Nov 2021 14:20:07 +0100
+Subject: [PATCH 32/N] docs: skip building texinfo and PDF files
+
+The MSYS2 packages lack the infrastructure to build those.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/doc/Makefile.am | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/winsup/doc/Makefile.am b/winsup/doc/Makefile.am
+index 534d674..d448ede 100644
+--- a/winsup/doc/Makefile.am
++++ b/winsup/doc/Makefile.am
+@@ -10,9 +10,7 @@ man1_MANS =
+ man3_MANS =
+ man5_MANS =
+ 
+-doc_DATA = \
+-	cygwin-ug-net/cygwin-ug-net.pdf \
+-	cygwin-api/cygwin-api.pdf
++doc_DATA =
+ 
+ htmldir = $(datarootdir)/doc
+ 
+@@ -28,8 +26,7 @@ all-local: Makefile.dep \
+ 	cygwin-ug-net/cygwin-ug-net.html \
+ 	faq/faq.html faq/faq.body \
+ 	cygwin-ug-net/cygwin-ug-net-nochunks.html.gz \
+-	api2man.stamp intro2man.stamp utils2man.stamp \
+-	cygwin-api.info cygwin-ug-net.info
++	api2man.stamp intro2man.stamp utils2man.stamp
+ 
+ clean-local:
+ 	rm -f Makefile.dep
+@@ -69,7 +66,7 @@ install-etc:
+ 	@$(MKDIR_P) $(DESTDIR)$(sysconfdir)/preremove
+ 	$(INSTALL_SCRIPT) $(srcdir)/etc.preremove.cygwin-doc.sh $(DESTDIR)$(sysconfdir)/preremove/cygwin-doc.sh
+ 
+-install-data-hook: install-extra-man install-html-local install-info-local install-etc
++install-data-hook: install-extra-man install-html-local install-etc
+ 
+ uninstall-extra-man:
+ 	for i in *.1 ; do \

--- a/msys2-runtime-3.3/0033-install-libs-depend-on-the-toollibs.patch
+++ b/msys2-runtime-3.3/0033-install-libs-depend-on-the-toollibs.patch
@@ -1,0 +1,28 @@
+From 31b5e84ef74da21c7a8f9fea5c7395154f1ae36b Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 8 Nov 2021 16:22:57 +0100
+Subject: [PATCH 33/N] install-libs: depend on the "toollibs"
+
+Before symlinking libg.a, we need the symlink source `libmsys-2.0.a`: in
+MSYS2, we copy by default (if we were creating Unix-style symlinks, the
+target would not have to exist before symlinking, but when copying we do
+need the source _right away_).
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/Makefile.am b/winsup/cygwin/Makefile.am
+index 23a3c23..f1fe01d 100644
+--- a/winsup/cygwin/Makefile.am
++++ b/winsup/cygwin/Makefile.am
+@@ -727,7 +727,7 @@ man_MANS = regex/regex.3 regex/regex.7
+ install-exec-hook: install-libs
+ install-data-local: install-headers install-ldif
+ 
+-install-libs:
++install-libs: install-toollibDATA
+ 	@$(MKDIR_P) $(DESTDIR)$(bindir)
+ 	$(INSTALL_PROGRAM) $(TEST_DLL_NAME) $(DESTDIR)$(bindir)/$(DLL_NAME)
+ 	@$(MKDIR_P) $(DESTDIR)$(toollibdir)

--- a/msys2-runtime-3.3/0034-POSIX-ify-the-SHELL-variable.patch
+++ b/msys2-runtime-3.3/0034-POSIX-ify-the-SHELL-variable.patch
@@ -1,0 +1,108 @@
+From ae6fceff61edab2e97a3af6dcb2ded9a738c8bf0 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 23 Nov 2015 20:03:11 +0100
+Subject: [PATCH 34/N] POSIX-ify the SHELL variable
+
+When calling a non-MSys2 binary, all of the environment is converted from
+POSIX to Win32, including the SHELL environment variable. In Git for
+Windows, for example, `SHELL=/usr/bin/bash` is converted to
+`SHELL=C:\Program Files\Git\usr\bin\bash.exe` when calling the `git.exe`
+binary. This is appropriate because non-MSys2 binaries would not handle
+POSIX paths correctly.
+
+Under certain circumstances, however, `git.exe` calls an *MSys2* binary in
+turn, such as `git config --edit` calling `vim.exe` unless Git is
+configured to use another editor specifically.
+
+Now, when this "improved vi" calls shell commands, it uses that $SHELL
+variable *without quoting*, resulting in a nasty error:
+
+	C:\Program: No such file or directory
+
+Many other programs behave in the same manner, assuming that $SHELL does
+not contain spaces and hence needs no quoting, unfortunately including
+some of Git's own scripts.
+
+Therefore let's make sure that $SHELL gets "posified" again when entering
+MSys2 programs.
+
+Earlier attempts by Git for Windows contributors claimed that adding
+`SHELL` to the `conv_envvars` array does not have the intended effect.
+These reports just missed that the `conv_start_chars` array (which makes
+the code more performant) needs to be adjusted, too.
+
+Note that we set the `immediate` flag to `true` so that the environment
+variable is set immediately by the MSys2 runtime, i.e. not only spawned
+processes will see the POSIX-ified `SHELL` variable, but the MSys2 runtime
+*itself*, too.
+
+This fixes https://github.com/git-for-windows/git/issues/542,
+https://github.com/git-for-windows/git/issues/498, and
+https://github.com/git-for-windows/git/issues/468.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/environ.cc | 8 +++++++-
+ winsup/cygwin/environ.h  | 2 +-
+ 2 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index 18c37ee..5c197a6 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -327,6 +327,7 @@ static win_env conv_envvars[] =
+     {NL ("HOME="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
+     {NL ("LD_LIBRARY_PATH="), NULL, NULL,
+ 			       env_plist_to_posix, env_plist_to_win32, true},
++    {NL ("SHELL="), NULL, NULL, env_path_to_posix, env_path_to_win32, true, true},
+     {NL ("TMPDIR="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
+     {NL ("TMP="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
+     {NL ("TEMP="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
+@@ -355,7 +356,7 @@ static const unsigned char conv_start_chars[256] =
+     WC,       0,        0,        0,        WC,       0,        0,        0,
+     /*  80 */
+ /*  P         Q         R         S         T         U         V         W */
+-    WC,       0,        0,        0,        WC,       0,        0,        0,
++    WC,       0,        0,        WC,       WC,       0,        0,        0,
+     /*  88 */
+ /*  x         Y         Z                                                   */
+     0,        0,        0,        0,        0,        0,        0,        0,
+@@ -384,6 +385,7 @@ win_env::operator = (struct win_env& x)
+   toposix = x.toposix;
+   towin32 = x.towin32;
+   immediate = false;
++  skip_if_empty = x.skip_if_empty;
+   return *this;
+ }
+ 
+@@ -405,6 +407,8 @@ win_env::add_cache (const char *in_posix, const char *in_native)
+       native = (char *) realloc (native, namelen + 1 + strlen (in_native));
+       stpcpy (stpcpy (native, name), in_native);
+     }
++  else if (skip_if_empty && !*in_posix)
++    native = (char *) calloc(1, 1);
+   else
+     {
+       tmp_pathbuf tp;
+@@ -470,6 +474,8 @@ posify_maybe (char **here, const char *value, char *outenv)
+     return;
+ 
+   int len = strcspn (src, "=") + 1;
++  if (conv->skip_if_empty && !src[len])
++    return;
+ 
+   /* Turn all the items from c:<foo>;<bar> into their
+      mounted equivalents - if there is one.  */
+diff --git a/winsup/cygwin/environ.h b/winsup/cygwin/environ.h
+index 71c3f22..f33740d 100644
+--- a/winsup/cygwin/environ.h
++++ b/winsup/cygwin/environ.h
+@@ -21,7 +21,7 @@ struct win_env
+     char *native;
+     ssize_t (*toposix) (const void *, void *, size_t);
+     ssize_t (*towin32) (const void *, void *, size_t);
+-    bool immediate;
++    bool immediate, skip_if_empty;
+     void __reg3 add_cache (const char *in_posix, const char *in_native = NULL);
+     const char * get_native () const {return native ? native + namelen : NULL;}
+     const char * get_posix () const {return posix ? posix : NULL;}

--- a/msys2-runtime-3.3/0035-Handle-ORIGINAL_PATH-just-like-PATH.patch
+++ b/msys2-runtime-3.3/0035-Handle-ORIGINAL_PATH-just-like-PATH.patch
@@ -1,0 +1,48 @@
+From 7af6781845542e53a96def2997912f68537202e8 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 21 Mar 2017 13:18:38 +0100
+Subject: [PATCH 35/N] Handle ORIGINAL_PATH just like PATH
+
+MSYS2 recently introduced that hack where the ORIGINAL_PATH variable is
+set to the original PATH value in /etc/profile, unless previously set.
+In Git for Windows' default mode, that ORIGINAL_PATH value is the used
+to define the PATH variable explicitly.
+
+So far so good.
+
+The problem: when calling from inside an MSYS2 process (such as Bash) a
+MINGW executable (such as git.exe) that then calls another MSYS2
+executable (such as bash.exe), that latter call will try to re-convert
+ORIGINAL_PATH after the previous call converted ORIGINAL_PATH from POSIX
+to Windows paths. And this conversion may very well fail, e.g. when the
+path list contains mixed semicolons and colons.
+
+So let's just *force* the MSYS2 runtime to handle ORIGINAL_PATH in the
+same way as the PATH variable (which conversion works, as we know).
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/environ.cc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index 5c197a6..5afac8d 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -327,6 +327,7 @@ static win_env conv_envvars[] =
+     {NL ("HOME="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
+     {NL ("LD_LIBRARY_PATH="), NULL, NULL,
+ 			       env_plist_to_posix, env_plist_to_win32, true},
++    {NL ("ORIGINAL_PATH="), NULL, NULL, env_PATH_to_posix, env_plist_to_win32, true},
+     {NL ("SHELL="), NULL, NULL, env_path_to_posix, env_path_to_win32, true, true},
+     {NL ("TMPDIR="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
+     {NL ("TMP="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
+@@ -353,7 +354,7 @@ static const unsigned char conv_start_chars[256] =
+     0,        0,        0,        0,        0,        0,        0,        0,
+     /*  72 */
+ /*  H         I         J         K         L         M         N         O */
+-    WC,       0,        0,        0,        WC,       0,        0,        0,
++    WC,       0,        0,        0,        WC,       0,        0,        WC,
+     /*  80 */
+ /*  P         Q         R         S         T         U         V         W */
+     WC,       0,        0,        WC,       WC,       0,        0,        0,

--- a/msys2-runtime-3.3/0036-uname-allow-setting-the-system-name-to-CYGWIN.patch
+++ b/msys2-runtime-3.3/0036-uname-allow-setting-the-system-name-to-CYGWIN.patch
@@ -1,0 +1,82 @@
+From 1a5f889bdb136397b64e25311ad68c93806b3bea Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Sun, 3 Jul 2022 22:39:32 +0200
+Subject: [PATCH 36/N] uname: allow setting the system name to CYGWIN
+
+We are currently trying to move our cygwin build environment closer
+to cygwin and some autotools/bash based build systems call "uname -s"
+to figure out the OS and in many cases only handle the cygwin case, so
+we have to patch them.
+
+With this instead of patching we can set MSYSTEM=CYGWIN and change
+uname output that way.
+
+The next step would be to always output CYGWIN in an msys env by default,
+but for now this allows us to get rid of all the patches without
+affecting users.
+---
+ winsup/cygwin/uname.cc | 36 ++++++++++++++++++++++--------------
+ 1 file changed, 22 insertions(+), 14 deletions(-)
+
+diff --git a/winsup/cygwin/uname.cc b/winsup/cygwin/uname.cc
+index daed73f..f6a5f88 100644
+--- a/winsup/cygwin/uname.cc
++++ b/winsup/cygwin/uname.cc
+@@ -23,6 +23,24 @@ extern "C" int getdomainname (char *__name, size_t __len);
+ #define ATTRIBUTE_NONSTRING
+ #endif
+ 
++static const char*
++get_sysname()
++{
++#ifdef __MSYS__
++  char* msystem = getenv("MSYSTEM");
++  if (!msystem || strcmp(msystem, "MSYS") == 0)
++    return "MSYS";
++  else if (strcmp(msystem, "CYGWIN") == 0)
++    return "CYGWIN";
++  else if (strstr(msystem, "32") != NULL)
++    return "MINGW32";
++  else
++    return "MINGW64";
++#else
++  return "CYGWIN";
++#endif
++}
++
+ /* uname: POSIX 4.4.1.1 */
+ 
+ /* New entrypoint for applications since API 335 */
+@@ -36,12 +54,9 @@ uname_x (struct utsname *name)
+ 
+       memset (name, 0, sizeof (*name));
+       /* sysname */
+-      char* msystem = getenv("MSYSTEM");
+-      const char* msystem_sysname = "MSYS";
+-      if (msystem != NULL && *msystem && strcmp(msystem, "MSYS") != 0)
+-        msystem_sysname = (strstr(msystem, "32") != NULL) ? "MINGW32" : "MINGW64";;
++      const char* sysname = get_sysname();
+       __small_sprintf (name->sysname, "%s_%s-%u%s",
+-		       msystem_sysname,
++		       sysname,
+ 		       wincap.osname (), wincap.build_number (),
+ 		       wincap.is_wow64 () ? "-WOW64" : "");
+       /* nodename */
+@@ -103,15 +118,8 @@ uname (struct utsname *in_name)
+       char *snp = strstr  (cygwin_version.dll_build_date, "SNP");
+ 
+       memset (name, 0, sizeof (*name));
+-#ifdef __MSYS__
+-      char* msystem = getenv("MSYSTEM");
+-      const char* msystem_sysname = "MSYS";
+-      if (msystem != NULL && *msystem && strcmp(msystem, "MSYS") != 0)
+-        msystem_sysname = (strstr(msystem, "32") != NULL) ? "MINGW32" : "MINGW64";
+-      __small_sprintf (name->sysname, "%s_%s", msystem_sysname, wincap.osname ());
+-#else
+-      __small_sprintf (name->sysname, "CYGWIN_%s", wincap.osname ());
+-#endif
++      const char* sysname = get_sysname();
++      __small_sprintf (name->sysname, "%s_%s", sysname, wincap.osname ());
+ 
+       /* Add a hint to the sysname, that we're running under WOW64.  This might
+ 	 give an early clue if somebody encounters problems. */

--- a/msys2-runtime-3.3/0037-fixup-Revert-Default-to-disable_pcon.patch
+++ b/msys2-runtime-3.3/0037-fixup-Revert-Default-to-disable_pcon.patch
@@ -1,0 +1,25 @@
+From f5d37650e7077d214ec5895b0175918863172086 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Tue, 13 Sep 2022 09:36:38 +0200
+Subject: [PATCH 37/N] fixup! Revert "Default to `disable_pcon`"
+
+This reverts commit 8e89fffcfb0884da1398dd55f0d0cc57294549ec.
+
+We want to try enabling it by default again, see #98
+---
+ winsup/cygwin/globals.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/globals.cc b/winsup/cygwin/globals.cc
+index 6c15138..6a65dd6 100644
+--- a/winsup/cygwin/globals.cc
++++ b/winsup/cygwin/globals.cc
+@@ -74,7 +74,7 @@ bool pipe_byte;
+ bool reset_com;
+ bool wincmdln = true;
+ winsym_t allow_winsymlinks = WSYM_deepcopy;
+-bool disable_pcon = true;
++bool disable_pcon;
+ bool winjitdebug = false;
+ bool nativeinnerlinks = true;
+ 

--- a/msys2-runtime-3.3/0038-Pass-environment-variables-with-empty-values.patch
+++ b/msys2-runtime-3.3/0038-Pass-environment-variables-with-empty-values.patch
@@ -1,0 +1,45 @@
+From 5812c2fb3534a9203cc110cc052fdae730920a3e Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 18 Feb 2015 12:32:17 +0000
+Subject: [PATCH 38/N] Pass environment variables with empty values
+
+There is a difference between an empty value and an unset environment
+variable. We should not confuse both; If the user wants to unset an
+environment variable, they can certainly do so (unsetenv(3), or in the
+shell: 'unset ABC').
+
+This fixes Git's t3301-notes.sh, which overrides environment variables
+with empty values.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/environ.cc | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index 5afac8d..522d7d5 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -1339,11 +1339,11 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
+ 	     Note that this doesn't stop invalid strings without '=' in it
+ 	     etc., but we're opting for speed here for now.  Adding complete
+ 	     checking would be pretty expensive. */
+-	  if (len == 1 || !*rest)
++	  if (len == 1)
+ 	    continue;
+ 
+ 	  /* See if this entry requires posix->win32 conversion. */
+-	  conv = getwinenv (*srcp, rest, &temp);
++	  conv = !*rest ? NULL : getwinenv (*srcp, rest, &temp);
+ 	  if (conv)
+ 	    {
+ 	      p = conv->native;	/* Use win32 path */
+@@ -1357,7 +1357,7 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
+ 		}
+ 	    }
+ #ifdef __MSYS__
+-	  else if (!keep_posix) {
++	  else if (!keep_posix && *rest) {
+ 	    char *win_arg = arg_heuristic_with_exclusions
+ 		   (*srcp, msys2_env_conv_excl_env, msys2_env_conv_excl_count);
+ 	    debug_printf("WIN32_PATH is %s", win_arg);

--- a/msys2-runtime-3.3/0039-Optionally-disallow-empty-environment-values-again.patch
+++ b/msys2-runtime-3.3/0039-Optionally-disallow-empty-environment-values-again.patch
@@ -1,0 +1,57 @@
+From 96283acb9d8fe69bb921ee84c584bc79b1eb262f Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 6 Sep 2022 10:40:58 +0200
+Subject: [PATCH 39/N] Optionally disallow empty environment values again
+
+We just disabled the code that skips environment variables whose values
+are empty.
+
+However, this code was introduced a long time ago into Cygwin in
+d6b1ac7faa (* environ.cc (build_env): Don't put an empty environment
+variable into the environment.  Optimize use of "len". * errno.cc
+(ERROR_MORE_DATA): Translate to EMSGSIZE rather than EAGAIN.,
+2006-09-07), seemingly without any complaints.
+
+Meaning: There might very well be use cases out there where it makes
+sense to skip empty-valued environment variables.
+
+Therefore, it seems like a good idea to have a "knob" to turn it back
+on. With this commit, we introduce such a knob: by setting
+`noemptyenvvalues` the `MSYS` variable (or appending it if that variable
+is already set), users can tell the MSYS2 runtime to behave just like in
+the olden times.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/environ.cc | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index 522d7d5..128f34d 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -36,6 +36,7 @@ static char **lastenviron;
+ /* Parse CYGWIN options */
+ 
+ static NO_COPY bool export_settings = false;
++static bool emptyenvvalues = true;
+ 
+ enum settings
+   {
+@@ -130,6 +131,7 @@ static struct parse_thing
+   {"enable_pcon", {&disable_pcon}, setnegbool, NULL, {{true}, {false}}},
+   {"winjitdebug", {&winjitdebug}, setbool, NULL, {{false}, {true}}},
+   {"nativeinnerlinks", {&nativeinnerlinks}, setbool, NULL, {{false}, {true}}},
++  {"emptyenvvalues", {&emptyenvvalues}, setbool, NULL, {{false}, {true}}},
+   {NULL, {0}, setdword, 0, {{0}, {0}}}
+ };
+ 
+@@ -1339,7 +1341,7 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
+ 	     Note that this doesn't stop invalid strings without '=' in it
+ 	     etc., but we're opting for speed here for now.  Adding complete
+ 	     checking would be pretty expensive. */
+-	  if (len == 1)
++	  if (len == 1 || (!emptyenvvalues && !*rest))
+ 	    continue;
+ 
+ 	  /* See if this entry requires posix->win32 conversion. */

--- a/msys2-runtime-3.3/0040-build_env-respect-the-MSYS-environment-variable.patch
+++ b/msys2-runtime-3.3/0040-build_env-respect-the-MSYS-environment-variable.patch
@@ -1,0 +1,34 @@
+From 97c2d7fa8bb424012aad77b8d86f3262a35fab0a Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 6 Sep 2022 12:18:18 +0200
+Subject: [PATCH 40/N] build_env(): respect the `MSYS` environment variable
+
+With this commit, you can call
+
+	MSYS=noemptyenvvalues my-command
+
+and it does what is expected: to pass no empty-valued environment
+variables to `my-command`.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/environ.cc | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/environ.cc b/winsup/cygwin/environ.cc
+index 128f34d..b431d3c 100644
+--- a/winsup/cygwin/environ.cc
++++ b/winsup/cygwin/environ.cc
+@@ -1217,7 +1217,11 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
+     {
+       bool calc_tl = !no_envblock;
+ #ifdef __MSYS__
+-      if (!keep_posix)
++      if (ascii_strncasematch(*srcp, "MSYS=", 5))
++        {
++          parse_options (*srcp + 5);
++	}
++      else if (!keep_posix)
+         {
+           /* Don't pass timezone environment to non-msys applications */
+           if (ascii_strncasematch(*srcp, "TZ=", 3))

--- a/msys2-runtime-3.3/0041-Cygwin-pty-Fix-Bad-address-error-when-running-cmd.ex.patch
+++ b/msys2-runtime-3.3/0041-Cygwin-pty-Fix-Bad-address-error-when-running-cmd.ex.patch
@@ -1,0 +1,50 @@
+From f975120d20d51ca11217e4abbf16cc51ab8c9290 Mon Sep 17 00:00:00 2001
+From: Takashi Yano <takashi.yano@nifty.ne.jp>
+Date: Sat, 22 Oct 2022 14:05:40 +0900
+Subject: [PATCH 41/N] Cygwin: pty: Fix 'Bad address' error when running
+ 'cmd.exe /c dir'
+
+- If the command executed is 'cmd.exe /c [...]', runpath in spawn.cc
+  will be NULL. In this case, is_console_app(runpath) check causes
+  access violation. This case also the command executed is obviously
+  console app., therefore, treat it as console app to fix this issue.
+
+  Addresses: https://github.com/msys2/msys2-runtime/issues/108
+
+This is a backport of 08281cf4cc (Cygwin: pty: Fix 'Bad address' error
+when running 'cmd.exe /c dir', 2022-10-22).
+
+The original patch that was replaced by this commit had this additional
+information that is now sadly lost in Cygwin's history:
+
+In 2b4f986e49 (Cygwin: pty: Treat *.bat and *.cmd as a non-cygwin
+console app., 2022-07-31), we introduced a bug fix that specifically
+looks for a suffix of the command's file name.
+
+However, that file name might be set to `NULL`, namely when
+`null_app_name == true`, which is the case when we detected a
+command-line `cmd /c [...]`.
+
+But the commit mentioned above did not account for that possibility,
+instead assuming that it always has to check the file name for a `.bat`
+or `.cmd` suffix. As a consequence, `cmd /c [...]` invocations are
+completely broken in v3.3.6, resulting in a `Bad address` error.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/spawn.cc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/winsup/cygwin/spawn.cc b/winsup/cygwin/spawn.cc
+index bc9dc5a..9636109 100644
+--- a/winsup/cygwin/spawn.cc
++++ b/winsup/cygwin/spawn.cc
+@@ -198,6 +198,8 @@ handle (int fd, bool writing)
+ static bool
+ is_console_app (WCHAR *filename)
+ {
++  if (filename == NULL)
++    return true; /* The command executed is command.com or cmd.exe. */
+   HANDLE h;
+   const int id_offset = 92;
+   h = CreateFileW (filename, GENERIC_READ, FILE_SHARE_READ,

--- a/msys2-runtime-3.3/0042-ci-avoid-using-Node.js-12-Actions.patch
+++ b/msys2-runtime-3.3/0042-ci-avoid-using-Node.js-12-Actions.patch
@@ -1,0 +1,39 @@
+From 205042e70b50cdd688b3891cca53c90859597df6 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 8 Nov 2022 17:05:57 +0100
+Subject: [PATCH 42/N] ci: avoid using Node.js 12 Actions
+
+As mentioned in
+https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
+GitHub workflows should avoid using Actions that use Node.js 12 and
+instead upgrade to versions of those Actions that use Node.js 16.
+
+So let's do that.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ .github/workflows/build.yaml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/.github/workflows/build.yaml b/.github/workflows/build.yaml
+index 4e1d498..5069dbd 100644
+--- a/.github/workflows/build.yaml
++++ b/.github/workflows/build.yaml
+@@ -8,7 +8,7 @@ jobs:
+ 
+     steps:
+       - name: Checkout code
+-        uses: actions/checkout@v2
++        uses: actions/checkout@v3
+ 
+       - name: setup-msys2
+         uses: msys2/setup-msys2@v2
+@@ -30,7 +30,7 @@ jobs:
+           make DESTDIR="$(pwd)"/_dest install
+ 
+       - name: Upload
+-        uses: actions/upload-artifact@v2
++        uses: actions/upload-artifact@v3
+         with:
+           name: install
+           path: _dest/

--- a/msys2-runtime-3.3/0043-When-converting-to-a-Unix-path-avoid-double-trailing.patch
+++ b/msys2-runtime-3.3/0043-When-converting-to-a-Unix-path-avoid-double-trailing.patch
@@ -1,0 +1,33 @@
+From 1a46b7d8d3d3359db09a81f063711e4523aedb68 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 8 Nov 2022 16:24:20 +0100
+Subject: [PATCH 43/N] When converting to a Unix path, avoid double trailing
+ slashes
+
+When calling `cygpath -u C:/msys64/` in an MSYS2 setup that was
+installed into `C:/msys64/`, the result should be `/`, not `//`.
+
+Let's ensure that we do not append another trailing slash if the
+converted path already ends in a slash.
+
+This fixes https://github.com/msys2/msys2-runtime/issues/112
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/mount.cc | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/winsup/cygwin/mount.cc b/winsup/cygwin/mount.cc
+index 22d7b31..cbc3100 100644
+--- a/winsup/cygwin/mount.cc
++++ b/winsup/cygwin/mount.cc
+@@ -923,6 +923,9 @@ mount_info::conv_to_posix_path (const char *src_path, char *posix_path,
+ 	nextchar = 1;
+ 
+       int addslash = nextchar > 0 ? 1 : 0;
++      /* avoid appending a slash if the result already has a trailing slash */
++      if (append_slash && mi.posix_pathlen && mi.posix_path[mi.posix_pathlen-1] == '/')
++	append_slash = addslash = 0;
+       if ((mi.posix_pathlen + (pathbuflen - mi.native_pathlen) + addslash) >= NT_MAX_PATH)
+ 	return ENAMETOOLONG;
+       strcpy (posix_path, mi.posix_path);

--- a/msys2-runtime-3.3/0044-amend-Special-case-for-converting-root-directory-to-.patch
+++ b/msys2-runtime-3.3/0044-amend-Special-case-for-converting-root-directory-to-.patch
@@ -1,0 +1,64 @@
+From 358b4547f7c159ca544a24938aca350b3aac84dd Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 20 Sep 2022 21:47:34 +0200
+Subject: [PATCH 44/N] amend! Special case for converting root directory to
+ have training slash
+
+path_conv: special-case root directory to have trailing slash
+
+When converting `/c/` to `C:\`, the trailing slash is actually really
+necessary, as `C:` is not an absolute path.
+
+We must be very careful to do this only for root directories, though. If
+we kept the trailing slash also for, say, `/y/directory/`, we would run
+into the following issue: On FAT file systems, the normalized path is
+used to fake inode numbers. As a result, `Y:\directory\` and
+`Y:\directory` have different inode numbers!!!
+
+This would result in very non-obvious symptoms. Back when we were too
+careless about keeping the trailing slash, it was reported to the Git
+for Windows project that the `find` and `rm` commands can error out on
+FAT file systems with very confusing "No such file or directory" errors,
+for no good reason.
+
+During the original investigation, Vasil Minkov pointed out in
+https://github.com/git-for-windows/git/issues/1497#issuecomment-372665870,
+that this bug had been fixed in Cygwin as early as 1997... and the bug
+was unfortunately reintroduced into early MSYS2 versions.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/path.cc | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/winsup/cygwin/path.cc b/winsup/cygwin/path.cc
+index 9a3ad7a..e191b9e 100644
+--- a/winsup/cygwin/path.cc
++++ b/winsup/cygwin/path.cc
+@@ -1254,17 +1254,17 @@ path_conv::check (const char *src, unsigned opt,
+ 		cfree (wide_path);
+ 	      wide_path = NULL;
+ 	    }
+-	}
+ 
+-      if (need_directory)
+-	{
+-	  size_t n = strlen (this->path);
+-	  /* Do not add trailing \ to UNC device names like \\.\a: */
+-	  if (this->path[n - 1] != '\\' &&
+-	      (strncmp (this->path, "\\\\.\\", 4) != 0))
++	  if (need_directory)
+ 	    {
+-	      this->modifiable_path ()[n] = '\\';
+-	      this->modifiable_path ()[n + 1] = '\0';
++	      size_t n = strlen (this->path);
++	      /* Do not add trailing \ to UNC device names like \\.\a: */
++	      if (this->path[n - 1] != '\\' &&
++		  (strncmp (this->path, "\\\\.\\", 4) != 0))
++		{
++		  this->modifiable_path ()[n] = '\\';
++		  this->modifiable_path ()[n + 1] = '\0';
++		}
+ 	    }
+ 	}
+ 

--- a/msys2-runtime-3.3/0045-msys2_path_conv-pass-PC_NOFULL-to-path_conv.patch
+++ b/msys2-runtime-3.3/0045-msys2_path_conv-pass-PC_NOFULL-to-path_conv.patch
@@ -1,0 +1,38 @@
+From 68060d237a33743ce94c6c74a39475acfcfaa965 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Sun, 20 Nov 2022 13:57:36 +0100
+Subject: [PATCH 45/N] msys2_path_conv: pass PC_NOFULL to path_conv
+
+In theory this doesn't make a difference because posix_to_win32_path()
+is only called with rooted/absolute paths, but as pointed out in
+https://github.com/msys2/msys2-runtime/pull/103 PC_NOFULL will preserve
+the trailing slash of unix paths (for some reason).
+
+See "cygpath -m /bin/" (preserved) vs "cygpath -am /bin/" (dropped)
+
+One use case where we need to trailing slashes to be preserved is the GCC build
+system:
+https://github.com/gcc-mirror/gcc/blob/6d82e0fea5f988e829912a/gcc/Makefile.in#L2314
+
+The Makefile appends a slash to the prefixes and the C code doing relocation will
+treat the path as a directory if there is a trailing slash. See
+https://github.com/msys2/MINGW-packages/issues/14173 for details.
+
+With this change all our MSYS2 path_conv tests pass again.
+---
+ winsup/cygwin/msys2_path_conv.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/msys2_path_conv.cc b/winsup/cygwin/msys2_path_conv.cc
+index 2d401ca..b8f280b 100644
+--- a/winsup/cygwin/msys2_path_conv.cc
++++ b/winsup/cygwin/msys2_path_conv.cc
+@@ -622,7 +622,7 @@ void posix_to_win32_path(const char* from, const char* to, char** dst, const cha
+         strncpy(one_path, from, to-from);
+         one_path[to-from] = '\0';
+ 
+-        path_conv conv (one_path, 0);
++        path_conv conv (one_path, PC_NOFULL);
+         if (conv.error)
+         {
+           set_errno(conv.error);

--- a/msys2-runtime-3.3/PKGBUILD
+++ b/msys2-runtime-3.3/PKGBUILD
@@ -1,0 +1,268 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Ray Donnelly <mingw.android@gmail.com>
+
+pkgbase=msys2-runtime-3.3
+pkgname=('msys2-runtime-3.3' 'msys2-runtime-3.3-devel')
+pkgver=3.3.6
+pkgrel=1
+pkgdesc="Cygwin POSIX emulation engine"
+arch=('i686' 'x86_64')
+url="https://www.cygwin.com/"
+license=('GPL')
+makedepends=('cocom'
+             'git'
+             'perl'
+             'gcc'
+             'mingw-w64-cross-crt-git'
+             'mingw-w64-cross-gcc'
+             'mingw-w64-cross-zlib'
+             'zlib-devel'
+             'gettext-devel'
+             'libiconv-devel'
+             'autotools'
+             'xmlto'
+             'docbook-xsl')
+# re zipman: https://github.com/msys2/MSYS2-packages/pull/2687#issuecomment-965714874
+options=('!zipman')
+source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-${pkgver//./_}-release
+        0001-Add-MSYS2-triplet.patch
+        0002-Fix-msys-library-name-in-import-libraries.patch
+        0003-Rename-dll-from-cygwin-to-msys.patch
+        0004-Add-functionality-for-converting-UNIX-paths-in-argum.patch
+        0005-Add-functionality-for-changing-OS-name-via-MSYSTEM-e.patch
+        0006-Move-root-to-usr.-Change-sorting-mount-points.-By-de.patch
+        0007-Instead-of-creating-Cygwin-symlinks-use-deep-copy-by.patch
+        0008-Automatically-rewrite-TERM-msys-to-TERM-cygwin-With-.patch
+        0009-Do-not-convert-environment-for-strace.patch
+        0010-Special-case-for-converting-root-directory-to-have-t.patch
+        0011-dcrt0.cc-Untangle-allow_glob-from-winshell.patch
+        0012-dcrt0.cc-globify-Don-t-quote-literal-strings-differe.patch
+        0013-strace.cc-Don-t-set-MSYS-noglob.patch
+        0014-Add-debugging-for-build_argv.patch
+        0015-Add-debugging-for-strace-make_command_line.patch
+        0016-environ.cc-New-facility-environment-variable-MSYS2_E.patch
+        0017-Fix-native-symbolic-link-spawn-passing-wrong-arg0.patch
+        0018-QueryUnbiasedInterruptTime-must-be-load-from-kernel3.patch
+        0019-strace-quiet-be-really-quiet.patch
+        0020-Default-to-disable_pcon.patch
+        0021-Introduce-the-enable_pcon-value-for-MSYS.patch
+        0022-popen-call-usr-bin-sh-instead-of-bin-sh.patch
+        0023-CI-add-a-GHA-for-doing-a-basic-build-test.patch
+        0024-Set-up-a-GitHub-Action-to-keep-in-sync-with-Cygwin.patch
+        0025-Expose-full-command-lines-to-other-Win32-processes-b.patch
+        0026-Disable-the-cygwin-GitHub-workflow.patch
+        0027-Do-not-show-Error-dialogs-by-default.patch
+        0028-Add-a-helper-to-obtain-a-function-s-address-in-kerne.patch
+        0029-Emulate-GenerateConsoleCtrlEvent-upon-Ctrl-C.patch
+        0030-kill-kill-Win32-processes-more-gently.patch
+        0031-Cygwin-make-option-for-native-inner-link-handling.patch
+        0032-docs-skip-building-texinfo-and-PDF-files.patch
+        0033-install-libs-depend-on-the-toollibs.patch
+        0034-POSIX-ify-the-SHELL-variable.patch
+        0035-Handle-ORIGINAL_PATH-just-like-PATH.patch
+        0036-uname-allow-setting-the-system-name-to-CYGWIN.patch
+        0037-fixup-Revert-Default-to-disable_pcon.patch
+        0038-Pass-environment-variables-with-empty-values.patch
+        0039-Optionally-disallow-empty-environment-values-again.patch
+        0040-build_env-respect-the-MSYS-environment-variable.patch
+        0041-Cygwin-pty-Fix-Bad-address-error-when-running-cmd.ex.patch
+        0042-ci-avoid-using-Node.js-12-Actions.patch
+        0043-When-converting-to-a-Unix-path-avoid-double-trailing.patch
+        0044-amend-Special-case-for-converting-root-directory-to-.patch
+        0045-msys2_path_conv-pass-PC_NOFULL-to-path_conv.patch)
+sha256sums=('SKIP'
+            'c375315e58181ee5589b7966101aa095de3f864a579c3c3f0f0683595d4e428d'
+            '01ea2b131cf5a3b27fdbc458019eac14e45a36782ce3ce33e62328eefcd2d02e'
+            '475ddea4d86605ab097f98ec764951a9d647ea3100dea0e1620f57044ea4a114'
+            '6775247d7a213268bbb2315f764ebc9faf9967b70a95dbc6e9de53fe04142433'
+            '91e2a72a980aeefadc215cd36147c56666679bbcd68c60120278b6270454b710'
+            '54cd198f3ce3931884220c8938bd0f348e0889c20b36d110ded9302ec7364c34'
+            '31a4bcb985e03c45f16644a1604ebc649dc50586968050f8819035b84f80bcf3'
+            'e9cfe4d79ac294e19e648f51a8bb491231204d8eb9c6a2e998a7cc2506ca47ea'
+            '816e98ee5ad15d3cfb75598e2e20e11272ac6867a7bd9b0a3fea0ac0ba4daf69'
+            'e895d76936f4668bb7b67581ef642e845968dfb86e21d654dde98727f0ebabb2'
+            'f416f109d323618ff3d7240ea7845d5ab3221a8a6c6074e36a34e62fbaabdbfd'
+            'e710a9eed8bd767d97acb2d2cdc56eef880e02b20f1b14fdf462678954e3a896'
+            'ce72bc18fcf101d14c0623c1d459b141ba883934939c70d198d69932ec4873c7'
+            '5f5850cd725c4df6ce6cc86d07da1ed696e119d8bb80602380c4941aa10d0784'
+            '8df334362506dbe9de56017c0df1d3459b5c6e29860b73a5e9ebd0421b2f3a6a'
+            '988a2d365302c73ab482bd1f0d4edea8e687de7fdf068e5bec3aafaf33d63a58'
+            'f9aa893686405b8b92b3d585b7a7dff35f9345a64a282f75d8962e92f86bea25'
+            'b3073a6b2acf836f5b3286ff8be66633ed4f93280d50186635a3fcfb4cdc3745'
+            '52cd166461fc2cc3c880c174160516a93d456dad44f382aed518aa9bfa36303f'
+            'cee973f136152e6a5cd987bba85937584c9459aff1c2777134a99526b2d5512d'
+            '221dacc354d4f27443665bfe32b114235ef7305c55c9189c77f636c46522ee80'
+            'bd985989895e51688072d7751976ecb83720c8e0786126d7025ba355b64f6edc'
+            '0f9e96fab22bb5ea0d4d6dc4a943ab56f28c0dab675e57a75b892c491d51808b'
+            '61a9684bde1165f4afbf1ace3ddb873e6c8cc92e65930aff0c45e20b4d12a86a'
+            'a02f701e524e0508149e3f16296db4f76382482ff114b170a1cc136d3ad65b2d'
+            '205a6b56ab3bfa9209c3c1f89aac1491a75b6700e7656252f9afd84800bb3bc1'
+            '8f817df7130fdec6477a69ba77394183c0dd7d8c2edb133b680f3be542e2896f'
+            '5e7661cb53a050bc5470ea2d749d5e7524b02ae89dc929d17a9272508ddc6d4c'
+            '13bbe25b3b60791b327163109e697ba160a70f58d13684aa52ab9bac00d5a555'
+            '0b2c75b5f7e04c479d0a5ec7170e430e641b5449aa24232b5c3f073767a8fdbc'
+            '53e11ea902756768f8601fa243ed6602b54c30df514a652c0d8e15de245a46c3'
+            '1f03ce6418812425494695290711b7076c8678aeca36b2683ef0ec1875d1e0c3'
+            '25c1e568b9f03772ca7a1bce1c90b6a9e22d49e15b7b372a0921dcd0e66c98d2'
+            'bf0ff70c2ee6a4b9db7ed52154f5ba02d4a1d92cbfc2618ac86723c49156034f'
+            '658ee069e968c7def37300bb7058bb17cd6e079eb789fe86b3af0fe1ae86a4cb'
+            '59836bc012a3cf8dd245615f4cbeb4c3cb141434a30226c5e9647f265b589faf'
+            'de0e56d2f01f02f1d4014cade92b4c78a90fb85f2409846a932b57b3c6d0b213'
+            '30a3f2c7fba69aa9942f18f98c4289a8d89d6a6187f84a57895dbaa65f54d30e'
+            'fcf8caa3cab42f0ea228b8e3213238ce2354f13dea27289c6899b0a209ffd204'
+            '0e5ba38fa125822330b1842d487aee78126bf7ea503eb1fe970440cf1504f25f'
+            'd5f6913d0d1439973a3687b3ef8948b6859ec302c0f810e9343c7e44f9146176'
+            '65af62e9ca7870930b5d2b673f8eadfe3ce72c9672b8554790bd7dc65c0039dd'
+            '6d062c34feca04b5dbd38273f8bb7d270947a368ade550fdfc8b11f0daa1a17c'
+            '0454442f2ad3312df83ec86bf872b5ad0bc1c014ed13dad1fbac7dd8e8de8f7a'
+            '61276aec4c9b7132487fd1d91e6c5991a24909f24a6de0312f62f1f99608e9c0')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
+
+apply_git_am_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    git apply "${srcdir}/${_patch}"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"/msys2-runtime
+  if test true != "$(git config core.symlinks)"
+  then
+    git config core.symlinks true &&
+    /usr/bin/git reset --hard
+  fi
+  del_file_exists winsup/cygwin/msys2_path_conv.cc \
+    winsup/cygwin/msys2_path_conv.h
+ apply_git_am_with_msg 0001-Add-MSYS2-triplet.patch \
+  0002-Fix-msys-library-name-in-import-libraries.patch \
+  0003-Rename-dll-from-cygwin-to-msys.patch \
+  0004-Add-functionality-for-converting-UNIX-paths-in-argum.patch \
+  0005-Add-functionality-for-changing-OS-name-via-MSYSTEM-e.patch \
+  0006-Move-root-to-usr.-Change-sorting-mount-points.-By-de.patch \
+  0007-Instead-of-creating-Cygwin-symlinks-use-deep-copy-by.patch \
+  0008-Automatically-rewrite-TERM-msys-to-TERM-cygwin-With-.patch \
+  0009-Do-not-convert-environment-for-strace.patch \
+  0010-Special-case-for-converting-root-directory-to-have-t.patch \
+  0011-dcrt0.cc-Untangle-allow_glob-from-winshell.patch \
+  0012-dcrt0.cc-globify-Don-t-quote-literal-strings-differe.patch \
+  0013-strace.cc-Don-t-set-MSYS-noglob.patch \
+  0014-Add-debugging-for-build_argv.patch \
+  0015-Add-debugging-for-strace-make_command_line.patch \
+  0016-environ.cc-New-facility-environment-variable-MSYS2_E.patch \
+  0017-Fix-native-symbolic-link-spawn-passing-wrong-arg0.patch \
+  0018-QueryUnbiasedInterruptTime-must-be-load-from-kernel3.patch \
+  0019-strace-quiet-be-really-quiet.patch \
+  0020-Default-to-disable_pcon.patch \
+  0021-Introduce-the-enable_pcon-value-for-MSYS.patch \
+  0022-popen-call-usr-bin-sh-instead-of-bin-sh.patch \
+  0023-CI-add-a-GHA-for-doing-a-basic-build-test.patch \
+  0024-Set-up-a-GitHub-Action-to-keep-in-sync-with-Cygwin.patch \
+  0025-Expose-full-command-lines-to-other-Win32-processes-b.patch \
+  0026-Disable-the-cygwin-GitHub-workflow.patch \
+  0027-Do-not-show-Error-dialogs-by-default.patch \
+  0028-Add-a-helper-to-obtain-a-function-s-address-in-kerne.patch \
+  0029-Emulate-GenerateConsoleCtrlEvent-upon-Ctrl-C.patch \
+  0030-kill-kill-Win32-processes-more-gently.patch \
+  0031-Cygwin-make-option-for-native-inner-link-handling.patch \
+  0032-docs-skip-building-texinfo-and-PDF-files.patch \
+  0033-install-libs-depend-on-the-toollibs.patch \
+  0034-POSIX-ify-the-SHELL-variable.patch \
+  0035-Handle-ORIGINAL_PATH-just-like-PATH.patch \
+  0036-uname-allow-setting-the-system-name-to-CYGWIN.patch \
+  0037-fixup-Revert-Default-to-disable_pcon.patch \
+  0038-Pass-environment-variables-with-empty-values.patch \
+  0039-Optionally-disallow-empty-environment-values-again.patch \
+  0040-build_env-respect-the-MSYS-environment-variable.patch \
+  0041-Cygwin-pty-Fix-Bad-address-error-when-running-cmd.ex.patch \
+  0042-ci-avoid-using-Node.js-12-Actions.patch \
+  0043-When-converting-to-a-Unix-path-avoid-double-trailing.patch \
+  0044-amend-Special-case-for-converting-root-directory-to-.patch \
+  0045-msys2_path_conv-pass-PC_NOFULL-to-path_conv.patch
+}
+
+build() {
+  [[ -d "${srcdir}"/build-${CHOST} ]] && rm -rf "${srcdir}"/build-${CHOST}
+  mkdir -p "${srcdir}"/build-${CHOST} && cd "${srcdir}"/build-${CHOST}
+
+  # Gives more verbose compile output when debugging.
+  local -a extra_config
+  if check_option "debug" "y"; then
+    export CCWRAP_VERBOSE=1
+    OPTIM="-O0"
+    extra_config+=(--enable-debugging)
+  else
+    OPTIM="-O2"
+  fi
+
+  CFLAGS="$OPTIM -pipe -ggdb -Wno-error=deprecated -Wno-error=stringop-truncation -Wno-error=missing-attributes -Wno-error=maybe-uninitialized" #-Wno-error=class-memaccess
+  CXXFLAGS="$OPTIM -pipe -ggdb -Wno-error=deprecated -Wno-error=stringop-truncation -Wno-error=missing-attributes -Wno-error=maybe-uninitialized" #-Wno-error=class-memaccess
+
+  (cd "${srcdir}/msys2-runtime/winsup" && ./autogen.sh)
+
+  "${srcdir}"/msys2-runtime/configure \
+    --prefix=/usr \
+    --build=${CHOST} \
+    --sysconfdir=/etc \
+    "${extra_config[@]}"
+  LC_ALL=C make
+  LC_ALL=C make -j1 DESTDIR="${srcdir}"/dest install
+
+  rm -rf "${srcdir}"/dest/etc
+}
+
+package_msys2-runtime-3.3() {
+  pkgdesc="Posix emulation engine for Windows"
+  options=('!strip')
+  provides=("msys2-runtime=${pkgver}")
+  conflicts=('catgets' 'libcatgets' 'msys2-runtime')
+  replaces=('catgets' 'libcatgets')
+
+  mkdir -p "${pkgdir}"/usr
+  cp -rf "${srcdir}"/dest/usr/bin "${pkgdir}"/usr/
+  cp -rf "${srcdir}"/dest/usr/libexec "${pkgdir}"/usr/
+  rm -f "${pkgdir}"/usr/bin/msys-2.0.dbg
+  rm -f "${pkgdir}"/usr/bin/cyglsa-config
+  rm -f "${pkgdir}"/usr/bin/cyglsa.dll
+  rm -f "${pkgdir}"/usr/bin/cyglsa64.dll
+  rm -f "${pkgdir}"/usr/bin/cygserver-config
+  cp -rf "${srcdir}"/dest/usr/share "${pkgdir}"/usr/
+}
+
+package_msys2-runtime-3.3-devel() {
+  pkgdesc="MSYS2 headers and libraries"
+  depends=("msys2-runtime=${pkgver}")
+  provides=("msys2-runtime-devel=${pkgver}")
+  options=('staticlibs' '!strip')
+  conflicts=('libcatgets-devel' 'msys2-runtime-devel')
+  replaces=('libcatgets-devel')
+
+  mkdir -p "${pkgdir}"/usr/bin
+  cp -f "${srcdir}"/dest/usr/bin/msys-2.0.dbg "${pkgdir}"/usr/bin/
+  cp -rLf "${srcdir}"/dest/usr/${CHOST}/include "${pkgdir}"/usr/
+  rm -f "${pkgdir}"/usr/include/iconv.h
+  rm -f "${pkgdir}"/usr/include/unctrl.h
+  # provided by libtirpc
+  rm -fr "${pkgdir}"/usr/include/rpc/
+
+  cp -rLf "${srcdir}"/dest/usr/${CHOST}/lib "${pkgdir}"/usr/
+}

--- a/msys2-runtime-3.3/README.md
+++ b/msys2-runtime-3.3/README.md
@@ -1,0 +1,4 @@
+The patches for this package are auto generated and managed in git:
+https://github.com/msys2/Cygwin
+
+Run `./update-patches.sh` to re-create the patches.

--- a/msys2-runtime-3.3/update-patches.sh
+++ b/msys2-runtime-3.3/update-patches.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+
+die () {
+	echo "$*" >&2
+	exit 1
+}
+
+cd "$(dirname "$0")" ||
+die "Could not cd to msys2-runtime/"
+
+git rev-parse --verify HEAD >/dev/null &&
+git update-index -q --ignore-submodules --refresh &&
+git diff-files --quiet --ignore-submodules &&
+git diff-index --cached --quiet --ignore-submodules HEAD -- ||
+die "Clean worktree required"
+
+git rm 0*.patch ||
+die "Could not remove previous patches"
+
+base_tag=refs/tags/cygwin-"$(sed -ne 'y/./_/' -e 's/^pkgver=//p' <PKGBUILD)"-release
+msys2_branch=refs/heads/msys2-${base_tag#refs/tags/cygwin-}
+url=https://github.com/msys2/Cygwin
+
+test -d msys2-runtime ||
+git clone --bare $url msys2-runtime ||
+die "Could not clone msys2-runtime"
+
+git -C msys2-runtime fetch --no-tags $url $base_tag:$base_tag $msys2_branch:$msys2_branch
+
+git -c core.abbrev=7 \
+	-c diff.renames=true \
+	-c format.from=false \
+	-c format.numbered=auto \
+	-c format.useAutoBase=false \
+	-C msys2-runtime \
+	format-patch \
+		--no-signature \
+		--topo-order \
+		--diff-algorithm=default \
+		--no-attach \
+		--no-add-header \
+		--no-cover-letter \
+		--no-thread \
+		--suffix=.patch \
+		--subject-prefix=PATCH \
+		--output-directory .. \
+			$base_tag..$msys2_branch ||
+die "Could not generate new patch set"
+
+patches="$(ls -1 0*.patch)" &&
+for p in $patches
+do
+	sed -i 's/^\(Subject: \[PATCH [0-9]*\/\)[1-9][0-9]*/\1N/' $p ||
+	die "Could not fix Subject: line in $p"
+done &&
+git add $patches ||
+die "Could not stage new patch set"
+
+in_sources="$(echo "$patches" | sed "{s/^/        /;:1;N;s/\\n/\\\\n        /;b1}")"
+in_prepare="$(echo "$patches" | tr '\n' '\\' | sed -e 's/\\$//' -e 's/\\/ &&&n  /g')"
+sed -i -e "/^        0.*\.patch$/{:1;N;/[^)]$/b1;s|.*|$in_sources)|}" \
+	-e "/^ *apply_git_am_with_msg /{:2;N;/[^}]$/b2;s|.*| apply_git_am_with_msg $in_prepare\\n\\}|}" \
+	PKGBUILD ||
+die "Could not update the patch set in PKGBUILD"
+
+if git rev-parse --verify HEAD >/dev/null &&
+	git update-index -q --ignore-submodules --refresh &&
+	git diff-files --quiet --ignore-submodules &&
+	git diff-index --cached --quiet --ignore-submodules HEAD --
+then
+	echo "Already up to date!" >&2
+	exit 0
+fi
+
+updpkgsums ||
+die "Could not update the patch set checksums in PKGBUILD"
+
+# bump pkgrel
+if ! git diff @{u} -- PKGBUILD | grep -q '^+pkgver'
+then
+	pkgrel=$((1+$(sed -n -e 's/^pkgrel=//p' <PKGBUILD))) &&
+	sed -i -e "s/^\(pkgrel=\).*/\1$pkgrel/" PKGBUILD ||
+	die "Could not increment pkgrel"
+fi
+
+git add PKGBUILD ||
+die "Could not stage updates in PKGBUILD"


### PR DESCRIPTION
Provides and conflicts with msys2-runtime, so can be used to replace it if wanted.

Keep this as a separate package to test for regressions in cygwin and to have (in theory) a runtime that supports 32bit in the repo.

There is no guarantee for how long we are going to keep this.