### PR TITLE
wget: switch from openssl to gnutls

### DIFF
--- a/wget/PKGBUILD
+++ b/wget/PKGBUILD
@@ -2,14 +2,14 @@
 
 pkgname=wget
 pkgver=1.21.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A network utility to retrieve files from the Web"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/wget/"
 license=('GPL3')
-depends=('gcc-libs' 'libiconv' 'libidn2' 'libintl' 'libgpgme' 'libpcre2_8' 'libpsl' 'libuuid' 'openssl' 'zlib')
+depends=('gcc-libs' 'libiconv' 'libidn2' 'libintl' 'libgpgme' 'libpcre2_8' 'libpsl' 'libuuid' 'libgnutls' 'zlib')
 makedepends=('autoconf-archive' 'gettext-devel' 'libidn2-devel' 'libgpgme-devel' 'libuuid-devel'
-             'libpsl-devel' 'openssl-devel' 'pcre2-devel' 'zlib-devel' 'python' 'libunistring-devel' 'autotools' 'gcc')
+             'libpsl-devel' 'libgnutls-devel' 'pcre2-devel' 'zlib-devel' 'python' 'libunistring-devel' 'autotools' 'gcc')
 checkdepends=('perl-HTTP-Daemon' 'perl-IO-Socket-SSL')
 optdepends=('ca-certificates: HTTPS downloads')
 backup=('etc/wgetrc')
@@ -37,7 +37,7 @@ build() {
     --prefix=/usr \
     --sysconfdir=/etc \
     --localstatedir=/var \
-    --with-ssl=openssl \
+    --with-ssl=gnutls \
     --with-libpsl \
     --without-libiconv-prefix \
     --without-libintl-prefix \


### PR DESCRIPTION
This follows what Arch/Fedora/Debian do:
https://github.com/archlinux/svntogit-packages/commit/b9ffaf59269e655fb4b4

This also avoids any potential openssl v3 compat issues