### PR TITLE
python-yaml: Update to 6.0

### DIFF
--- a/python-yaml/PKGBUILD
+++ b/python-yaml/PKGBUILD
@@ -4,41 +4,43 @@ _pyname=PyYAML
 _realname=yaml
 pkgbase=python-${_realname}
 pkgname=("python-${_realname}")
-pkgver=5.3.1
-pkgrel=4
+pkgver=6.0
+pkgrel=1
 pkgdesc='Python bindings for YAML, using fast libYAML library'
 arch=('i686' 'x86_64')
 url='https://pyyaml.org/'
-license=('MIT')
+license=('spdx:MIT')
 depends=('python' 'libyaml')
-makedepends=('cython' 'python-setuptools' 'libyaml-devel' 'python-devel' 'gcc')
-options=('staticlibs' 'strip' '!debug')
-source=("https://pyyaml.org/download/pyyaml/${_pyname}-${pkgver}.tar.gz")
-install=python-yaml.install
-sha512sums=('87372877d396bd06cdb6b9052ef8822ef0589a211659bf27d7a1c4deca8429cb39e120a23e5d590d7adc0f8059ce1c8af42409bebd7c6d504d49dc8504d5683a')
+makedepends=(
+  'python-build'
+  'python-installer'
+  'cython'
+  'python-setuptools'
+  'python-wheel'
+  'libyaml-devel'
+  'python-devel'
+  'gcc'
+)
+source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
+sha256sums=('68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2')
 
-prepare() {
-  # Force cython rebuild
-  rm ${_pyname}-${pkgver}/ext/_yaml.c
-  rm -rf python-build-${CARCH} | true
-  cp -r "${_pyname}-${pkgver}" "python-build-${CARCH}"
-}
+build() {
+  cd "${_pyname}-${pkgver}"
 
-build() {  
-  msg "Python build for ${CARCH}"  
-  cd "${srcdir}/python-build-${CARCH}"
-  /usr/bin/python setup.py --with-libyaml build
+  python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
-  msg "Python test for ${CARCH}"
-  cd "${srcdir}/python-build-${CARCH}"
-  /usr/bin/python setup.py test
+  cd "${_pyname}-${pkgver}"
+
+  python setup.py test
 }
 
 package() {
-  cd "${srcdir}/python-build-${CARCH}"
-  /usr/bin/python setup.py --with-libyaml install --root="${pkgdir}" --optimize=1 --skip-build
+  cd "${_pyname}-${pkgver}"
+
+  python -m installer --destdir="${pkgdir}" dist/*.whl
+
   install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/python-${_realname}/COPYING"
-  install -Dm644 CHANGES README -t "${pkgdir}/usr/share/doc/python-${_realname}"
+  install -Dm644 CHANGES README.md -t "${pkgdir}/usr/share/doc/python-${_realname}"
 }

--- a/python-yaml/python-yaml.install
+++ b/python-yaml/python-yaml.install
@@ -1,7 +1,0 @@
-post_install() {
-  cat << EOT
-==> Note that even though this package uses libyaml library,
-==> slower pure python implementation is used by default.
-==> See https://pyyaml.org/wiki/PyYAMLDocumentation
-EOT
-}


### PR DESCRIPTION
port to build/installer
drop install file - the warning isn't msys2 specific, that's how the package works.