### PR TITLE
msys2-runtime: disable dynamicbase again

### DIFF
--- a/msys2-runtime/1001-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch
+++ b/msys2-runtime/1001-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch
@@ -1,0 +1,28 @@
+From 83ad226237e22c1a6e87da88ca017b3ccb38b0f0 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Sat, 17 Dec 2022 20:14:49 +0100
+Subject: [PATCH] Revert "Cygwin: Enable dynamicbase on the Cygwin DLL by
+ default"
+
+This reverts commit 943433b00cacdde0cb9507d0178770a2fb67bd71.
+---
+ winsup/cygwin/Makefile.am | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/winsup/cygwin/Makefile.am b/winsup/cygwin/Makefile.am
+index 673bb7b5e4..ec782dc6b9 100644
+--- a/winsup/cygwin/Makefile.am
++++ b/winsup/cygwin/Makefile.am
+@@ -585,8 +585,7 @@ $(NEW_DLL_NAME): $(LDSCRIPT) libdll.a $(VERSION_OFILES) $(LIBSERVER)\
+ 		  $(newlib_build)/libm.a $(newlib_build)/libc.a
+ 	$(AM_V_CXXLD)$(CXX) $(CXXFLAGS) \
+ 	-mno-use-libstdc-wrappers \
+-	-Wl,--gc-sections -nostdlib -Wl,-T$(LDSCRIPT) \
+-	-Wl,--dynamicbase -static \
++	-Wl,--gc-sections -nostdlib -Wl,-T$(LDSCRIPT) -static \
+ 	-Wl,--heap=0 -Wl,--out-implib,msysdll.a -shared -o $@ \
+ 	-e @DLL_ENTRY@ $(DEF_FILE) \
+ 	-Wl,-whole-archive libdll.a -Wl,-no-whole-archive \
+-- 
+2.39.0
+

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.4.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -25,6 +25,7 @@ makedepends=('cocom'
 # re zipman: https://github.com/msys2/MSYS2-packages/pull/2687#issuecomment-965714874
 options=('!zipman')
 source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-${pkgver}
+        1001-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch
         0001-Add-MSYS2-triplet.patch
         0002-Fix-msys-library-name-in-import-libraries.patch
         0003-Rename-dll-from-cygwin-to-msys.patch
@@ -62,6 +63,7 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0035-When-converting-to-a-Unix-path-avoid-double-trailing.patch
         0036-msys2_path_conv-pass-PC_NOFULL-to-path_conv.patch)
 sha256sums=('SKIP'
+            '350b0322efb826f5975f8dd7693e83ab06f8a62f0f730bcde962698faf9b40ff'
             '26fce1982a4f7e932fe302ca053d4bcf1fbe19a91c54ba5e611f7850d16f795e'
             'd99c884591a640e018f4a03f9b67e04e73cb33998ad0a8c9dd40373383e99c9b'
             '2509540dcd0669f31fc943c37f03021694638a5507666f20ca9dcdf83e3eac7b'
@@ -171,6 +173,8 @@ prepare() {
   0034-build_env-respect-the-MSYS-environment-variable.patch \
   0035-When-converting-to-a-Unix-path-avoid-double-trailing.patch \
   0036-msys2_path_conv-pass-PC_NOFULL-to-path_conv.patch
+
+  git apply "${srcdir}/1001-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch"
 }
 
 build() {


### PR DESCRIPTION
We are seeing fork errors in Docker, which might be related to 3.4.x setting dynamicbase. Let's see if reverting that helps.