### PR TITLE
openssl: disable cleanup in DLL_THREAD_DETACH

### DIFF
--- a/openssl/0005-skip-dllmain-detach.patch
+++ b/openssl/0005-skip-dllmain-detach.patch
@@ -1,0 +1,24 @@
+--- openssl-3.0.7/crypto/dllmain.c.orig	2022-12-22 12:52:31.011614800 +0100
++++ openssl-3.0.7/crypto/dllmain.c	2022-12-22 12:52:32.210778100 +0100
+@@ -35,7 +35,9 @@
+     case DLL_THREAD_ATTACH:
+         break;
+     case DLL_THREAD_DETACH:
++# ifndef __CYGWIN__
+         OPENSSL_thread_stop();
++# endif
+         break;
+     case DLL_PROCESS_DETACH:
+         break;
+--- openssl-3.0.7/providers/fips/self_test.c.orig	2022-12-22 12:51:17.776136100 +0100
++++ openssl-3.0.7/providers/fips/self_test.c	2022-12-22 12:51:26.809452500 +0100
+@@ -96,7 +96,9 @@
+         init();
+         break;
+     case DLL_PROCESS_DETACH:
++# ifndef __CYGWIN__
+         cleanup();
++# endif
+         break;
+     default:
+         break;

--- a/openssl/PKGBUILD
+++ b/openssl/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('openssl' 'libopenssl' 'openssl-devel' 'openssl-docs')
 pkgver=3.0.7
-pkgrel=1
+pkgrel=2
 pkgdesc='The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
 arch=('i686' 'x86_64')
 url='https://www.openssl.org'
@@ -13,12 +13,14 @@ noextract=(${pkgname}-${pkgver}.tar.gz)
 source=("https://www.openssl.org/source/${pkgname}-${pkgver}.tar.gz"{,.asc}
         '0001-Use-usr-ssl-as-ca-dir-instead-of-.-demoCA.patch'
         '0002-Support-MSYS2.patch'
-        '0004-Override-engines-directory.patch')
+        '0004-Override-engines-directory.patch'
+        '0005-skip-dllmain-detach.patch')
 sha256sums=('83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e'
             'SKIP'
             '7ff3213d8d085238695f076d254f16d15b16a9baca1f9393c1bed0057006da2c'
             'b73a45cf26830bbb3c110a8f9e042ea5c71a9627204d5d172b04c43aff5b0f1a'
-            '345350546bf55dd069133e0c56b2c5f7e037db237a30f7ad38159bd61b6d4daf')
+            '345350546bf55dd069133e0c56b2c5f7e037db237a30f7ad38159bd61b6d4daf'
+            '79b56c97da803493eb9bbc04dc67ddf3662a8486efb9ec7b15e668b8c0fa4e0f')
 # https://www.openssl.org/community/otc.html
 validpgpkeys=(
   '8657ABB260F056B1E5190839D9C4D26D0E604491' # Matt Caswell <matt@openssl.org>
@@ -34,6 +36,12 @@ prepare() {
   patch -p1 -i ${srcdir}/0001-Use-usr-ssl-as-ca-dir-instead-of-.-demoCA.patch
   patch -p1 -i ${srcdir}/0002-Support-MSYS2.patch
   patch -p1 -i ${srcdir}/0004-Override-engines-directory.patch
+
+  # For example "meson test" crashes without this, see
+  # https://github.com/msys2/MSYS2-packages/issues/3013#issuecomment-1362734102
+  # https://cygwin.com/pipermail/cygwin/2011-March/194454.html
+  # (but this was never patched in cygwin from what I see)
+  patch -p1 -i ${srcdir}/0005-skip-dllmain-detach.patch
 }
 
 build() {


### PR DESCRIPTION
openssl/cygwin crashes when pthread APIs are called in DllMain:

0  0x0000000000000000 in ?? ()
1  0x00000001801619bd in pthread_rwlock_wrlock (rwlock=0x800275ff0)
   at /c/S/msys2-runtime-3.3/src/msys2-runtime/winsup/cygwin/thread.cc:3228
2  0x000000018019905b in _sigfe () at sigfe.s:35
3  0x00000004358490c9 in CRYPTO_THREAD_write_lock () from /usr/bin/msys-crypto-3.dll 4  0x000000043583c414 in init_thread_remove_handlers () from /usr/bin/msys-crypto-3.dll 5  0x000000043583c843 in OPENSSL_thread_stop () from /usr/bin/msys-crypto-3.dll 6  0x000000043583a953 in DllMain () from /usr/bin/msys-crypto-3.dll

It can be reliably reproduced by calling "meson test", which spawns threads for tests.

Something similar was discussed on the cygwin mailing list years ago, and it seems nothing has changed/improved there, and with openssl v3 it always crashes:

https://cygwin.com/pipermail/cygwin/2011-March/194454.html

Let's do what corinna suggested there, skip OPENSSL_thread_stop() under cygwin. This is a hacky workaround, but better to leak things then to crash.