### PR TITLE
opensp: autoreconf

### DIFF
--- a/opensp/PKGBUILD
+++ b/opensp/PKGBUILD
@@ -1,14 +1,19 @@
 pkgname=opensp
 pkgver=1.5.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A library and a set of tools for validating, parsing and manipulating SGML and XML documents"
 arch=('i686' 'x86_64')
 url="http://openjade.sourceforge.net/"
 license=('spdx:MIT')
 depends=('sgml-common' 'perl')
-makedepends=('xmlto' 'docbook-xsl' 'autotools' 'gcc')
+makedepends=('xmlto' 'docbook-xsl' 'autotools' 'gettext-devel' 'gcc')
 source=("https://downloads.sourceforge.net/project/openjade/opensp/$pkgver/OpenSP-$pkgver.tar.gz")
 sha256sums=('57f4898498a368918b0d49c826aa434bb5b703d2c3b169beb348016ab25617ce')
+
+prepare() {
+  cd OpenSP-$pkgver
+  autoreconf -fiv
+}
 
 build() {
   cd OpenSP-$pkgver


### PR DESCRIPTION
For some reason, libtool was screwing up when I tried to build this for 32-bit msys2, even though it apparently built fine on 64-bit msys2. autoreconf to get updated (and presumably bugfixed) libtool files.