### PR TITLE
base-devel: remove groff

### DIFF
--- a/base-devel/PKGBUILD
+++ b/base-devel/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
 
 pkgname=base-devel
-pkgver=2022.01
-pkgrel=2
+pkgver=2022.12
+pkgrel=1
 pkgdesc='Minimal package set for building packages with makepkg'
 url='https://www.msys2.org'
 arch=('any')
@@ -20,7 +20,6 @@ depends=(
   'gettext'
   'gperf'
   'grep'
-  'groff'
   'texinfo'
   'texinfo-tex'
   'make'

--- a/coreutils/PKGBUILD
+++ b/coreutils/PKGBUILD
@@ -8,7 +8,7 @@ arch=('i686' 'x86_64')
 license=('GPL3')
 url="https://www.gnu.org/software/coreutils"
 depends=('gmp' 'libiconv' 'libintl')
-makedepends=('gmp-devel' 'libiconv-devel' 'gettext-devel' 'help2man' 'autotools' 'gcc')
+makedepends=('groff' 'gmp-devel' 'libiconv-devel' 'gettext-devel' 'help2man' 'autotools' 'gcc')
 source=(https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz{,.sig}
         001-coreutils-8.30.patch
         002-coreutils-8.32-enable-stdbuf.patch

--- a/cvs/PKGBUILD
+++ b/cvs/PKGBUILD
@@ -8,7 +8,7 @@ arch=('i686' 'x86_64')
 license=('GPL')
 url="http://cvs.nongnu.org/"
 depends=('heimdal' 'zlib' 'libcrypt' 'libopenssl')
-makedepends=('heimdal-devel' 'zlib-devel' 'gcc' 'libcrypt-devel' 'openssl-devel' 'autotools')
+makedepends=('groff' 'heimdal-devel' 'zlib-devel' 'gcc' 'libcrypt-devel' 'openssl-devel' 'autotools')
 options=('staticlibs')
 source=(https://ftp.gnu.org/non-gnu/cvs/source/stable/${pkgver}/${pkgname}-${pkgver}.tar.bz2
     cvs-1.11.1p1-bs.patch

--- a/gettext/PKGBUILD
+++ b/gettext/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc="GNU internationalization library"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/gettext/"
 license=('GPL')
-makedepends=('libiconv-devel' 'autotools' 'gcc')
+makedepends=('groff' 'libiconv-devel' 'autotools' 'gcc')
 options=(!docs)
 source=(https://ftp.gnu.org/pub/gnu/gettext/${pkgname}-${pkgver}.tar.gz{,.sig}
         gettext-0.18.1.1-autopoint-V.patch

--- a/zsh/PKGBUILD
+++ b/zsh/PKGBUILD
@@ -7,7 +7,7 @@ pkgrel=2
 arch=('i686' 'x86_64')
 url='https://www.zsh.org/'
 license=('custom')
-makedepends=('ncurses-devel' 'pcre-devel' 'libiconv-devel' 'libgdbm-devel' 'autotools' 'gcc')
+makedepends=('ncurses-devel' 'pcre-devel' 'libiconv-devel' 'libgdbm-devel' 'autotools' 'gcc' 'groff')
 source=("https://www.zsh.org/pub/zsh-${pkgver}.tar.xz"{,.asc}
         "https://www.zsh.org/pub/zsh-${pkgver}-doc.tar.xz"{,.asc}
         'zprofile'


### PR DESCRIPTION
Not many packages need it, so try to move it to explicit
makedepends instead.