### PR TITLE
pax: rebuild

### DIFF
--- a/pax/PKGBUILD
+++ b/pax/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=pax
 pkgver=20201030
-pkgrel=1
+pkgrel=2
 pkgdesc="Portable Archive Interchange - the POSIX standard archive tool for cpio and tar formats"
 arch=('i686' 'x86_64')
 url="https://www.mirbsd.org/pax.htm"
@@ -11,7 +11,7 @@ provides=("${pkgname}-git")
 conflicts=("${pkgname}-git")
 replaces=("${pkgname}-git")
 makedepends=('gcc')
-source=("https://www.mirbsd.org/MirOS/dist/mir/cpio/paxmirabilis-${pkgver}.cpio.gz")
+source=("http://www.mirbsd.org/MirOS/dist/mir/cpio/paxmirabilis-${pkgver}.cpio.gz")
 noextract=("paxmirabilis-${pkgver}.cpio.gz")
 sha256sums=('fe3f99c28ba7a46c4bce0b329da3742908b87fe8fbe17f0db1f99a1bd053d46b')
 


### PR DESCRIPTION
switch to http since the upstream TLS setup is no longer supported by openssl