### PR TITLE
filesystem: drop agm2 function

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -4,8 +4,8 @@
 # Contributor: Alethea Rose <alethea@alethearose.com>
 
 pkgname=filesystem
-pkgver=2022.01
-pkgrel=7
+pkgver=2023.01
+pkgrel=1
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -60,7 +60,7 @@ sha256sums=('742a7d66b7a5ebd2b8461728c5b44a46b2305fd2116208eecae5f45828938ea0'
             '6dbc86dd88d0dfbe69271e3f49095135fde755ac6e454bc6a984ec081a1e2258'
             '602d7075b29cf5ed00de83fe010fcae4f0ad7c3321f5a2563a096b2eaf027c06'
             'f327a822ef33e5d39e94af0419a9083a3e2cbb0d8bff4070453403f68bb6351b'
-            '5a51474700064f5c4527e4423a866ac957332f7e932675ab5fa6a419b47b1834'
+            '0e3f00cb2cc7778a1fb5440fc979cfeeafeca72c3059dd474f38ed6b99b46070'
             '387ca1e86c1a18a143eb077ca194ad44c0a2faf98795a0d437f2d210d5a6df18'
             'f8f1b5943d385e8a7e3b5a4a2c7d64004108c94c17b2f936016e2ae50bdb65af'
             '91b4a790aad38a102565f0cfcba6c0e6d274f6cda0b37b128d9cc43c5ad6b24d'

--- a/filesystem/dot.profile
+++ b/filesystem/dot.profile
@@ -27,26 +27,3 @@ if [ -n "${BASH_VERSION}" ]; then
     source "${HOME}/.bashrc"
   fi
 fi
-
-agm2() {
-  local MINGW_DIRS="mingw32 mingw64"
-  local AG_FIND=
-  
-  for dir in ${MINGW_DIRS}; do
-    if type -p /${dir}/bin/ag >/dev/null; then
-      AG_FIND=/${dir}/bin/ag
-    fi
-  done
-  
-  if ! type -p /usr/bin/git >/dev/null; then
-    echo "bash: git: command not found. Please install \"git\" package."
-    exit 1
-  fi
-  
-  if [ -n "$AG_FIND" ]; then
-    $AG_FIND --makepkg --depth 1 "$@" $(git rev-parse --show-toplevel)
-  else
-    echo "bash: ag: conmmand not found. Please install \"mingw-w64-i686-ag\" or \"mingw-w64-x86_64-ag\" package."
-    exit 1
-  fi
-}


### PR DESCRIPTION
This was added in e259adce916745c3934

(1) this isn't executed if bash_profile exists, which is the default and (2) I don't think we should include msys2 development related functions here