### PR TITLE
msys2-runtime: explicitely set a runtime version

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -73,7 +73,7 @@ for package in "${packages[@]}"; do
 
         echo "::group::[uninstall] ${pkgname}"
         message "Uninstalling $pkgname"
-        pacman -R --recursive --unneeded --noconfirm --noprogressbar "$pkgname"
+        grep -qFx "${package}" "$DIR/ci-dont-install-list.txt" || pacman -R --recursive --unneeded --noconfirm --noprogressbar "$pkgname"
         echo "::endgroup::"
     done
     cd - > /dev/null

--- a/.ci/ci-dont-install-list.txt
+++ b/.ci/ci-dont-install-list.txt
@@ -1,4 +1,3 @@
 msys2-runtime
 msys2-runtime-3.3
-msys2-runtime-3.4
 bash

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.4.3
-pkgrel=4
+pkgrel=5
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -192,6 +192,9 @@ build() {
 
   CFLAGS="$OPTIM -pipe -ggdb -Wno-error=deprecated -Wno-error=stringop-truncation -Wno-error=missing-attributes -Wno-error=maybe-uninitialized" #-Wno-error=class-memaccess
   CXXFLAGS="$OPTIM -pipe -ggdb -Wno-error=deprecated -Wno-error=stringop-truncation -Wno-error=missing-attributes -Wno-error=maybe-uninitialized" #-Wno-error=class-memaccess
+
+  # otherwise it asks git which appends "-dirty" because of our uncommited patches
+  CFLAGS+=" -DCYGPORT_RELEASE_INFO=${pkgver}"
 
   (cd "${srcdir}/msys2-runtime/winsup" && ./autogen.sh)
 


### PR DESCRIPTION
so we get "3.4.3.x86_64" instead of "3.4.3-dirty.x86_64"