### PR TITLE
ca-certificates: just call update-ca-trust in the install script

### DIFF
--- a/ca-certificates/PKGBUILD
+++ b/ca-certificates/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=ca-certificates
 pkgver=20211016
-pkgrel=2
+pkgrel=3
 pkgdesc='Common CA certificates'
 arch=('any')
 url='https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/'

--- a/ca-certificates/ca-certificates.install
+++ b/ca-certificates/ca-certificates.install
@@ -1,25 +1,7 @@
-export LC_ALL=C
-
 post_install() {
-  local DEST=etc/pki/ca-trust/extracted
-
-  # OpenSSL PEM bundle that includes trust flags
-  # (BEGIN TRUSTED CERTIFICATE)
-  usr/bin/p11-kit extract --format=openssl-bundle --filter=certificates --overwrite --comment $DEST/openssl/ca-bundle.trust.crt
-  usr/bin/p11-kit extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose server-auth $DEST/pem/tls-ca-bundle.pem
-  usr/bin/p11-kit extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose email $DEST/pem/email-ca-bundle.pem
-  usr/bin/p11-kit extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose code-signing $DEST/pem/objsign-ca-bundle.pem
-  usr/bin/p11-kit extract --format=java-cacerts --filter=ca-anchors --overwrite --purpose server-auth $DEST/java/cacerts
-
-  mkdir -p usr/ssl/certs
-  cp -f $DEST/pem/tls-ca-bundle.pem usr/ssl/certs/ca-bundle.crt
-  cp -f $DEST/pem/tls-ca-bundle.pem usr/ssl/cert.pem
-  cp -f $DEST/openssl/ca-bundle.trust.crt usr/ssl/certs/ca-bundle.trust.crt
-
-  #usr/bin/update-ca-trust >/dev/null 2>&1
+  usr/bin/update-ca-trust
 }
 
 post_upgrade() {
   post_install
 }
-


### PR DESCRIPTION
currently the install script is more or less a copy of update-ca-trust, so to simplify things just call update-ca-trust in the install script