### PR TITLE
readline: add etc/inputrc

### DIFF
--- a/readline/PKGBUILD
+++ b/readline/PKGBUILD
@@ -5,15 +5,15 @@ pkgname=('libreadline' 'libreadline-devel')
 _basever=8.2
 _patchlevel=001 #prepare for some patches
 pkgver=${_basever}.${_patchlevel}
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU readline library"
 arch=('i686' 'x86_64')
 url="https://tiswww.case.edu/php/chet/readline/rltop.html"
 license=('GPL')
 makedepends=('ncurses-devel' 'autotools' 'gcc')
-#backup=('etc/inputrc')
 options=('!emptydirs')
 source=(https://ftp.gnu.org/gnu/readline/readline-${_basever}.tar.gz{,.sig}
+        inputrc
         readline-7.0.3-3.clipboard.patch
         readline-7.0.3-3.src.patch
         readline-6.3-msys2.patch
@@ -25,6 +25,7 @@ if [ $_patchlevel -gt 0 ]; then
 fi
 sha256sums=('3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35'
             'SKIP'
+            '6ff0b86e0b98f453b3ce06270c649ef336e2b881be0bc7dd8f5d470afbdac75e'
             '2f5e37a3260e61de1300b6467bff0c4561f45dbfde187f996981007602098774'
             'cdb4f97d641acde59ada6f22141e6a6743f756fc183f5cb43d6c9f8ae563da29'
             '96d002c8815b29ed5dbe89d9b251182c6e60111acc3d236acb8d1bbb2f896457'
@@ -83,10 +84,13 @@ build() {
 package_libreadline() {
   depends=('ncurses')
   groups=('libraries')
+  backup=('etc/inputrc')
 
   mkdir -p ${pkgdir}/usr
   cp -rf ${srcdir}/dest/usr/bin ${pkgdir}/usr/
   cp -rf ${srcdir}/dest/usr/share ${pkgdir}/usr/
+
+  install -Dm644 inputrc "${pkgdir}"/etc/inputrc
 }
 
 package_libreadline-devel() {

--- a/readline/inputrc
+++ b/readline/inputrc
@@ -1,0 +1,103 @@
+# To the extent possible under law, the author(s) have dedicated all 
+# copyright and related and neighboring rights to this software to the 
+# public domain worldwide. This software is distributed without any warranty. 
+# You should have received a copy of the CC0 Public Domain Dedication along 
+# with this software. 
+# If not, see <https://creativecommons.org/publicdomain/zero/1.0/>. 
+
+# "\e[3~": delete-char
+
+# VT
+# "\e[1~": beginning-of-line
+# "\e[4~": end-of-line
+
+# kvt
+# "\e[H": beginning-of-line
+# "\e[F": end-of-line
+
+# rxvt and konsole (i.e. the KDE-app...)
+# "\e[7~": beginning-of-line
+# "\e[8~": end-of-line
+
+# VT220
+# "\eOH": beginning-of-line
+# "\eOF": end-of-line
+
+# Allow 8-bit input/output
+# set meta-flag on
+# set convert-meta off
+# set input-meta on
+# set output-meta on
+#$if Bash
+  # Don't ring bell on completion
+  set bell-style none
+
+  # or, don't beep at me - show me
+  #set bell-style visible
+
+  # Show all instead of beeping first
+  set show-all-if-ambiguous off
+
+  # Filename completion/expansion
+  set completion-ignore-case on
+  #set show-all-if-ambiguous on
+
+  # Expand homedir name
+  #set expand-tilde on
+
+  # Append "/" to all dirnames
+  #set mark-directories on
+  #set mark-symlinked-directories on
+
+  # visible-stats
+  # Append a mark according to the file type in a listing
+  set visible-stats off
+  set mark-directories on
+
+  # Match all files
+  #set match-hidden-files on
+
+  # 'Magic Space'
+  # Insert a space character then performs
+  # a history expansion in the line
+  #Space: magic-space
+#$endif
+
+# MSYSTEM is emacs based
+$if mode=emacs
+  # Common to Console & RXVT
+  "\e[2~": paste-from-clipboard      # "Ins. Key"
+  "\e[5~": beginning-of-history      # Page up
+  "\e[6~": end-of-history            # Page down
+
+  $if term=msys # RXVT
+    "\e[7~": beginning-of-line      # Home Key
+    "\e[8~": end-of-line            # End Key
+    "\e[11~": display-shell-version # F1
+    "\e[15~": re-read-init-file     # F5
+    "\e[12~": "Function Key 2"
+    "\e[13~": "Function Key 3"
+    "\e[14~": "Function Key 4"
+    "\e[17~": "Function Key 6"
+    "\e[18~": "Function Key 7"
+    "\e[19~": "Function Key 8"
+    "\e[20~": "Function Key 9"
+    "\e[21~": "Function Key 10"
+  $else
+  # Eh, normal Console is not really cygwin anymore, is it? Using 'else' instead. -mstormo
+  # $if term=cygwin # Console
+    "\e[1~": beginning-of-line      # Home Key
+    "\e[4~": end-of-line            # End Key
+    "\e[3~": delete-char      # Delete Key
+    "\e\e[C": forward-word      # Alt-Right
+    "\e\e[D": backward-word      # Alt-Left
+    "\e[1;5C": forward-word   # ctrl + right
+    "\e[1;5D": backward-word  # ctrl + left 
+    "\e[17~": "Function Key 6"
+    "\e[18~": "Function Key 7"
+    "\e[19~": "Function Key 8"
+    "\e[20~": "Function Key 9"
+    "\e[21~": "Function Key 10"
+    "\e[23~": "Function Key 11"
+  $endif
+$endif


### PR DESCRIPTION
This is just a copy of the current inputrc from the "filesystem" package which currently gets installed as ~/.inputrc on the first start.

The goal is to remove ~/.inputrc, so that on the first msys2 start the config is already there and a shell restart is no longer needed.

readline is statically linked into bash, so there is no readline dependency, so we assume that libreadline is installed with "base" in some way.