### PR TITLE
update ansible to 2.14.1, add ansible community collections

### DIFF
--- a/ansible-core/PKGBUILD
+++ b/ansible-core/PKGBUILD
@@ -20,10 +20,7 @@ sha512sums=('d3710aff1dbb04746b663b7c987c3597005dd8633df82f645312e20ddb9c679e731
 noextract=("${pkgname}-${pkgver}.tar.gz")
 
 prepare() {
-  [[ -d ${pkgname}-${pkgver} ]] && rm -rf ${pkgname}-${pkgver}
-  # Workaround an issue with symbolic links in the tarball.
-  tar zxf "${srcdir}/${pkgname}-${pkgver}.tar.gz" || true
-  MSYS=winsymlinks:lnk tar zxf "${srcdir}/${pkgname}-${pkgver}.tar.gz"
+  tar zxf "${srcdir}/${pkgname}-${pkgver}.tar.gz" || tar zxf "${srcdir}/${pkgname}-${pkgver}.tar.gz"
 }
 
 build() {

--- a/ansible-core/PKGBUILD
+++ b/ansible-core/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Alexandre Ferreira <contact@alexjorgef.com>
+
+pkgname=ansible-core
+pkgver=2.14.1
+pkgrel=1
+pkgdesc='Radically simple IT automation platform'
+arch=('any')
+url='https://pypi.org/project/ansible-core'
+license=('spdx:GPL-3.0-or-later')
+depends=('python' 'python-yaml' 'python-jinja' 'python-packaging' 'msys2-runtime-devel')
+provides=('python-ansible' 'ansible-base')
+optdepends=(
+	'sshpass: for ssh connections with password'
+)
+makedepends=('tar' 'python-build' 'python-installer' 'python-setuptools' 'python-wheel')
+replaces=('ansible-base')
+backup=('etc/ansible/ansible.cfg')
+source=("https://pypi.python.org/packages/source/a/ansible-core/ansible-core-${pkgver}.tar.gz")
+sha512sums=('d3710aff1dbb04746b663b7c987c3597005dd8633df82f645312e20ddb9c679e7315968c0cf2876ae22ba91d17e4c54ef9cbdb6b825ee1d6f4229e887f8b4571')
+noextract=("${pkgname}-${pkgver}.tar.gz")
+
+prepare() {
+  [[ -d ${pkgname}-${pkgver} ]] && rm -rf ${pkgname}-${pkgver}
+  # Workaround an issue with symbolic links in the tarball.
+  tar zxf "${srcdir}/${pkgname}-${pkgver}.tar.gz" || true
+  MSYS=winsymlinks:lnk tar zxf "${srcdir}/${pkgname}-${pkgver}.tar.gz"
+}
+
+build() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd ${pkgname}-${pkgver}
+  python -m installer --destdir="${pkgdir}" dist/*.whl
+  install -Dm644 COPYING "${pkgdir}"/usr/share/doc/${pkgname}/COPYING
+
+  install -d "${pkgdir}"/usr/share/ansible/doc
+  cp -dpr --no-preserve=ownership ./examples "${pkgdir}"/usr/share/ansible/doc/
+  install -Dm644 examples/ansible.cfg "${pkgdir}"/etc/ansible/ansible.cfg
+
+  install -d "${pkgdir}"/usr/share/man/man1
+  cp -dpr --no-preserve=ownership docs/man/man1/*.1 "${pkgdir}"/usr/share/man/man1
+}

--- a/ansible/PKGBUILD
+++ b/ansible/PKGBUILD
@@ -7,19 +7,30 @@ pkgdesc='Official assortment of Ansible collections'
 arch=('any')
 url='https://pypi.org/project/ansible/'
 license=('spdx:GPL-3.0-or-later')
-depends=('python' 'ansible-core')
-provides=('python-ansible_collections')
-makedepends=('python-setuptools')
+depends=(
+  'python'
+  'ansible-core'
+)
+makedepends=(
+  'python-setuptools'
+  'python-build'
+  'python-installer'
+  'python-setuptools'
+  'python-wheel'
+)
 source=("https://pypi.python.org/packages/source/a/ansible/ansible-${pkgver}.tar.gz")
 sha512sums=('bd3c5f12021f4ae1805889790bbf29c748418580e08b4e5a19aeb1dc88510f7a2cabaf4e045d98361246a1f52f3d31cbebf5a1441a60fec3095b8a4628572557')
 
 build() {
   cd ansible-${pkgver}
-  python setup.py build
+
+  python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 package() {
   cd ansible-${pkgver}
-  python setup.py install -O1 --root="${pkgdir}"
+
+  python -m installer --destdir="${pkgdir}" dist/*.whl
+
   install -Dm644 COPYING "${pkgdir}"/usr/share/doc/${pkgname}/COPYING
 }

--- a/ansible/PKGBUILD
+++ b/ansible/PKGBUILD
@@ -1,48 +1,25 @@
-# Maintainer: Alexandre Ferreira < alex.jorge.m [at] gmail.com >
+# Maintainer: Alexandre Ferreira <contact@alexjorgef.com>
 
 pkgname=ansible
-pkgver=2.9.21
-pkgrel=4
-pkgdesc='Radically simple IT automation platform'
+pkgver=7.1.0
+pkgrel=1
+pkgdesc='Official assortment of Ansible collections'
 arch=('any')
-url='https://www.ansible.com'
+url='https://pypi.org/project/ansible/'
 license=('spdx:GPL-3.0-or-later')
-depends=('python' 'python-yaml' 'python-jinja')
-provides=('python-ansible')
-optdepends=('sshpass: for ssh connections with password')
-makedepends=(
-  'tar'
-  "python-setuptools"
-  "python-wheel"
-  "python-build"
-  "python-installer"
-)
-backup=('etc/ansible/ansible.cfg')
-source=("https://releases.ansible.com/ansible/ansible-${pkgver}.tar.gz")
-sha512sums=('572f04736bea590770db9b58e7fca8cf3b53b858a0cd2e16667e9d1935d173fa2a0a116d04e0ed976095fbd6b8cd878d21d3e5c4749046b39d121b9ac8b5c441')
-noextract=("${pkgname}-${pkgver}.tar.gz")
-
-prepare() {
-  [[ -d ${pkgname}-${pkgver} ]] && rm -rf ${pkgname}-${pkgver}
-  # Workaround an issue with symbolic links in the tarball.
-  tar zxf "${srcdir}/${pkgname}-${pkgver}.tar.gz" || true
-  MSYS=winsymlinks:lnk tar zxf "${srcdir}/${pkgname}-${pkgver}.tar.gz"
-}
+depends=('python' 'ansible-core')
+provides=('python-ansible_collections')
+makedepends=('python-setuptools')
+source=("https://pypi.python.org/packages/source/a/ansible/ansible-${pkgver}.tar.gz")
+sha512sums=('bd3c5f12021f4ae1805889790bbf29c748418580e08b4e5a19aeb1dc88510f7a2cabaf4e045d98361246a1f52f3d31cbebf5a1441a60fec3095b8a4628572557')
 
 build() {
-  cd "${srcdir}/${pkgname}-${pkgver}"
-  python -m build --wheel --skip-dependency-check --no-isolation
+  cd ansible-${pkgver}
+  python setup.py build
 }
 
 package() {
-  cd ${pkgname}-${pkgver}
-  python -m installer --destdir="${pkgdir}" dist/*.whl
-  install -Dm644 COPYING "${pkgdir}"/usr/share/doc/ansible/COPYING
-
-  install -d "${pkgdir}"/usr/share/ansible/doc
-  cp -dpr --no-preserve=ownership ./examples "${pkgdir}"/usr/share/ansible/doc/
-  install -Dm644 examples/ansible.cfg "${pkgdir}"/etc/ansible/ansible.cfg
-
-  install -d "${pkgdir}"/usr/share/man/man1
-  cp -dpr --no-preserve=ownership docs/man/man1/*.1 "${pkgdir}"/usr/share/man/man1
+  cd ansible-${pkgver}
+  python setup.py install -O1 --root="${pkgdir}"
+  install -Dm644 COPYING "${pkgdir}"/usr/share/doc/${pkgname}/COPYING
 }


### PR DESCRIPTION
With this, package `ansible-core` was added, which contains only the core logic. `ansible` package now contains the community collection library that depends on `ansible-core`.

When Ansible updated to the 3.0.0 version as they mention, the known ansible-base package moved to ansible-core (see reference: [Ansible 3.0.0 Q&A](https://www.ansible.com/blog/ansible-3.0.0-qa)).

> The former became known as ansible-base (soon to be [ansible-core](https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/roadmap/ROADMAP_2_11.rst)). The latter became additions on top of the core, available either ad-hoc or as part of the Ansible community package, which includes a set of curated and maintained Collections.

Solves:

* https://github.com/msys2/MSYS2-packages/issues/3187