### PR TITLE
python-packaging: Update to 23.0

### DIFF
--- a/python-packaging/PKGBUILD
+++ b/python-packaging/PKGBUILD
@@ -3,23 +3,23 @@
 _realname=packaging
 pkgbase="python-${_realname}"
 pkgname=("python-${_realname}")
-pkgver=22.0
+pkgver=23.0
 pkgrel=1
 pkgdesc="Core utilities for Python packages"
 arch=('any')
 url="https://github.com/pypa/packaging"
 license=('spdx:BSD-2-Clause OR Apache-2.0')
 depends=('python')
-makedepends=('python-build' 'python-installer' 'python-flit-core' )
+makedepends=('python-installer' 'python-flit-core' )
 provides=("python3-${_realname}")
 replaces=("python3-${_realname}")
 conflicts=("python3-${_realname}")
 source=("https://pypi.io/packages/source/p/packaging/packaging-${pkgver}.tar.gz")
-sha256sums=('2198ec20bd4c017b8f9717e00f0c8714076fc2fd93816750ab48e2c41de2cfd3')
+sha256sums=('b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97')
 
 build() {
   cd "${srcdir}"/packaging-${pkgver}
-  /usr/bin/python -m build --wheel --skip-dependency-check --no-isolation
+  /usr/bin/python -m flit_core.wheel
 }
 
 package() {


### PR DESCRIPTION
and don't depend on python-build, to avoid a cycle