### PR TITLE
less: Update to v621

### DIFF
--- a/less/PKGBUILD
+++ b/less/PKGBUILD
@@ -1,22 +1,28 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=less
-pkgver=608
-pkgrel=2
+pkgver=621
+pkgrel=1
 pkgdesc="A terminal based program for viewing text files"
 license=('GPL3')
 arch=('i686' 'x86_64')
 url="http://www.greenwoodsoftware.com/less"
 depends=('ncurses' 'libpcre2_8')
-makedepends=('ncurses-devel' 'pcre2-devel' 'autotools' 'gcc')
-source=("http://www.greenwoodsoftware.com/${pkgname}/${pkgname}-${pkgver}.tar.gz"
-       "$pkgname-$pkgver.tar.gz.sig::http://www.greenwoodsoftware.com/$pkgname/$pkgname-$pkgver.sig")
-sha256sums=('a69abe2e0a126777e021d3b73aa3222e1b261f10e64624d41ec079685a6ac209'
-            'SKIP')
+makedepends=('ncurses-devel' 'pcre2-devel' 'autotools' 'gcc' 'groff')
+source=("https://github.com/gwsw//${pkgname}/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('88920b41585dc3702a69064f498e599c209eda5b2d820e40d372a625b984dd83')
 validpgpkeys=('AE27252BD6846E7D6EAE1DD6F153A7C833235259') # Mark Nudelman
+
+prepare() {
+  cd ${srcdir}/${pkgname}-${pkgver}
+
+  autoreconf -vfi
+}
 
 build() {
   cd ${srcdir}/${pkgname}-${pkgver}
+  make -f Makefile.aut distfiles
+
   ./configure \
       --build=${CHOST} \
       --prefix=/usr \


### PR DESCRIPTION
There are many commits in the main branch of `less` since the last version that was released "for general use" (v608).

Hoping that some of those commits fix issues reported in the Git for Windows bug tracker, let's update to the latest tagged version, v621.

An alternative would be to backport individual patches, but due to some sweeping changes (e.g. to convert from Kernighan & Ritchie style to C89 style function definitions), I've failed to backport them separately.

Switch to a GitHub archive since this release isn't available on the website yet.