### PR TITLE
pacman: sync -march flags from mingw to msys

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.0.1
-pkgrel=30
+pkgrel=31
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -146,7 +146,7 @@ build() {
   cd ${srcdir}/${pkgname}-${pkgver}
 
   LDFLAGS+=" -static-libgcc" \
-  meson build-${CARCH} \
+  meson setup build-${CARCH} \
     --buildtype=plain \
     --prefix=/usr \
     --sysconfdir=/etc \
@@ -184,12 +184,12 @@ package() {
   i686)
     mycarch="i686"
     mychost="i686-pc-msys"
-    myflags="-march=i686"
+    myflags="-march=pentium4"
   ;;
   x86_64)
     mycarch="x86_64"
     mychost="x86_64-pc-msys"
-    myflags="-march=x86-64"
+    myflags="-march=nocona -msahf"
   ;;
   esac
 


### PR DESCRIPTION
With win7/8 support dropped now we can bump our CPU requirements for msys packages.

This makes them match what we already use for mingw packages.