### PR TITLE
Heimdal: Rebuild

### DIFF
--- a/heimdal/PKGBUILD
+++ b/heimdal/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=heimdal
 pkgname=('heimdal' 'heimdal-libs' 'heimdal-devel')
 pkgver=7.8.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Implementation of Kerberos V5 libraries"
 arch=('i686' 'x86_64')
 url="https://www.h5l.org/"


### PR DESCRIPTION
To link with OpenSSL 3.

Without my ssh, curl, and thus git didn't work anymore.

Took me literally hours to figure out which DLL still was looking for OpenSSL 1.1, because these seem to be loaded at runtime, not statically.

And rebuilding is also not quite easy when curl doesn't work...