### PR TITLE
file: re-enable zstd support

### DIFF
--- a/file/PKGBUILD
+++ b/file/PKGBUILD
@@ -2,13 +2,13 @@
 
 pkgname=file
 pkgver=5.44
-pkgrel=2
+pkgrel=3
 pkgdesc="File type identification utility"
 arch=('i686' 'x86_64')
 license=('custom')
 url="https://www.darwinsys.com/file/"
-depends=('gcc-libs' 'zlib' 'libbz2' 'liblzma')
-makedepends=('python' 'zlib-devel' 'libbz2-devel' 'liblzma-devel' 'autotools' 'gcc')
+depends=('gcc-libs' 'zlib' 'libbz2' 'liblzma' 'libzstd')
+makedepends=('python' 'zlib-devel' 'libbz2-devel' 'liblzma-devel' 'libzstd-devel' 'autotools' 'gcc')
 options=('!libtool')
 source=("https://astron.com/pub/$pkgname/$pkgname-$pkgver.tar.gz"{,.asc})
 sha256sums=('3751c7fba8dbc831cb8d7cc8aff21035459b8ce5155ef8b0880a27d028475f3b'
@@ -30,7 +30,11 @@ build() {
     --build=${CYGWIN_CHOST} \
     --host=${CYGWIN_CHOST} \
     --target=${CYGWIN_CHOST} \
-    --enable-fsect-man5
+    --enable-fsect-man5 \
+    --enable-zlib \
+    --enable-bzlib \
+    --enable-xzlib \
+    --enable-zstdlib
 
   make
 }


### PR DESCRIPTION
enable all compression variants we support, so this doesn't regress again.