### PR TITLE
socat: fix missing openssl support

### DIFF
--- a/socat/PKGBUILD
+++ b/socat/PKGBUILD
@@ -5,13 +5,13 @@
 
 pkgname=socat
 pkgver=1.7.4.4
-pkgrel=1
+pkgrel=2
 pkgdesc='Multipurpose relay'
 url='http://www.dest-unreach.org/socat/'
 license=('GPL2')
 arch=('i686' 'x86_64')
-depends=('libreadline' 'openssl')
-makedepends=('libreadline-devel' 'tar' 'autotools' 'gcc')
+depends=('libreadline' 'libopenssl')
+makedepends=('libreadline-devel' 'openssl-devel' 'tar' 'autotools' 'gcc')
 source=("http://www.dest-unreach.org/socat/download/${pkgname}-${pkgver}.tar.gz")
 sha256sums=('0f8f4b9d5c60b8c53d17b60d79ababc4a0f51b3bb6d2bd3ae8a6a4b9d68f195e')
 noextract=("${pkgname}-${pkgver}.tar.gz")


### PR DESCRIPTION
it was missing the devel package and depending on the libraries should be enough.