### PR TITLE
zstd: Update to 1.5.4

### DIFF
--- a/zstd/PKGBUILD
+++ b/zstd/PKGBUILD
@@ -2,20 +2,22 @@
 
 pkgbase=zstd
 pkgname=('zstd' 'libzstd' 'libzstd-devel')
-pkgver=1.5.2
-pkgrel=2
+pkgver=1.5.4
+pkgrel=1
 pkgdesc="Zstandard - Fast real-time compression algorithm"
 arch=('i686' 'x86_64')
 url='https://facebook.github.io/zstd/'
 license=('BSD')
 makedepends=('gcc' 'ninja' 'cmake')
 source=("https://github.com/facebook/${pkgbase}/releases/download/v${pkgver}/${pkgbase}-${pkgver}.tar.gz"{,.sig})
-sha256sums=('7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0'
+sha256sums=('0f470992aedad543126d06efab344dc5f3e171893810455787d38347343a4424'
             'SKIP')
-options=(!libtool)
 validpgpkeys=('4EF4AC63455FC9F4545D9B7DEF8FE99528B52FFD')
+noextract=("${pkgbase}-${pkgver}.tar.gz")
 
 prepare() {
+  tar -xzf "${pkgbase}-${pkgver}.tar.gz" 2> /dev/null || tar -xzf "${pkgbase}-${pkgver}.tar.gz"
+
   cd "${srcdir}/${pkgbase}-${pkgver}"
 }
 
@@ -26,6 +28,7 @@ build() {
     -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=/usr \
+    -DZSTD_PROGRAMS_LINK_SHARED=ON \
     ../${pkgbase}-${pkgver}/build/cmake
 
   cmake --build .


### PR DESCRIPTION
* work around symlink in tarball
* don't statically link the .exes, there is no need to