### PR TITLE
brotli: link brotli.exe against the shared libs

### DIFF
--- a/brotli/0001-link-exe-shared.patch
+++ b/brotli/0001-link-exe-shared.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt.orig
++++ b/CMakeLists.txt
+@@ -183,7 +183,7 @@ endif()
+ 
+ # Build the brotli executable
+ add_executable(brotli ${BROTLI_CLI_C})
+-target_link_libraries(brotli ${BROTLI_LIBRARIES_STATIC})
++target_link_libraries(brotli ${BROTLI_LIBRARIES})
+ 
+ # Installation
+ if(NOT BROTLI_BUNDLED_MODE)

--- a/brotli/PKGBUILD
+++ b/brotli/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=brotli
 pkgname=('brotli' 'brotli-devel' 'python-brotli' 'brotli-testdata')
 pkgver=1.0.9
-pkgrel=5
+pkgrel=6
 pkgdesc='Brotli compression library'
 arch=('i686' 'x86_64')
 license=('MIT')
@@ -20,15 +20,21 @@ makedepends=(
 )
 source=("${pkgbase}-${pkgver}.tar.gz::https://github.com/google/$pkgbase/archive/v${pkgver}.tar.gz"
         brotli-rename-static-libs.patch
+        0001-link-exe-shared.patch
         09b0992b6acb7faa6fd3b23f9bc036ea117230fc.patch)
 sha256sums=('f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46'
             '25c2e154e805f6bd2999343a3d38efefa213577e09f5ea932bfa7eb42cf97f35'
+            '3033aee5791cdec47732450000707f6df3c8a18b31897e7ce1744c15258c693d'
             '0b1c8045b4fa745e620b5c1a75377f9cda839fbb07c90bf3358b583866f063ee')
 
 prepare() {
   cd brotli-${pkgver}
   patch -p1 -i ${srcdir}/brotli-rename-static-libs.patch
   patch -p1 -i ${srcdir}/09b0992b6acb7faa6fd3b23f9bc036ea117230fc.patch
+
+  # https://github.com/google/brotli/issues/751
+  patch -p1 -i ${srcdir}/0001-link-exe-shared.patch
+
   cd ..
   mkdir -p build
 }


### PR DESCRIPTION
they are in the same package anyway, so saves some space