### PR TITLE
brotli: split out python-brotli into its own PKGBUILD

### DIFF
--- a/brotli/PKGBUILD
+++ b/brotli/PKGBUILD
@@ -1,9 +1,9 @@
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 
 pkgbase=brotli
-pkgname=('brotli' 'brotli-devel' 'python-brotli' 'brotli-testdata')
+pkgname=('brotli' 'brotli-devel' 'brotli-testdata')
 pkgver=1.0.9
-pkgrel=7
+pkgrel=8
 pkgdesc='Brotli compression library'
 arch=('i686' 'x86_64')
 license=('MIT')
@@ -11,12 +11,7 @@ url='https://github.com/google/brotli'
 depends=('gcc-libs')
 makedepends=(
   'cmake'
-  'python-devel'
   'gcc'
-  "python-setuptools"
-  "python-wheel"
-  "python-build"
-  "python-installer"
 )
 source=("${pkgbase}-${pkgver}.tar.gz::https://github.com/google/$pkgbase/archive/v${pkgver}.tar.gz"
         brotli-rename-static-libs.patch
@@ -41,8 +36,6 @@ prepare() {
 
 build() {
   cd "${srcdir}"/brotli-${pkgver}
-
-  python -m build --wheel --skip-dependency-check --no-isolation
 
   cd "${srcdir}"/build
   cmake \
@@ -70,15 +63,6 @@ package_brotli-devel() {
   cd build
   make DESTDIR=${pkgdir} install
   rm -rf ${pkgdir}/usr/bin
-}
-
-package_python-brotli() {
-  depends=('python')
-
-  cd brotli-${pkgver}
-
-  python -m installer --destdir="${pkgdir}" dist/*.whl
-  install -D -m644 "${srcdir}"/brotli-${pkgver}/LICENSE "${pkgdir}"/usr/share/licenses/${pkgname}/LICENSE
 }
 
 package_brotli-testdata() {

--- a/python-brotli/PKGBUILD
+++ b/python-brotli/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Oleg Titov <oleg.titov@gmail.com>
+
+pkgname=python-brotli
+pkgver=1.0.9
+pkgrel=8
+pkgdesc='Brotli compression library - python library'
+arch=('i686' 'x86_64')
+license=('MIT')
+url='https://github.com/google/brotli'
+depends=('python')
+makedepends=(
+  'python-devel'
+  'gcc'
+  "python-setuptools"
+  "python-wheel"
+  "python-build"
+  "python-installer"
+)
+source=("brotli-${pkgver}.tar.gz::https://github.com/google/brotli/archive/v${pkgver}.tar.gz")
+sha256sums=('f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46')
+
+build() {
+  cd "${srcdir}"/brotli-${pkgver}
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+package() {
+  cd brotli-${pkgver}
+
+  python -m installer --destdir="${pkgdir}" dist/*.whl
+  install -D -m644 "${srcdir}"/brotli-${pkgver}/LICENSE "${pkgdir}"/usr/share/licenses/${pkgname}/LICENSE
+}


### PR DESCRIPTION
so there are fewer dep cycles. (hopefully)

Fixes #3562