### PR TITLE
Add .pyc files to some packages

### DIFF
--- a/file/PKGBUILD
+++ b/file/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=file
 pkgver=5.44
-pkgrel=4
+pkgrel=5
 pkgdesc="File type identification utility"
 arch=('i686' 'x86_64')
 license=('custom')
@@ -47,5 +47,6 @@ package() {
 
   PYTHON_SITELIB=$(/usr/bin/python -c 'from distutils.sysconfig import * ; print(get_python_lib(0,0));')
   mkdir -p ${pkgdir}/${PYTHON_SITELIB}
-  cp -f ${srcdir}/${pkgname}-${pkgver}/python/magic.py ${pkgdir}/$PYTHON_SITELIB
+  cp -f ${srcdir}/${pkgname}-${pkgver}/python/magic.py "${pkgdir}/$PYTHON_SITELIB"
+  python3 -m compileall -o 0 -o 1 -s "${pkgdir}" "${pkgdir}/$PYTHON_SITELIB"
 }

--- a/gdb/PKGBUILD
+++ b/gdb/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=gdb
 pkgver=11.1
-pkgrel=5
+pkgrel=6
 _gcc_ver=11.3.0
 pkgdesc="GNU Debugger (MSYS2 version)"
 arch=('i686' 'x86_64')
@@ -89,6 +89,8 @@ package() {
   # these are shipped by binutils
   rm -fr ${pkgdir}/usr/{include,lib}/ ${pkgdir}/usr/share/locale/
   rm -f ${pkgdir}/usr/share/info/{bfd,configure,standards}.info
+
+  python3 -m compileall -o 0 -o 1 -s "${pkgdir}" "${pkgdir}/usr/share/gdb/python"
 
   # install license files
   install -Dm644 "${srcdir}/${pkgname}-${pkgver}/README" "${pkgdir}/usr/share/licenses/${pkgname}/README"

--- a/glib2/PKGBUILD
+++ b/glib2/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=glib2
 pkgname=(glib2 glib2-devel glib2-docs)
 pkgver=2.74.4
-pkgrel=2
+pkgrel=3
 pkgdesc="Common C routines used by GTK+ and other libs"
 license=(LGPL2)
 url="https://www.gtk.org/"
@@ -68,7 +68,6 @@ check() {
 
 package_glib2() {
   depends=('libxslt' 'libpcre2_8' 'libffi' 'libiconv' 'zlib')
-  optdepends=('python3: for gdbus-codegen and gtester-report')
   options=('!docs' '!emptydirs')
   license=('LGPL')
 
@@ -90,12 +89,15 @@ package_glib2() {
   for _i in "${pkgdir}/usr/share/bash-completion/completions/"*; do
     chmod -x "$_i"
   done
+
+  python3 -m compileall -o 0 -o 1 -s "${pkgdir}" "${pkgdir}/usr/share"
 }
 
 package_glib2-devel() {
   pkgdesc="glib2 headers and libraries"
   groups=('development')
   depends=("glib2=${pkgver}" 'gettext-devel' 'libffi-devel' 'libiconv-devel' 'pcre2-devel' 'zlib-devel')
+  optdepends=('python3: for gdbus-codegen and gtester-report')
   options=('emptydirs')
 
   mkdir -p ${pkgdir}/usr/{bin,lib,share}
@@ -115,8 +117,7 @@ package_glib2-devel() {
   rm -rf ${pkgdir}/usr/share/glib-2.0/gdb
   rm -rf ${pkgdir}/usr/share/glib-2.0/schemas
 
-  python3 -m compileall -d "/usr/share/glib-2.0/codegen" "${pkgdir}/usr/share/glib-2.0/codegen"
-  python3 -O -m compileall -d "/usr/share/glib-2.0/codegen" "${pkgdir}/usr/share/glib-2.0/codegen"
+  python3 -m compileall -o 0 -o 1 -s "${pkgdir}" "${pkgdir}/usr/share/glib-2.0/codegen"
 }
 
 package_glib2-docs() {

--- a/znc/PKGBUILD
+++ b/znc/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=znc
 pkgver=1.8.2
-pkgrel=11
+pkgrel=12
 pkgdesc='An IRC bouncer with modules & scripts support'
 url='https://znc.in/'
 license=('spdx:Apache-2.0')
@@ -56,5 +56,8 @@ build() {
 package() {
   cd "${srcdir}/build-${CARCH}"
   make DESTDIR="${pkgdir}" install
+
+  python3 -m compileall -o 0 -o 1 -s "${pkgdir}" "${pkgdir}/usr/lib/znc"
+
   install -Dm644 ${srcdir}/${pkgname}-${pkgver}/LICENSE ${pkgdir}/usr/share/licenses/${_pkgname}/LICENSE
 }


### PR DESCRIPTION
Now that we switch to Python 3.11 we can do so without creating upgrade conflicts.