### PR TITLE
make: Update to 4.4.1

### DIFF
--- a/make/PKGBUILD
+++ b/make/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Ray Donnelly <mingw.android@gmail.com>
 
 pkgname=make
-pkgver=4.4
+pkgver=4.4.1
 pkgrel=1
 pkgdesc="GNU make utility to maintain groups of programs"
 arch=('i686' 'x86_64')
@@ -12,7 +12,7 @@ depends=('libintl' 'sh')
 makedepends=('gettext' 'procps' 'autotools' 'gcc' 'gettext-devel')
 options=() # 'debug' '!strip')
 source=("https://ftp.gnu.org/gnu/make/${pkgname}-${pkgver}.tar.gz"{,.sig})
-sha256sums=('581f4d4e872da74b3941c874215898a7d35802f03732bdccee1d4a7979105d18'
+sha256sums=('dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3'
             'SKIP')
 validpgpkeys=('6D4EEB02AD834703510B117680CB727A20C79BB2')  # Paul D. Smith <psmith@gnu.org>
 
@@ -25,12 +25,8 @@ prepare() {
 build() {
   cd ${srcdir}/${pkgname}-${pkgver}
 
-  # 32bit msys make is broken without --disable-posix-spawn somehow.
-  # posix_spawn in cygwin likely isn't faster anway so just disable
-  # it everywhere: https://github.com/msys2/MSYS2-packages/issues/2801
-  # edit: it even seems to be slower with posix_spawn:
-  # https://github.com/msys2/MSYS2-packages/pull/2803#issuecomment-1010253935
-
+  # Disable posix_spawn because it is slower.
+  # openssl with "make clean; time make -j32": 1m35s vs 1m53s
   ./configure \
     --build=${CHOST} \
     --prefix=/usr \


### PR DESCRIPTION
Update the posix_spawn comment, as the issue has been fixed in cygwin. I tested the performance issue again, and posix_spawn is still slower, so adjust the comment and keep posix_spawn disabled.