### PR TITLE
cdecl: switch to fork

### DIFF
--- a/cdecl/PKGBUILD
+++ b/cdecl/PKGBUILD
@@ -1,32 +1,35 @@
-# Maintainer: John Butera <john@jbutera.net>
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
 
-_realname=cdecl-blocks
 pkgname=cdecl
-pkgver=2.5
+pkgver=14.0
 pkgrel=1
-pkgdesc="A program for encoding and decoding C (or C++) type declarations"
+pkgdesc="Composing and deciphering C (or C++) declarations or casts, aka 'gibberish.'"
 arch=('i686' 'x86_64')
-url="https://cdecl.org/"
-options=('strip' 'staticlibs' '!makeflags')
-license=('public-domain')
-depends=("libedit")
-makedepends=("gcc" 'make' 'libedit-devel' 'flex' 'bison')
-source=("https://cdecl.org/files/cdecl-blocks-2.5.tar.gz"
-        "build.patch")
-sha256sums=('9ee6402be7e4f5bb5e6ee60c6b9ea3862935bf070e6cecd0ab0842305406f3ac'
-            'a69609f569dd332879d803f60ef400e9243dc7b91ee9842b9c149151fbd49066')
+url="https://github.com/paul-j-lucas/cdecl"
+license=('spdx:GPL-3.0-or-later')
+depends=('ncurses' 'libreadline')
+makedepends=('gcc' 'make' 'ncurses-devel' 'libreadline-devel' 'flex' 'bison' 'autotools')
+source=("https://github.com/paul-j-lucas/cdecl/releases/download/cdecl-${pkgver}/cdecl-${pkgver}.tar.gz")
+sha256sums=('a3947baaf40d2534b7c3d989cb56e008bd3cb730077643090012e3a2678262c9')
 
 prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
-  patch -p1 -i "${srcdir}/build.patch"
+  cd "${pkgname}-${pkgver}"
+
+  autoreconf -vfi
 }
 
 build() {
-  cd ${srcdir}/${_realname}-${pkgver}
+  cd "${pkgname}-${pkgver}"
+
+  ./configure \
+    --build=${CHOST} \
+    --prefix=/usr
+
   make
 }
 
 package() {
-  cd ${srcdir}/${_realname}-${pkgver}
-  make PREFIX="${pkgdir}" install
+  cd "${pkgname}-${pkgver}"
+
+  make DESTDIR="${pkgdir}" install
 }


### PR DESCRIPTION
This is the fork gentoo and opensuse switched to.

* https://packages.gentoo.org/packages/dev-util/cdecl
* https://build.opensuse.org/package/show/openSUSE:Factory/cdecl

The old upstream no longer exists.