### PR TITLE
bison: enable relocatability

### DIFF
--- a/bison/PKGBUILD
+++ b/bison/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=bison
 pkgver=3.8.2
-pkgrel=4
+pkgrel=5
 pkgdesc="The GNU general-purpose parser generator"
 arch=('i686' 'x86_64')
 license=('spdx:GPL-3.0-or-later')
@@ -31,7 +31,8 @@ build() {
   local CYGWIN_CHOST="${CHOST/-msys/-cygwin}"
   ./configure \
     --build=${CYGWIN_CHOST} \
-    --prefix=/usr
+    --prefix=/usr \
+    --enable-relocatable
   make
 }
 


### PR DESCRIPTION
See https://github.com/akimd/bison#relocatability

With that change I was able to create a small bundle with just bison, flex and bash and successfully compiled MESA w/ MSVC.

Bison tried to open paths in the form of `/usr/share/bison/...` and thus could not find the supporting files. After enabling that option everything worked. Maybe it can also be helpful for cases where MSYS2 is installed in paths other than `C:\msys64`

Feel free to merge or just close this PR :)