### PR TITLE
openssl: disable zlib support

### DIFF
--- a/openssl/PKGBUILD
+++ b/openssl/PKGBUILD
@@ -2,12 +2,12 @@
 
 pkgname=('openssl' 'libopenssl' 'openssl-devel' 'openssl-docs')
 pkgver=3.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc='The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
 arch=('i686' 'x86_64')
 url='https://www.openssl.org'
 license=('spdx:Apache-2.0')
-makedepends=('gcc' 'tar' 'perl' 'zlib-devel' 'diffutils' 'nasm')
+makedepends=('gcc' 'tar' 'perl' 'diffutils' 'nasm')
 noextract=(${pkgname}-${pkgver}.tar.gz)
 source=("https://www.openssl.org/source/${pkgname}-${pkgver}.tar.gz"{,.asc}
         '0001-Use-usr-ssl-as-ca-dir-instead-of-.-demoCA.patch'
@@ -58,7 +58,6 @@ build() {
     --openssldir=/usr/ssl \
     --libdir=lib \
     shared \
-    zlib \
     "${openssltarget}"
 
   make depend
@@ -78,7 +77,7 @@ check() {
 }
 
 package_openssl() {
-  depends=('libopenssl' 'zlib')
+  depends=('libopenssl')
   optdepends=('ca-certificates' 'perl')
 
   mkdir -p ${pkgdir}/usr/bin
@@ -98,7 +97,7 @@ package_openssl-docs() {
 }
 
 package_libopenssl() {
-  depends=('zlib')
+  depends=()
   groups=('libraries')
 
   mkdir -p ${pkgdir}/usr/bin
@@ -114,7 +113,7 @@ package_libopenssl() {
 package_openssl-devel() {
   pkgdesc="Openssl headers and libraries"
   groups=('development')
-  depends=("libopenssl=${pkgver}" 'zlib-devel')
+  depends=("libopenssl=${pkgver}")
 
   mkdir -p ${pkgdir}/usr/lib
   cp -rf ${srcdir}/dest/usr/include ${pkgdir}/usr/


### PR DESCRIPTION
To follow what other distros do, like Arch or Debian

Fixes #3731