### PR TITLE
gradle: Fix "Error opening zip file or JAR manifest missing"

### DIFF
--- a/gradle/PKGBUILD
+++ b/gradle/PKGBUILD
@@ -8,7 +8,7 @@
 
 pkgname=('gradle' 'gradle-doc')
 pkgver=8.1
-pkgrel=1
+pkgrel=2
 arch=('any')
 url='https://www.gradle.org/'
 license=('APACHE')
@@ -26,11 +26,13 @@ package_gradle(){
 
   # create the necessary directory structure
   mkdir -p "${pkgdir}/usr/share/java/${pkgname}/bin"
+  mkdir -p "${pkgdir}/usr/share/java/${pkgname}/lib/agents"
   mkdir -p "${pkgdir}/usr/share/java/${pkgname}/lib/plugins"
   mkdir -p "${pkgdir}/usr/bin"
 
   # copy across jar files
   install -Dm644 lib/*.jar "${pkgdir}/usr/share/java/${pkgname}/lib" || return 1
+  install -Dm644 lib/agents/*.jar "${pkgdir}/usr/share/java/${pkgname}/lib/agents" || return 1
   install -Dm644 lib/plugins/*.jar "${pkgdir}/usr/share/java/${pkgname}/lib/plugins" || return 1
 
   # copy across supporting text documentation and scripts


### PR DESCRIPTION
gradle-8.1-1 was broken and failed to start with these messages:

    Error opening zip file or JAR manifest missing : C:\msys64\usr\share\java\gradle/lib/agents/gradle-instrumentation-agent-8.1.jar
    Error occurred during initialization of VM
    agent library failed to init: instrument

Sorry!
