### PR TITLE
less: update to 633

### DIFF
--- a/less/PKGBUILD
+++ b/less/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=less
-pkgver=629
+pkgver=633
 pkgrel=1
 pkgdesc="A terminal based program for viewing text files"
 license=('GPL3')
@@ -10,7 +10,7 @@ url="http://www.greenwoodsoftware.com/less"
 depends=('ncurses' 'libpcre2_8')
 makedepends=('ncurses-devel' 'pcre2-devel' 'autotools' 'gcc' 'groff')
 source=("https://github.com/gwsw//${pkgname}/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('0259e16854b5417a14eaef3d766e265aa4da3c3d75e0bd76d37791ba90d908e8')
+sha256sums=('50beee5b8d47d5ec86b50f5693a210f4b984a502cd5563cc49b99ed38d0ad02d')
 validpgpkeys=('AE27252BD6846E7D6EAE1DD6F153A7C833235259') # Mark Nudelman
 
 prepare() {


### PR DESCRIPTION
This is the latest version marked for general use: https://www.greenwoodsoftware.com/less/index.html