### PR TITLE
mingw-w64-cross: remove "replaces"

### DIFF
--- a/mingw-w64-cross-crt-git/PKGBUILD
+++ b/mingw-w64-cross-crt-git/PKGBUILD
@@ -4,11 +4,10 @@
 _realname=crt
 _mingw_suff=mingw-w64-cross
 pkgname=("${_mingw_suff}-${_realname}-git")
-replaces=("${_mingw_suff}-${_realname}")
 provides=("${_mingw_suff}-${_realname}")
 conflicts=("${_mingw_suff}-${_realname}")
-pkgver=9.0.0.6158.1c773877
-pkgrel=1
+pkgver=9.0.0.6158.1c773877f
+pkgrel=2
 pkgdesc='MinGW-w64 CRT for cross-compiler'
 arch=('i686' 'x86_64')
 url='https://mingw-w64.sourceforge.io/'
@@ -52,11 +51,13 @@ build() {
   esac
     mkdir -p ${srcdir}/crt-${_target} && cd ${srcdir}/crt-${_target}
 
+    unset CC
     ${srcdir}/mingw-w64/mingw-w64-crt/configure \
     --build=${CHOST} \
     --prefix=/opt/${_target} \
     --host=${_target} \
     --enable-wildcard \
+    --disable-dependency-tracking \
     ${_crt_configure_args}
 
     make

--- a/mingw-w64-cross-headers-git/PKGBUILD
+++ b/mingw-w64-cross-headers-git/PKGBUILD
@@ -4,11 +4,10 @@
 _realname=headers
 _mingw_suff=mingw-w64-cross
 pkgname=("${_mingw_suff}-${_realname}-git")
-replaces=("${_mingw_suff}-${_realname}")
 provides=("${_mingw_suff}-${_realname}")
 conflicts=("${_mingw_suff}-${_realname}")
-pkgver=9.0.0.6158.1c773877
-pkgrel=1
+pkgver=9.0.0.6158.1c773877f
+pkgrel=2
 pkgdesc="MinGW-w64 headers for cross-compiler"
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"

--- a/mingw-w64-cross-tools-git/PKGBUILD
+++ b/mingw-w64-cross-tools-git/PKGBUILD
@@ -4,17 +4,16 @@
 _realname=tools
 _mingw_suff=mingw-w64-cross
 pkgname=("${_mingw_suff}-${_realname}-git")
-replaces=("${_mingw_suff}-${_realname}")
 provides=("${_mingw_suff}-${_realname}")
 conflicts=("${_mingw_suff}-${_realname}")
 pkgdesc="MinGW-w64 headers for cross-compiler"
-pkgver=9.0.0.6158.1c773877
-pkgrel=1
+pkgver=9.0.0.6158.1c773877f
+pkgrel=2
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
 license=('custom')
 groups=("${_mingw_suff}-toolchain" "${_mingw_suff}")
-makedepends=('git' 'autotools')
+makedepends=('git' 'autotools' "${_mingw_suff}-gcc" "${_mingw_suff}-binutils")
 options=('!strip' '!libtool' '!emptydirs' '!buildflags')
 _commit='1c773877f4a13c8bd7bfb8da80e1e8761a889f51'
 source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit")
@@ -40,6 +39,7 @@ build() {
     msg "Configuring ${_target} tools"
     for cur in ${_tools}; do
       mkdir -p ${srcdir}/${cur}-${_target} && cd ${srcdir}/${cur}-${_target}
+      unset CC
       ${srcdir}/mingw-w64/mingw-w64-tools/${cur}/configure \
         --build=${CHOST} \
         --host=${_target} \

--- a/mingw-w64-cross-winpthreads-git/PKGBUILD
+++ b/mingw-w64-cross-winpthreads-git/PKGBUILD
@@ -3,11 +3,10 @@
 _realname=winpthreads
 _mingw_suff=mingw-w64-cross
 pkgname="${_mingw_suff}-${_realname}-git"
-replaces=("${_mingw_suff}-${_realname}")
 provides=("${_mingw_suff}-${_realname}")
 conflicts=("${_mingw_suff}-${_realname}")
-pkgver=9.0.0.6158.1c773877
-pkgrel=1
+pkgver=9.0.0.6158.1c773877f
+pkgrel=2
 pkgdesc="MinGW-w64 winpthreads library for cross-compiler"
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
@@ -44,6 +43,7 @@ prepare() {
 build() {
   for _target in ${_targets}; do
     mkdir -p ${srcdir}/winpthreads-build-${_target} && cd ${srcdir}/winpthreads-build-${_target}
+    unset CC
     ${srcdir}/mingw-w64/mingw-w64-libraries/winpthreads/configure \
       --prefix=/opt/${_target} \
       --build=${CHOST} \

--- a/mingw-w64-cross-winstorecompat-git/PKGBUILD
+++ b/mingw-w64-cross-winstorecompat-git/PKGBUILD
@@ -3,11 +3,10 @@
 _realname=winstorecompat
 _mingw_suff=mingw-w64-cross
 pkgname="${_mingw_suff}-${_realname}-git"
-replaces=("${_mingw_suff}-${_realname}")
 provides=("${_mingw_suff}-${_realname}")
 conflicts=("${_mingw_suff}-${_realname}")
-pkgver=9.0.0.6158.1c773877
-pkgrel=1
+pkgver=9.0.0.6158.1c773877f
+pkgrel=2
 pkgdesc="MinGW-w64 winRT compat library"
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
@@ -35,6 +34,7 @@ pkgver() {
 build() {
   for _target in ${_targets}; do
     mkdir -p ${srcdir}/build-${_target} && cd ${srcdir}/build-${_target}
+    unset CC
     ${srcdir}/mingw-w64/mingw-w64-libraries/winstorecompat/configure \
       --prefix=/opt/${_target} \
       --build=${CHOST} \


### PR DESCRIPTION
we want to get rid of the "git" suffix, so remove "replaces" first to avoid temporary replace cycles.

We export CC in makepkg now and that makes autotools try to use it
instead of the host compiler, so unset it.