### PR TITLE
DONE: #3764 Fixed glib-compile-schemas.

### DIFF
--- a/glib2/002-glib-compile-schemas.patch
+++ b/glib2/002-glib-compile-schemas.patch
@@ -1,0 +1,44 @@
+diff --git a/gio/glib-compile-schemas.c b/gio/glib-compile-schemas.c
+index 83184e1e8..32b02fa39 100644
+--- a/gio/glib-compile-schemas.c
++++ b/gio/glib-compile-schemas.c
+@@ -2166,6 +2166,7 @@ main (int argc, char **argv)
+   gboolean strict = FALSE;
+   gchar **schema_files = NULL;
+   gchar **override_files = NULL;
++  gchar **command_line = NULL;
+   GOptionContext *context = NULL;
+   gint retval;
+   GOptionEntry entries[] = {
+@@ -2207,12 +2208,22 @@ main (int argc, char **argv)
+        "and the cache file is called gschemas.compiled."));
+   g_option_context_add_main_entries (context, entries, GETTEXT_PACKAGE);
+ 
+-  if (!g_option_context_parse (context, &argc, &argv, &error))
++#ifdef G_OS_WIN32
++  command_line = g_win32_get_command_line ();
++  if (!g_option_context_parse_strv(context, command_line, &error))
++    {
++      fprintf (stderr, "%s\n", error->message);
++      retval = 1;
++      goto done;
++    }
++#else
++  if (!g_option_context_parse(context, &argc, &argv, &error))
+     {
+       fprintf (stderr, "%s\n", error->message);
+       retval = 1;
+       goto done;
+     }
++#endif
+ 
+   if (show_version_and_exit)
+     {
+@@ -2317,6 +2328,7 @@ done:
+   g_free (target);
+   g_strfreev (schema_files);
+   g_strfreev (override_files);
++  g_strfreev (command_line);
+   g_option_context_free (context);
+ 
+ #ifdef G_OS_WIN32

--- a/glib2/PKGBUILD
+++ b/glib2/PKGBUILD
@@ -21,10 +21,12 @@ makedepends=('docbook-xsl'
              'ninja'
              'zlib-devel')
 source=(https://download.gnome.org/sources/glib/${pkgver%.*}/glib-$pkgver.tar.xz
-        001-gmodule-lib-prefix.patch)
+        001-gmodule-lib-prefix.patch
+        002-glib-compile-schemas.patch)
 noextract=("glib-$pkgver.tar.xz")
 sha256sums=('43dc0f6a126958f5b454136c4398eab420249c16171a769784486e25f2fda19f'
-            '31bce1aff2dab2262ea372d101081162a77e9310fe0d68400da8c85d698ce65e')
+            '31bce1aff2dab2262ea372d101081162a77e9310fe0d68400da8c85d698ce65e'
+    	    '2a000d8f46ca7aa4eace1c277a01054295a10458f1f30188642799b18da8568c')
 
 prepare() {
   bsdtar -zxf "glib-${pkgver}.tar.xz" || true
@@ -32,6 +34,7 @@ prepare() {
   cd glib-${pkgver}
 
   patch -p1 -i ${srcdir}/001-gmodule-lib-prefix.patch
+  patch -p1 -i ${srcdir}/002-glib-compile-schemas.patch
 }
 
 build() {


### PR DESCRIPTION
Fixed: glib-compile-schemas failed when the source directory has non Latin symbols, under MNGW64 on MS Windows platform.

Root cause: using g_option_context_parse is incorrect under the MS Windows platform due the it expects system codepage instead of UTF-8.

Resolution: using g_option_context_parse_strv when G_OS_WIN32 is defined with g_win32_get_command_line.