### PR TITLE
sqlite 3.42.0: remove unnecessary dependencies from split packages

### DIFF
--- a/sqlite/PKGBUILD
+++ b/sqlite/PKGBUILD
@@ -9,7 +9,7 @@ pkgname=('sqlite' 'libsqlite' 'libsqlite-devel' 'sqlite-doc'
 _sqlite_year=2023
 _amalgamationver=3420000
 pkgver=3.42.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A C library that implements an SQL database engine"
 arch=('i686' 'x86_64')
 license=(PublicDomain)
@@ -145,6 +145,7 @@ package_sqlite() {
 package_libsqlite() {
   pkgdesc="Sqlite3 library"
   groups=('libraries')
+  depends=()
   options+=(!staticlibs)
   provides=("libsqlite=${pkgver}")
   # make pacman remove the following packages dependant on a certain version
@@ -178,6 +179,7 @@ package_libsqlite-devel() {
 
 package_sqlite-doc() {
   pkgdesc="Most of the static HTML files that comprise Sqlite ${pkgver} website, including all of the SQL Syntax and the C/C++ interface specs and other miscellaneous documentation"
+  depends=()
   provides=("sqlite3-doc=${pkgver}")
 
   cd ${srcdir}/sqlite-doc-${_amalgamationver}
@@ -219,6 +221,7 @@ package_tcl-sqlite() {
 
 package_lemon() {
   pkgdesc="The LEMON LALR Parser Generator used in SQLite ${pkgver} (MSYS2)"
+  depends=()
 
   mkdir -p ${pkgdir}/usr/{bin,share/lemon,share/licenses/lemon}
   cp -v lemon.exe  ${pkgdir}/usr/bin/


### PR DESCRIPTION
NB: The github action run on my fork hangs in step `dll check` for whatever reason. Let's see what happens here.