### PR TITLE
mtools: add package

### DIFF
--- a/mtools/PKGBUILD
+++ b/mtools/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: Simon Kissane <skissane@gmail.com>
+
+pkgname=mtools
+pkgver=4.0.43
+pkgrel=1
+pkgdesc="collection of utilities to access FAT filesystems without mounting them"
+arch=('i686' 'x86_64')
+license=('spdx:GPL-2.0-or-later')
+url="https://www.gnu.org/software/mtools"
+depends=('libiconv')
+makedepends=('autotools' 'gcc' 'libiconv-devel')
+source=(https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.lz{,.sig})
+sha256sums=('997ffe4125a19de1fd433ed63f128f7d54bc1a5915f3cdb36da6491ef917f217'
+            'SKIP')
+validpgpkeys=('51A23D9D7C4DF41AA48FA893E99CF5537790B839')
+
+build() {
+  [[ -d ${srcdir}/build-${CHOST} ]] && rm -rf ${srcdir}/build-${CHOST}
+  mkdir -p ${srcdir}/build-${CHOST} && cd ${srcdir}/build-${CHOST}
+
+  ../${pkgname}-${pkgver}/configure \
+    --build=${CHOST} \
+    --prefix=/usr \
+    --libexecdir=/usr/lib \
+    --sysconfdir=/etc \
+    --localstatedir=/var
+  make USERLDLIBS=-"liconv"
+}
+
+package() {
+  cd ${srcdir}/build-${CHOST}
+  make DESTDIR=${pkgdir} install
+  install -Dm644 ${srcdir}/${pkgname}-${pkgver}/README "${pkgdir}/usr/share/licenses/${pkgname}/README"
+  install -Dm644 ${srcdir}/${pkgname}-${pkgver}/COPYING "${pkgdir}/usr/share/licenses/${pkgname}/COPYING"
+}


### PR DESCRIPTION
[GNU mtools](https://www.gnu.org/software/mtools/) is a package for accessing FAT-formatted floppy disks on Unix systems without mounting them. On Windows, it still has some value, since you can use it to read/create/update floppy disk image files without having to install any virtual floppy driver. Some people still want to do that even in 2023, for various reasons (legacy embedded systems that still use real or virtual floppies; retro-computing; virtual floppies still have some popularity in hobbyist OS development)

I haven't actually tested this with a physical floppy drive, since I'm only interested in using it for disk image files, for which I can confirm it works. The build excludes the floppy daemon (`floppyd`), since (1) that requires X11 which MSYS2 lacks and (2) the use case it exists for (remote access to physical floppy drives) is unlikely to be useful to many people nowadays.

I wasn't sure if I should submit this here or to https://github.com/msys2/MINGW-packages – but I was having trouble compiling it as part of the later (due to missing `langinfo.h` header), whereas here it builds fine for me.