### PR TITLE
WIP: Windows Arm64 port of binutils

### DIFF
--- a/binutils/.gitignore
+++ b/binutils/.gitignore
@@ -1,0 +1,1 @@
+binutils/

--- a/binutils/PKGBUILD
+++ b/binutils/PKGBUILD
@@ -1,30 +1,45 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
-pkgname=binutils
-pkgver=2.40
+_realname=binutils
+pkgname=${_realname}
 pkgrel=1
 pkgdesc="A set of programs to assemble and manipulate binary and object files"
-arch=('i686' 'x86_64')
+arch=('any')
 url="https://www.gnu.org/software/binutils/"
 license=('GPL')
-depends=('libiconv' 'libintl' 'zlib')
+depends=('libiconv' 'libintl' 'zlib' 'gmp' 'mpfr')
 checkdepends=('dejagnu' 'bc')
-makedepends=('libiconv-devel' 'gettext-devel' 'zlib-devel' 'autotools' 'gcc')
+makedepends=('git'
+             'libiconv-devel' 
+             'gettext-devel'
+             'zlib-devel'
+             'autotools'
+             'gcc'
+             'texinfo'
+             'bison'
+             'flex'
+             'gmp-devel'
+             'mpfr-devel')
 options=('staticlibs' '!distcc' '!ccache')
-source=(https://ftp.gnu.org/gnu/binutils/binutils-${pkgver}.tar.xz{,.sig}
+source=("${_realname}"::"git+https://github.com/ZacWalk/binutils-woarm64.git#branch=woarm64"
         0050-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
         0100-binutils-2.37-msys2.patch
         2002-Allow-spaces-in-the-name-of-the-external-preprocesso.patch)
-sha256sums=('0f8a4c272d7f17f369ded10a4aca28b8e304828e95526da482b0ccc4dfc9d8e1'
-            'SKIP'
+sha256sums=('SKIP'
             '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18'
             '2acce83fb67a32e2cd54708ca97c31c79085d0c0f5e2f42b7d103c1fba3250fc'
             '57478b9971183d430c93701b1d533e3724dab5334bbf44db924777e4a93c1063')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
 
+pkgver() {
+  cd "${srcdir}/${_realname}"
+
+  printf "%s" "$(git rev-parse --short HEAD)"
+}
+
 prepare() {
-  cd "${srcdir}"/binutils-${pkgver}
+  cd "${srcdir}/${_realname}"
   patch -p1 -i "${srcdir}"/0050-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
   patch -p1 -i "${srcdir}"/0100-binutils-2.37-msys2.patch
 
@@ -34,12 +49,12 @@ prepare() {
   # hack! - libiberty configure tests for header files using "$CPP $CPPFLAGS"
   sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure
 
-  mkdir "${srcdir}"/binutils-${CARCH}
+  mkdir -p "${srcdir}"/binutils-${CARCH}
 }
 
 build() {
   cd "${srcdir}"/binutils-${CARCH}
-  ../binutils-${pkgver}/configure \
+  ../${_realname}/configure \
     --prefix=/usr \
     --{build,host,target}=${CHOST} \
     --disable-werror \
@@ -47,7 +62,8 @@ build() {
     --enable-64-bit-bfd \
     --enable-install-libiberty \
     --without-libiconv-prefix \
-    --without-libintl-prefix
+    --without-libintl-prefix \
+    --with-{gmp,mpfr}="${MINGW_PREFIX}"
 
   make
 }


### PR DESCRIPTION
Pre-liminary WIP PR building binutils MSYS2 package for Windows Arm64 using https://github.com/ZacWalk/binutils-woarm64.git fork.

Contributes to #3834 .