### PR TITLE
texinfo: remove libcrypt dependency

### DIFF
--- a/texinfo/PKGBUILD
+++ b/texinfo/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('texinfo' 'info' 'texinfo-tex')
 pkgver=7.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Utilities to work with and produce manuals, ASCII text, and on-line documentation from a single source file"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/texinfo/"
@@ -77,7 +77,7 @@ package_texinfo() {
 }
 
 package_info() {
-  depends=('gzip' 'libcrypt' 'libintl' 'ncurses')
+  depends=('gzip' 'libintl' 'ncurses')
 
   mkdir -p ${pkgdir}/usr/{bin,share}
   mkdir -p ${pkgdir}/usr/share/info


### PR DESCRIPTION
it doesn't seem to be used