### PR TITLE
python: add missing libcrypt dep

### DIFF
--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=python
 pkgname=('python' 'python-devel')
 pkgver=3.11.4
-pkgrel=1
+pkgrel=2
 _pybasever=${pkgver%.*}
 pkgdesc="Next generation of the python high-level scripting language"
 arch=('i686' 'x86_64')
@@ -131,7 +131,7 @@ check() {
 }
 
 package_python() {
-  depends=('libbz2' 'libexpat' 'libffi' 'liblzma' 'ncurses' 'libopenssl' 'libreadline' 'mpdecimal' 'libsqlite' 'zlib')
+  depends=('libbz2' 'libexpat' 'libffi' 'liblzma' 'ncurses' 'libopenssl' 'libreadline' 'mpdecimal' 'libsqlite' 'zlib' 'libcrypt')
   provides=('python3')
   replaces=('python3')
 


### PR DESCRIPTION
_crypt.cpython-311-x86_64-msys.dll depends on it