### PR TITLE
curl: remove libcrypt dependency

### DIFF
--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -3,13 +3,13 @@
 pkgbase=curl
 pkgname=('curl' 'libcurl' 'libcurl-devel')
 pkgver=8.1.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Multi-protocol file transfer utility"
 arch=('i686' 'x86_64')
 url="https://curl.haxx.se"
 license=('spdx:MIT')
 depends=('ca-certificates')
-makedepends=('brotli-devel' 'heimdal-devel' 'libcrypt-devel' 'libidn2-devel' 'autotools'
+makedepends=('brotli-devel' 'heimdal-devel' 'libidn2-devel' 'autotools'
              'libunistring-devel' 'libnghttp2-devel' 'libpsl-devel' 'libssh2-devel' 'openssl-devel' 'zlib-devel' 'libzstd-devel' 'gcc')
 source=("https://github.com/curl/curl/releases/download/${pkgbase}-${pkgver//./_}/${pkgbase}-${pkgver}.tar.xz"{,.asc}
         curl-7.58.0-libpsl-static-libs.patch
@@ -66,7 +66,7 @@ build() {
 }
 
 package_curl() {
-  depends=('ca-certificates' 'libcurl' 'libcrypt'
+  depends=('ca-certificates' 'libcurl'
            'libunistring' 'libnghttp2' 'libpsl' 'openssl' 'zlib')
 
   mkdir -p ${pkgdir}/usr/bin
@@ -78,7 +78,7 @@ package_curl() {
 
 package_libcurl() {
   pkgdesc="Multi-protocol file transfer library (runtime)"
-  depends=('brotli' 'ca-certificates' 'heimdal-libs' 'libcrypt' 'libidn2'
+  depends=('brotli' 'ca-certificates' 'heimdal-libs' 'libidn2'
           'libunistring' 'libnghttp2' 'libpsl' 'libssh2' 'openssl' 'zlib' 'libzstd')
   groups=('libraries')
 
@@ -88,7 +88,7 @@ package_libcurl() {
 
 package_libcurl-devel() {
   pkgdesc="Libcurl headers and libraries"
-  depends=("libcurl=${pkgver}" 'brotli-devel' 'heimdal-devel' 'libcrypt-devel' 'libidn2-devel'
+  depends=("libcurl=${pkgver}" 'brotli-devel' 'heimdal-devel' 'libidn2-devel'
            'libunistring-devel' 'libnghttp2-devel' 'libpsl-devel' 'libssh2-devel' 'openssl-devel' 'zlib-devel')
   options=('staticlibs')
   groups=('development')


### PR DESCRIPTION
it doesn't seem to be used (at least not directly)