### PR TITLE
perl-XML-Parser: remove libcrypt dependency

### DIFF
--- a/perl-XML-Parser/PKGBUILD
+++ b/perl-XML-Parser/PKGBUILD
@@ -3,13 +3,13 @@
 _realname=XML-Parser
 pkgname=perl-${_realname}
 pkgver=2.46
-pkgrel=5
+pkgrel=6
 pkgdesc="Expat-based XML parser module for perl"
 arch=('i686' 'x86_64')
 license=('GPL' 'PerlArtistic')
 url="https://metacpan.org/dist/XML-Parser"
 groups=('perl-modules')
-depends=('perl' 'libexpat' 'libcrypt')
+depends=('perl' 'libexpat')
 makedepends=('libexpat-devel' 'perl-devel' 'make' 'gcc')
 replaces=('perlxml')
 provides=("perlxml=${pkgver}")


### PR DESCRIPTION
doesn't seem to be used directly