### PR TITLE
inetutils: remove libcrypt dependency

### DIFF
--- a/inetutils/PKGBUILD
+++ b/inetutils/PKGBUILD
@@ -2,13 +2,13 @@
 
 pkgname=inetutils
 pkgver=2.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A collection of common network programs."
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/inetutils/"
 license=('spdx:GPL-3.0-or-later')
-depends=('gcc-libs' 'libintl' 'libcrypt' 'libreadline' 'ncurses')
-makedepends=('gettext-devel' 'libcrypt-devel' 'libreadline-devel' 'ncurses-devel' 'autotools' 'gcc' 'tftp-hpa' 'help2man')
+depends=('gcc-libs' 'libintl' 'libreadline' 'ncurses')
+makedepends=('gettext-devel' 'libreadline-devel' 'ncurses-devel' 'autotools' 'gcc' 'tftp-hpa' 'help2man')
 options=('!emptydirs')
 source=(https://ftp.gnu.org/gnu/inetutils/${pkgname}-${pkgver}.tar.xz
         inetutils-2.4-1.src.patch


### PR DESCRIPTION
doesn't seem to be used directly