### PR TITLE
emacs: remove libcrypt dependency

### DIFF
--- a/emacs/PKGBUILD
+++ b/emacs/PKGBUILD
@@ -2,14 +2,14 @@
 
 pkgname=emacs
 pkgver=27.2
-pkgrel=1
+pkgrel=2
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (msys2)"
 url="https://www.gnu.org/software/${pkgname}/"
 license=('GPL3')
 arch=('i686' 'x86_64')
-depends=('ncurses' 'zlib' 'libxml2' 'libiconv' 'libcrypt' 'libgnutls' 'glib2' 'libhogweed')
+depends=('ncurses' 'zlib' 'libxml2' 'libiconv' 'libgnutls' 'glib2' 'libhogweed')
 groups=('editors')
-makedepends=('gawk' 'libiconv-devel' 'libxml2-devel' 'libiconv-devel' 'ncurses-devel' 'libcrypt-devel' 'libgnutls-devel' 'libunistring-devel' 'autotools' 'gcc')
+makedepends=('gawk' 'libiconv-devel' 'libxml2-devel' 'libiconv-devel' 'ncurses-devel' 'libgnutls-devel' 'libunistring-devel' 'autotools' 'gcc')
 options=('strip')
 source=("https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz"{,.sig}
         'configure.ac.diff')


### PR DESCRIPTION
doesn't seem to be used