### PR TITLE
Replace libcrypt-devel with libxcrypt-devel

### DIFF
--- a/libcrypt/PKGBUILD
+++ b/libcrypt/PKGBUILD
@@ -1,9 +1,10 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgbase=libcrypt
-pkgname=('libcrypt' 'libcrypt-devel')
+pkgname=('libcrypt')
+# 2023-07-14: TODO: remove this package in a year
 pkgver=2.1
-pkgrel=4
+pkgrel=5
 pkgdesc="Encryption/Decryption utility and library"
 arch=('i686' 'x86_64')
 license=('custom')
@@ -27,23 +28,11 @@ build() {
   make DESTDIR=${srcdir}/dest install
 }
 
-package_libcrypt() {
+package() {
   pkgdesc="Encryption/Decryption library"
   groups=('libraries')
   depends=('gcc-libs')
   mkdir -p ${pkgdir}/usr/bin
 
   cp -f ${srcdir}/dest/usr/bin/*.dll ${pkgdir}/usr/bin/
-}
-
-package_libcrypt-devel() {
-  pkgdesc="Libcrypt headers and libraries"
-  groups=('development')
-  depends=("libcrypt=${pkgver}")
-  options=('staticlibs')
-
-  mkdir -p ${pkgdir}/usr
-
-  cp -rf ${srcdir}/dest/usr/include ${pkgdir}/usr/
-  cp -rf ${srcdir}/dest/usr/lib ${pkgdir}/usr/
 }

--- a/libxcrypt/PKGBUILD
+++ b/libxcrypt/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=libxcrypt
 pkgname=('libxcrypt' 'libxcrypt-devel')
 pkgver=4.4.35
-pkgrel=1
+pkgrel=2
 pkgdesc='Modern library for one-way hashing of passwords'
 arch=('i686' 'x86_64')
 url='https://github.com/besser82/libxcrypt/'
@@ -60,6 +60,8 @@ package_libxcrypt() {
 package_libxcrypt-devel() {
   depends=("libxcrypt=${pkgver}")
   conflicts=('libcrypt-devel')
+  provides=('libcrypt-devel')
+  replaces=('libcrypt-devel')
 
   mkdir -p ${pkgdir}/usr
 


### PR DESCRIPTION
* Replace/provides so users will be moved over
* Remove libcrypt-devel, so no one can link against it
* Keep the old DLL around for now to avoid breaking external users.

Fixes #3505