### PR TITLE
libuv: remove workaround for c89 with cygwin

### DIFF
--- a/libuv/PKGBUILD
+++ b/libuv/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=libuv
 pkgname=("${pkgbase}" "${pkgbase}-devel")
 pkgver=1.46.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Multi-platform support library with a focus on asynchronous I/O"
 arch=('i686' 'x86_64')
 url="https://github.com/libuv/libuv"
@@ -27,7 +27,6 @@ prepare() {
 build() {
   export lt_cv_deplibs_check_method='pass_all'
 
-  CFLAGS+=" -std=gnu99"  # cygwin requires c99
   export MSYSTEM=CYGWIN
   local CYGWIN_CHOST="${CHOST/-msys/-cygwin}"
   cd "${srcdir}"/${pkgbase}-v${pkgver}


### PR DESCRIPTION
see https://github.com/msys2/msys2-runtime/pull/164