### PR TITLE
msys2-runtime: backport fix for `tar xf` with symlinks

### DIFF
--- a/msys2-runtime/0041-Cygwin-Fix-and-streamline-AT_EMPTY_PATH-handling.patch
+++ b/msys2-runtime/0041-Cygwin-Fix-and-streamline-AT_EMPTY_PATH-handling.patch
@@ -1,0 +1,109 @@
+From 763848a9c0cf76b90227efbe507ea614baa906f0 Mon Sep 17 00:00:00 2001
+From: Corinna Vinschen <corinna@vinschen.de>
+Date: Wed, 12 Jul 2023 14:08:03 +0200
+Subject: [PATCH 41/N] Cygwin: Fix and streamline AT_EMPTY_PATH handling
+
+The GLIBC extension AT_EMPTY_PATH allows the functions fchownat
+and fstatat to operate on dirfd alone, if the given pathname is an
+empty string.  This also allows to operate on any file type, not
+only directories.
+
+Commit fa84aa4dd2fb4 broke this.  It only allows dirfd to be a
+directory in calls to these two functions.
+
+Fix that by handling AT_EMPTY_PATH right in gen_full_path_at.
+A valid dirfd and an empty pathname is now a valid combination
+and, noticably, this returns a valid path in path_ret.  That
+in turn allows to remove the additional path generation code
+from the callers.
+
+Fixes: fa84aa4dd2fb ("Cygwin: fix errno values set by readlinkat")
+Reported-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+Signed-off-by: Corinna Vinschen <corinna@vinschen.de>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/syscalls.cc | 47 +++++++++------------------------------
+ 1 file changed, 11 insertions(+), 36 deletions(-)
+
+diff --git a/winsup/cygwin/syscalls.cc b/winsup/cygwin/syscalls.cc
+index cd1826c..1279fdb 100644
+--- a/winsup/cygwin/syscalls.cc
++++ b/winsup/cygwin/syscalls.cc
+@@ -4440,7 +4440,7 @@ gen_full_path_at (char *path_ret, int dirfd, const char *pathname,
+ 	  cygheap_fdget cfd (dirfd);
+ 	  if (cfd < 0)
+ 	    return -1;
+-	  if (!cfd->pc.isdir ())
++	  if (!cfd->pc.isdir () && !(flags & AT_EMPTY_PATH))
+ 	    {
+ 	      set_errno (ENOTDIR);
+ 	      return -1;
+@@ -4456,6 +4456,8 @@ gen_full_path_at (char *path_ret, int dirfd, const char *pathname,
+ 	{
+ 	  if (!*pathname)
+ 	    {
++	      if (flags & AT_EMPTY_PATH)
++		return 0;
+ 	      set_errno (ENOENT);
+ 	      return -1;
+ 	    }
+@@ -4577,29 +4579,14 @@ fchownat (int dirfd, const char *pathname, uid_t uid, gid_t gid, int flags)
+ 	  __leave;
+ 	}
+       char *path = tp.c_get ();
+-      int res = gen_full_path_at (path, dirfd, pathname);
++      int res = gen_full_path_at (path, dirfd, pathname, flags);
+       if (res)
++	__leave;
++      if (!*pathname) /* Implies AT_EMPTY_PATH */
+ 	{
+-	  if (!(errno == ENOENT && (flags & AT_EMPTY_PATH)))
+-	    __leave;
+-	  /* pathname is an empty string.  Operate on dirfd. */
+-	  if (dirfd == AT_FDCWD)
+-	    {
+-	      cwdstuff::acquire_read ();
+-	      strcpy (path, cygheap->cwd.get_posix ());
+-	      cwdstuff::release_read ();
+-	    }
+-	  else
+-	    {
+-	      cygheap_fdget cfd (dirfd);
+-	      if (cfd < 0)
+-		__leave;
+-	      strcpy (path, cfd->get_name ());
+-	      /* If dirfd refers to a symlink (which was necessarily
+-		 opened with O_PATH | O_NOFOLLOW), we must operate
+-		 directly on that symlink.. */
+-	      flags = AT_SYMLINK_NOFOLLOW;
+-	    }
++	  /* If dirfd refers to a symlink (which was necessarily opened with
++	     O_PATH | O_NOFOLLOW), we must operate directly on that symlink. */
++	  flags = AT_SYMLINK_NOFOLLOW;
+ 	}
+       return chown_worker (path, (flags & AT_SYMLINK_NOFOLLOW)
+ 				 ? PC_SYM_NOFOLLOW : PC_SYM_FOLLOW, uid, gid);
+@@ -4622,21 +4609,9 @@ fstatat (int dirfd, const char *__restrict pathname, struct stat *__restrict st,
+ 	  __leave;
+ 	}
+       char *path = tp.c_get ();
+-      int res = gen_full_path_at (path, dirfd, pathname);
++      int res = gen_full_path_at (path, dirfd, pathname, flags);
+       if (res)
+-	{
+-	  if (!(errno == ENOENT && (flags & AT_EMPTY_PATH)))
+-	    __leave;
+-	  /* pathname is an empty string.  Operate on dirfd. */
+-	  if (dirfd == AT_FDCWD)
+-	    {
+-	      cwdstuff::acquire_read ();
+-	      strcpy (path, cygheap->cwd.get_posix ());
+-	      cwdstuff::release_read ();
+-	    }
+-	  else
+-	    return fstat (dirfd, st);
+-	}
++	  __leave;
+       path_conv pc (path, ((flags & AT_SYMLINK_NOFOLLOW)
+ 			   ? PC_SYM_NOFOLLOW : PC_SYM_FOLLOW)
+ 			  | PC_POSIX | PC_KEEP_HANDLE, stat_suffixes);

--- a/msys2-runtime/0042-Cygwin-use-new-_AT_NULL_PATHNAME_ALLOWED-flag.patch
+++ b/msys2-runtime/0042-Cygwin-use-new-_AT_NULL_PATHNAME_ALLOWED-flag.patch
@@ -1,0 +1,43 @@
+From d66c2dd7632213f63f1c4d3abca1e3ea941c5771 Mon Sep 17 00:00:00 2001
+From: Corinna Vinschen <corinna@vinschen.de>
+Date: Wed, 12 Jul 2023 14:08:02 +0200
+Subject: [PATCH 42/N] Cygwin: use new _AT_NULL_PATHNAME_ALLOWED flag
+
+Convert gen_full_path_at to take flag values from the caller, rather
+than just a bool indicating that empty paths are allowed.  This is in
+preparation of a better AT_EMPTY_PATH handling in a followup patch.
+
+Signed-off-by: Corinna Vinschen <corinna@vinschen.de>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/syscalls.cc | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/winsup/cygwin/syscalls.cc b/winsup/cygwin/syscalls.cc
+index 1279fdb..22490ff 100644
+--- a/winsup/cygwin/syscalls.cc
++++ b/winsup/cygwin/syscalls.cc
+@@ -4414,11 +4414,10 @@ pclose (FILE *fp)
+ 
+ static int
+ gen_full_path_at (char *path_ret, int dirfd, const char *pathname,
+-		  bool null_pathname_allowed = false)
++		  int flags = 0)
+ {
+-  /* Set null_pathname_allowed to true to allow GLIBC compatible behaviour
+-     for NULL pathname.  Only used by futimesat. */
+-  if (!pathname && !null_pathname_allowed)
++  /* futimesat allows a NULL pathname. */
++  if (!pathname && !(flags & _AT_NULL_PATHNAME_ALLOWED))
+     {
+       set_errno (EFAULT);
+       return -1;
+@@ -4656,7 +4655,7 @@ futimesat (int dirfd, const char *pathname, const struct timeval times[2])
+   __try
+     {
+       char *path = tp.c_get ();
+-      if (gen_full_path_at (path, dirfd, pathname, true))
++      if (gen_full_path_at (path, dirfd, pathname, _AT_NULL_PATHNAME_ALLOWED))
+ 	__leave;
+       return utimes (path, times);
+     }

--- a/msys2-runtime/0043-Define-_AT_NULL_PATHNAME_ALLOWED.patch
+++ b/msys2-runtime/0043-Define-_AT_NULL_PATHNAME_ALLOWED.patch
@@ -1,0 +1,39 @@
+From 4448cc07c36859a9b0db180bcbb79898723249a4 Mon Sep 17 00:00:00 2001
+From: Corinna Vinschen <corinna@vinschen.de>
+Date: Wed, 12 Jul 2023 14:08:01 +0200
+Subject: [PATCH 43/N] Define _AT_NULL_PATHNAME_ALLOWED
+
+Cygwin needs an internal flag to allow specifying an empty pathname
+in utimesat (GLIBC extension). We define it in _default_fcntl.h to
+make sure we never introduce a value collision accidentally.
+While at it, define the values as 16 bit hex values.
+
+Signed-off-by: Corinna Vinschen <corinna@vinschen.de>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ newlib/libc/include/sys/_default_fcntl.h | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/newlib/libc/include/sys/_default_fcntl.h b/newlib/libc/include/sys/_default_fcntl.h
+index 48914c9..ce721fa 100644
+--- a/newlib/libc/include/sys/_default_fcntl.h
++++ b/newlib/libc/include/sys/_default_fcntl.h
+@@ -162,12 +162,13 @@ extern "C" {
+ #define AT_FDCWD -2
+ 
+ /* Flag values for faccessat2) et al. */
+-#define AT_EACCESS              1
+-#define AT_SYMLINK_NOFOLLOW     2
+-#define AT_SYMLINK_FOLLOW       4
+-#define AT_REMOVEDIR            8
++#define AT_EACCESS                 0x0001
++#define AT_SYMLINK_NOFOLLOW        0x0002
++#define AT_SYMLINK_FOLLOW          0x0004
++#define AT_REMOVEDIR               0x0008
+ #if __GNU_VISIBLE
+-#define AT_EMPTY_PATH          16
++#define AT_EMPTY_PATH              0x0010
++#define _AT_NULL_PATHNAME_ALLOWED  0x4000 /* Internal flag used by futimesat */
+ #endif
+ #endif
+ 

--- a/msys2-runtime/0044-Cygwin-gen_full_path_at-drop-never-reached-code.patch
+++ b/msys2-runtime/0044-Cygwin-gen_full_path_at-drop-never-reached-code.patch
@@ -1,0 +1,32 @@
+From f60a070abf3a898759478d0e13c4feaff5011b57 Mon Sep 17 00:00:00 2001
+From: Corinna Vinschen <corinna@vinschen.de>
+Date: Wed, 12 Jul 2023 14:08:00 +0200
+Subject: [PATCH 44/N] Cygwin: gen_full_path_at: drop never reached code
+
+The check if the local variable p is NULL is useless.  The preceeding
+code always sets p to a valid pointer, or it crashes if path_ret is
+invalid (which would be a bug in Cygwin).
+
+Fixes:c57b57e5c43a ("* cygwin.din: Sort.")
+Signed-off-by: Corinna Vinschen <corinna@vinschen.de>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/syscalls.cc | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/winsup/cygwin/syscalls.cc b/winsup/cygwin/syscalls.cc
+index 22490ff..068aeeb 100644
+--- a/winsup/cygwin/syscalls.cc
++++ b/winsup/cygwin/syscalls.cc
+@@ -4446,11 +4446,6 @@ gen_full_path_at (char *path_ret, int dirfd, const char *pathname,
+ 	    }
+ 	  p = stpcpy (path_ret, cfd->get_name ());
+ 	}
+-      if (!p)
+-	{
+-	  set_errno (ENOTDIR);
+-	  return -1;
+-	}
+       if (pathname)
+ 	{
+ 	  if (!*pathname)

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.4.7
-pkgrel=2
+pkgrel=3
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -64,7 +64,11 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0037-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch
         0038-Stop-assuming-that-there-are-no-spaces-in-POSIX-styl.patch
         0039-Cygwin-Make-sys-cpuset.h-safe-for-c89-compilations.patch
-        0040-Cygwin-Make-gcc-specific-code-in-sys-cpuset.h-compil.patch)
+        0040-Cygwin-Make-gcc-specific-code-in-sys-cpuset.h-compil.patch
+        0041-Cygwin-Fix-and-streamline-AT_EMPTY_PATH-handling.patch
+        0042-Cygwin-use-new-_AT_NULL_PATHNAME_ALLOWED-flag.patch
+        0043-Define-_AT_NULL_PATHNAME_ALLOWED.patch
+        0044-Cygwin-gen_full_path_at-drop-never-reached-code.patch)
 sha256sums=('SKIP'
             'c092f44f33e526c93282de5f1b12628665b38d607c2e7628d8437634ce9d133f'
             'a19b83098b577f64b7df42197ada140b58601f0acb20feba304f4dcdce8563c7'
@@ -105,7 +109,11 @@ sha256sums=('SKIP'
             'abc27017d8c750f971a96df5d00f494bbfffe46258b5635ffc2118b9524c897c'
             'a2f11abdc21acc7c0c98f048ea5cb99d33c6a0f232f920f5765bac6a3d86295b'
             'e3ffb5ca250876dc364a9c5599edfbef52f7fddc59d1d81371d3521ef1d57c1d'
-            '92e77e073e9ed5015d64bb29ad02a3b08e42e3eabbca4cd5c95a2e4c7c2cd923')
+            '92e77e073e9ed5015d64bb29ad02a3b08e42e3eabbca4cd5c95a2e4c7c2cd923'
+            'a755a940f98dfb7f86cbaeb0564f327b31dbdbb806645c16bc30e947f7b5409b'
+            'ec381cde7ba5f72cf4e8f0f2831cb819798c20d49ee78c80ef875c5e66a7b848'
+            '31816dba7fdb7d809b30429d959574648ef708b5e023e439162091803b6b481d'
+            '403097fac106999d0e8c1dabb16057315d6a8fa1d3beb389c5d42b18924d8520')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -182,7 +190,11 @@ prepare() {
   0037-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch \
   0038-Stop-assuming-that-there-are-no-spaces-in-POSIX-styl.patch \
   0039-Cygwin-Make-sys-cpuset.h-safe-for-c89-compilations.patch \
-  0040-Cygwin-Make-gcc-specific-code-in-sys-cpuset.h-compil.patch
+  0040-Cygwin-Make-gcc-specific-code-in-sys-cpuset.h-compil.patch \
+  0041-Cygwin-Fix-and-streamline-AT_EMPTY_PATH-handling.patch \
+  0042-Cygwin-use-new-_AT_NULL_PATHNAME_ALLOWED-flag.patch \
+  0043-Define-_AT_NULL_PATHNAME_ALLOWED.patch \
+  0044-Cygwin-gen_full_path_at-drop-never-reached-code.patch
 }
 
 build() {


### PR DESCRIPTION
This corresponds to https://github.com/msys2/msys2-runtime/pull/166

/cc @alex-tee