### PR TITLE
protobuf: fix build error

### DIFF
--- a/protobuf/0001-constant-initializer.patch
+++ b/protobuf/0001-constant-initializer.patch
@@ -1,0 +1,26 @@
+--- protobuf-21.12/src/google/protobuf/port_def.inc.orig	2022-12-13 01:03:12.000000000 +0100
++++ protobuf-21.12/src/google/protobuf/port_def.inc	2023-09-15 19:26:43.043423700 +0200
+@@ -638,7 +638,7 @@
+ #ifdef PROTOBUF_CONSTINIT
+ #error PROTOBUF_CONSTINIT was previously defined
+ #endif
+-#if defined(__cpp_constinit) && !defined(_MSC_VER)
++#if defined(__cpp_constinit) && !defined(_MSC_VER) && !defined(__CYGWIN__)
+ #define PROTOBUF_CONSTINIT constinit
+ #define PROTOBUF_CONSTEXPR constexpr
+ // Some older Clang versions incorrectly raise an error about
+@@ -646,12 +646,12 @@
+ // higher seem to work, except that XCode 12.5.1 shows the error even though it
+ // uses Clang 12.0.5.
+ // Clang-cl on Windows raises error also.
+-#elif !defined(_MSC_VER) && __has_cpp_attribute(clang::require_constant_initialization) && \
++#elif !defined(_MSC_VER) && !defined(__CYGWIN__) && __has_cpp_attribute(clang::require_constant_initialization) && \
+     ((defined(__APPLE__) && __clang_major__ >= 13) ||                \
+      (!defined(__APPLE__) && __clang_major__ >= 12))
+ #define PROTOBUF_CONSTINIT [[clang::require_constant_initialization]]
+ #define PROTOBUF_CONSTEXPR constexpr
+-#elif PROTOBUF_GNUC_MIN(12, 2)
++#elif PROTOBUF_GNUC_MIN(12, 2) && !defined(__CYGWIN__)
+ #define PROTOBUF_CONSTINIT __constinit
+ #define PROTOBUF_CONSTEXPR constexpr
+ // MSVC 17 currently seems to raise an error about constant-initialized pointers.

--- a/protobuf/PKGBUILD
+++ b/protobuf/PKGBUILD
@@ -3,23 +3,37 @@
 pkgbase=protobuf
 pkgname=('protobuf' 'protobuf-devel')
 pkgver=21.12
-pkgrel=2
+pkgrel=3
 pkgdesc="Protocol Buffers - Google's data interchange format"
 arch=('i686' 'x86_64')
 url='https://developers.google.com/protocol-buffers/'
 groups=('libraries')
-license=('BSD')
+license=('spdx:BSD-3-Clause')
 depends=('gcc-libs' 'zlib')
 makedepends=('zlib-devel' 'autotools' 'gcc')
-source=(protobuf-${pkgver}.tar.gz::https://github.com/protocolbuffers/protobuf/archive/v${pkgver}.tar.gz)
-sha256sums=('22fdaf641b31655d4b2297f9981fa5203b2866f8332d3c6333f6b0107bb320de')
+source=(protobuf-${pkgver}.tar.gz::https://github.com/protocolbuffers/protobuf/archive/v${pkgver}.tar.gz
+        0001-constant-initializer.patch # based on https://github.com/protocolbuffers/protobuf/commit/ddf2c6b6d0f3c73afac13bdfce9a8f626f9fd6d2
+        )
+sha256sums=('22fdaf641b31655d4b2297f9981fa5203b2866f8332d3c6333f6b0107bb320de'
+            '39629ddb18fa890686755515096705ab7d0301f4f8eb05b29a24d5543ea31343')
 noextract=("protobuf-${pkgver}.tar.gz")
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
 
 prepare() {
   [[ -d ${srcdir}/protobuf-${pkgver} ]] && rm -rf ${srcdir}/protobuf-${pkgver}
   tar -xzf "${srcdir}/protobuf-${pkgver}.tar.gz"
 
   cd  ${srcdir}/protobuf-${pkgver}
+  apply_patch_with_msg \
+    0001-constant-initializer.patch
+
   ./autogen.sh
 }
 


### PR DESCRIPTION
Protobuf doesn't build for staging with the following error:
```
  google/protobuf/struct.pb.cc: At global scope:
  google/protobuf/struct.pb.cc:47:110: error: 'constinit' variable 'google::protobuf::_Struct_default_instance_' does not have a constant initializer
     47 | PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 StructDefaultTypeInternal _Struct_default_instance_;
        |                                                                                                              ^~~~~~~~~~~~~~~~~~~~~~~~~
  google/protobuf/struct.pb.cc:47:110:   in 'constexpr' expansion of 'google::protobuf::StructDefaultTypeInternal()'
  google/protobuf/struct.pb.cc:41:9: error: 'constexpr google::protobuf::Struct::Struct(google::protobuf::internal::ConstantInitialized)' called in a constant expression
     41 |       : _instance(::_pbi::ConstantInitialized{}) {}
        |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  google/protobuf/struct.pb.cc:35:20: note: 'constexpr google::protobuf::Struct::Struct(google::protobuf::internal::ConstantInitialized)' declared here
     35 | PROTOBUF_CONSTEXPR Struct::Struct(
        |                    ^~~~~~
  make[2]: *** [Makefile:4514: google/protobuf/struct.pb.lo] Error 1
```

Use patch based on upstream to avoid that build error.