### PR TITLE
pacman: set CARCHFLAGS for MSYS environment

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.0.2
-pkgrel=9
+pkgrel=10
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -77,7 +77,7 @@ validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@a
               'B8151B117037781095514CA7BBDFFC92306B1121') # Andrew Gregory (pacman) <andrew@archlinux.org>
 sha256sums=('SKIP'
             '53c0c2d42bc10f265aa41bc412a6ebc2d98177d9356b0fa9a2a130caec46ac2d'
-            'c12da01ede663a4924d0817a0d1bd6082b1380383cfb74cc1cea08f9d73e4902'
+            '1faf0ceeaef7edea0e0ae30145296dce36f5e903c970fe69951fa272e26edae3'
             '8cb6b244d39107afc6cff74d919708ffc58b903c42f82d050d1d49bbf31208ab'
             '98198e1f0f252eae0560d271bee4b9149e127399dd0d3fd5d8d24579d9e0550f'
             'd272176dea508bf0972dde6396ca655e900d509099d0a496bd6a138f98bb48df'

--- a/pacman/makepkg.conf
+++ b/pacman/makepkg.conf
@@ -41,8 +41,8 @@ CHOST="@CHOST@"
 CC=gcc
 CXX=g++
 CPPFLAGS=
-CFLAGS="@CARCHFLAGS@ -mtune=generic -O2 -pipe"
-CXXFLAGS="@CARCHFLAGS@ -mtune=generic -O2 -pipe"
+CFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe"
+CXXFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe"
 LDFLAGS="-pipe"
 #-- Make Flags: change this for DistCC/SMP systems
 MAKEFLAGS="-j$(($(nproc)+1))"


### PR DESCRIPTION
CARCHFLAGS was removed since 4.0.0
see: https://gitlab.archlinux.org/pacman/pacman/-/commit/f0803f6e