### PR TITLE
jsoncpp: rebuild

### DIFF
--- a/jsoncpp/PKGBUILD
+++ b/jsoncpp/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase="jsoncpp"
 pkgname=("${pkgbase}" "${pkgbase}-devel")
 pkgver=1.9.5
-pkgrel=2
+pkgrel=3
 pkgdesc="A C++ library for interacting with JSON"
 arch=('any')
 url="https://github.com/open-source-parsers/jsoncpp"
@@ -12,7 +12,6 @@ depends=("gcc-libs")
 makedepends=("gcc"
              "cmake"
              "python")
-options=('staticlibs' '!strip' '!buildflags')
 source=(${pkgname}-${pkgver}.tar.gz::"https://github.com/open-source-parsers/jsoncpp/archive/${pkgver}.tar.gz")
 sha256sums=('f409856e5920c18d0c2fb85276e24ee607d2a09b5e7d5f0a371368903c275da2')
 
@@ -52,7 +51,6 @@ build() {
 }
 
 package_jsoncpp() {
-  install=jsoncpp.install
   groups=("libraries")
   cd "${srcdir}/dest"
   mkdir -p ${pkgdir}/usr/bin

--- a/jsoncpp/jsoncpp.install
+++ b/jsoncpp/jsoncpp.install
@@ -1,7 +1,0 @@
-post_install() {
-  echo "JsonCpp headers and build libraries are now in jsoncpp-devel."
-}
-
-post_upgrade() {
-  post_install "$1"
-}


### PR DESCRIPTION
remove non-default build options, git history doesn't show
why they were added, they shouldn't be needed.

Remove install file which just prints a warning