### PR TITLE
tar: disable check for year 2038 support on 32-bit.

### DIFF
--- a/tar/PKGBUILD
+++ b/tar/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=tar
 pkgver=1.35
-pkgrel=1
+pkgrel=2
 pkgdesc="Utility used to store, backup, and transport files"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/tar/tar.html"
@@ -37,12 +37,19 @@ build() {
 
   export gl_cv_have_weak=no
   local CYGWIN_CHOST="${CHOST/-msys/-cygwin}"
+  local -a extra_config
+  # 32-bit cygwin only has 32-bit time_t
+  # https://github.com/msys2/MSYS2-packages/issues/4078
+  if [[ "$CARCH" == "i686" ]]; then
+    extra_config+=("--disable-year2038")
+  fi
   ./configure \
     --build=${CYGWIN_CHOST} \
     --prefix=/usr \
     --sbindir=/usr/bin \
     --libexecdir=/usr/lib/tar \
-    --enable-backup-scripts
+    --enable-backup-scripts \
+    "${extra_config[@]}"
   make
 }
 


### PR DESCRIPTION
32-bit cygwin (and thus msys2) only supports 32-bit time_t, so this configure check was failing there.  Yet another reason not to use 32-bit anymore.  This might also be relevant to @dscho in git-for-windows

Fixes #4078