### PR TITLE
subversion: depend on libxcrypt

### DIFF
--- a/subversion/PKGBUILD
+++ b/subversion/PKGBUILD
@@ -2,14 +2,14 @@
 
 pkgname=subversion
 pkgver=1.14.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A Modern Concurrent Version Control System"
 arch=('i686' 'x86_64')
 url="https://subversion.apache.org/"
 license=('APACHE')
 groups=('VCS')
-depends=('libsqlite' 'file' 'liblz4' 'libserf' 'libsasl')
-makedepends=('python' 'python-py3c' 'perl' 'swig' 'ruby' 'liblz4-devel' 'libsqlite-devel' 'libserf-devel' 'libsasl-devel' 'gmp-devel' 'autotools' 'gcc')
+depends=('libsqlite' 'file' 'liblz4' 'libserf' 'libsasl' 'libxcrypt')
+makedepends=('python' 'python-py3c' 'perl' 'swig' 'ruby' 'liblz4-devel' 'libsqlite-devel' 'libserf-devel' 'libsasl-devel' 'gmp-devel' 'autotools' 'gcc' 'libxcrypt-devel')
 optdepends=('bash-completion: for svn bash completion'
             'python: for some hook scripts'
             'ruby: for some hook scripts')


### PR DESCRIPTION
svn still links against the old libcrypt, it was likely missed in the libxcrypt transition because it wasn't listed as a dependency

Fixes #4110