### PR TITLE
apr-util: add missing dependency on libxcrypt

### DIFF
--- a/apr-util/PKGBUILD
+++ b/apr-util/PKGBUILD
@@ -2,11 +2,11 @@
 
 pkgname=('apr-util' 'apr-util-devel')
 pkgver=1.6.3
-pkgrel=1
+pkgrel=2
 pkgdesc="The Apache Portable Runtime"
 arch=('i686' 'x86_64')
 url="https://apr.apache.org/"
-makedepends=('apr-devel' 'libexpat-devel' 'libsqlite-devel' 'autotools' 'gcc')
+makedepends=('apr-devel' 'libexpat-devel' 'libsqlite-devel' 'autotools' 'gcc' 'libxcrypt-devel')
 options=('!libtool')
 license=('spdx:Apache-2.0')
 source=("https://archive.apache.org/dist/apr/apr-util-${pkgver}.tar.bz2"
@@ -47,7 +47,7 @@ check() {
 }
 
 package_apr-util() {
-  depends=('apr' 'expat' 'libsqlite')
+  depends=('apr' 'expat' 'libsqlite' 'libxcrypt')
   groups=('libraries')
 
   mkdir -p ${pkgdir}/usr/bin


### PR DESCRIPTION
Fixes #4110