### PR TITLE
nghttp2: Update to 1.58.0

### DIFF
--- a/nghttp2/PKGBUILD
+++ b/nghttp2/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=nghttp2
 pkgname=("nghttp2" "libnghttp2" "libnghttp2-devel")
-pkgver=1.57.0
+pkgver=1.58.0
 pkgrel=1
 pkgdesc='Framing layer of HTTP/2 is implemented as a reusable C library'
 arch=(i686 x86_64)
@@ -15,15 +15,11 @@ depends=("jansson"
          "gcc-libs")
 makedepends=('jansson-devel' 'libevent-devel' 'openssl-devel' 'libcares-devel' 'zlib-devel' 'autotools' 'gcc' 'make')
 license=('spdx:MIT')
-source=(https://github.com/nghttp2/nghttp2/releases/download/v$pkgver/nghttp2-${pkgver}.tar.xz
-        "https://github.com/nghttp2/nghttp2/commit/4262c901481213d82e2a5ab0d33ce4b082572d72.patch")
-sha256sums=('9210b0113109f43be526ac5835d58a701411821a4d39e155c40d67c40f47a958'
-            'bfdfc189f47ea3b4c2ae1818b38ecc696641bb437ef333f9d06b7d7813d17acf')
+source=(https://github.com/nghttp2/nghttp2/releases/download/v$pkgver/nghttp2-${pkgver}.tar.xz)
+sha256sums=('4a68a3040da92fd9872c056d0f6b0cd60de8410de10b578f8ade9ecc14d297e0')
 
 prepare() {
   cd nghttp2-${pkgver}
-
-  patch -Np1 -i "${srcdir}/4262c901481213d82e2a5ab0d33ce4b082572d72.patch"
 
   autoreconf -fiv
 }


### PR DESCRIPTION
patch is included in this release