### PR TITLE
gawk: Update to 5.3.0

### DIFF
--- a/gawk/PKGBUILD
+++ b/gawk/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=gawk
-pkgver=5.2.2
+pkgver=5.3.0
 pkgrel=1
 pkgdesc="GNU version of awk"
 arch=('i686' 'x86_64')
@@ -11,7 +11,7 @@ depends=('sh' 'mpfr' 'libintl' 'libreadline')
 makedepends=('gettext-devel' 'mpfr-devel' 'libreadline-devel' 'autotools' 'gcc')
 provides=('awk')
 source=(https://ftp.gnu.org/pub/gnu/${pkgname}/${pkgname}-${pkgver}.tar.gz{,.sig})
-sha256sums=('945aef7ccff101f20b22a10802bc005e994ab2b8ea3e724cc1a197c62f41f650'
+sha256sums=('378f8864ec21cfceaa048f7e1869ac9b4597b449087caf1eb55e440d30273336'
             'SKIP')
 validpgpkeys=('D1967C63788713177D861ED7DF597815937EC0D2')
 
@@ -29,8 +29,7 @@ build() {
               --prefix=/usr \
               --libexecdir=/usr/lib \
               --without-libiconv-prefix \
-              --without-libintl-prefix \
-              --without-libsigsegv
+              --without-libintl-prefix
 
   make
 }


### PR DESCRIPTION
* PKGBUILD:
  - remove configure flag --without-libsigsegv obsolete since 5.3.0