### PR TITLE
perl-Term-Table: Update to 0.018

### DIFF
--- a/perl-Term-Table/PKGBUILD
+++ b/perl-Term-Table/PKGBUILD
@@ -2,17 +2,17 @@
 
 _realname=Term-Table
 pkgname=perl-${_realname}
-pkgver=0.016
+pkgver=0.018
 pkgrel=1
 pkgdesc="Format a header and rows into a table"
 arch=('any')
 url="https://metacpan.org/dist/Term-Table"
 groups=('perl-modules')
 license=('spdx:Artistic-1.0-Perl' 'spdx:GPL-1.0-or-later')
-depends=('perl-Importer')
+depends=()
 options=('!emptydirs')
 source=("https://cpan.metacpan.org/authors/id/E/EX/EXODIST/${_realname}-${pkgver}.tar.gz")
-sha256sums=('8fb4fbb8e96a2d6c514949eb8cfd7e66319bcb1cbf7cea0ab19af887a72d97bf')
+sha256sums=('9159b9131ee6b3f3956b74f45422985553574babbfaeba60be5c17bc114ac011')
 
 build() {
   cd  "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
Importer is no longer used since 0.017