### PR TITLE
Remove incomplete GCC support for armv7-w64-mingw32

### DIFF
--- a/mingw-w64-cross-binutils/PKGBUILD
+++ b/mingw-w64-cross-binutils/PKGBUILD
@@ -28,7 +28,7 @@ msys2_references=(
   'archlinux: binutils'
 )
 
-_targets="i686-w64-mingw32 x86_64-w64-mingw32" # armv7-w64-mingw32
+_targets="i686-w64-mingw32 x86_64-w64-mingw32"
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -50,11 +50,7 @@ build() {
   for _target in ${_targets}; do
     mkdir -p ${srcdir}/binutils-build-${_target} && cd ${srcdir}/binutils-build-${_target}
 
-    if [ "${_target}" != "armv7-w64-mingw32" ]; then
-      local _conf='--enable-lto'
-    else
-      local _conf=''
-    fi
+    local _conf='--enable-lto'
 
     if [ "${_target}" = "x86_64-w64-mingw32" ]; then
      _conf+=' --enable-64-bit-bfd'

--- a/mingw-w64-cross-crt/PKGBUILD
+++ b/mingw-w64-cross-crt/PKGBUILD
@@ -25,7 +25,7 @@ msys2_references=(
   'archlinux: mingw-w64-crt'
 )
 
-_targets="x86_64-w64-mingw32 i686-w64-mingw32" #armv7-w64-mingw32
+_targets="x86_64-w64-mingw32 i686-w64-mingw32"
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
@@ -46,9 +46,6 @@ build() {
     ;;
     x86_64*)
       _crt_configure_args="--disable-lib32 --enable-lib64"
-    ;;
-    armv7*)
-      _crt_configure_args="--disable-lib32 --disable-lib64 --enable-libarm32"
     ;;
   esac
     mkdir -p ${srcdir}/crt-${_target} && cd ${srcdir}/crt-${_target}

--- a/mingw-w64-cross-gcc/PKGBUILD
+++ b/mingw-w64-cross-gcc/PKGBUILD
@@ -84,7 +84,7 @@ sha256sums=('27e879dccc639cd7b0cc08ed575c1669492579529b53c9ff27b0b96265fa867d'
             '369c7a74312ea06e8e7298e4fcca018a39a626650cd4a5dd565b6f929a0f4787')
 
 _threads="win32"
-_targets="i686-w64-mingw32 x86_64-w64-mingw32" #armv7-w64-mingw32 
+_targets="i686-w64-mingw32 x86_64-w64-mingw32"
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {

--- a/mingw-w64-cross-headers/PKGBUILD
+++ b/mingw-w64-cross-headers/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${_mingw_suff}-${_realname}-git")
 conflicts=("${_mingw_suff}-${_realname}-git")
 replaces=("${_mingw_suff}-${_realname}-git")
 pkgver=11.0.1.r0.gc3e587c06
-pkgrel=1
+pkgrel=2
 pkgdesc="MinGW-w64 headers for cross-compiler"
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
@@ -23,7 +23,7 @@ msys2_references=(
   'archlinux: mingw-w64-headers'
 )
 
-_targets="i686-w64-mingw32 x86_64-w64-mingw32 armv7-w64-mingw32"
+_targets="i686-w64-mingw32 x86_64-w64-mingw32"
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
@@ -36,6 +36,7 @@ prepare() {
 }
 
 build() {
+  unset CC CXX
   for _target in ${_targets}; do
     msg "Configuring ${_target} headers"
     mkdir -p ${srcdir}/headers-${_target} && cd ${srcdir}/headers-${_target}

--- a/mingw-w64-cross-tools/PKGBUILD
+++ b/mingw-w64-cross-tools/PKGBUILD
@@ -25,7 +25,7 @@ msys2_references=(
 )
 _tools="gendef genlib genidl genpeimg" #widl
 
-_targets="i686-w64-mingw32 x86_64-w64-mingw32" #armv7-w64-mingw32
+_targets="i686-w64-mingw32 x86_64-w64-mingw32"
 
 pkgver() {
   cd "${srcdir}/mingw-w64"

--- a/mingw-w64-cross-ucrt-crt/PKGBUILD
+++ b/mingw-w64-cross-ucrt-crt/PKGBUILD
@@ -21,7 +21,7 @@ msys2_references=(
   'archlinux: mingw-w64-crt'
 )
 
-_targets="x86_64-w64-mingw32 i686-w64-mingw32" #armv7-w64-mingw32
+_targets="x86_64-w64-mingw32 i686-w64-mingw32"
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
@@ -44,9 +44,6 @@ build() {
     ;;
     x86_64*)
       _crt_configure_args="--disable-lib32 --enable-lib64"
-    ;;
-    armv7*)
-      _crt_configure_args="--disable-lib32 --disable-lib64 --enable-libarm32"
     ;;
   esac
     mkdir -p ${srcdir}/crt-${_target} && cd ${srcdir}/crt-${_target}

--- a/mingw-w64-cross-ucrt-headers/PKGBUILD
+++ b/mingw-w64-cross-ucrt-headers/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${_mingw_suff}-${_realname}")
 conflicts=("${_mingw_suff%-*}-${_realname}")
 pkgdesc="MinGW-w64 headers for cross-compiler"
 pkgver=9.0.0.6158.1c773877
-pkgrel=1
+pkgrel=2
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
 license=('custom')
@@ -20,7 +20,7 @@ msys2_references=(
   'archlinux: mingw-w64-headers'
 )
 
-_targets="i686-w64-mingw32 x86_64-w64-mingw32 armv7-w64-mingw32"
+_targets="i686-w64-mingw32 x86_64-w64-mingw32"
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
@@ -35,6 +35,7 @@ prepare() {
 }
 
 build() {
+  unset CC CXX
   for _target in ${_targets}; do
     msg "Configuring ${_target} headers"
     mkdir -p ${srcdir}/headers-${_target} && cd ${srcdir}/headers-${_target}


### PR DESCRIPTION
remove some leftovers from various packages. As far as I see this was never finished. Also it's unlikely we'll target armv7 in the future.