### PR TITLE
mingw-w64-cross-gcc: disable stripping again

### DIFF
--- a/mingw-w64-cross-gcc/PKGBUILD
+++ b/mingw-w64-cross-gcc/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gcc
 _mingw_suff=mingw-w64-cross
 pkgname=("${_mingw_suff}-${_realname}")
 pkgver=13.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Cross GCC for the MinGW-w64"
 arch=('i686' 'x86_64')
 url="https://gcc.gnu.org"
@@ -21,7 +21,7 @@ depends=("zlib" "mpc" "isl" "libzstd"
          "${_mingw_suff}-windows-default-manifest")
 makedepends=("gcc" 'lndir' "gmp-devel" "mpc-devel" "zlib-devel" "isl-devel" 'autotools' 'gperf' 'libzstd-devel')
 #checkdepends=('dejagnu')
-options=('staticlibs' '!emptydirs' '!buildflags')
+options=('!strip' 'staticlibs' '!emptydirs' '!buildflags')
 source=(https://ftp.gnu.org/gnu/gcc/gcc-${pkgver}/gcc-${pkgver}.tar.gz
         0001-Cygwin-use-SysV-ABI-on-x86_64.patch
         0002-Cygwin-add-dummy-pthread-tsaware-and-large-address-a.patch

--- a/mingw-w64-cross-gcc/PKGBUILD
+++ b/mingw-w64-cross-gcc/PKGBUILD
@@ -21,7 +21,11 @@ depends=("zlib" "mpc" "isl" "libzstd"
          "${_mingw_suff}-windows-default-manifest")
 makedepends=("gcc" 'lndir' "gmp-devel" "mpc-devel" "zlib-devel" "isl-devel" 'autotools' 'gperf' 'libzstd-devel')
 #checkdepends=('dejagnu')
-options=('!strip' 'staticlibs' '!emptydirs' '!buildflags')
+options=('staticlibs' '!emptydirs' '!buildflags')
+if [[ "${CARCH}" == "i686" ]]; then
+  # https://github.com/msys2/MSYS2-packages/pull/4168#issuecomment-1813274876
+  options+=('!strip'')
+fi
 source=(https://ftp.gnu.org/gnu/gcc/gcc-${pkgver}/gcc-${pkgver}.tar.gz
         0001-Cygwin-use-SysV-ABI-on-x86_64.patch
         0002-Cygwin-add-dummy-pthread-tsaware-and-large-address-a.patch


### PR DESCRIPTION
This was causing x86_64 libgcc.a to fail to link on an i686 msys host, apparently due to strip messing up the non-native libraries.  See https://github.com/msys2/MSYS2-packages/pull/4168#issuecomment-1813274876