### PR TITLE
mingw-w64-cross: add x86_64-w64-mingw32ucrt

### DIFF
--- a/mingw-w64-cross-binutils/PKGBUILD
+++ b/mingw-w64-cross-binutils/PKGBUILD
@@ -5,7 +5,7 @@ _realname=binutils
 _mingw_suff=mingw-w64-cross
 pkgname=("${_mingw_suff}-${_realname}")
 pkgver=2.41
-pkgrel=1
+pkgrel=2
 pkgdesc="A set of programs to assemble and manipulate binary and object files"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/binutils/"
@@ -28,7 +28,7 @@ msys2_references=(
   'archlinux: binutils'
 )
 
-_targets="i686-w64-mingw32 x86_64-w64-mingw32"
+_targets="x86_64-w64-mingw32ucrt i686-w64-mingw32 x86_64-w64-mingw32"
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -52,7 +52,7 @@ build() {
 
     local _conf='--enable-lto'
 
-    if [ "${_target}" = "x86_64-w64-mingw32" ]; then
+    if [ "${_target}" != "i686-w64-mingw32" ]; then
      _conf+=' --enable-64-bit-bfd'
     fi
 

--- a/mingw-w64-cross-crt/PKGBUILD
+++ b/mingw-w64-cross-crt/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${_mingw_suff}-${_realname}-git")
 conflicts=("${_mingw_suff}-${_realname}-git")
 replaces=("${_mingw_suff}-${_realname}-git")
 pkgver=11.0.1.r0.gc3e587c06
-pkgrel=1
+pkgrel=2
 pkgdesc='MinGW-w64 CRT for cross-compiler'
 arch=('i686' 'x86_64')
 url='https://mingw-w64.sourceforge.io/'
@@ -25,7 +25,7 @@ msys2_references=(
   'archlinux: mingw-w64-crt'
 )
 
-_targets="x86_64-w64-mingw32 i686-w64-mingw32"
+_targets="x86_64-w64-mingw32ucrt x86_64-w64-mingw32 i686-w64-mingw32"
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
@@ -50,12 +50,19 @@ build() {
   esac
     mkdir -p ${srcdir}/crt-${_target} && cd ${srcdir}/crt-${_target}
 
+    if [[ "${_target}" == "x86_64-w64-mingw32ucrt" ]]; then
+      _default_msvcrt=ucrt
+    else
+      _default_msvcrt=msvcrt
+    fi
+
     unset CC
     ${srcdir}/mingw-w64/mingw-w64-crt/configure \
     --build=${CHOST} \
     --prefix=/opt/${_target} \
     --host=${_target} \
     --enable-wildcard \
+    --with-default-msvcrt=${_default_msvcrt} \
     --disable-dependency-tracking \
     ${_crt_configure_args}
 

--- a/mingw-w64-cross-gcc/PKGBUILD
+++ b/mingw-w64-cross-gcc/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gcc
 _mingw_suff=mingw-w64-cross
 pkgname=("${_mingw_suff}-${_realname}")
 pkgver=13.2.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Cross GCC for the MinGW-w64"
 arch=('i686' 'x86_64')
 url="https://gcc.gnu.org"
@@ -72,7 +72,7 @@ sha256sums=('8cb4be3796651976f94b9356fa08d833524f62420d6292c5033a9a26af315078'
             'b0a98a41fea4a68f15d35b44495a487183a4d85ea9cb70cd4a645b4ed6583122')
 
 _threads="win32"
-_targets="i686-w64-mingw32 x86_64-w64-mingw32"
+_targets="x86_64-w64-mingw32ucrt i686-w64-mingw32 x86_64-w64-mingw32"
 
 apply_patch_with_msg() {
   for _fname in "$@"

--- a/mingw-w64-cross-headers/PKGBUILD
+++ b/mingw-w64-cross-headers/PKGBUILD
@@ -8,7 +8,7 @@ provides=("${_mingw_suff}-${_realname}-git")
 conflicts=("${_mingw_suff}-${_realname}-git")
 replaces=("${_mingw_suff}-${_realname}-git")
 pkgver=11.0.1.r0.gc3e587c06
-pkgrel=2
+pkgrel=3
 pkgdesc="MinGW-w64 headers for cross-compiler"
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
@@ -23,7 +23,7 @@ msys2_references=(
   'archlinux: mingw-w64-headers'
 )
 
-_targets="i686-w64-mingw32 x86_64-w64-mingw32"
+_targets="x86_64-w64-mingw32ucrt i686-w64-mingw32 x86_64-w64-mingw32"
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
@@ -38,6 +38,15 @@ prepare() {
 build() {
   unset CC CXX
   for _target in ${_targets}; do
+
+    if [[ "${_target}" == "x86_64-w64-mingw32ucrt" ]]; then
+      _default_msvcrt=ucrt
+      _default_win32_winnt=0x603  # Windows 8.1
+    else
+      _default_msvcrt=msvcrt
+      _default_win32_winnt=0x601  # Windows 7
+    fi
+  
     msg "Configuring ${_target} headers"
     mkdir -p ${srcdir}/headers-${_target} && cd ${srcdir}/headers-${_target}
     ${srcdir}/mingw-w64/mingw-w64-headers/configure \
@@ -45,9 +54,8 @@ build() {
     --host=${_target} \
     --prefix=/opt/${_target} \
     --enable-sdk=all \
-    --enable-secure-api \
-    --with-default-win32-winnt=0x601 \
-    --with-default-msvcrt=msvcrt
+    --with-default-win32-winnt=${_default_win32_winnt} \
+    --with-default-msvcrt=${_default_msvcrt}
   done
 }
 

--- a/mingw-w64-cross-windows-default-manifest/PKGBUILD
+++ b/mingw-w64-cross-windows-default-manifest/PKGBUILD
@@ -5,7 +5,7 @@ _mingw_suff=mingw-w64-cross
 pkgname=("${_mingw_suff}-${_realname}")
 groups=("${_mingw_suff}-toolchain" "${_mingw_suff}")
 pkgver=6.4
-pkgrel=3
+pkgrel=4
 pkgdesc='Default Windows application manifest'
 url='https://cygwin.com/'
 arch=('i686' 'x86_64')
@@ -19,7 +19,7 @@ msys2_references=(
   'cygwin: windows-default-manifest'
 )
 
-_targets="i686-w64-mingw32 x86_64-w64-mingw32"
+_targets="x86_64-w64-mingw32ucrt i686-w64-mingw32 x86_64-w64-mingw32"
 
 prepare() {
   cd ${srcdir}/${_realname}

--- a/mingw-w64-cross-winpthreads/PKGBUILD
+++ b/mingw-w64-cross-winpthreads/PKGBUILD
@@ -7,7 +7,7 @@ provides=("${_mingw_suff}-${_realname}-git")
 conflicts=("${_mingw_suff}-${_realname}-git")
 replaces=("${_mingw_suff}-${_realname}-git")
 pkgver=11.0.1.r0.gc3e587c06
-pkgrel=1
+pkgrel=2
 pkgdesc="MinGW-w64 winpthreads library for cross-compiler"
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
@@ -27,7 +27,7 @@ msys2_references=(
   'archlinux: mingw-w64-winpthreads'
 )
 
-_targets="i686-w64-mingw32 x86_64-w64-mingw32"
+_targets="x86_64-w64-mingw32ucrt i686-w64-mingw32 x86_64-w64-mingw32"
 
 pkgver() {
   cd "$srcdir/mingw-w64"

--- a/mingw-w64-cross-zlib/PKGBUILD
+++ b/mingw-w64-cross-zlib/PKGBUILD
@@ -5,7 +5,7 @@ _mingw_suff=mingw-w64-cross
 pkgname=("${_mingw_suff}-${_realname}")
 pkgdesc="Compression library implementing the deflate compression method found in gzip and PKZIP"
 pkgver=1.3
-pkgrel=3
+pkgrel=4
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
 license=('custom')
@@ -25,7 +25,7 @@ msys2_references=(
   'archlinux: zlib'
 )
 
-_targets="i686-w64-mingw32 x86_64-w64-mingw32"
+_targets="x86_64-w64-mingw32ucrt i686-w64-mingw32 x86_64-w64-mingw32"
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}


### PR DESCRIPTION
This is a cross compiler targeting for 64bit ucrt. The target triple is the some Fedora decided to use: https://fedoraproject.org/wiki/Changes/F37MingwUCRT