### PR TITLE
libxml2: Update to 2.12.0

### DIFF
--- a/libxml2/PKGBUILD
+++ b/libxml2/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=libxml2
 pkgname=('libxml2' 'libxml2-devel' 'libxml2-python')
-pkgver=2.11.6
+pkgver=2.12.0
 pkgrel=1
 pkgdesc="XML parsing library, version 2"
 arch=(i686 x86_64)
@@ -13,7 +13,7 @@ url="https://gitlab.gnome.org/GNOME/libxml2/-/wikis/"
 source=("https://download.gnome.org/sources/libxml2/${pkgver%.*}/${pkgbase}-${pkgver}.tar.xz"
         https://www.w3.org/XML/Test/xmlts20130923.tar.gz
         libxml2-2.9.8-python3-unicode-errors.patch)
-sha256sums=('c90eee7506764abbe07bb616b82da452529609815aefef423d66ef080eb0c300'
+sha256sums=('431521c8e19ca396af4fa97743b5a6bfcccddbba90e16426a15e5374cd64fe0d'
             '9b61db9f5dbffa545f4b8d78422167083a8568c59bd1129f94138f936cf6fc1f'
             '0f5d465503b24271e11752262af89c58eb0b26b4901c3b021bd843e6e5d4e95a')
 
@@ -70,6 +70,7 @@ build() {
     --without-icu \
     --enable-shared \
     --enable-static \
+    --with-legacy \
     --with-python=/usr/bin/python
   make
   make DESTDIR=${srcdir}/dest install


### PR DESCRIPTION
"Starting with this release, it should be enough to add the --with-legacy configuration option to provide maximum ABI compatibility."

So why not I guess