### PR TITLE
msys2-runtime: avoid "Bad address" errors in the MSYS2 path conversion

### DIFF
--- a/msys2-runtime/0039-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+++ b/msys2-runtime/0039-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
@@ -1,0 +1,30 @@
+From 0e7d0755a911149d0c517c6b93887b3155a9cfe0 Mon Sep 17 00:00:00 2001
+From: Kai Pastor <dg0yt@darc.de>
+Date: Tue, 21 Nov 2023 09:24:03 +0100
+Subject: [PATCH 39/N] fixup! Add functionality for converting UNIX paths in
+ arguments and environment variables to Windows form for native Win32
+ applications.
+
+Don't memchr behind end, it+1
+---
+ winsup/cygwin/msys2_path_conv.cc | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/winsup/cygwin/msys2_path_conv.cc b/winsup/cygwin/msys2_path_conv.cc
+index 2bdf0ae..d4f0192 100644
+--- a/winsup/cygwin/msys2_path_conv.cc
++++ b/winsup/cygwin/msys2_path_conv.cc
+@@ -349,6 +349,13 @@ path_type find_path_start_and_type(const char** src, int recurse, const char* en
+ 
+     path_type result = NONE;
+ 
++    if (it + 1 == end) {
++        switch (*it) {
++        case '/':   return ROOTED_PATH ;
++        default:    return SIMPLE_WINDOWS_PATH;
++        }
++    }
++
+     if (isalpha(*it) && *(it + 1) == ':') {
+         if (*(it + 2) == '\\') {
+             return SIMPLE_WINDOWS_PATH;

--- a/msys2-runtime/0040-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+++ b/msys2-runtime/0040-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
@@ -1,0 +1,34 @@
+From 677ece60fc37b0c5d336db1e345a4c33ffff15f6 Mon Sep 17 00:00:00 2001
+From: Kai Pastor <dg0yt@darc.de>
+Date: Tue, 21 Nov 2023 09:25:58 +0100
+Subject: [PATCH 40/N] fixup! Add functionality for converting UNIX paths in
+ arguments and environment variables to Windows form for native Win32
+ applications.
+
+Don't memchr behind end, it2
+---
+ winsup/cygwin/msys2_path_conv.cc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/winsup/cygwin/msys2_path_conv.cc b/winsup/cygwin/msys2_path_conv.cc
+index d4f0192..5c59291 100644
+--- a/winsup/cygwin/msys2_path_conv.cc
++++ b/winsup/cygwin/msys2_path_conv.cc
+@@ -431,7 +431,7 @@ path_type find_path_start_and_type(const char** src, int recurse, const char* en
+             if (isalpha(ch) && (*(it2+1) == ':') && (*(it2+2) == '/')) {
+                 return SIMPLE_WINDOWS_PATH;
+             }
+-            if (ch == '/'&& memchr(it2, ',', end - it) == NULL) {
++            if (ch == '/'&& memchr(it2, ',', end - it2) == NULL) {
+                 *src = it2;
+                 return find_path_start_and_type(src, true, end);
+             }
+@@ -458,7 +458,7 @@ path_type find_path_start_and_type(const char** src, int recurse, const char* en
+                 } else {
+                     return POSIX_PATH_LIST;
+                 }
+-            } else if (memchr(it2, '=', end - it) == NULL) {
++            } else if (memchr(it2, '=', end - it2) == NULL) {
+                 return SIMPLE_WINDOWS_PATH;
+             }
+         }

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.4.9
-pkgrel=2
+pkgrel=3
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -65,7 +65,9 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0035-When-converting-to-a-Unix-path-avoid-double-trailing.patch
         0036-msys2_path_conv-pass-PC_NOFULL-to-path_conv.patch
         0037-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch
-        0038-dumper-avoid-linker-problem-when-libbfd-depends-on-l.patch)
+        0038-dumper-avoid-linker-problem-when-libbfd-depends-on-l.patch
+        0039-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+        0040-fixup-Add-functionality-for-converting-UNIX-paths-in.patch)
 sha256sums=('SKIP'
             '021fd67841a12ef09dd72d08e3ed4a1ccc58d38dc475bdf79ecff3a90c7d6197'
             '6b6187c8e9343cf2875fe8d622762892bfb2d8087f1e510882928ec63584e4bc'
@@ -104,7 +106,9 @@ sha256sums=('SKIP'
             'f9cf227e20e491a823d1bd8fac12f0be9d371e21239368e8b30f203a48b18995'
             '6defe4f95bda4ba9ec52c6aab4bb6f61e51aad5e2b5aef25dc277e108bdef553'
             '9226d25556c04de2506ee6d9d8ebc1e369d456fe5ca8d335705c2dd090b3cb64'
-            '54b45f5a0b86057bdd7225d9d1d69674dfd93e923ce3b053d7129f43700b1aeb')
+            '54b45f5a0b86057bdd7225d9d1d69674dfd93e923ce3b053d7129f43700b1aeb'
+            '1d0649096bcf1254a77a90fbd8d80436cdb6b6a7dbadc3b2928f3d9a27be08db'
+            'd583155004ecea979144cc8c92f56a3b79364fd3fe2d74ec9be7295969b00353')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -179,7 +183,9 @@ prepare() {
   0035-When-converting-to-a-Unix-path-avoid-double-trailing.patch \
   0036-msys2_path_conv-pass-PC_NOFULL-to-path_conv.patch \
   0037-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch \
-  0038-dumper-avoid-linker-problem-when-libbfd-depends-on-l.patch
+  0038-dumper-avoid-linker-problem-when-libbfd-depends-on-l.patch \
+  0039-fixup-Add-functionality-for-converting-UNIX-paths-in.patch \
+  0040-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
 }
 
 build() {


### PR DESCRIPTION
This commit corresponds to https://github.com/msys2/msys2-runtime/pull/179 and should fix https://github.com/msys2/MSYS2-packages/issues/2282 and maybe even https://github.com/microsoft/vcpkg/pull/34274.