### PR TITLE
binutils: make sure to use the system zlib

### DIFF
--- a/binutils/PKGBUILD
+++ b/binutils/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=binutils
 pkgver=2.41
-pkgrel=3
+pkgrel=4
 pkgdesc="A set of programs to assemble and manipulate binary and object files"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/binutils/"
@@ -51,7 +51,8 @@ build() {
     --enable-64-bit-bfd \
     --enable-install-libiberty \
     --without-libiconv-prefix \
-    --without-libintl-prefix
+    --without-libintl-prefix \
+    --with-system-zlib
 
   make
 }


### PR DESCRIPTION
it defaults to the internal one by default

Fixes #4218