### PR TITLE
lemon: fix lempar.c search

### DIFF
--- a/sqlite/0010-sqlite-3.34.0-lemon.patch
+++ b/sqlite/0010-sqlite-3.34.0-lemon.patch
@@ -1,25 +1,22 @@
---- lemon.c.orig	2020-12-01 21:30:32.470000000 +0100
-+++ lemon.c	2020-12-01 21:28:20.268940000 +0100
-@@ -3672,6 +3672,10 @@
-     toFree = tpltname = pathsearch(lemp->argv0,templatename,0);
+--- lemon.c.orig        2023-12-04 17:56:38.260892600 +0100
++++ lemon.c     2023-12-04 19:20:21.727095900 +0100
+@@ -3688,11 +3688,19 @@
+     tpltname = templatename;
+   }else{
+     toFree = tpltname = pathsearch(lemp->argv[0],templatename,0);
++    if ( tpltname==0 || access(tpltname,004)!=0 ) {
++      tpltname = 0;
++      sprintf(buf,"/usr/share/lemon/%s",templatename);
++      if ( access(buf,004)==0 ) {
++        tpltname = buf;
++      }
++    }
    }
    if( tpltname==0 ){
-+    sprintf(buf,"/usr/share/lemon/%s",templatename);
-+    tpltname = buf;
-+  }
-+  if( tpltname==0 ){
      fprintf(stderr,"Can't find the parser driver template file \"%s\".\n",
      templatename);
      lemp->errorcnt++;
-@@ -3679,6 +3683,11 @@
++    free(toFree);
+     return 0;
    }
    in = fopen(tpltname,"rb");
-   if( in==0 ){
-+    sprintf(buf,"/usr/share/lemon/%s",tpltname);
-+    tpltname = buf;
-+    in = fopen(tpltname,"rb");
-+  }
-+  if( in==0 ){
-     fprintf(stderr,"Can't open the template file \"%s\".\n",tpltname);
-     lemp->errorcnt++;
-   }

--- a/sqlite/PKGBUILD
+++ b/sqlite/PKGBUILD
@@ -10,7 +10,7 @@ _sqlite_year=2023
 _srcver=3440200
 _docver=${_srcver}
 pkgver=3.44.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A C library that implements an SQL database engine"
 arch=('i686' 'x86_64')
 license=(PublicDomain)
@@ -29,7 +29,7 @@ source=(https://www.sqlite.org/${_sqlite_year}/sqlite-src-${_srcver}.zip
 sha256sums=('73187473feb74509357e8fa6cb9fd67153b2d010d00aeb2fddb6ceeb18abaf27'
             '62e51962552fb204ef0a541d51f8f721499d1a3fffae6e86558d251c96084fcf'
             '0b76663a90e034f3d7f2af5bfada4cedec5ebc275361899eccc5c18e6f01ff1f'
-            'ee6bdd979a97205a1a2dd760e90c8588f45523cecb5256c0d927f24494f7fc9f'
+            '99804c57f4affc213681badd0f0332de16921f1f2484e13f4ef8d0cf233cd680'
             '589b7182343dba3dd8225c13ff1d7d275e5f714e7793bac1c88f7cfdd569d9e0'
             'b717c73804be44b82048d90bbb8e0c61ff081339a5757194e9769bd4d9c048e5'
             '10f30378e83423f8b84462c1dd5b58501913816865cfd595f69a7b9ddd7e4e2b'


### PR DESCRIPTION
Because of a typo in the `0010-sqlite-3.34.0-lemon.patch` (`tpltname` with the leftover value was used instead of `templatename`) lemon couldn't find the `lempar.c` template. Also `tplt_open` was refactored to correctly emit error about missing `lempar.c`.

Fixes #4226