### PR TITLE
pacman-mirrors: Update to 20231208

### DIFF
--- a/pacman-mirrors/PKGBUILD
+++ b/pacman-mirrors/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Ray Donnelly <mingwandroid@gmail.com>
 
 pkgname=pacman-mirrors
-pkgver=20221016
+pkgver=20231208
 pkgrel=1
 pkgdesc="MSYS2 mirror list for use by pacman"
 arch=('any')
@@ -9,8 +9,8 @@ url="https://www.msys2.org/dev/mirrors/"
 license=('GPL')
 source=(mirrorlist.msys
         mirrorlist.mingw)
-sha256sums=('f105e99b174b409dbcec37d0e5e7473b22092cdbf5cd52ef9c5943f62b955017'
-            '9bf93b4feeddcfc788fee17965dc6339f91d4fc3059812a9b3bc349e6bde0065')
+sha256sums=('7f287f7ed32756b71fdbf872ac44657543e1a0de24535a370a40b381abf70397'
+            '80c393828f58fc412bb3b7429fd65eaf94c1af478d21ef81a658a0c89132c73c')
 backup=(
   'etc/pacman.d/mirrorlist.msys'
   'etc/pacman.d/mirrorlist.mingw'

--- a/pacman-mirrors/mirrorlist.mingw
+++ b/pacman-mirrors/mirrorlist.mingw
@@ -22,19 +22,17 @@ Server = https://repo.extreme-ix.org/msys2/mingw/$repo/
 Server = https://mirrors.hit.edu.cn/msys2/mingw/$repo/
 Server = https://mirror.clarkson.edu/msys2/mingw/$repo/
 Server = https://quantum-mirror.hu/mirrors/pub/msys2/mingw/$repo/
-Server = https://mirror2.sandyriver.net/pub/software/msys2/mingw/$repo/
 Server = https://mirror.archlinux.tw/MSYS2/mingw/$repo/
+Server = https://fastmirror.pp.ua/msys2/mingw/$repo/
 
 ## Tier 2
 Server = https://mirror.ufro.cl/msys2/mingw/$repo/
-Server = https://fastmirror.pp.ua/msys2/mingw/$repo/
 Server = https://ftp.cc.uoc.gr/mirrors/msys2/mingw/$repo/
 Server = https://mirror.jmu.edu/pub/msys2/mingw/$repo/
 Server = https://mirrors.piconets.webwerks.in/msys2-mirror/mingw/$repo/
 Server = https://www2.futureware.at/~nickoe/msys2-mirror/mingw/$repo/
 Server = https://mirrors.sjtug.sjtu.edu.cn/msys2/mingw/$repo/
 Server = https://mirrors.bit.edu.cn/msys2/mingw/$repo/
-Server = https://repo.casualgamer.ca/mingw/$repo/
 Server = https://mirrors.aliyun.com/msys2/mingw/$repo/
 Server = https://mirror.iscas.ac.cn/msys2/mingw/$repo/
-Server = https://mirrors.tencent.com/msys2/mingw/$repo/
+Server = https://mirrors.cloud.tencent.com/msys2/mingw/$repo/

--- a/pacman-mirrors/mirrorlist.msys
+++ b/pacman-mirrors/mirrorlist.msys
@@ -22,19 +22,17 @@ Server = https://repo.extreme-ix.org/msys2/msys/$arch/
 Server = https://mirrors.hit.edu.cn/msys2/msys/$arch/
 Server = https://mirror.clarkson.edu/msys2/msys/$arch/
 Server = https://quantum-mirror.hu/mirrors/pub/msys2/msys/$arch/
-Server = https://mirror2.sandyriver.net/pub/software/msys2/msys/$arch/
 Server = https://mirror.archlinux.tw/MSYS2/msys/$arch/
+Server = https://fastmirror.pp.ua/msys2/msys/$arch/
 
 ## Tier 2
 Server = https://mirror.ufro.cl/msys2/msys/$arch/
-Server = https://fastmirror.pp.ua/msys2/msys/$arch/
 Server = https://ftp.cc.uoc.gr/mirrors/msys2/msys/$arch/
 Server = https://mirror.jmu.edu/pub/msys2/msys/$arch/
 Server = https://mirrors.piconets.webwerks.in/msys2-mirror/msys/$arch/
 Server = https://www2.futureware.at/~nickoe/msys2-mirror/msys/$arch/
 Server = https://mirrors.sjtug.sjtu.edu.cn/msys2/msys/$arch/
 Server = https://mirrors.bit.edu.cn/msys2/msys/$arch/
-Server = https://repo.casualgamer.ca/msys/$arch/
 Server = https://mirrors.aliyun.com/msys2/msys/$arch/
 Server = https://mirror.iscas.ac.cn/msys2/msys/$arch/
-Server = https://mirrors.tencent.com/msys2/msys/$arch/
+Server = https://mirrors.cloud.tencent.com/msys2/msys/$arch/


### PR DESCRIPTION
mirror2.sandyriver.net: gone
repo.casualgamer.ca: gone
fastmirror.pp.ua: move to tier one
mirrors.tencent.com: better URL, see https://github.com/msys2/msys2.github.io/issues/297