### PR TITLE
msys2-runtime: backport Git for Windows' pathconv improvements

### DIFF
--- a/msys2-runtime/0039-path-conversion-Introduce-ability-to-switch-off-conv.patch
+++ b/msys2-runtime/0039-path-conversion-Introduce-ability-to-switch-off-conv.patch
@@ -1,0 +1,55 @@
+From 4f2214a1d6349884135f0485a36e3bfad31350a2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=EB=A7=88=EB=88=84=EC=97=98?= <nalla@hamal.uberspace.de>
+Date: Wed, 17 Jun 2015 09:30:41 +0200
+Subject: [PATCH 39/N] path-conversion: Introduce ability to switch off
+ conversion.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When calling windows native apps from MSYS2, the runtime tries to
+convert commandline arguments by a specific set of rules. This idea was
+inherited from the MSys/MinGW project (which is now seemingly stale, yet
+must be credited with championing this useful feature, see MinGW wiki
+https://web.archive.org/web/20201112005258/http://www.mingw.org/wiki/Posix_path_conversion).
+
+If the user does not want that behavior on a big scale, e.g. inside a
+Bash script, with the changes introduced in this commit, the user can
+now set the the environment variable `MSYS_NO_PATHCONV` when calling
+native windows commands.
+
+This is a feature that has been introduced in Git for Windows via
+https://github.com/git-for-windows/msys2-runtime/pull/11 and it predates
+support for the `MSYS2_ENV_CONV_EXCL` and `MSYS2_ARG_CONV_EXCL`
+environment variables in the MSYS2 runtime; Many users find the
+simplicity of `MSYS_NO_PATHCONV` appealing.
+
+So let's teach MSYS2 proper this simple trick that still allows using
+the sophisticated `MSYS2_*_CONV_EXCL` facilities but also offers a
+convenient catch-all "just don't convert anything" knob.
+
+Signed-off-by: 마누엘 <nalla@hamal.uberspace.de>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/msys2_path_conv.cc | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/winsup/cygwin/msys2_path_conv.cc b/winsup/cygwin/msys2_path_conv.cc
+index 5c59291..875be6f 100644
+--- a/winsup/cygwin/msys2_path_conv.cc
++++ b/winsup/cygwin/msys2_path_conv.cc
+@@ -341,6 +341,14 @@ path_type find_path_start_and_type(const char** src, int recurse, const char* en
+ 
+     if (*it == '\0' || it == end) return NONE;
+ 
++    /*
++     * Skip path mangling when environment indicates it.
++     */
++    const char *no_pathconv = getenv ("MSYS_NO_PATHCONV");
++
++    if (no_pathconv)
++      return NONE;
++
+     while (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
+         recurse = true;
+         it = ++*src;

--- a/msys2-runtime/0040-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+++ b/msys2-runtime/0040-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
@@ -1,0 +1,58 @@
+From 7f5ce2cb55bf18020a68f88c2861ea862feb8178 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Sun, 15 Feb 2015 11:45:48 +0000
+Subject: [PATCH 40/N] fixup! Add functionality for converting UNIX paths in
+ arguments and environment variables to Windows form for native Win32
+ applications.
+
+This teaches MSYS2's path conversion to leave arguments starting with a
+tilde or quote alone: It is not a good idea to expand, say, ~/.gitconfig
+partially: replacing it by ~C:\msys64\.gitconfig is most likely the
+wrong thing to do!
+
+This addresses the expectations of the following test cases in the test
+suite of https://github.com/git/git/tree/v2.43.0:
+
+-t0001.19 init with init.templatedir using ~ expansion
+-t0003.12 core.attributesfile
+-t0003.13 attribute test: read paths from stdin
+-t0003.15 attribute test: --all option
+-t0003.16 attribute test: --cached option
+-t0003.17 root subdir attribute test
+-t0003.18 negative patterns
+-t0003.19 patterns starting with exclamation
+-t0003.20 "**" test
+-t0003.21 "**" with no slashes test
+-t0003.23 using --source
+-t0003.32 bare repository: check that --cached honors index
+-t0003.34 binary macro expanded by -a
+-t0003.35 query binary macro directly
+-t0003.40 large attributes line ignored in tree
+-t0003.41 large attributes line ignores trailing content in tree
+-t0003.43 large attributes line ignored in index
+-t0003.44 large attributes line ignores trailing content in index
+-t0068.1 run based on configured value
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/msys2_path_conv.cc | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/winsup/cygwin/msys2_path_conv.cc b/winsup/cygwin/msys2_path_conv.cc
+index 875be6f..35b7757 100644
+--- a/winsup/cygwin/msys2_path_conv.cc
++++ b/winsup/cygwin/msys2_path_conv.cc
+@@ -349,6 +349,13 @@ path_type find_path_start_and_type(const char** src, int recurse, const char* en
+     if (no_pathconv)
+       return NONE;
+ 
++    /* Let's not convert ~/.file to ~C:\msys64\.file */
++    if (*it == '~') {
++skip_p2w:
++        *src = end;
++        return NONE;
++    }
++
+     while (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
+         recurse = true;
+         it = ++*src;

--- a/msys2-runtime/0041-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+++ b/msys2-runtime/0041-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
@@ -1,0 +1,88 @@
+From 4b20e4fc67735ce82bb47c60a6e8f46bbcb33127 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 18 Feb 2015 11:07:17 +0000
+Subject: [PATCH 41/N] fixup! Add functionality for converting UNIX paths in
+ arguments and environment variables to Windows form for native Win32
+ applications.
+
+Let's teach MSYS2's path conversion to leave Git's :name and :/message
+arguments alone, please. These arguments start with colons and are hence
+unlikely to contain a path list (a path list starting with a colon would
+start with an empty item?!?).
+
+Without this patch, you will see this:
+
+$ GIT_TRACE=1 /c/Program\ Files/Git/cmd/git version :/message
+13:48:44.258390 exec-cmd.c:244          trace: resolved executable dir: C:/Program Files/Git/mingw64/bin
+13:48:44.269314 git.c:463               trace: built-in: git version ';C:\msys64\message'
+git version 2.43.0.windows.1
+
+In other words, the argument `:/message` is mangled in an undesired way.
+
+This addresses the expectations of the following test cases in the test
+suite of https://github.com/git/git/tree/v2.43.0:
+
+-t0060.81 <drive-letter>:\\abc is an absolute path
+-t1501.35 Auto discovery
+-t1501.36 $GIT_DIR/common overrides core.worktree
+-t1501.37 $GIT_WORK_TREE overrides $GIT_DIR/common
+-t1506.3 correct relative file objects (0)
+-t1506.8 correct relative file objects (5)
+-t1506.9 correct relative file objects (6)
+-t2070.7 restore --staged uses HEAD as source
+-t3013.16 git ls-files --format with relative path
+-t3400.6 rebase, with <onto> and <upstream> specified as :/quuxery
+-t3404.84 rebase -i, with <onto> and <upstream> specified as :/quuxery
+-t3703.2 add :/
+-t3703.3 add :/anothersub
+-t4202.8 oneline
+-t4202.22 git log --no-walk <commits> sorts by commit time
+-t4202.23 git log --no-walk=sorted <commits> sorts by commit time
+-t4202.24 git log --line-prefix="=== " --no-walk <commits> sorts by commit time
+-t4202.25 git log --no-walk=unsorted <commits> leaves list of commits as given
+-t4202.26 git show <commits> leaves list of commits as given
+-t4202.138 log --source paints branch names
+-t4202.139 log --source paints tag names
+-t4202.140 log --source paints symmetric ranges
+-t4208.2 "git log :/" should not be ambiguous
+-t4208.3 "git log :/a" should be ambiguous (applied both rev and worktree)
+-t4208.4 "git log :/a -- " should not be ambiguous
+-t4208.5 "git log :/detached -- " should find a commit only in HEAD
+-t4208.7 "git log :/detached -- " should find HEAD only of own worktree
+-t4208.10 "git log :/in" should not be ambiguous
+-t4208.13 git log HEAD -- :/
+-t5616.43 lazy-fetch in submodule succeeds
+-t6132.7 t_e_i() exclude sub2 from sub
+-t6132.14 m_p_d() exclude sub2 from sub
+-t6132.19 grep --untracked PATTERN
+-t6132.21 grep --untracked PATTERN :(exclude)*FILE
+-t6133.6 :/*.t from a subdir dwims to a pathspec
+-t7201.14 checkout to detach HEAD with :/message
+-t9903.37 prompt - untracked files status indicator - untracked files
+-t9903.39 prompt - untracked files status indicator - non-empty untracked dir
+-t9903.40 prompt - untracked files status indicator - untracked files outside cwd
+-t9903.44 prompt - untracked files status indicator - shell variable set with config enabled
+-t9903.56 prompt - bash color pc mode - untracked files status indicator
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/msys2_path_conv.cc | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/winsup/cygwin/msys2_path_conv.cc b/winsup/cygwin/msys2_path_conv.cc
+index 35b7757..8870d38 100644
+--- a/winsup/cygwin/msys2_path_conv.cc
++++ b/winsup/cygwin/msys2_path_conv.cc
+@@ -356,6 +356,12 @@ skip_p2w:
+         return NONE;
+     }
+ 
++    /*
++     * Prevent Git's :file.txt and :/message syntax from beeing modified.
++     */
++    if (*it == ':')
++        goto skip_p2w;
++
+     while (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
+         recurse = true;
+         it = ++*src;

--- a/msys2-runtime/0042-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+++ b/msys2-runtime/0042-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
@@ -1,0 +1,145 @@
+From cfc7696e0825563fb4245377ab70887cde160cd1 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Sun, 22 Feb 2015 18:33:48 +0100
+Subject: [PATCH 42/N] fixup! Add functionality for converting UNIX paths in
+ arguments and environment variables to Windows form for native Win32
+ applications.
+
+With this change, MSYS2's path conversion leaves paths containing any
+special characters alone.
+
+This addresses the expectations of the following test cases in the test
+suite of https://github.com/git/git/tree/v2.43.0:
+
+-t1091.13 set sparse-checkout using builtin
+-t1092.82 grep sparse directory within submodules
+-t1402.56 ref name '*/foo' is valid with options --refspec-pattern
+-t1402.57 ref name '*/foo' is valid with options --refspec-pattern --allow-onelevel
+-t1402.59 ref name '*/foo' is valid with options --refspec-pattern --normalize
+-t3001.25 ls-files with "**" patterns
+-t3001.26 ls-files with "**" patterns and --directory
+-t3070.423 wildmatch: match 'foo' '**/foo'
+-t3070.425 iwildmatch: match 'foo' '**/foo'
+-t3070.433 wildmatch: match 'XXX/foo' '**/foo'
+-t3070.435 iwildmatch: match 'XXX/foo' '**/foo'
+-t3070.437 pathmatch: match 'XXX/foo' '**/foo'
+-t3070.439 ipathmatch: match 'XXX/foo' '**/foo'
+-t3070.443 wildmatch: match 'bar/baz/foo' '**/foo'
+-t3070.445 iwildmatch: match 'bar/baz/foo' '**/foo'
+-t3070.447 pathmatch: match 'bar/baz/foo' '**/foo'
+-t3070.449 ipathmatch: match 'bar/baz/foo' '**/foo'
+-t3070.457 pathmatch: match 'bar/baz/foo' '*/foo'
+-t3070.459 ipathmatch: match 'bar/baz/foo' '*/foo'
+-t3070.467 pathmatch: match 'foo/bar/baz' '**/bar*'
+-t3070.469 ipathmatch: match 'foo/bar/baz' '**/bar*'
+-t3070.473 wildmatch: match 'deep/foo/bar/baz' '**/bar/*'
+-t3070.475 iwildmatch: match 'deep/foo/bar/baz' '**/bar/*'
+-t3070.477 pathmatch: match 'deep/foo/bar/baz' '**/bar/*'
+-t3070.479 ipathmatch: match 'deep/foo/bar/baz' '**/bar/*'
+-t3070.487 pathmatch: match 'deep/foo/bar/baz/' '**/bar/*'
+-t3070.489 ipathmatch: match 'deep/foo/bar/baz/' '**/bar/*'
+-t3070.493 wildmatch: match 'deep/foo/bar/baz/' '**/bar/**'
+-t3070.495 iwildmatch: match 'deep/foo/bar/baz/' '**/bar/**'
+-t3070.497 pathmatch: match 'deep/foo/bar/baz/' '**/bar/**'
+-t3070.499 ipathmatch: match 'deep/foo/bar/baz/' '**/bar/**'
+-t3070.513 wildmatch: match 'deep/foo/bar/' '**/bar/**'
+-t3070.515 iwildmatch: match 'deep/foo/bar/' '**/bar/**'
+-t3070.517 pathmatch: match 'deep/foo/bar/' '**/bar/**'
+-t3070.519 ipathmatch: match 'deep/foo/bar/' '**/bar/**'
+-t3070.527 pathmatch: match 'foo/bar/baz' '**/bar**'
+-t3070.529 ipathmatch: match 'foo/bar/baz' '**/bar**'
+-t3070.533 wildmatch: match 'foo/bar/baz/x' '*/bar/**'
+-t3070.535 iwildmatch: match 'foo/bar/baz/x' '*/bar/**'
+-t3070.537 pathmatch: match 'foo/bar/baz/x' '*/bar/**'
+-t3070.539 ipathmatch: match 'foo/bar/baz/x' '*/bar/**'
+-t3070.547 pathmatch: match 'deep/foo/bar/baz/x' '*/bar/**'
+-t3070.549 ipathmatch: match 'deep/foo/bar/baz/x' '*/bar/**'
+-t3070.553 wildmatch: match 'deep/foo/bar/baz/x' '**/bar/*/*'
+-t3070.555 iwildmatch: match 'deep/foo/bar/baz/x' '**/bar/*/*'
+-t3070.557 pathmatch: match 'deep/foo/bar/baz/x' '**/bar/*/*'
+-t3070.559 ipathmatch: match 'deep/foo/bar/baz/x' '**/bar/*/*'
+-t3070.633 wildmatch: match 'XXX/\' '*/\\'
+-t3070.635 iwildmatch: match 'XXX/\' '*/\\'
+-t3070.637 pathmatch: match 'XXX/\' '*/\\'
+-t3070.639 ipathmatch: match 'XXX/\' '*/\\'
+-t3070.763 wildmatch: match 'foo/bar/baz/to' '**/t[o]'
+-t3070.765 iwildmatch: match 'foo/bar/baz/to' '**/t[o]'
+-t3070.767 pathmatch: match 'foo/bar/baz/to' '**/t[o]'
+-t3070.769 ipathmatch: match 'foo/bar/baz/to' '**/t[o]'
+-t3070.1493 wildmatch: match 'abcd/abcdefg/abcdefghijk/abcdefghijklmnop.txt' '**/*a*b*g*n*t'
+-t3070.1495 iwildmatch: match 'abcd/abcdefg/abcdefghijk/abcdefghijklmnop.txt' '**/*a*b*g*n*t'
+-t3070.1497 pathmatch: match 'abcd/abcdefg/abcdefghijk/abcdefghijklmnop.txt' '**/*a*b*g*n*t'
+-t3070.1499 ipathmatch: match 'abcd/abcdefg/abcdefghijk/abcdefghijklmnop.txt' '**/*a*b*g*n*t'
+-t3070.1533 wildmatch: match 'foo/bba/arr' '*/*/*'
+-t3070.1535 iwildmatch: match 'foo/bba/arr' '*/*/*'
+-t3070.1537 pathmatch: match 'foo/bba/arr' '*/*/*'
+-t3070.1539 ipathmatch: match 'foo/bba/arr' '*/*/*'
+-t3070.1547 pathmatch: match 'foo/bb/aa/rr' '*/*/*'
+-t3070.1549 ipathmatch: match 'foo/bb/aa/rr' '*/*/*'
+-t3070.1553 wildmatch: match 'foo/bb/aa/rr' '**/**/**'
+-t3070.1555 iwildmatch: match 'foo/bb/aa/rr' '**/**/**'
+-t3070.1557 pathmatch: match 'foo/bb/aa/rr' '**/**/**'
+-t3070.1559 ipathmatch: match 'foo/bb/aa/rr' '**/**/**'
+-t3070.1583 wildmatch: match 'ab/cXd/efXg/hi' '*/*X*/*/*i'
+-t3070.1585 iwildmatch: match 'ab/cXd/efXg/hi' '*/*X*/*/*i'
+-t3070.1587 pathmatch: match 'ab/cXd/efXg/hi' '*/*X*/*/*i'
+-t3070.1589 ipathmatch: match 'ab/cXd/efXg/hi' '*/*X*/*/*i'
+-t3070.1593 wildmatch: match 'ab/cXd/efXg/hi' '**/*X*/**/*i'
+-t3070.1595 iwildmatch: match 'ab/cXd/efXg/hi' '**/*X*/**/*i'
+-t3070.1597 pathmatch: match 'ab/cXd/efXg/hi' '**/*X*/**/*i'
+-t3070.1599 ipathmatch: match 'ab/cXd/efXg/hi' '**/*X*/**/*i'
+-t5500.154 fetch-pack --diag-url ./[::1]:repo
+-t5500.156 fetch-pack --diag-url ./[::1]:23:repo
+-t5500.165 fetch-pack --diag-url [::1]:/~repo
+-t5500.251 fetch-pack --diag-url ./[::1]:re:po
+-t5500.253 fetch-pack --diag-url ./[::1]:23:re:po
+-t5500.262 fetch-pack --diag-url [::1]:/~re:po
+-t5500.348 fetch-pack --diag-url ./[::1]:re/po
+-t5500.350 fetch-pack --diag-url ./[::1]:23:re/po
+-t5500.358 fetch-pack --diag-url [::1]:re/po
+-t5500.359 fetch-pack --diag-url [::1]:/~re/po
+-t5601.63 clone [::1]:rep/home/project
+-t5601.66 clone [::1]:/~repo
+-t6018.17 rev-parse --exclude with --branches
+-t6018.85 rev-list --exclude with --branches
+-t6130.20 **/ works with --glob-pathspecs
+-t7817.1 setup
+-t7817.2 working tree grep honors sparse checkout
+-t7817.3 grep searches unmerged file despite not matching sparsity patterns
+-t7817.5 grep --recurse-submodules honors sparse checkout in submodule
+-t7817.7 working tree grep does not search the index with CE_VALID and SKIP_WORKTREE
+-t9902.55 __git_refs - full refs
+-t9902.58 __git_refs - remote on local file system - full refs
+-t9902.75 __git refs - excluding full refs
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/msys2_path_conv.cc | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/winsup/cygwin/msys2_path_conv.cc b/winsup/cygwin/msys2_path_conv.cc
+index 8870d38..2646dc0 100644
+--- a/winsup/cygwin/msys2_path_conv.cc
++++ b/winsup/cygwin/msys2_path_conv.cc
+@@ -362,6 +362,21 @@ skip_p2w:
+     if (*it == ':')
+         goto skip_p2w;
+ 
++    while (it != end && *it) {
++        switch (*it) {
++        case '`':
++        case '\'':
++        case '"':
++        case '*':
++        case '?':
++        case '[':
++        case ']':
++            goto skip_p2w;
++        }
++        ++it;
++    }
++    it = *src;
++
+     while (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
+         recurse = true;
+         it = ++*src;

--- a/msys2-runtime/0043-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+++ b/msys2-runtime/0043-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
@@ -1,0 +1,39 @@
+From 6ed5a4279665baad20f30017adb38c6fcec3c2d3 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 18 Feb 2015 11:07:17 +0000
+Subject: [PATCH 43/N] fixup! Add functionality for converting UNIX paths in
+ arguments and environment variables to Windows form for native Win32
+ applications.
+
+We do not perform tilde expansion in the MSys2 runtime; let's leave
+paths containing '/~' intact for programs that want to expand such paths
+themselves.
+
+This addresses the expectations of the following test cases in the test
+suite of https://github.com/git/git/tree/v2.43.0:
+
+-t5500.163 fetch-pack --diag-url host:/~repo
+-t5500.260 fetch-pack --diag-url host:/~re:po
+-t5500.357 fetch-pack --diag-url host:/~re/po
+-t5601.65 clone host:/~repo
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/msys2_path_conv.cc | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/winsup/cygwin/msys2_path_conv.cc b/winsup/cygwin/msys2_path_conv.cc
+index 2646dc0..b292add 100644
+--- a/winsup/cygwin/msys2_path_conv.cc
++++ b/winsup/cygwin/msys2_path_conv.cc
+@@ -372,6 +372,10 @@ skip_p2w:
+         case '[':
+         case ']':
+             goto skip_p2w;
++        case '/':
++            if (it + 1 < end && it[1] == '~')
++                goto skip_p2w;
++            break;
+         }
+         ++it;
+     }

--- a/msys2-runtime/0044-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+++ b/msys2-runtime/0044-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
@@ -1,0 +1,69 @@
+From c94cf814671d0c2891d9f82495c42608b39ef5bd Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 18 Feb 2015 11:07:17 +0000
+Subject: [PATCH 44/N] fixup! Add functionality for converting UNIX paths in
+ arguments and environment variables to Windows form for native Win32
+ applications.
+
+This skips posix-to-windows conversion when '::' is seen: The substring
+'::' most often found in an IPv6 address, never in a path (and only in
+bogus path lists that contain empty elements).
+
+This addresses the expectations of the following test cases in the test
+suite of https://github.com/git/git/tree/v2.43.0:
+
+-t0060.197 test_submodule_relative_url: (null) helper:://hostname/repo ../subrepo => helper:://hostname/subrepo
+-t0060.198 test_submodule_relative_url: (null) helper:://hostname/repo ../../subrepo => helper:://subrepo
+-t0060.199 test_submodule_relative_url: (null) helper:://hostname/repo ../../../subrepo => helper::/subrepo
+-t0060.200 test_submodule_relative_url: (null) helper:://hostname/repo ../../../../subrepo => helper::subrepo
+-t0060.201 test_submodule_relative_url: (null) helper:://hostname/repo ../../../../../subrepo => helper:subrepo
+-t0060.202 test_submodule_relative_url: (null) helper:://hostname/repo ../../../../../../subrepo => .:subrepo
+-t5801.2 cloning from local repo
+-t5801.4 pulling from local repo
+-t5801.5 pushing to local repo
+-t5801.6 fetch new branch
+-t5801.7 fetch multiple branches
+-t5801.8 push when remote has extra refs
+-t5801.9 push new branch by name
+-t5801.10 push new branch with old:new refspec
+-t5801.11 push new branch with HEAD:new refspec
+-t5801.12 push delete branch
+-t5801.13 forced push
+-t5801.14 cloning without refspec
+-t5801.15 pulling without refspecs
+-t5801.16 pushing without refspecs
+-t5801.17 pulling without marks
+-t5801.19 push all with existing object
+-t5801.20 push ref with existing object
+-t5801.23 push update refs
+-t5801.24 push update refs disabled by no-private-update
+-t5801.25 push update refs failure
+-t5801.26 proper failure checks for fetching
+-t5801.27 proper failure checks for pushing
+-t5801.28 push messages
+-t5801.29 fetch HEAD
+-t5801.30 fetch url
+-t5801.31 fetch tag
+-t7400.80 ../subrepo works with helper URL- helper:://hostname/repo
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/msys2_path_conv.cc | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/winsup/cygwin/msys2_path_conv.cc b/winsup/cygwin/msys2_path_conv.cc
+index b292add..71c4735 100644
+--- a/winsup/cygwin/msys2_path_conv.cc
++++ b/winsup/cygwin/msys2_path_conv.cc
+@@ -376,6 +376,11 @@ skip_p2w:
+             if (it + 1 < end && it[1] == '~')
+                 goto skip_p2w;
+             break;
++        case ':':
++            // Avoid mangling IPv6 addresses
++            if (it + 1 < end && it[1] == ':')
++                goto skip_p2w;
++            break;
+         }
+         ++it;
+     }

--- a/msys2-runtime/0045-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+++ b/msys2-runtime/0045-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
@@ -1,0 +1,62 @@
+From 9944652c41fb96f555d221865f4ed5d0c8b33514 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 18 Feb 2015 11:07:17 +0000
+Subject: [PATCH 45/N] fixup! Add functionality for converting UNIX paths in
+ arguments and environment variables to Windows form for native Win32
+ applications.
+
+With this commit, the POSIX-to-Windows conversion also leaves Git's
+`<rev>:./<name>` syntax alone. Such a string would otherwise be mistaken
+for indicating a path list, but path lists are expected to contain only
+absolute paths, which would not be the case here.
+
+This addresses the expectations of the following test cases in the test
+suite of https://github.com/git/git/tree/v2.43.0:
+
+-t1506.4 correct relative file objects (1)
+-t1506.5 correct relative file objects (2)
+-t1506.6 correct relative file objects (3)
+-t1506.7 correct relative file objects (4)
+-t1506.14 relative path not found
+-t1506.15 relative path outside worktree
+-t1506.16 relative path when cwd is outside worktree
+-t1513.5 empty prefix HEAD:./path
+-t1513.6 valid prefix HEAD:./path
+-t1513.7 valid prefix HEAD:../path
+-t2070.4 restore a file on worktree from another ref
+-t2070.5 restore a file in the index from another ref
+-t2070.6 restore a file in both the index and worktree from another ref
+-t2070.8 restore --worktree --staged uses HEAD as source
+-t7900.33 start and stop macOS maintenance
+-t7900.34 use launchctl list to prevent extra work
+-t7900.35 start and stop Windows maintenance
+-t7900.36 start and stop Linux/systemd maintenance
+-t7900.37 start and stop when several schedulers are available
+-t9300.195 Y: rewrite submodules
+-t9304.6 import with submodule mapping
+-t9304.7 paths adjusted for relative subdir
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/msys2_path_conv.cc | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/winsup/cygwin/msys2_path_conv.cc b/winsup/cygwin/msys2_path_conv.cc
+index 71c4735..0ac47f0 100644
+--- a/winsup/cygwin/msys2_path_conv.cc
++++ b/winsup/cygwin/msys2_path_conv.cc
+@@ -380,6 +380,14 @@ skip_p2w:
+             // Avoid mangling IPv6 addresses
+             if (it + 1 < end && it[1] == ':')
+                 goto skip_p2w;
++
++            // Leave Git's <rev>:./name syntax alone
++            if (it + 1 < end && it[1] == '.') {
++                if (it + 2 < end && it[2] == '/')
++                    goto skip_p2w;
++                if (it + 3 < end && it[2] == '.' && it[3] == '/')
++                    goto skip_p2w;
++            }
+             break;
+         }
+         ++it;

--- a/msys2-runtime/0046-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+++ b/msys2-runtime/0046-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
@@ -1,0 +1,57 @@
+From dba012d3e739305f4c08068a330cfe5db885dad6 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 18 Feb 2015 11:07:17 +0000
+Subject: [PATCH 46/N] fixup! Add functionality for converting UNIX paths in
+ arguments and environment variables to Windows form for native Win32
+ applications.
+
+Do not let MSYS2's path conversion mistake arguments starting with '@@'
+for being paths.
+
+This addresses the expectations of the following test cases in the test
+suite of https://github.com/git/git/tree/v2.43.0:
+
+-t1508.1 setup
+-t1508.2 HEAD = refs/heads/new-branch
+-t1508.3 @{1} = new-one
+-t1508.4 HEAD@{1} = new-one
+-t1508.5 @{now} = new-two
+-t1508.6 HEAD@{now} = new-two
+-t1508.7 @{-1} = refs/heads/old-branch
+-t1508.8 @{-1}@{0} = old-two
+-t1508.9 @{-1}@{1} = old-one
+-t1508.10 @{u} = refs/heads/upstream-branch
+-t1508.11 HEAD@{u} = refs/heads/upstream-branch
+-t1508.12 @{u}@{1} = upstream-one
+-t1508.13 @{-1}@{u} = refs/heads/main
+-t1508.14 @{-1}@{u}@{1} = main-one
+-t1508.15 @ = new-two
+-t1508.16 @@{u} = refs/heads/upstream-branch
+-t1508.17 @@/at-test = refs/heads/@@/at-test
+-t1508.18 @at-test = refs/heads/@at-test
+-t1508.24 HEAD@{3} = old-two
+-t1508.26 switch to old-branch
+-t1508.27 HEAD = refs/heads/old-branch
+-t1508.28 HEAD@{1} = new-two
+-t1508.29 @{1} = old-one
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/msys2_path_conv.cc | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/winsup/cygwin/msys2_path_conv.cc b/winsup/cygwin/msys2_path_conv.cc
+index 0ac47f0..0976cf9 100644
+--- a/winsup/cygwin/msys2_path_conv.cc
++++ b/winsup/cygwin/msys2_path_conv.cc
+@@ -389,6 +389,10 @@ skip_p2w:
+                     goto skip_p2w;
+             }
+             break;
++        case '@':
++            // Paths do not contain '@@'
++            if (it + 1 < end && it[1] == '@')
++                goto skip_p2w;
+         }
+         ++it;
+     }

--- a/msys2-runtime/0047-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+++ b/msys2-runtime/0047-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
@@ -1,0 +1,63 @@
+From e9a55f1ac61a079533fa01a3dad2b65e721d13f3 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 18 Feb 2015 11:07:17 +0000
+Subject: [PATCH 47/N] fixup! Add functionality for converting UNIX paths in
+ arguments and environment variables to Windows form for native Win32
+ applications.
+
+Let's prevent scp-style arguments from being mangled by MSYS2's path
+conversion.
+
+An argument like `me@example.com:/tmp/` is not something we should convert
+into a Windows path; Use the absence of a slash before the colon as a
+tell-tale that it is *not* a POSIX path list (exception: if the part
+left of the colon is `.` or `..`).
+
+This addresses the expectations of the following test cases in the test
+suite of https://github.com/git/git/tree/v2.43.0:
+
+-t5516.8 fetch with insteadOf
+-t5516.16 push with insteadOf
+-t5516.17 push with pushInsteadOf
+-t5602.2 clone calls git upload-pack unqualified with no -u option
+-t5602.3 clone calls specified git upload-pack with -u option
+-t5603.31 clone of host:/ goes to host (non-bare)
+-t5603.35 clone of user@host:/ goes to host (non-bare)
+-t5813.81 full paths still work
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/msys2_path_conv.cc | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/winsup/cygwin/msys2_path_conv.cc b/winsup/cygwin/msys2_path_conv.cc
+index 0976cf9..1e9cdbe 100644
+--- a/winsup/cygwin/msys2_path_conv.cc
++++ b/winsup/cygwin/msys2_path_conv.cc
+@@ -470,6 +470,8 @@ skip_p2w:
+ 
+     int starts_with_minus = 0;
+     int starts_with_minus_alpha = 0;
++    int only_dots = *it == '.';
++    int has_slashes = 0;
+     if (*it == '-') {
+       starts_with_minus = 1;
+       it += 1;
+@@ -513,11 +515,17 @@ skip_p2w:
+                 if (ch == '/' && *(it2 + 1) == '/') {
+                     return URL;
+                 } else {
++                    if (!only_dots && !has_slashes)
++                        goto skip_p2w;
+                     return POSIX_PATH_LIST;
+                 }
+             } else if (memchr(it2, '=', end - it2) == NULL) {
+                 return SIMPLE_WINDOWS_PATH;
+             }
++        } else if (ch != '.') {
++            only_dots = 0;
++            if (ch == '/' || ch == '\\')
++                has_slashes = 1;
+         }
+     }
+ 

--- a/msys2-runtime/0048-Handle-8-bit-characters-under-LOCALE-C.patch
+++ b/msys2-runtime/0048-Handle-8-bit-characters-under-LOCALE-C.patch
@@ -1,0 +1,68 @@
+From 6ab2da6525debb34ba20ecf85fc431e44c52ff09 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Fri, 20 Feb 2015 13:56:22 +0000
+Subject: [PATCH 48/N] Handle 8-bit characters under LOCALE=C
+
+When the character set is specified as ASCII (by setting the locale to
+`C`), we should handle data outside the 7-bit range gracefully by simply
+copying it, even if it is technically no longer ASCII.
+
+Cygwin, however, wants to be a lot stricter than that.
+
+Let's be more lenient in MSYS2 by making the strict 7-bit only handling
+contingent on the `STRICTLY_7BIT_ASCII` macro (which we never set
+because we don't want it).
+
+This addresses the expectations of two of Git's test cases:
+t7400.108(submodule with UTF-8 name) and t9300.193(X: handling
+encoding).
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ newlib/libc/stdlib/mbtowc_r.c | 2 +-
+ newlib/libc/stdlib/wctomb_r.c | 2 +-
+ winsup/cygwin/strfuncs.cc     | 4 ++++
+ 3 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/newlib/libc/stdlib/mbtowc_r.c b/newlib/libc/stdlib/mbtowc_r.c
+index ca876f9..ee43736 100644
+--- a/newlib/libc/stdlib/mbtowc_r.c
++++ b/newlib/libc/stdlib/mbtowc_r.c
+@@ -36,7 +36,7 @@ __ascii_mbtowc (struct _reent *r,
+   if (n == 0)
+     return -2;
+ 
+-#ifdef __CYGWIN__
++#ifdef STRICTLY_7BIT_ASCII
+   if ((wchar_t)*t >= 0x80)
+     {
+       _REENT_ERRNO(r) = EILSEQ;
+diff --git a/newlib/libc/stdlib/wctomb_r.c b/newlib/libc/stdlib/wctomb_r.c
+index a7f87cd..2c536ce 100644
+--- a/newlib/libc/stdlib/wctomb_r.c
++++ b/newlib/libc/stdlib/wctomb_r.c
+@@ -29,7 +29,7 @@ __ascii_wctomb (struct _reent *r,
+   if (s == NULL)
+     return 0;
+  
+-#ifdef __CYGWIN__
++#ifdef STRICTLY_7BIT_ASCII
+   if ((size_t)wchar >= 0x80)
+ #else
+   if ((size_t)wchar >= 0x100)
+diff --git a/winsup/cygwin/strfuncs.cc b/winsup/cygwin/strfuncs.cc
+index 0ab2290..ebd559b 100644
+--- a/winsup/cygwin/strfuncs.cc
++++ b/winsup/cygwin/strfuncs.cc
+@@ -616,7 +616,11 @@ _sys_mbstowcs (mbtowc_p f_mbtowc, wchar_t *dst, size_t dlen, const char *src,
+ 	     to store them in a symmetric way. */
+ 	  bytes = 1;
+ 	  if (dst)
++#ifdef STRICTLY_7BIT_ASCII
+ 	    *ptr = L'\xf000' | *pmbs;
++#else
++	    *ptr = *pmbs;
++#endif
+ 	  memset (&ps, 0, sizeof ps);
+ 	}
+ 

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.4.10
-pkgrel=2
+pkgrel=3
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -65,7 +65,17 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0035-When-converting-to-a-Unix-path-avoid-double-trailing.patch
         0036-msys2_path_conv-pass-PC_NOFULL-to-path_conv.patch
         0037-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch
-        0038-dumper-avoid-linker-problem-when-libbfd-depends-on-l.patch)
+        0038-dumper-avoid-linker-problem-when-libbfd-depends-on-l.patch
+        0039-path-conversion-Introduce-ability-to-switch-off-conv.patch
+        0040-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+        0041-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+        0042-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+        0043-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+        0044-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+        0045-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+        0046-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+        0047-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
+        0048-Handle-8-bit-characters-under-LOCALE-C.patch)
 sha256sums=('SKIP'
             '351bb1efdbdafe80c981e92d6b425c6ab71c85ce4e990db184e2118158eb2ab6'
             'd3d3a01feeae9f7d5e6cb32f4662df74fc9476ff11a1aac3dad2df3e43fd88e4'
@@ -104,7 +114,17 @@ sha256sums=('SKIP'
             'd5981d518ba4756dd6e976e9cc20ff8f52001aac588ee083a33045d260e02d6b'
             '599905c7454e2f3039c717de8186d4e1cb7943f9b47a7745ce36e4acfa100e31'
             'd37c835bc188786a4e8050f0a73d4f0b3070ded9030943ba2a6c47b03d9d96e8'
-            'a799e7edde58a0ec519bb7df6d0bcf4177e1c6236a72a8240936c574be1bdd61')
+            'a799e7edde58a0ec519bb7df6d0bcf4177e1c6236a72a8240936c574be1bdd61'
+            'aef2222ac4444efbd77de36bb92628f32f1467acea522e344fd28153ea235721'
+            '5f61639a3c449ae90358cb621c67bade1b65ebef73fda64a7bc369f6fed4b266'
+            '9b31f6d42920df0103f16ef51d6467b5f0db91d462545430047bf207fcc59371'
+            'cda68bcfe03c76fc57435a25540c6f29aedf003bdb3dc434ecce86599f8293cc'
+            '3fc79c86927d0983f892e99a978ab448f808f3fcdad6e5b101f35fc213af7f63'
+            '22bb5e0738f16d0e8d2732307efe336226a58165d54616297aa5caf82e5bea4d'
+            '58d8d131f62e7424e284c012504eb704f1a94c30a8572f04f8c4d77d1501eebd'
+            'f5a6e7d85741b44daf62f7f80ac1e64f0336d3be084ebe9b7ce2e796f493b952'
+            '73e74ea6f4f05d212fbdfab2b8dec2ad1faded660a833b24b55a058719ad7c01'
+            '6c4cc6db864addb7ac78c5e2cbb0be41c7f853726c08b92fa33d573c8dcf0c16')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -179,7 +199,17 @@ prepare() {
   0035-When-converting-to-a-Unix-path-avoid-double-trailing.patch \
   0036-msys2_path_conv-pass-PC_NOFULL-to-path_conv.patch \
   0037-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch \
-  0038-dumper-avoid-linker-problem-when-libbfd-depends-on-l.patch
+  0038-dumper-avoid-linker-problem-when-libbfd-depends-on-l.patch \
+  0039-path-conversion-Introduce-ability-to-switch-off-conv.patch \
+  0040-fixup-Add-functionality-for-converting-UNIX-paths-in.patch \
+  0041-fixup-Add-functionality-for-converting-UNIX-paths-in.patch \
+  0042-fixup-Add-functionality-for-converting-UNIX-paths-in.patch \
+  0043-fixup-Add-functionality-for-converting-UNIX-paths-in.patch \
+  0044-fixup-Add-functionality-for-converting-UNIX-paths-in.patch \
+  0045-fixup-Add-functionality-for-converting-UNIX-paths-in.patch \
+  0046-fixup-Add-functionality-for-converting-UNIX-paths-in.patch \
+  0047-fixup-Add-functionality-for-converting-UNIX-paths-in.patch \
+  0048-Handle-8-bit-characters-under-LOCALE-C.patch
 }
 
 build() {


### PR DESCRIPTION
This combines the patches introduced via
https://github.com/msys2/msys2-runtime/pull/181 and https://github.com/msys2/msys2-runtime/pull/182.