### PR TITLE
man-db: disable check for year 2038 support on 32-bit.

### DIFF
--- a/man-db/PKGBUILD
+++ b/man-db/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=man-db
 pkgver=2.12.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A utility for reading man pages"
 arch=('i686' 'x86_64')
 url="https://www.nongnu.org/man-db/"
@@ -31,6 +31,12 @@ build() {
   cd ${srcdir}/${pkgname}-${pkgver}
 
   local CYGWIN_CHOST="${CHOST/-msys/-cygwin}"
+  local -a extra_config
+  # 32-bit cygwin only has 32-bit time_t
+  # https://github.com/msys2/MSYS2-packages/issues/4078
+  if [[ "$CARCH" == "i686" ]]; then
+    extra_config+=("--disable-year2038")
+  fi
   ./configure \
     --prefix=/usr \
     --build=${CYGWIN_CHOST} \
@@ -44,7 +50,8 @@ build() {
     --enable-static \
     --disable-shared \
     --with-sections="1 n l 8 3 0 2 5 4 9 6 7" \
-    --with-systemdsystemunitdir=/usr/lib/systemd/system
+    --with-systemdsystemunitdir=/usr/lib/systemd/system \
+    "${extra_config[@]}"
   make
 }
 


### PR DESCRIPTION
This seems to have gotten the same configure check as tar in #4078.