### PR TITLE
[CI] run PKGBUILD's function CHECK if env var CI_MAKEPKG_RUN_CHECK is set

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -100,12 +100,19 @@ pacman -R --recursive --unneeded --noconfirm --noprogressbar git python
 # Enable linting
 export MAKEPKG_LINT_PKGBUILD=1
 
+# Run function CHECK if env var CI_MAKEPKG_RUN_CHECK is set (to any value)
+if test "${CI_MAKEPKG_RUN_CHECK+set}" = set; then
+    MAKEPKG_RUN_CHECK_FLAG=''
+else
+    MAKEPKG_RUN_CHECK_FLAG='--nocheck'
+fi
+
 message 'Building packages'
 for package in "${packages[@]}"; do
     echo "::group::[build] ${package}"
     execute 'Clear cache' pacman -Scc --noconfirm
     execute 'Fetch keys' "$DIR/fetch-validpgpkeys.sh"
-    execute 'Building binary' makepkg --noconfirm --noprogressbar --nocheck --syncdeps --rmdeps --cleanbuild
+    execute 'Building binary' makepkg --noconfirm --noprogressbar --syncdeps --rmdeps --cleanbuild "${MAKEPKG_RUN_CHECK_FLAG}"
     repo-add $PWD/artifacts/ci.db.tar.gz $PWD/$package/*.pkg.tar.*
     pacman -Sy
     cp $PWD/$package/*.pkg.tar.* $PWD/artifacts


### PR DESCRIPTION
This allows developers to run the check function by simply defining the fork's env variable CI_MAKEPKG_RUN_CHECK.

Rf.: How to set an environment variable for a repository: https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository