### PR TITLE
ccache(4.8.3): add function CHECK (check segfaults and hangs)

### DIFF
--- a/ccache/PKGBUILD
+++ b/ccache/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=ccache
 pkgver=4.8.3
-pkgrel=2
+pkgrel=3
 pkgdesc="A compiler cache (mingw-w64)"
 arch=('i686' 'x86_64')
 url="https://ccache.samba.org/"
@@ -36,6 +36,11 @@ build() {
     ../${pkgname}-${pkgver}
 
   cmake --build .
+}
+
+check() {
+  cd "build-${CHOST}"
+  /usr/bin/ctest .
 }
 
 package() {


### PR DESCRIPTION
Running check, CCACHE segfaults in the first test, then hangs in the second.  This needs to be fixed.