### PR TITLE
add picotool package

### DIFF
--- a/picotool/PKGBUILD
+++ b/picotool/PKGBUILD
@@ -1,0 +1,54 @@
+# Maintainer: Thewh1teagle
+
+_realname=picotool
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver="1.1.2"
+pkgrel=1
+pkgdesc="Tool for inspecting RP2040 binaries and interacting with RP2040 devices."
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+url="https://github.com/raspberrypi/picotool"
+pico_sdk_url="https://github.com/raspberrypi/pico-sdk"
+pico_sdk_version="1.5.1"
+
+license=('BSD-3-Clause')
+
+makedepends=("git" "${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-libusb" "${MINGW_PACKAGE_PREFIX}-make" "${MINGW_PACKAGE_PREFIX}-gcc")
+
+source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/${pkgver}.tar.gz"
+	"pico-sdk-${pico_sdk_version}.tar.gz::${pico_sdk_url}/archive/refs/tags/${pico_sdk_version}.tar.gz"
+)
+sha256sums=(
+	"f1746ead7815c13be1152f0645db8ea3b277628eb0110d42a0a186db37d40a91"
+	"95f5e522be3919e36a47975ffd3b208c38880c14468bd489ac672cfe3cec803c"
+)
+
+build() {
+	export PICO_SDK_PATH="${srcdir}/pico-sdk-${pico_sdk_version}"
+	if [ -z "${srcdir}/${PICO_SDK_PATH}" ]; then
+		if [ -d "/usr/share/pico-sdk" ]; then
+			warning "PICO_SDK_PATH is not set! Using default path: /usr/share/pico-sdk"
+			export PICO_SDK_PATH=/usr/share/pico-sdk
+		else
+			error "Couldn't find pico-sdk! Is it set up?"
+			exit 1
+		fi
+	fi
+
+	cd "${srcdir}"
+	# Build staticly picotool so we can also use it outside of MSYS environment
+	cmake -B build -S "${_realname}-${pkgver}" -G "MinGW Makefiles" -DLIBUSB_LIBRARIES=/ucrt64/lib/libusb-1.0.a -DCMAKE_EXE_LINKER_FLAGS="-static -static-libgcc -static-libstdc++"
+	cmake --build build
+}
+
+package() {
+	# Install application
+	install -Dm755 "${srcdir}/build/picotool" -t "${pkgdir}/usr/bin/"
+
+	# Install docs
+	install -Dm644 "${srcdir}/${_realname}-${pkgver}/README.md" -t "${pkgdir}/usr/share/doc/${pkgname}"
+
+	# Install license
+	install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.TXT" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+}


### PR DESCRIPTION
Add picotool package from 
https://github.com/raspberrypi/picotool
Inspired by picotool arch Linux package.

Statically linked libraries so users can use it outside msys too.
Final binary size is ~1.32MB
