### PR TITLE
ccache: Update to 4.9 + fix crash (still broken)

### DIFF
--- a/ccache/0001-fix-blake3-segfault.patch
+++ b/ccache/0001-fix-blake3-segfault.patch
@@ -1,0 +1,11 @@
+--- ccache-4.9/src/third_party/blake3/CMakeLists.txt.orig	2024-01-07 19:44:27.592646500 +0100
++++ ccache-4.9/src/third_party/blake3/CMakeLists.txt	2024-01-07 19:44:37.726993400 +0100
+@@ -19,7 +19,7 @@
+ 
+   if(MSVC)
+     set(suffix "_x86-64_windows_msvc.asm")
+-  elseif(WIN32)
++  elseif(WIN32 OR CYGWIN)
+     set(suffix "_x86-64_windows_gnu.S")
+   else()
+     set(suffix "_x86-64_unix.S")

--- a/ccache/PKGBUILD
+++ b/ccache/PKGBUILD
@@ -2,8 +2,8 @@
 # Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 pkgname=ccache
-pkgver=4.8.3
-pkgrel=3
+pkgver=4.9
+pkgrel=1
 pkgdesc="A compiler cache (mingw-w64)"
 arch=('i686' 'x86_64')
 url="https://ccache.samba.org/"
@@ -18,10 +18,18 @@ makedepends=("cmake"
 depends=("gcc-libs" "zlib" "libzstd")
 options=('staticlibs' 'strip')
 install="${pkgname}.install"
-source=(https://github.com/ccache/ccache/releases/download/v${pkgver}/ccache-${pkgver}.tar.xz{,.asc})
+source=(https://github.com/ccache/ccache/releases/download/v${pkgver}/ccache-${pkgver}.tar.xz{,.asc}
+        "0001-fix-blake3-segfault.patch")
 validpgpkeys=("5A939A71A46792CF57866A51996DDA075594ADB8") #Joel Rosdahl <joel@rosdahl.net>
-sha256sums=('e47374c810b248cfca3665ee1d86c7c763ffd68d9944bc422d9c1872611f2b11'
-            'SKIP')
+sha256sums=('1ebc72324e3ab52af0b562bf54189d108e85eef6478d6304a345a3c2dc4018e0'
+            'SKIP'
+            '0d9e9f9dd4ff87a010e017091ab503945c40b46766aaee520bca09633ab00927')
+
+prepare() {
+  cd "${pkgname}-${pkgver}"
+
+  patch -Np1 -i "${srcdir}/0001-fix-blake3-segfault.patch"
+}
 
 build() {
   [[ -d build-${CHOST} ]] && rm -rf build-${CHOST}
@@ -32,7 +40,6 @@ build() {
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_BUILD_TYPE=Release \
     -DREDIS_STORAGE_BACKEND=OFF \
-    -DUSE_CCACHE=OFF \
     ../${pkgname}-${pkgver}
 
   cmake --build .


### PR DESCRIPTION
Note: this package is still broken

* Remove cmake option that no longer exists
* Fix blake3 using the wrong asm for the platform and crashing

See #4311