### PR TITLE
[new package] fisher 4.4.4

### DIFF
--- a/fisher/PKGBUILD
+++ b/fisher/PKGBUILD
@@ -1,0 +1,20 @@
+# Maintainer: Maksim Bondarenkov <maksapple2306@gmail.com>
+
+pkgname=fisher
+pkgver=4.4.4
+pkgrel=1
+pkgdesc='A package manager for the fish shell'
+arch=('any')
+url='https://github.com/jorgebucaran/fisher'
+license=('spdx:MIT')
+depends=('fish' 'curl')
+source=("https://github.com/jorgebucaran/fisher/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz")
+sha256sums=('856e490e35cb9b1f1f02d54c77c6f4e86eb6f97fb5cfd8883a9df7b1d148a8e6')
+
+package() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+
+  install -Dm644 functions/fisher.fish "${pkgdir}/usr/share/fish/vendor_functions.d/fisher.fish"
+  install -Dm644 completions/fisher.fish "${pkgdir}/usr/share/fish/vendor_completions.d/fisher.fish"
+  install -Dm644 LICENSE.md "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.md"
+}


### PR DESCRIPTION
tried with `jethrokuan/z` plugin (`fisher install jethrokuan/z`). recieved `mkdir: невозможно изменить права доступа «/home/maksa/.local/share/z»: Permission denied` (translate: `mkdir: unable to change permissions "/home/maksa/.local/share/z": Permission denied`) and plugin doesn't work as intended