### PR TITLE
libxml2: Update to 2.12.4

### DIFF
--- a/libxml2/PKGBUILD
+++ b/libxml2/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=libxml2
 pkgname=('libxml2' 'libxml2-devel' 'libxml2-python')
-pkgver=2.12.3
+pkgver=2.12.4
 pkgrel=1
 pkgdesc="XML parsing library, version 2"
 arch=(i686 x86_64)
@@ -13,7 +13,7 @@ url="https://gitlab.gnome.org/GNOME/libxml2/-/wikis/"
 source=("https://download.gnome.org/sources/libxml2/${pkgver%.*}/${pkgbase}-${pkgver}.tar.xz"
         https://www.w3.org/XML/Test/xmlts20130923.tar.gz
         libxml2-2.9.8-python3-unicode-errors.patch)
-sha256sums=('8c8f1092340a89ff32bc44ad5c9693aff9bc8a7a3e161bb239666e5d15ac9aaa'
+sha256sums=('497360e423cf0bd99eacdb7c6215dea92e6d6e89ee940393c2bae0e77cb9b7d0'
             '9b61db9f5dbffa545f4b8d78422167083a8568c59bd1129f94138f936cf6fc1f'
             '0f5d465503b24271e11752262af89c58eb0b26b4901c3b021bd843e6e5d4e95a')
 
@@ -70,7 +70,6 @@ build() {
     --without-icu \
     --enable-shared \
     --enable-static \
-    --with-legacy \
     --with-python=/usr/bin/python
   make
   make DESTDIR=${srcdir}/dest install


### PR DESCRIPTION
Also disable the legacy APIs, like we did for the mingw build recently There shouldn't be any users left.