### PR TITLE
libinih: backport patch to fix wrong version

### DIFF
--- a/libinih/PKGBUILD
+++ b/libinih/PKGBUILD
@@ -3,14 +3,26 @@
 pkgbase=libinih
 pkgname=(libinih libinih-devel)
 pkgver=57
-pkgrel=1
+pkgrel=2
 pkgdesc='A simple .INI file parser written in C'
 license=('spdx:BSD-3-Clause')
 url='https://github.com/benhoyt/inih'
+msys2_references=(
+  'archlinux: libinih'
+  'cygwin: inih'
+)
 arch=('i686' 'x86_64')
 makedepends=('gcc' 'pkgconf' 'python' 'meson' 'ninja')
-source=(https://github.com/benhoyt/inih/archive/refs/tags/r${pkgver}.tar.gz)
-sha256sums=('f03f98ca35c3adb56b2358573c8d3eda319ccd5287243d691e724b7eafa970b3')
+source=(https://github.com/benhoyt/inih/archive/refs/tags/r${pkgver}.tar.gz
+        "https://patch-diff.githubusercontent.com/raw/benhoyt/inih/pull/157.patch")
+sha256sums=('f03f98ca35c3adb56b2358573c8d3eda319ccd5287243d691e724b7eafa970b3'
+            '289c3c3ab5b30387410e42d2061a4ab5aa96e134045be280ad34f6303a8407f8')
+
+prepare() {
+  cd "${srcdir}"/inih-r${pkgver}
+
+  patch -p1 -i "${srcdir}"/157.patch
+}
 
 build() {
   mkdir "${srcdir}"/build && cd "${srcdir}"/build


### PR DESCRIPTION
as pointed out at
https://github.com/msys2/MSYS2-packages/commit/f0b92831254aca8334858cb863a1306feaf7e91c#commitcomment-137495120