### PR TITLE
binutils: Update to 2.42

### DIFF
--- a/binutils/0100-binutils-2.37-msys2.patch
+++ b/binutils/0100-binutils-2.37-msys2.patch
@@ -200,9 +200,9 @@ diff -Naur binutils-2.37-orig/bfd/configure.ac binutils-2.37/bfd/configure.ac
    esac
  
    if test -n "$SHARED_LIBADD"; then
---- binutils-2.39/binutils/configure.orig	2022-08-05 11:56:21.000000000 +0200
-+++ binutils-2.39/binutils/configure	2022-10-15 10:29:41.791949500 +0200
-@@ -5504,7 +5504,7 @@
+--- binutils-2.42/binutils/configure.orig	2024-01-29 01:00:00.000000000 +0100
++++ binutils-2.42/binutils/configure	2024-01-30 07:56:22.381185600 +0100
+@@ -5344,7 +5344,7 @@
      lt_cv_sys_max_cmd_len=-1;
      ;;
  
@@ -211,7 +211,7 @@ diff -Naur binutils-2.37-orig/bfd/configure.ac binutils-2.37/bfd/configure.ac
      # On Win9x/ME, this test blows up -- it succeeds, but takes
      # about 5 minutes as the teststring grows exponentially.
      # Worse, since 9x/ME are not pre-emptively multitasking,
-@@ -5846,7 +5846,7 @@
+@@ -5686,7 +5686,7 @@
    lt_cv_file_magic_test_file=/shlib/libc.so
    ;;
  
@@ -220,7 +220,7 @@ diff -Naur binutils-2.37-orig/bfd/configure.ac binutils-2.37/bfd/configure.ac
    # func_win32_libid is a shell function defined in ltmain.sh
    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
    lt_cv_file_magic_cmd='func_win32_libid'
-@@ -6457,7 +6457,7 @@
+@@ -6302,7 +6302,7 @@
  aix*)
    symcode='[BCDT]'
    ;;
@@ -229,7 +229,7 @@ diff -Naur binutils-2.37-orig/bfd/configure.ac binutils-2.37/bfd/configure.ac
    symcode='[ABCDGISTW]'
    ;;
  hpux*)
-@@ -8072,7 +8072,7 @@
+@@ -7919,7 +7919,7 @@
        # PIC is the default for these OSes.
        ;;
  
@@ -238,7 +238,7 @@ diff -Naur binutils-2.37-orig/bfd/configure.ac binutils-2.37/bfd/configure.ac
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        # Although the cygwin gcc ignores -fPIC, still need this for old-style
-@@ -8154,7 +8154,7 @@
+@@ -8001,7 +8001,7 @@
        fi
        ;;
  
@@ -247,7 +247,7 @@ diff -Naur binutils-2.37-orig/bfd/configure.ac binutils-2.37/bfd/configure.ac
        # This hack is so that the source file can tell whether it is being
        # built for inclusion in a dll (and should export symbols for example).
        lt_prog_compiler_pic='-DDLL_EXPORT'
-@@ -8616,7 +8616,7 @@
+@@ -8463,7 +8463,7 @@
    extract_expsyms_cmds=
  
    case $host_os in
@@ -256,7 +256,7 @@ diff -Naur binutils-2.37-orig/bfd/configure.ac binutils-2.37/bfd/configure.ac
      # FIXME: the MSVC++ port hasn't been tested in a loooong time
      # When not using gcc, we currently assume that we are using
      # Microsoft Visual C++.
-@@ -8731,7 +8731,7 @@
+@@ -8578,7 +8578,7 @@
        fi
        ;;
  
@@ -265,7 +265,7 @@ diff -Naur binutils-2.37-orig/bfd/configure.ac binutils-2.37/bfd/configure.ac
        # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
        # as there is no search path for DLLs.
        hardcode_libdir_flag_spec='-L$libdir'
-@@ -9162,7 +9162,7 @@
+@@ -9009,7 +9009,7 @@
        export_dynamic_flag_spec=-rdynamic
        ;;
  
@@ -274,7 +274,7 @@ diff -Naur binutils-2.37-orig/bfd/configure.ac binutils-2.37/bfd/configure.ac
        # When not using gcc, we currently assume that we are using
        # Microsoft Visual C++.
        # hardcode_libdir_flag_spec is actually meaningless, as there is
-@@ -10063,14 +10063,14 @@
+@@ -9910,14 +9910,14 @@
    # libtool to hard-code these into programs
    ;;
  
@@ -291,7 +291,7 @@ diff -Naur binutils-2.37-orig/bfd/configure.ac binutils-2.37/bfd/configure.ac
      library_names_spec='$libname.dll.a'
      # DLL is installed to $(libdir)/../bin by postinstall_cmds
      postinstall_cmds='base_file=`basename \${file}`~
-@@ -10094,6 +10094,12 @@
+@@ -9941,6 +9941,12 @@
  
        sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
        ;;
@@ -304,7 +304,7 @@ diff -Naur binutils-2.37-orig/bfd/configure.ac binutils-2.37/bfd/configure.ac
      mingw* | cegcc*)
        # MinGW DLLs use traditional 'lib' prefix
        soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
-@@ -10720,7 +10726,7 @@
+@@ -10591,7 +10597,7 @@
      lt_cv_dlopen_libs=
      ;;
  
@@ -313,7 +313,7 @@ diff -Naur binutils-2.37-orig/bfd/configure.ac binutils-2.37/bfd/configure.ac
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
-@@ -13733,7 +13739,7 @@
+@@ -15676,7 +15682,7 @@
  
  
  case "${host}" in
@@ -322,44 +322,62 @@ diff -Naur binutils-2.37-orig/bfd/configure.ac binutils-2.37/bfd/configure.ac
  
  $as_echo "#define USE_BINARY_FOPEN 1" >>confdefs.h
   ;;
-@@ -14689,7 +14695,7 @@
- 	  BUILD_WINDRES='$(WINDRES_PROG)$(EXEEXT)'
- 	  BUILD_WINDMC='$(WINDMC_PROG)$(EXEEXT)'
- 	  ;;
--	x86_64-*-mingw* | x86_64-*-cygwin*)
-+	x86_64-*-mingw* | x86_64-*-cygwin* | x86_64-*-msys*)
-   	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
- 	  if test -z "$DLLTOOL_DEFAULT"; then
- 	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_MX86_64"
-@@ -14699,7 +14705,7 @@
- 	  BUILD_WINDMC='$(WINDMC_PROG)$(EXEEXT)'
- 	  BUILD_DLLWRAP='$(DLLWRAP_PROG)$(EXEEXT)'
- 	  ;;
--	i[3-7]86-*-pe* | i[3-7]86-*-cygwin* | i[3-7]86-*-mingw32**)
-+	i[3-7]86-*-pe* | i[3-7]86-*-cygwin* | i[3-7]86-*-msys* | i[3-7]86-*-mingw32**)
-   	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
- 	  if test -z "$DLLTOOL_DEFAULT"; then
+@@ -16229,7 +16235,7 @@
+ 	BUILD_WINDRES='$(WINDRES_PROG)$(EXEEXT)'
+ 	BUILD_WINDMC='$(WINDMC_PROG)$(EXEEXT)'
+ 	;;
+-    i[3-7]86-*-pe* | i[3-7]86-*-cygwin* | i[3-7]86-*-mingw32** | all)
++    i[3-7]86-*-pe* | i[3-7]86-*-cygwin* |  i[3-7]86-*-msys* | i[3-7]86-*-mingw32** | all)
+ 	BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
+ 	if test -z "$DLLTOOL_DEFAULT"; then
  	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_I386"
---- binutils-2.39/binutils/configure.ac.orig	2022-07-08 11:46:47.000000000 +0200
-+++ binutils-2.39/binutils/configure.ac	2022-10-15 10:29:29.745286500 +0200
-@@ -365,7 +365,7 @@
- 	  BUILD_WINDRES='$(WINDRES_PROG)$(EXEEXT)'
- 	  BUILD_WINDMC='$(WINDMC_PROG)$(EXEEXT)'
- 	  ;;
--	x86_64-*-mingw* | x86_64-*-cygwin*)
-+	x86_64-*-mingw* | x86_64-*-cygwin* | x86_64-*-msys*)
-   	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
- 	  if test -z "$DLLTOOL_DEFAULT"; then
+@@ -16271,7 +16277,7 @@
+ 	BUILD_WINDRES='$(WINDRES_PROG)$(EXEEXT)'
+ 	BUILD_WINDMC='$(WINDMC_PROG)$(EXEEXT)'
+ 	;;
+-    x86_64-*-mingw* | x86_64-*-cygwin*)
++    x86_64-*-mingw* | x86_64-*-cygwin* | x86_64-*-msys*)
+ 	BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
+ 	if test -z "$DLLTOOL_DEFAULT"; then
  	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_MX86_64"
-@@ -376,7 +376,7 @@
- 	  BUILD_DLLWRAP='$(DLLWRAP_PROG)$(EXEEXT)'
- 	  ;;
+@@ -16295,7 +16301,7 @@
+     powerpc*-*-aix* | rs6000-*-aix*)
+ 	od_vectors="$od_vectors objdump_private_desc_xcoff"
+ 	;;
+-    *-*-pe* | *-*-cygwin* | *-*-mingw*)
++    *-*-pe* | *-*-cygwin* | *-*-msys* | *-*-mingw*)
+ 	 od_vectors="$od_vectors objdump_private_desc_pe"
+ 	 ;;
+     *-*-darwin*)
+--- binutils-2.42/binutils/configure.ac.orig	2024-01-30 07:51:14.212953500 +0100
++++ binutils-2.42/binutils/configure.ac	2024-01-30 07:53:24.015164500 +0100
+@@ -396,7 +396,7 @@
+ 	BUILD_WINDMC='$(WINDMC_PROG)$(EXEEXT)'
+ 	;;
  changequote(,)dnl
--	i[3-7]86-*-pe* | i[3-7]86-*-cygwin* | i[3-7]86-*-mingw32**)
-+	i[3-7]86-*-pe* | i[3-7]86-*-cygwin* | i[3-7]86-*-msys* | i[3-7]86-*-mingw32**)
+-    i[3-7]86-*-pe* | i[3-7]86-*-cygwin* | i[3-7]86-*-mingw32** | all)
++    i[3-7]86-*-pe* | i[3-7]86-*-cygwin* | i[3-7]86-*-msys* | i[3-7]86-*-mingw32** | all)
  changequote([,])dnl
-   	  BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
- 	  if test -z "$DLLTOOL_DEFAULT"; then
+ 	BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
+ 	if test -z "$DLLTOOL_DEFAULT"; then
+@@ -441,7 +441,7 @@
+ 	BUILD_WINDRES='$(WINDRES_PROG)$(EXEEXT)'
+ 	BUILD_WINDMC='$(WINDMC_PROG)$(EXEEXT)'
+ 	;;
+-    x86_64-*-mingw* | x86_64-*-cygwin*)
++    x86_64-*-mingw* | x86_64-*-cygwin* | x86_64-*-msys*)
+ 	BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
+ 	if test -z "$DLLTOOL_DEFAULT"; then
+ 	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_MX86_64"
+@@ -465,7 +465,7 @@
+     powerpc*-*-aix* | rs6000-*-aix*)
+ 	od_vectors="$od_vectors objdump_private_desc_xcoff"
+ 	;;
+-    *-*-pe* | *-*-cygwin* | *-*-mingw*)
++    *-*-pe* | *-*-cygwin* | *-*-msys* | *-*-mingw*)
+ 	 od_vectors="$od_vectors objdump_private_desc_pe"
+ 	 ;;
+     *-*-darwin*)
 diff -Naur binutils-2.37-orig/binutils/dllwrap.c binutils-2.37/binutils/dllwrap.c
 --- binutils-2.37-orig/binutils/dllwrap.c	2021-11-30 08:19:29.866519000 +0100
 +++ binutils-2.37/binutils/dllwrap.c	2021-11-30 08:55:46.638625700 +0100
@@ -687,10 +705,9 @@ diff -Naur binutils-2.37-orig/configure binutils-2.37/configure
        FLAGS_FOR_TARGET=$FLAGS_FOR_TARGET' -L$$r/$(TARGET_SUBDIR)/winsup/cygwin -isystem $$s/winsup/cygwin/include'
        ;;
     esac
-diff -Naur binutils-2.37-orig/configure.ac binutils-2.37/configure.ac
---- binutils-2.37-orig/configure.ac	2021-11-30 08:19:41.276294300 +0100
-+++ binutils-2.37/configure.ac	2021-11-30 09:21:29.929743500 +0100
-@@ -408,7 +408,7 @@
+--- binutils-2.42/configure.ac.orig	2024-01-29 01:00:00.000000000 +0100
++++ binutils-2.42/configure.ac	2024-01-30 07:46:38.185503100 +0100
+@@ -442,7 +442,7 @@
  # Configure extra directories which are host specific
  
  case "${host}" in
@@ -699,7 +716,7 @@ diff -Naur binutils-2.37-orig/configure.ac binutils-2.37/configure.ac
      configdirs="$configdirs libtermcap" ;;
  esac
  
-@@ -774,7 +774,7 @@
+@@ -838,7 +838,7 @@
  # Disable the go frontend on systems where it is known to not work. Please keep
  # this in sync with contrib/config-list.mk.
  case "${target}" in
@@ -708,7 +725,7 @@ diff -Naur binutils-2.37-orig/configure.ac binutils-2.37/configure.ac
      unsupported_languages="$unsupported_languages go"
      ;;
  esac
-@@ -803,7 +803,7 @@
+@@ -867,7 +867,7 @@
  	# PR 46986
  	noconfigdirs="$noconfigdirs target-libgo"
  	;;
@@ -716,8 +733,8 @@ diff -Naur binutils-2.37-orig/configure.ac binutils-2.37/configure.ac
 +    *-*-cygwin* | *-*-msys* | *-*-mingw*)
  	noconfigdirs="$noconfigdirs target-libgo"
  	;;
-     esac
-@@ -1071,7 +1071,7 @@
+     bpf-*-*)
+@@ -1162,7 +1162,7 @@
    i[[3456789]]86-*-mingw*)
      target_configdirs="$target_configdirs target-winsup"
      ;;
@@ -726,7 +743,7 @@ diff -Naur binutils-2.37-orig/configure.ac binutils-2.37/configure.ac
      target_configdirs="$target_configdirs target-libtermcap target-winsup"
      noconfigdirs="$noconfigdirs target-libgloss"
      # always build newlib if winsup directory is present.
-@@ -1219,7 +1219,7 @@
+@@ -1318,7 +1318,7 @@
    i[[3456789]]86-*-msdosdjgpp*)
      host_makefile_frag="config/mh-djgpp"
      ;;
@@ -735,7 +752,7 @@ diff -Naur binutils-2.37-orig/configure.ac binutils-2.37/configure.ac
      ACX_CHECK_CYGWIN_CAT_WORKS
      host_makefile_frag="config/mh-cygwin"
      ;;
-@@ -1782,7 +1782,7 @@
+@@ -1928,7 +1928,7 @@
    build_lto_plugin=yes
  ],[if test x"$default_enable_lto" = x"yes" ; then
      case $target in
@@ -744,7 +761,7 @@ diff -Naur binutils-2.37-orig/configure.ac binutils-2.37/configure.ac
        # On other non-ELF platforms, LTO has yet to be validated.
        *) enable_lto=no ;;
      esac
-@@ -1793,7 +1793,7 @@
+@@ -1939,7 +1939,7 @@
    # warn during gcc/ subconfigure; unless you're bootstrapping with
    # -flto it won't be needed until after installation anyway.
      case $target in
@@ -753,7 +770,7 @@ diff -Naur binutils-2.37-orig/configure.ac binutils-2.37/configure.ac
        *) if test x"$enable_lto" = x"yes"; then
  	AC_MSG_ERROR([LTO support is not enabled for this target.])
          fi
-@@ -1803,7 +1803,7 @@
+@@ -1949,7 +1949,7 @@
    # Among non-ELF, only Windows platforms support the lto-plugin so far.
    # Build it unless LTO was explicitly disabled.
    case $target in
@@ -762,7 +779,7 @@ diff -Naur binutils-2.37-orig/configure.ac binutils-2.37/configure.ac
      *) ;;
    esac
  ])
-@@ -2676,7 +2676,7 @@
+@@ -2958,7 +2958,7 @@
  case "${host}" in
    *-*-hpux*) RPATH_ENVVAR=SHLIB_PATH ;;
    *-*-darwin*) RPATH_ENVVAR=DYLD_LIBRARY_PATH ;;
@@ -771,7 +788,7 @@ diff -Naur binutils-2.37-orig/configure.ac binutils-2.37/configure.ac
    *) RPATH_ENVVAR=LD_LIBRARY_PATH ;;
  esac
  
-@@ -3205,7 +3205,7 @@
+@@ -3527,7 +3527,7 @@
    case " $target_configargs " in
    *" --with-newlib "*)
     case "$target" in
@@ -1068,18 +1085,6 @@ diff -Naur binutils-2.37-orig/gprof/configure binutils-2.37/gprof/configure
      lt_cv_dlopen="dlopen"
      lt_cv_dlopen_libs=
      ;;
-diff -Naur binutils-2.37-orig/intl/configure binutils-2.37/intl/configure
---- binutils-2.37-orig/intl/configure	2021-11-30 08:19:29.180460000 +0100
-+++ binutils-2.37/intl/configure	2021-11-30 09:12:15.714525700 +0100
-@@ -6838,6 +6838,8 @@
- 	;;
-     i[34567]86-*-cygwin* | x86_64-*-cygwin*)
- 	;;
-+    i[34567]86-*-msys* | x86_64-*-msys*)
-+	;;
-     i[34567]86-*-mingw* | x86_64-*-mingw*)
- 	;;
-     i[34567]86-*-interix[3-9]*)
 diff -Naur binutils-2.37-orig/ld/configure binutils-2.37/ld/configure
 --- binutils-2.37-orig/ld/configure	2021-11-30 08:19:34.423226900 +0100
 +++ binutils-2.37/ld/configure	2021-11-30 08:46:47.738991300 +0100

--- a/binutils/PKGBUILD
+++ b/binutils/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=binutils
-pkgver=2.41
-pkgrel=4
+pkgver=2.42
+pkgrel=1
 pkgdesc="A set of programs to assemble and manipulate binary and object files"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/binutils/"
@@ -14,14 +14,12 @@ options=('staticlibs' '!distcc' '!ccache')
 source=(https://ftp.gnu.org/gnu/binutils/binutils-${pkgver}.tar.xz{,.sig}
         0050-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
         0100-binutils-2.37-msys2.patch
-        2002-Allow-spaces-in-the-name-of-the-external-preprocesso.patch
-        "f82ee0c8dc4ee32556e23e6cd83ef083618f704f.patch::https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=f82ee0c8dc4ee32556e23e6cd83ef083618f704f")
-sha256sums=('ae9a5789e23459e59606e6714723f2d3ffc31c03174191ef0d015bdf06007450'
+        2002-Allow-spaces-in-the-name-of-the-external-preprocesso.patch)
+sha256sums=('f6e4d41fd5fc778b06b7891457b3620da5ecea1006c6a4a41ae998109f85a800'
             'SKIP'
             '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18'
-            '2acce83fb67a32e2cd54708ca97c31c79085d0c0f5e2f42b7d103c1fba3250fc'
-            '57478b9971183d430c93701b1d533e3724dab5334bbf44db924777e4a93c1063'
-            'ce18efabddb009037b95ab3295af9f9c9fba69f99470cc24e83c84a2232323a2')
+            '78a8fece3e244272bb3c52924ddcdeedc483631236cc71206a7f21b0949f5a49'
+            '57478b9971183d430c93701b1d533e3724dab5334bbf44db924777e4a93c1063')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
 
@@ -29,8 +27,6 @@ prepare() {
   cd "${srcdir}"/binutils-${pkgver}
   patch -p1 -i "${srcdir}"/0050-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
   patch -p1 -i "${srcdir}"/0100-binutils-2.37-msys2.patch
-  # https://sourceware.org/bugzilla/show_bug.cgi?id=30724
-  patch -p1 -i "${srcdir}"/f82ee0c8dc4ee32556e23e6cd83ef083618f704f.patch
 
   # https://github.com/msys2/MSYS2-packages/issues/2379
   patch -R -p1 -i "${srcdir}"/2002-Allow-spaces-in-the-name-of-the-external-preprocesso.patch


### PR DESCRIPTION
* Remove backport which is included in the new release
* 0100-binutils-2.37-msys2.patch: simple refresh