### PR TITLE
xz: remove unneeded dependencies

### DIFF
--- a/xz/PKGBUILD
+++ b/xz/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('xz' 'liblzma' 'liblzma-devel')
 pkgver=5.4.6
-pkgrel=1
+pkgrel=2
 pkgdesc='Library and command line tools for XZ and LZMA compressed files'
 arch=('i686' 'x86_64')
 url='https://tukaani.org/xz/'
@@ -56,6 +56,7 @@ package_xz() {
 package_liblzma() {
   pkgdesc="Library for XZ and LZMA compressed files"
   groups=('libraries')
+  depends=()
 
   mkdir -p ${pkgdir}/usr/bin
   cp -f ${srcdir}/dest/usr/bin/*.dll ${pkgdir}/usr/bin/


### PR DESCRIPTION
It was inheriting them from pkgbase, but it's only depending
on the runtime and nothing more.