### PR TITLE
msys2-w32api-headers: work around `__buildreadseg` errors

### DIFF
--- a/msys2-w32api-headers/0001-Work-around-Warray-bounds-warning-for-__readfsdword-.patch
+++ b/msys2-w32api-headers/0001-Work-around-Warray-bounds-warning-for-__readfsdword-.patch
@@ -1,0 +1,70 @@
+From 006dd2f19262c89ebbd0f4f2b920825783e7c107 Mon Sep 17 00:00:00 2001
+From: LIU Hao <lh_mouse@126.com>
+Date: Wed, 29 Jun 2022 07:38:24 -0700
+Subject: [PATCH] Work around -Warray-bounds warning for __readfsdword and
+ __readgsqword
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+在 2022-06-29 19:51, Ozkan Sezer 写道:
+
+    Noticed this in github CI runs of vkQuake. Is the warning bogus?
+
+    D:/a/_temp/msys64/mingw32/include/psdk_inc/intrin-impl.h:2164:1:
+    warning: array subscript 0 is outside array bounds of 'long unsigned int[0]' [-Warray-bounds]
+      2164 | __buildreadseg(__readfsdword, unsigned __LONG32, "fs", "l")
+           | ^~~~~~~~~~~~~~
+
+I have been aware of this too. The asm statement is passed an
+indirection by a constant offset in the FS/GS segment, which itself is
+valid, but GCC thinks it was about the default DS segment and fails to
+calculate its size.
+
+This may be solved for GCC by casting the input offset to a pointer to
+an array of unknown bound. So instead of writing
+
+  [offset] "m" ((*(y *) (size_t) Offset))
+
+we write
+
+  [offset] "m" ((*(y (*)[]) (size_t) Offset))
+
+Unfortunately Clang does not like this:
+
+  test.c:5:53: error: dereference of pointer to incomplete type 'unsigned long[]'
+
+Let's guard this so that only newer GCC sees this.
+
+Proposed-in: https://sourceforge.net/p/mingw-w64/mailman/message/37674508/
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ mingw-w64-headers/include/psdk_inc/intrin-impl.h | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/mingw-w64-headers/include/psdk_inc/intrin-impl.h b/mingw-w64-headers/include/psdk_inc/intrin-impl.h
+index 24624a501..2dbd0002c 100644
+--- a/mingw-w64-headers/include/psdk_inc/intrin-impl.h
++++ b/mingw-w64-headers/include/psdk_inc/intrin-impl.h
+@@ -217,11 +217,17 @@ Parameters: (FunctionName, DataType, Segment)
+    Type: b, w, l, q
+    */
+ 
++#if defined(__GNUC__) && __GNUC__ > 11
++#define __buildreadseg_star (*)[]
++#else
++#define __buildreadseg_star *
++#endif
++
+ #define __buildreadseg(x, y, z, a) y x(unsigned __LONG32 Offset) { \
+     y ret; \
+     __asm__ ("mov{" a " %%" z ":%[offset], %[ret] | %[ret], %%" z ":%[offset]}" \
+         : [ret] "=r" (ret) \
+-        : [offset] "m" ((*(y *) (size_t) Offset))); \
++        : [offset] "m" ((*(y __buildreadseg_star) (size_t) Offset))); \
+     return ret; \
+ }
+ 
+-- 
+2.43.0
+

--- a/msys2-w32api-headers/PKGBUILD
+++ b/msys2-w32api-headers/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname="msys2-w32api-headers"
 pkgver=11.0.1.r0.gc3e587c06
-pkgrel=2
+pkgrel=3
 pkgdesc="Win32 API headers for MSYS2 32bit toolchain"
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
@@ -11,8 +11,10 @@ depends=()
 makedepends=('git' 'mingw-w64-cross-gcc' 'autotools')
 options=('staticlibs' '!buildflags')
 _commit='c3e587c067a00a561899d49d3e63a659e38802ec'
-source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit")
-sha256sums=('SKIP')
+source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit"
+        "0001-Work-around-Warray-bounds-warning-for-__readfsdword-.patch")
+sha256sums=('SKIP'
+            '189dd0f614caae1428e1d3a06bc3ac436d26afd9cbdbd1a7ce58b1ee6478ff3f')
 msys2_references=(
   'cygwin: w32api-runtime'
 )
@@ -20,6 +22,12 @@ msys2_references=(
 pkgver() {
   cd "${srcdir}/mingw-w64"
   git describe --long ${_commit} | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
+}
+
+prepare() {
+  cd ${srcdir}/mingw-w64
+
+  patch -Np1 -i "${srcdir}"/0001-Work-around-Warray-bounds-warning-for-__readfsdword-.patch
 }
 
 build() {


### PR DESCRIPTION
In msys2/msys2-runtime@ae5462a53b (CI: fix the build with gcc 13, 2023-11-10), we worked around build errors that look like this:

```
  In member function ‘virtual ssize_t fhandler_console::write(const void*, size_t)’:
  cc1plus: note: source object is likely at address zero
  In function ‘long long unsigned int __readgsqword(unsigned int)’,
      inlined from ‘_TEB* NtCurrentTeb()’ at /usr/include/w32api/winnt.h:10013:86,
      inlined from ‘tmp_pathbuf::~tmp_pathbuf()’ at winsup/cygwin/local_includes/tls_pbuf.h:21:5,
      inlined from ‘virtual ssize_t fhandler_console::write(const void*, size_t)’ at winsup/cygwin/fhandler/console.cc:4047:1:
  /usr/include/w32api/psdk_inc/intrin-impl.h:838:1: warning: array subscript 0 is outside array bounds of ‘long long unsig
  ned int [0]’ [-Warray-bounds=]
    838 | __buildreadseg(__readgsqword, unsigned __int64, "gs", "q")
        | ^~~~~~~~~~~~~~
```

This happens since the recent upgrade in MSYS2 from GCC 11.3.0-4 -> 13.2.0-2.

The work-around was to add the big hammer `-Wno-error`, which was later toned down to `-Wno-error=array-bounds`, among other more surgical options, in msys2/msys2-runtime@76fd7eae5a (fixup! CI: fix the build with gcc 13, 2023-12-22).

Helpfully, a work-around for the actual compile error was proposed in https://sourceforge.net/p/mingw-w64/mailman/message/37674508/ on the mingw-w64-public mailing list. Let's use that for now.