### PR TITLE
tmux: add --enable-sixel

### DIFF
--- a/tmux/PKGBUILD
+++ b/tmux/PKGBUILD
@@ -39,6 +39,7 @@ prepare() {
 build() {
   cd "${srcdir}/${pkgname}-${_base_ver}${_bugfix/./}"
   ./configure \
+    --enable-sixel \
     --prefix=/usr \
     --sysconfdir=/etc \
     --localstatedir=/var \


### PR DESCRIPTION
This commit adds the --enable-sixel flag of tmux.