### PR TITLE
msys2-runtime-3.3: add -Wno-error for additional warning on i686 build

### DIFF
--- a/msys2-runtime-3.3/0057-Move-_cygheap_start-into-.cygheap-section.patch
+++ b/msys2-runtime-3.3/0057-Move-_cygheap_start-into-.cygheap-section.patch
@@ -1,0 +1,34 @@
+From 1f3be1e79303711927bf7462625a7522ef57a3d9 Mon Sep 17 00:00:00 2001
+From: Jeremy Drake <github@jdrake.com>
+Date: Tue, 20 Feb 2024 10:18:56 -0800
+Subject: [PATCH 57/N] Move _cygheap_start into .cygheap section.
+
+Binutils >= 2.41 started making .rsrc section read-only, which caused
+memset(_cygheap_start, ...) to segfault.  Instead, put _cygheap_start in
+the .cygheap section, which makes more sense anyway, but may result in
+reducing the difference between _cygheap_start and _cygheap_end by the
+fraction of a page not used in the .rsrc section.
+
+Fixes #200
+See-also: https://cygwin.com/pipermail/cygwin/2024-February/255472.html
+Signed-off-by: Jeremy Drake <github@jdrake.com>
+---
+ winsup/cygwin/cygwin.sc.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/winsup/cygwin/cygwin.sc.in b/winsup/cygwin/cygwin.sc.in
+index 264e240..dec8f87 100644
+--- a/winsup/cygwin/cygwin.sc.in
++++ b/winsup/cygwin/cygwin.sc.in
+@@ -142,10 +142,10 @@ SECTIONS
+   {
+     *(.rsrc)
+     *(SORT(.rsrc$*))
+-    _SYM (_cygheap_start) = .;
+   }
+   .cygheap ALIGN(__section_alignment__) :
+   {
++    _SYM (_cygheap_start) = .;
+ #ifdef __x86_64__
+     . = . + (3072 * 1024);
+ #else

--- a/msys2-runtime-3.3/0058-Cygwin-dumper-also-link-with-libzstd-as-libbfd-may-r.patch
+++ b/msys2-runtime-3.3/0058-Cygwin-dumper-also-link-with-libzstd-as-libbfd-may-r.patch
@@ -1,0 +1,61 @@
+From 69e4fbea86b07a7960c1fd98b0e17bd5bdb4d2b8 Mon Sep 17 00:00:00 2001
+From: Jon Turney <jon.turney@dronecode.org.uk>
+Date: Tue, 14 Feb 2023 13:52:39 +0000
+Subject: [PATCH 58/N] Cygwin: dumper: also link with libzstd, as libbfd may
+ require it
+
+Also allow that linkage to be dynamic, as libzstd-devel doesn't
+currently provide a static library.
+
+(cherry picked from commit 1387ea9f984d5a7aa096a66b67d61dc2cc565d21)
+---
+ winsup/configure.ac      | 10 ++++++----
+ winsup/utils/Makefile.am |  7 ++-----
+ 2 files changed, 8 insertions(+), 9 deletions(-)
+
+diff --git a/winsup/configure.ac b/winsup/configure.ac
+index ca2b8c0..977a5ce 100644
+--- a/winsup/configure.ac
++++ b/winsup/configure.ac
+@@ -110,10 +110,12 @@ AC_CHECK_LIB([bfd], [bfd_init], [true],
+ 
+ AM_CONDITIONAL(BUILD_DUMPER, [test "x$ac_cv_lib_bfd_bfd_init" = "xyes"])
+ 
+-AC_CHECK_LIB([sframe], [sframe_decode],
+-	     AC_MSG_NOTICE([Detected libsframe; Assuming that libbfd depends on it]), [true])
+-
+-AM_CONDITIONAL(HAVE_LIBSFRAME, [test "x$ac_cv_lib_sframe_sframe_decode" = "xyes"])
++# libbfd.a doesn't have a pkgconfig file, so we guess what it's dependencies
++# are, based on what's present in the build environment
++BFD_LIBS="-lintl -liconv -liberty -lz"
++AC_CHECK_LIB([sframe], [sframe_decode], [BFD_LIBS="${BFD_LIBS} -lsframe"])
++AC_CHECK_LIB([zstd], [ZSTD_isError], [BFD_LIBS="${BFD_LIBS} -lzstd"])
++AC_SUBST([BFD_LIBS])
+ 
+ AC_CONFIG_FILES([
+     Makefile
+diff --git a/winsup/utils/Makefile.am b/winsup/utils/Makefile.am
+index 08f6212..1132b09 100644
+--- a/winsup/utils/Makefile.am
++++ b/winsup/utils/Makefile.am
+@@ -78,7 +78,8 @@ LDADD = -lnetapi32
+ cygpath_CXXFLAGS = -fno-threadsafe-statics $(AM_CXXFLAGS)
+ cygpath_LDADD = $(LDADD) -luserenv -lntdll
+ dumper_CXXFLAGS = -I$(top_srcdir)/../include $(AM_CXXFLAGS)
+-dumper_LDADD = $(LDADD) -lpsapi -lbfd -lintl -liconv -liberty -lz -lntdll
++dumper_LDADD = $(LDADD) -lpsapi -lntdll -lbfd @BFD_LIBS@
++dumper_LDFLAGS =
+ ldd_LDADD = $(LDADD) -lpsapi -lntdll
+ mount_CXXFLAGS = -DFSTAB_ONLY $(AM_CXXFLAGS)
+ minidumper_LDADD = $(LDADD) -ldbghelp
+@@ -87,10 +88,6 @@ profiler_CXXFLAGS = -I$(srcdir) -idirafter ${top_srcdir}/cygwin -idirafter ${top
+ profiler_LDADD = $(LDADD) -lntdll
+ cygps_LDADD = $(LDADD) -lpsapi -lntdll
+ 
+-if HAVE_LIBSFRAME
+-dumper_LDADD += -lsframe
+-endif
+-
+ if CROSS_BOOTSTRAP
+ SUBDIRS = mingw
+ endif

--- a/msys2-runtime-3.3/0059-Cygwin-configure-Add-option-to-disable-building-dump.patch
+++ b/msys2-runtime-3.3/0059-Cygwin-configure-Add-option-to-disable-building-dump.patch
@@ -1,0 +1,41 @@
+From de1cae81d52a9f011a72e36d45e28b4066d4cb68 Mon Sep 17 00:00:00 2001
+From: Jon Turney <jon.turney@dronecode.org.uk>
+Date: Tue, 13 Dec 2022 23:17:48 +0000
+Subject: [PATCH 59/N] Cygwin: configure: Add option to disable building
+ 'dumper'
+
+Rather than guessing, based on just the presence of libbfd, add an
+explicit configuration option, to build dumper or not, defaulting to
+building it.
+
+This might have some use when bootstrapping Cygwin for a new
+architecture, or when building your own Cygwin-targetted cross-compiler,
+rather than installing one from the copr, along with the dependencies of
+libbfd.
+
+(cherry picked from commit 1b5fc91a1daa90fb955f57937f4590c5079dd161)
+(cherry picked from commit d7a76c6b6460efa26c690aaa97a1843c9391d19f)
+---
+ winsup/configure.ac | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/winsup/configure.ac b/winsup/configure.ac
+index 977a5ce..6afe334 100644
+--- a/winsup/configure.ac
++++ b/winsup/configure.ac
+@@ -105,10 +105,12 @@ AM_CONDITIONAL(CROSS_BOOTSTRAP, [test "x$with_cross_bootstrap" != "xyes"])
+ 
+ AC_EXEEXT
+ 
+-AC_CHECK_LIB([bfd], [bfd_init], [true],
+-	     AC_MSG_WARN([Not building dumper.exe since some required libraries or headers are missing]))
++AC_ARG_ENABLE([dumper],
++	      [AS_HELP_STRING([--disable-dumper], [do not build the 'dumper' utility])],
++	      [build_dumper=$enableval],
++	      [build_dumper=yes])
+ 
+-AM_CONDITIONAL(BUILD_DUMPER, [test "x$ac_cv_lib_bfd_bfd_init" = "xyes"])
++AM_CONDITIONAL(BUILD_DUMPER, [test "x$build_dumper" = "xyes"])
+ 
+ # libbfd.a doesn't have a pkgconfig file, so we guess what it's dependencies
+ # are, based on what's present in the build environment

--- a/msys2-runtime-3.3/0060-Work-around-fragile-include-in-binutils.patch
+++ b/msys2-runtime-3.3/0060-Work-around-fragile-include-in-binutils.patch
@@ -1,0 +1,84 @@
+From 5d96b10d53d19eeba5326a0c0bc2387a93c7c6ef Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Fri, 2 Feb 2024 13:40:28 +0100
+Subject: [PATCH 60/N] Work around fragile `#include` in binutils
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The `bfd.h` header file that is included in `binutils` has the line
+`#include "ansidecl.h"`, which is fragile because it prefers Cygwin's
+`include/ansidecl.h` (as opposed to `#include <ansidecl.h>`, which would
+only look in the system include paths).
+
+This matters because as of v2.42, `bfd.h` also makes use of the
+`ATTRIBUTE_WARN_UNUSED_RESULT` macro.
+
+So let's just copy that macro (and while at it, the other `ATTRIBUTE_*`
+macros) from binutils' `ansidecl.h` file, to avoid compile errors while
+compiling `dumper.o` that look like this:
+
+  /usr/include/bfd.h:2770:1: error: expected initializer before ‘ATTRIBUTE_WARN_UNUSED_RESULT’
+   2770 | ATTRIBUTE_WARN_UNUSED_RESULT;
+        | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+(cherry picked from commit 44b5e4eed0f2f119d312fe718c2124250c8626f9)
+---
+ include/ansidecl.h | 43 +++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 43 insertions(+)
+
+diff --git a/include/ansidecl.h b/include/ansidecl.h
+index 6e4bfc2..ceb356e 100644
+--- a/include/ansidecl.h
++++ b/include/ansidecl.h
+@@ -283,6 +283,49 @@ So instead we use the macro below and test it against specific values.  */
+ # endif /* GNUC >= 4.9 */
+ #endif /* ATTRIBUTE_NO_SANITIZE_UNDEFINED */
+ 
++/* Attribute 'nonstring' was valid as of gcc 8.  */
++#ifndef ATTRIBUTE_NONSTRING
++# if GCC_VERSION >= 8000
++#  define ATTRIBUTE_NONSTRING __attribute__ ((__nonstring__))
++# else
++#  define ATTRIBUTE_NONSTRING
++# endif
++#endif
++
++/* Attribute `alloc_size' was valid as of gcc 4.3.  */
++#ifndef ATTRIBUTE_RESULT_SIZE_1
++# if (GCC_VERSION >= 4003)
++#  define ATTRIBUTE_RESULT_SIZE_1 __attribute__ ((alloc_size (1)))
++# else
++#  define ATTRIBUTE_RESULT_SIZE_1
++#endif
++#endif
++
++#ifndef ATTRIBUTE_RESULT_SIZE_2
++# if (GCC_VERSION >= 4003)
++#  define ATTRIBUTE_RESULT_SIZE_2 __attribute__ ((alloc_size (2)))
++# else
++#  define ATTRIBUTE_RESULT_SIZE_2
++#endif
++#endif
++
++#ifndef ATTRIBUTE_RESULT_SIZE_1_2
++# if (GCC_VERSION >= 4003)
++#  define ATTRIBUTE_RESULT_SIZE_1_2 __attribute__ ((alloc_size (1, 2)))
++# else
++#  define ATTRIBUTE_RESULT_SIZE_1_2
++#endif
++#endif
++
++/* Attribute `warn_unused_result' was valid as of gcc 3.3.  */
++#ifndef ATTRIBUTE_WARN_UNUSED_RESULT
++# if GCC_VERSION >= 3003
++#  define ATTRIBUTE_WARN_UNUSED_RESULT __attribute__ ((__warn_unused_result__))
++# else
++#  define ATTRIBUTE_WARN_UNUSED_RESULT
++# endif
++#endif
++
+ /* We use __extension__ in some places to suppress -pedantic warnings
+    about GCC extensions.  This feature didn't work properly before
+    gcc 2.8.  */

--- a/msys2-runtime-3.3/PKGBUILD
+++ b/msys2-runtime-3.3/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime-3.3
 pkgname=('msys2-runtime-3.3' 'msys2-runtime-3.3-devel')
 pkgver=3.3.6
-pkgrel=6
+pkgrel=8
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -247,8 +247,8 @@ build() {
     OPTIM="-O2"
   fi
 
-  CFLAGS="$OPTIM -pipe -ggdb -Wno-error=deprecated -Wno-error=stringop-truncation -Wno-error=missing-attributes -Wno-error=maybe-uninitialized" #-Wno-error=class-memaccess
-  CXXFLAGS="$OPTIM -pipe -ggdb -Wno-error=deprecated -Wno-error=stringop-truncation -Wno-error=missing-attributes -Wno-error=maybe-uninitialized -Wno-error=overloaded-virtual -Wno-narrowing" #-Wno-error=class-memaccess
+  CFLAGS="$OPTIM -pipe -ggdb -Wno-error=deprecated -Wno-error=stringop-truncation -Wno-error=missing-attributes -Wno-error=maybe-uninitialized -Wno-error=format-overflow" #-Wno-error=class-memaccess
+  CXXFLAGS="$OPTIM -pipe -ggdb -Wno-error=deprecated -Wno-error=stringop-truncation -Wno-error=missing-attributes -Wno-error=maybe-uninitialized -Wno-error=format-overflow -Wno-error=overloaded-virtual -Wno-narrowing" #-Wno-error=class-memaccess
 
   (cd "${srcdir}/msys2-runtime/winsup" && ./autogen.sh)
 

--- a/msys2-runtime-3.3/PKGBUILD
+++ b/msys2-runtime-3.3/PKGBUILD
@@ -80,7 +80,11 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0053-CI-fix-the-build-with-gcc-13.patch
         0054-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
         0055-fixup-Add-functionality-for-converting-UNIX-paths-in.patch
-        0056-nlsfuncs-work-around-an-overzealous-GCC-warning.patch)
+        0056-nlsfuncs-work-around-an-overzealous-GCC-warning.patch
+        0057-Move-_cygheap_start-into-.cygheap-section.patch
+        0058-Cygwin-dumper-also-link-with-libzstd-as-libbfd-may-r.patch
+        0059-Cygwin-configure-Add-option-to-disable-building-dump.patch
+        0060-Work-around-fragile-include-in-binutils.patch)
 sha256sums=('SKIP'
             'c375315e58181ee5589b7966101aa095de3f864a579c3c3f0f0683595d4e428d'
             '01ea2b131cf5a3b27fdbc458019eac14e45a36782ce3ce33e62328eefcd2d02e'
@@ -137,7 +141,11 @@ sha256sums=('SKIP'
             '8024edf0bcce8900061fae947bb46b4c3fbdea09d327a3c6048e0af292c8e991'
             'bf366ac49fb1c4e9d6d16eb38267cf04cf12a1ca510bd7d1ddfc0b834146c295'
             '168025561b2d0150e40509bd028545dc0e7af4ae1dbca7aa9b8f37da801e37e3'
-            '6d985b7f92307cbe376af31fa1fc8010e2dc56e1354938b13423d4da06bc1d6c')
+            '6d985b7f92307cbe376af31fa1fc8010e2dc56e1354938b13423d4da06bc1d6c'
+            '658288b4dc8306fc56bfd37b32326cf9d05aba1960205c4ba73821c0341a56f9'
+            '1cdf4bff5af6b71c0710e608439f5fda3a097a895a565ad4c2542f301c108d3b'
+            '66193f7b677f46edfba8d054365d58a79b5f141354c9614adb788f89a7360d53'
+            'b6a286617f1c3278c2303db8e0bc7d94c455e1fb47e8bb8fd55aa9c5f477ccf0')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -230,7 +238,11 @@ prepare() {
   0053-CI-fix-the-build-with-gcc-13.patch \
   0054-fixup-Add-functionality-for-converting-UNIX-paths-in.patch \
   0055-fixup-Add-functionality-for-converting-UNIX-paths-in.patch \
-  0056-nlsfuncs-work-around-an-overzealous-GCC-warning.patch
+  0056-nlsfuncs-work-around-an-overzealous-GCC-warning.patch \
+  0057-Move-_cygheap_start-into-.cygheap-section.patch \
+  0058-Cygwin-dumper-also-link-with-libzstd-as-libbfd-may-r.patch \
+  0059-Cygwin-configure-Add-option-to-disable-building-dump.patch \
+  0060-Work-around-fragile-include-in-binutils.patch
 }
 
 build() {


### PR DESCRIPTION
On i686, an additional warning showed up that failed the build.  This adds this warning to the CFLAGS/CXXFLAGS exclusions.

```
/t/r/msys2-runtime-3.3/src/msys2-runtime/winsup/cygwin/fhandler_proc.cc: In function 'off_t format_proc_swaps(void*, char*&)': /t/r/msys2-runtime-3.3/src/msys2-runtime/winsup/cygwin/fhandler_proc.cc:1964:43: error: '%s' directive writing 4 bytes into a region of size between 1 and 2147483606 [-Werror=format-overflow=]
 1964 |           bufptr += sprintf (bufptr, "%s%s%s\t\t%llu%s\t%llu%s\t%d\n",
      |                                           ^~
......
 1967 |                                         "file",
      |                                         ~~~~~~
/t/r/msys2-runtime-3.3/src/msys2-runtime/winsup/cygwin/fhandler_proc.cc:1964:38: note: directive argument in the range [0, 18014398501093376]
 1964 |           bufptr += sprintf (bufptr, "%s%s%s\t\t%llu%s\t%llu%s\t%d\n",
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/t/r/msys2-runtime-3.3/src/msys2-runtime/winsup/cygwin/fhandler_proc.cc:1964:38: note: directive argument in the range [0, 18014398501093376]
/t/r/msys2-runtime-3.3/src/msys2-runtime/winsup/cygwin/fhandler_proc.cc:1964:29: note: 'sprintf' output between 54 and 2147483693 bytes into a destination of size 2147483647
 1964 |           bufptr += sprintf (bufptr, "%s%s%s\t\t%llu%s\t%llu%s\t%d\n",
      |                     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1965 |                                     filename,
      |                                     ~~~~~~~~~
 1966 |                                     tabo < 5 ? "\t\t\t\t\t" + tabo : " ",
      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1967 |                                         "file",
      |                                         ~~~~~~~
 1968 |                                             total >> 10,
      |                                             ~~~~~~~~~~~~
 1969 |                                             total < 10000000000 ? "\t" : "",
      |                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1970 |                                                 used  >> 10,
      |                                                 ~~~~~~~~~~~~
 1971 |                                                 used  < 10000000000 ? "\t" : "",
      |                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1972 |                                                                 0);
      |                                                                 ~~
```