### PR TITLE
xz: Switch from upstream tarball to git tarball

### DIFF
--- a/xz/PKGBUILD
+++ b/xz/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('xz' 'liblzma' 'liblzma-devel')
 pkgver=5.6.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Library and command line tools for XZ and LZMA compressed files'
 arch=('i686' 'x86_64')
 url='https://tukaani.org/xz/'
@@ -13,18 +13,19 @@ msys2_references=(
 )
 license=('GPL' 'LGPL' 'custom')
 depends=('sh' 'libiconv' 'gettext')
-makedepends=('libiconv-devel' 'gettext-devel' 'autotools' 'gcc')
+makedepends=('libiconv-devel' 'gettext-devel' 'autotools' 'gcc' 'po4a' 'doxygen')
 options=('staticlibs')
-source=("https://github.com/tukaani-project/xz/releases/download/v${pkgver}/xz-${pkgver}.tar.xz"{,.sig})
-sha256sums=('f334777310ca3ae9ba07206d78ed286a655aa3f44eec27854f740c26b2cd2ed0'
-            'SKIP')
-validpgpkeys=('3690C240CE51B4670D30AD1C38EE757D69184620' # Lasse Collin <lasse.collin@tukaani.org>
-              '22D465F2B4C173803B20C6DE59FCF207FEA7F445') # Jia Tan <jiat0218@gmail.com>
+# WARNING: don't use the upstream tarball until this is resolved:
+# https://github.com/tukaani-project/xz/issues/92
+# https://nvd.nist.gov/vuln/detail/CVE-2024-3094
+source=("https://github.com/tukaani-project/xz/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('237284fae40e5f8e9908f0a977e7d0b9a5c7c1c10a41b8e6ed0fb40e930467c8')
+validpgpkeys=('3690C240CE51B4670D30AD1C38EE757D69184620') # Lasse Collin <lasse.collin@tukaani.org>
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
 
-  autoreconf -ivf
+  ./autogen.sh
 }
 
 build() {


### PR DESCRIPTION
Run autogen to get the documentation built instead of just autoreconf Also needs extra build depends for things already included in the tarball.

And remove the signing key from the bad actor.