### PR TITLE
bash: Fix CR handling

### DIFF
--- a/bash/.gitattributes
+++ b/bash/.gitattributes
@@ -1,0 +1,1 @@
+*-bash-*-msys2-fix-lineendings.patch	-text

--- a/bash/0005-bash-4.3-msys2-fix-lineendings.patch
+++ b/bash/0005-bash-4.3-msys2-fix-lineendings.patch
@@ -14,6 +14,84 @@ index c1135ec..b388af6 100644
    if (niflp)
      *niflp = invfl;
    if  (vlp)
+diff --git a/parse.y b/parse.y
+index 8fd24a1c..232a33dc 100644
+--- a/parse.y
++++ b/parse.y
+@@ -1684,7 +1690,15 @@ rewind_input_string ()
+      into account, e.g., $(...\n) */
+   xchars = shell_input_line_len - shell_input_line_index;
+   if (bash_input.location.string[-1] == '\n')
+-    xchars++;
++    {
++      xchars++;
++#ifdef __MSYS__
++      {
++	if (bash_input.location.string[-2] == '\r')
++	  xchars++;
++      }
++#endif
++    }
+ 
+   /* XXX - how to reflect bash_input.location.string back to string passed to
+      parse_and_execute or xparse_dolparen? xparse_dolparen needs to know how
+diff --git a/tests/crlf.right b/tests/crlf.right
+new file mode 100644
+index 0000000..d7fd195
+--- /dev/null
++++ b/tests/crlf.right
+@@ -0,0 +1,8 @@
++Line with LF
++Line with CR
++Line with CRLF
++Line with
++ LF
++Line with CR
++Line with
++ CRLF
+diff --git a/tests/crlf.tests b/tests/crlf.tests
+new file mode 100644
+index 0000000..b2c4da7
+--- /dev/null
++++ b/tests/crlf.tests
+@@ -0,0 +1,6 @@
++echo $(echo -e "Line with\n LF")
++echo $(echo -e "Line with\r CR")
++echo $(echo -e "Line with\r\n CRLF")
++echo "$(echo -e "Line with\n LF")"
++echo "$(echo -e "Line with\r CR")"
++echo "$(echo -e "Line with\r\n CRLF")"
+diff --git a/tests/ps1lf.right b/tests/ps1lf.right
+new file mode 100644
+index 0000000..ee83131
+--- /dev/null
++++ b/tests/ps1lf.right
+@@ -0,0 +1,2 @@
++foo
++$ exit
+diff --git a/tests/ps1lf.tests b/tests/ps1lf.tests
+new file mode 100644
+index 0000000..01a2265
+--- /dev/null
++++ b/tests/ps1lf.tests
+@@ -0,0 +1 @@
++PS1='$(echo foo)\n\$ '
+diff --git a/tests/run-crlf b/tests/run-crlf
+new file mode 100644
+index 0000000..3f6037c
+--- /dev/null
++++ b/tests/run-crlf
+@@ -0,0 +1,2 @@
++${THIS_SH} ./crlf.tests > ${BASH_TSTOUT}
++diff ${BASH_TSTOUT} crlf.right && rm -f ${BASH_TSTOUT}
+diff --git a/tests/run-ps1lf b/tests/run-ps1lf
+new file mode 100644
+index 0000000..1617108
+--- /dev/null
++++ b/tests/run-ps1lf
+@@ -0,0 +1,2 @@
++${THIS_SH} --rcfile ./ps1lf.tests -i < /dev/null 2>&1 | tr -d '\r' > ${BASH_TSTOUT}
++diff ${BASH_TSTOUT} ps1lf.right && rm -f ${BASH_TSTOUT}
 diff --git a/variables.c b/variables.c
 index 028667c..a10594d 100644
 --- a/variables.c
@@ -39,18 +117,3 @@ index 028667c..a10594d 100644
    if (shell_variables == 0)
      create_variable_tables ();
  
-diff --git a/y.tab.c b/y.tab.c
-index 32b4c7c..ac70820 100644
---- a/y.tab.c
-+++ b/y.tab.c
-@@ -4746,6 +4752,10 @@ shell_getc (remove_quoted_newline)
- 	  else
- 	    RESIZE_MALLOCED_BUFFER (shell_input_line, i, 2, shell_input_line_size, 256);
- 
-+#ifdef __MSYS__
-+	  if (c == '\r')
-+	    continue;
-+#endif
- 	  if (c == EOF)
- 	    {
- 	      if (bash_input.type == st_stream)

--- a/bash/PKGBUILD
+++ b/bash/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=('bash' 'bash-devel')
 _basever=5.3
 _patchlevel=009 #prepare for some patches
 pkgver=${_basever}.${_patchlevel}
-pkgrel=1
+pkgrel=2
 pkgdesc="The GNU Bourne Again shell"
 arch=('i686' 'x86_64')
 license=('GPL')
@@ -16,7 +16,7 @@ msys2_references=(
   "cpe: cpe:/a:gnu:bash"
 )
 validpgpkeys=('7C0135FB088AAF6C66C650B9BB5869F064EA74AB') # Chet Ramey
-makedepends=('gettext-devel' 'libreadline-devel>=7.0' 'ncurses-devel' 'autotools' 'gcc')
+makedepends=('gettext-devel' 'libreadline-devel>=7.0' 'ncurses-devel' 'autotools' 'gcc' 'bison')
 source=(https://ftp.gnu.org/gnu/bash/bash-${_basever}.tar.gz{,.sig}
         0001-bash-4.4-cygwin.patch
         0002-bash-4.3-msysize.patch
@@ -81,7 +81,7 @@ build() {
 
 check() {
   cd ${srcdir}/${pkgname}-$_basever
-  make check
+  LC_ALL=C.UTF-8 make check
 }
 
 package_bash() {
@@ -128,7 +128,7 @@ sha256sums=('0d5cd86965f869a26cf64f4b71be7b96f90a3ba8b3d74e27e8e9d9d5550f31ba'
             'SKIP'
             'd46e6b06167af61cc8639236948daf6fd57db418893330bef728efd4acc40430'
             '16584e119db9418030912171f89aecae319858ecd357d3e56c95eba83667dae7'
-            '696e38540a9abfbf217d6dd17b2c6ffe274b9383815c5db76ce118fdddabd777'
+            'eed83a5381b3789b240859299cf49229586f20124ab3c973839e05be0398859f'
             '500c75c64593a70276585345a55c807226c0cc220d08b7cccece2ab005b3bcea'
             'cbae1aa81d56eba4e916bdaf2b2983731d6e2537dd8d606a3b378e49bcb81e79'
             '1f608434364af86b9b45c8b0ea3fb3b165fb830d27697e6cdfc7ac17dee3287f'


### PR DESCRIPTION
Fixes #1839

`0005-bash-4.3-msys2-fix-lineendings.patch` adds CRLF support. However, `0001-bash-4.4-cygwin.patch` already added `igncr` option to Bash to support CRLF.

I confirmed that the Cygwin version of Bash has also the same issue with #1839 when the `igncr` option is set.

After debugging, I found that there is an issue in `rewind_input_string()` in `parser.y` that it doesn't take the CR into account.

This PR adds the following changes:
* ~~Set the `igncr` option by default.~~
* ~~Remove unnecessary changes in `yy_input_name()` in `parser.y` and use the `igncr` implementation.~~
* Modify `rewind_input_string()` to take the CR into account. (It might be better to apply a similar change to the Cygwin version of Bash.)
* Remove all the changes from `y.tab.c`. This file should be automatically generated from `parser.y`.
* Set `LC_ALL=C.UTF-8` when running `make check` for running on non-English locales.
* Add two tests: `run-ps1lf` and `run-crlf`.