### PR TITLE
msys2-runtime: backport follow-up fix for offline files

### DIFF
--- a/msys2-runtime/0054-Cygwin-FILE_OPEN_NO_RECALL-is-incompatible-with-FILE.patch
+++ b/msys2-runtime/0054-Cygwin-FILE_OPEN_NO_RECALL-is-incompatible-with-FILE.patch
@@ -1,0 +1,51 @@
+From 260676cde0b49d30209387181a2371dd35ee364c Mon Sep 17 00:00:00 2001
+From: Corinna Vinschen <corinna@vinschen.de>
+Date: Thu, 4 Apr 2024 17:36:01 +0200
+Subject: [PATCH 54/N] Cygwin: FILE_OPEN_NO_RECALL is incompatible with
+ FILE_DIRECTORY_FILE
+
+If FILE_DIRECTORY_FILE is given, FILE_OPEN_NO_RECALL is not allowed,
+otherwise NtCreateFile returns STATUS_INVALID_PARAMETER.
+
+Drop FILE_OPEN_NO_RECALL where FILE_DIRECTORY_FILE is specified.
+
+Fixes: f6b56abec186 ("Cygwin: try to avoid recalling offline files")
+Reported-by: Bruce Jerrick <bmj001@gmail.com>
+Signed-off-by: Corinna Vinschen <corinna@vinschen.de>
+---
+ winsup/cygwin/fhandler/disk_file.cc | 1 -
+ winsup/cygwin/path.cc               | 2 --
+ 2 files changed, 3 deletions(-)
+
+diff --git a/winsup/cygwin/fhandler/disk_file.cc b/winsup/cygwin/fhandler/disk_file.cc
+index 87c14df..4df80dc 100644
+--- a/winsup/cygwin/fhandler/disk_file.cc
++++ b/winsup/cygwin/fhandler/disk_file.cc
+@@ -328,7 +328,6 @@ fhandler_base::fstat_by_name (struct stat *buf)
+       status = NtOpenFile (&dir, SYNCHRONIZE | FILE_LIST_DIRECTORY,
+ 			   &attr, &io, FILE_SHARE_VALID_FLAGS,
+ 			   FILE_SYNCHRONOUS_IO_NONALERT
+-			   | FILE_OPEN_NO_RECALL
+ 			   | FILE_OPEN_FOR_BACKUP_INTENT
+ 			   | FILE_DIRECTORY_FILE);
+       if (!NT_SUCCESS (status))
+diff --git a/winsup/cygwin/path.cc b/winsup/cygwin/path.cc
+index e61d370..46d1b8c 100644
+--- a/winsup/cygwin/path.cc
++++ b/winsup/cygwin/path.cc
+@@ -577,7 +577,6 @@ getfileattr (const char *path, bool caseinsensitive) /* path has to be always ab
+       status = NtOpenFile (&dir, SYNCHRONIZE | FILE_LIST_DIRECTORY,
+ 			   &attr, &io, FILE_SHARE_VALID_FLAGS,
+ 			   FILE_SYNCHRONOUS_IO_NONALERT
+-			   | FILE_OPEN_NO_RECALL
+ 			   | FILE_OPEN_FOR_BACKUP_INTENT
+ 			   | FILE_DIRECTORY_FILE);
+       if (NT_SUCCESS (status))
+@@ -3483,7 +3482,6 @@ restart:
+ 	      status = NtOpenFile (&dir, SYNCHRONIZE | FILE_LIST_DIRECTORY,
+ 				   &dattr, &io, FILE_SHARE_VALID_FLAGS,
+ 				   FILE_SYNCHRONOUS_IO_NONALERT
+-				   | FILE_OPEN_NO_RECALL
+ 				   | FILE_OPEN_FOR_BACKUP_INTENT
+ 				   | FILE_DIRECTORY_FILE);
+ 	      if (!NT_SUCCESS (status))

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.4.10
-pkgrel=6
+pkgrel=7
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -81,7 +81,8 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0050-pathconv-don-t-skip-arguments-with-double-quote.patch
         0051-Work-around-fragile-include-in-binutils.patch
         0052-Cygwin-try-to-avoid-recalling-offline-files.patch
-        0053-Cygwin-get-set-security-descriptors-using-FILE_OPEN_.patch)
+        0053-Cygwin-get-set-security-descriptors-using-FILE_OPEN_.patch
+        0054-Cygwin-FILE_OPEN_NO_RECALL-is-incompatible-with-FILE.patch)
 sha256sums=('SKIP'
             '351bb1efdbdafe80c981e92d6b425c6ab71c85ce4e990db184e2118158eb2ab6'
             'd3d3a01feeae9f7d5e6cb32f4662df74fc9476ff11a1aac3dad2df3e43fd88e4'
@@ -135,7 +136,8 @@ sha256sums=('SKIP'
             '1665c7654a3f5fbdf42fdc7c3b0bfeaa2f26a9534962ffece26da97122e3018e'
             '164527ad2e289050ed336a6f1aa8e1af40fb864e7e4aed545bde2703d41203bd'
             '9879a0fe09147b1e0d41f42211bb309dd08ea088186f413d4dec6e0300ef9fbc'
-            '677c013c456ca1ec239a694340ae36eae99a5700d0dda09e3679a29997234512')
+            '677c013c456ca1ec239a694340ae36eae99a5700d0dda09e3679a29997234512'
+            '266db90ae4f67f2818d015272cdda3d751a62724149d035d1a04a4407a7dbcef')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -225,7 +227,8 @@ prepare() {
   0050-pathconv-don-t-skip-arguments-with-double-quote.patch \
   0051-Work-around-fragile-include-in-binutils.patch \
   0052-Cygwin-try-to-avoid-recalling-offline-files.patch \
-  0053-Cygwin-get-set-security-descriptors-using-FILE_OPEN_.patch
+  0053-Cygwin-get-set-security-descriptors-using-FILE_OPEN_.patch \
+  0054-Cygwin-FILE_OPEN_NO_RECALL-is-incompatible-with-FILE.patch
 }
 
 build() {


### PR DESCRIPTION
This integrates https://github.com/msys2/msys2-runtime/pull/210 into MSYS2-packages.