### PR TITLE
pacman: remove `-pipe` from default `LDFLAGS` for all environments

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.0.2
-pkgrel=13
+pkgrel=14
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -82,8 +82,8 @@ validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@a
               'B8151B117037781095514CA7BBDFFC92306B1121') # Andrew Gregory (pacman) <andrew@archlinux.org>
 sha256sums=('SKIP'
             '53c0c2d42bc10f265aa41bc412a6ebc2d98177d9356b0fa9a2a130caec46ac2d'
-            'c12da01ede663a4924d0817a0d1bd6082b1380383cfb74cc1cea08f9d73e4902'
-            'a84354e88f6b0cae3a8005a944fcd88819a0860f4440501cc6f1c1f9abfe87c4'
+            'fa6c5fc52192484a3419a25bfae802d93be4103fc57281318b55dbea80cb9646'
+            'bbc323d1fa057c31ff5b8329eb1e6fdfde5af98ece7a3e7e2982f91a9ec1f23d'
             '98198e1f0f252eae0560d271bee4b9149e127399dd0d3fd5d8d24579d9e0550f'
             'd272176dea508bf0972dde6396ca655e900d509099d0a496bd6a138f98bb48df'
             '7e2a2fc6799ed8a9dbc8b0712b162be963ed22351e4cb29b3a4d4a4d3f28d7ed'

--- a/pacman/makepkg.conf
+++ b/pacman/makepkg.conf
@@ -43,7 +43,7 @@ CXX=g++
 CPPFLAGS=
 CFLAGS="@CARCHFLAGS@ -mtune=generic -O2 -pipe"
 CXXFLAGS="@CARCHFLAGS@ -mtune=generic -O2 -pipe"
-LDFLAGS="-pipe"
+LDFLAGS=""
 #-- Make Flags: change this for DistCC/SMP systems
 MAKEFLAGS="-j$(($(nproc)+1))"
 #-- Debugging flags

--- a/pacman/makepkg_mingw.conf
+++ b/pacman/makepkg_mingw.conf
@@ -44,7 +44,7 @@ if [[ "$MSYSTEM" == "MINGW64" ]]; then
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
   CFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong"
   CXXFLAGS="$CFLAGS"
-  LDFLAGS="-pipe"
+  LDFLAGS=""
 elif [[ "$MSYSTEM" == "MINGW32" ]]; then
   CARCH="i686"
   CHOST="i686-w64-mingw32"
@@ -56,7 +56,7 @@ elif [[ "$MSYSTEM" == "MINGW32" ]]; then
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
   CFLAGS="-march=pentium4 -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong"
   CXXFLAGS="$CFLAGS"
-  LDFLAGS="-pipe -Wl,--no-seh -Wl,--large-address-aware"
+  LDFLAGS="-Wl,--no-seh -Wl,--large-address-aware"
 elif [[ "$MSYSTEM" == "CLANG64" ]]; then
   CARCH="x86_64"
   CHOST="x86_64-w64-mingw32"
@@ -68,7 +68,7 @@ elif [[ "$MSYSTEM" == "CLANG64" ]]; then
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
   CFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong"
   CXXFLAGS="$CFLAGS"
-  LDFLAGS="-pipe"
+  LDFLAGS=""
 elif [[ "$MSYSTEM" == "CLANG32" ]]; then
   CARCH="i686"
   CHOST="i686-w64-mingw32"
@@ -80,7 +80,7 @@ elif [[ "$MSYSTEM" == "CLANG32" ]]; then
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
   CFLAGS="-march=pentium4 -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong"
   CXXFLAGS="$CFLAGS"
-  LDFLAGS="-pipe -Wl,--no-seh -Wl,--large-address-aware"
+  LDFLAGS="-Wl,--no-seh -Wl,--large-address-aware"
 elif [[ "$MSYSTEM" == "CLANGARM64" ]]; then
   CARCH="aarch64"
   CHOST="aarch64-w64-mingw32"
@@ -92,7 +92,7 @@ elif [[ "$MSYSTEM" == "CLANGARM64" ]]; then
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
   CFLAGS="-O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong"
   CXXFLAGS="$CFLAGS"
-  LDFLAGS="-pipe"
+  LDFLAGS=""
 elif [[ "$MSYSTEM" == "UCRT64" ]]; then
   CARCH="x86_64"
   CHOST="x86_64-w64-mingw32"
@@ -104,7 +104,7 @@ elif [[ "$MSYSTEM" == "UCRT64" ]]; then
   CPPFLAGS="-D__USE_MINGW_ANSI_STDIO=1"
   CFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong"
   CXXFLAGS="$CFLAGS"
-  LDFLAGS="-pipe"
+  LDFLAGS=""
 else
   echo "Unsupported MSYSTEM: $MSYSTEM"
   exit 1


### PR DESCRIPTION
It probably doesn't do anything and breaks Flang 18 when it is being called as a linker.

See https://github.com/msys2/MINGW-packages/pull/20591.