### PR TITLE
msys2-runtime: abort installation on Windows 7 and 8.0

### DIFF
--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.4.10
-pkgrel=8
+pkgrel=9
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -13,6 +13,7 @@ msys2_references=(
   'cygwin: cygwin'
   "cpe: cpe:/a:cygwin:cygwin"
 )
+install="msys2-runtime.install"
 makedepends=('cocom'
              'git'
              'perl'

--- a/msys2-runtime/msys2-runtime.install
+++ b/msys2-runtime/msys2-runtime.install
@@ -1,0 +1,26 @@
+_abort_too_old_windows()
+{
+    local winver
+    winver=$(uname -s)   # looks like `MINGW64_NT-10.0-22621`
+    winver=${winver#*-}  # strip off `<prefix>-`
+    winver=${winver%%-*} # strip off `-<suffix>`, if any
+    # 6.1 is Windows 7, 6.2 is Windows 8
+    if [ "$winver" = "6.1" ] || [ "$winver" = "6.2" ]; then
+        printf "\e[1;33mThe MSYS2 runtime version you are about to install will no longer run\n"
+        printf "on your version of Windows. To continue using MSYS2, please switch to\n"
+        printf "the legacy runtime using:\e[1;0m\n\n"
+        printf "\e[1;32mpacman --noconfirm -S msys2-runtime-3.4 msys2-runtime-3.4-devel\e[1;0m\n\n"
+        printf "\e[1;33mThe current update will now be aborted.\e[1;0m\n"
+
+        rm -f /var/lib/pacman/db.lck
+        kill -TERM "$PPID"
+    fi
+}
+
+pre_install() {
+    _abort_too_old_windows
+}
+
+pre_upgrade() {
+    _abort_too_old_windows
+}


### PR DESCRIPTION
Cygwin 3.5 no longer supports Windows 7 and 8.0 and letting users update would render all cygwin tools broken.

There is no good way to abort an installation from within a package, so we run an install script on pre install/upgrade and just kill pacman from there, after printing a message for how to fix things. Since killing pacman would leave the DB locked, remove the lock file before, so the suggested way forward works.

While we don't officially support Win 7/8.0 for quite a while now, this should help those remaining users keep using the parts that still work for a bit longer.