### PR TITLE
Work around pacman hangs on Windows/ARM64

### DIFF
--- a/gpgme/0003-Work-around-pacman-hangs-on-Windows-ARM64.patch
+++ b/gpgme/0003-Work-around-pacman-hangs-on-Windows-ARM64.patch
@@ -1,0 +1,62 @@
+From 7501c30e631fad336bb3ae9339d9d5738fea9102 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Sat, 4 May 2024 19:51:52 +0000
+Subject: [PATCH] Work around `pacman` hangs on Windows/ARM64
+
+When calling `pacman` in GitHub Actions runners that run Windows/ARM64,
+we frequently experience curious hangs while Pacman is verifying signatures.
+
+These hangs are somewhat flaky, it seems as if certain scenarios (slow
+machines, for example) make the hangs more likely.
+
+A common symptom is that the hanging process has a command-line that is
+identical to its parent process' command-line (indicating that it has
+been `fork()`ed), and anecdotally, the hang occurs when `_exit()` calls
+`proc_terminate()` which is then blocked by a call to
+`TerminateThread()` with an invalid thread handle (for more details, see
+https://github.com/msys2/msys2-autobuild/issues/62#issuecomment-1951796327).
+
+In my tests, I found that the hanging process is spawned from
+`_gpgme_io_spawn()` which lets the child process _immediately_ spawn
+another child. That seems like a fantastic way to find timing-related
+bugs in the MSYS2/Cygwin runtime.
+
+As a work-around, it does seem to help if we avoid that double-fork.
+
+This partially reverts 61aa1947 (... Use a double-fork approach...,
+2002-08-28).
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ src/posix-io.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/posix-io.c b/src/posix-io.c
+index a422d8f..8e4d9c5 100644
+--- a/src/posix-io.c
++++ b/src/posix-io.c
+@@ -552,7 +552,7 @@ _gpgme_io_spawn (const char *path, char *const argv[], unsigned int flags,
+   if (!pid)
+     {
+       /* Intermediate child to prevent zombie processes.  */
+-      if ((pid = fork ()) == 0)
++      // if ((pid = fork ()) == 0)
+ 	{
+ 	  /* Child.  */
+           int max_fds = -1;
+@@ -676,10 +676,12 @@ _gpgme_io_spawn (const char *path, char *const argv[], unsigned int flags,
+ 	_exit (0);
+     }
+ 
++#if 0
+   TRACE_LOG  ("waiting for child process pid=%i", pid);
+   _gpgme_io_waitpid (pid, 1, &status, &signo);
+   if (status)
+     return TRACE_SYSRES (-1);
++#endif
+ 
+   for (i = 0; fd_list[i].fd != -1; i++)
+     {
+-- 
+2.39.1.windows.1
+

--- a/gpgme/PKGBUILD
+++ b/gpgme/PKGBUILD
@@ -27,11 +27,13 @@ makedepends=(
 )
 source=(https://gnupg.org/ftp/gcrypt/${pkgbase}/${pkgbase}-${pkgver}.tar.bz2{,.sig}
         0001-fix-broken-version.patch
-        0002-gpgme-engine-cache-version.patch)
+        0002-gpgme-engine-cache-version.patch
+        0003-Work-around-pacman-hangs-on-Windows-ARM64.patch)
 sha256sums=('9499e8b1f33cccb6815527a1bc16049d35a6198a6c5fae0185f2bd561bce5224'
             'SKIP'
             '80771f9811ad809c8ff8977b05cfcc0d2d4a1c764c3df6ae5aa91c5aa7565a9a'
-            '241206490b1f6dbb044c167525f8d1d85fc816be5f17a4b991664c7863a887bb')
+            '241206490b1f6dbb044c167525f8d1d85fc816be5f17a4b991664c7863a887bb'
+            '97f0272b4a7dcaadf857ce8f63b1de73855ad977d046b5c926c87977b83ee157')
 #These might be signed by any of these keys https://gnupg.org/signature_key.html
 validpgpkeys=('5B80C5754298F0CB55D8ED6ABCEF7E294B092E28'
               '6DAA6E64A76D2840571B4902528897B826403ADA'
@@ -46,6 +48,9 @@ prepare() {
   # https://github.com/msys2/msys2-pacman/issues/26
   # https://dev.gnupg.org/T6369
   patch -p1 -i "${srcdir}/0002-gpgme-engine-cache-version.patch"
+
+  # https://github.com/msys2/MSYS2-packages/pull/4583
+  patch -p1 -i "${srcdir}/0003-Work-around-pacman-hangs-on-Windows-ARM64.patch"
 
   autoreconf -ivf
 }

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.1.0
-pkgrel=3
+pkgrel=4
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"


### PR DESCRIPTION
Both [in the MSYS2 project](https://github.com/msys2/msys2-autobuild/issues/62) as well as [in the Git for Windows project](https://github.com/git-for-windows/setup-git-for-windows-sdk/pull/590#issuecomment-1420789372), automated builds on Windows/ARM64 are plagued by semi-randomly hanging `pacman` processes.

@jeremyd2019 did a great job [diagnosing](https://github.com/git-for-windows/git-for-windows-automation/pull/22#issuecomment-1433600039) these, and I also started to dig into this. After many, many months (with many, many breaks), I found this here work-around.

[Here](https://github.com/git-for-windows/git-sdk-arm64/actions/runs/8953398866/job/24591861914) is a successful run of Git for Windows' `sync` job that tries to update, commit & push the `git-sdk-arm64` repository. Previously it consistently ran into those hangs, and replacing the `pacman.exe` with the version built in this here PR worked around those hangs.

### Technical description

A common symptom is that the hanging process has a command-line that is identical to its parent process' command-line (indicating that it has been `fork()`ed), and anecdotally, the hang occurs when `_exit()` calls `proc_terminate()` which is then blocked by a call to `TerminateThread()` with an invalid thread handle (for more details, see https://github.com/msys2/msys2-autobuild/issues/62#issuecomment-1951796327).

In my tests, I found that the hanging process is spawned from `_gpgme_io_spawn()` which lets the child process _immediately_ spawn another child. That seems like a fantastic way to find timing-related bugs in the MSYS2/Cygwin runtime.

As a work-around, it does seem to help if we avoid that double-fork.

This partially reverts [61aa1947](https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=commitdiff;h=61aa1947) (... Use a double-fork approach..., 2002-08-28).