### PR TITLE
msys2-runtime: attempt to use makepkg's split debuginfo feature

### DIFF
--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -237,6 +237,7 @@ package_msys2-runtime-devel() {
   depends=("msys2-runtime=${pkgver}")
   conflicts=('libcatgets-devel' 'msys2-runtime-3.4-devel' 'msys2-runtime-3.5-devel')
   replaces=('libcatgets-devel' 'msys2-runtime-3.5-devel')
+  options=('!strip')
 
   mkdir -p "${pkgdir}"/usr/bin
   cp -rLf "${srcdir}"/dest/usr/${CHOST}/include "${pkgdir}"/usr/

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.5.3
-pkgrel=2
+pkgrel=3
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -220,6 +220,7 @@ package_msys2-runtime() {
   pkgdesc="Posix emulation engine for Windows"
   conflicts=('catgets' 'libcatgets' 'msys2-runtime-3.4' 'msys2-runtime-3.5')
   replaces=('catgets' 'libcatgets' 'msys2-runtime-3.5')
+  options=('debug' 'strip')
 
   mkdir -p "${pkgdir}"/usr
   cp -rf "${srcdir}"/dest/usr/bin "${pkgdir}"/usr/
@@ -245,4 +246,7 @@ package_msys2-runtime-devel() {
   rm -fr "${pkgdir}"/usr/include/rpc/
 
   cp -rLf "${srcdir}"/dest/usr/${CHOST}/lib "${pkgdir}"/usr/
+
+  # debug info created during 'strip' by makepkg
+  cp -rLf "${pkgdir}/../msys2-runtime-debug/"* "${pkgdir}"
 }


### PR DESCRIPTION
To avoid additional changes to msys2-runtime's build (such as changing flags due to 'debug' being set), I didn't set debug at the top level of the PKGBUILD, but rather just in the msys2-runtime package.  This means that makepkg didn't attempt to actually package an msys2-runtime-debug package, so I included the files in msys2-runtime-devel.

It doesn't look like the debug info produced is large enough to be complete, and objdump seems to back this up.  Also, there are some extra files around the .exe files (whatever.exe.debug.exe in addition to some having whatever.exe.debug which is the name I would expect).

I think the makepkg procedure to produce split debuginfo is broken, but I wanted to open this as a draft to start the discussion.

Fixes #4595