### PR TITLE
gpgme: cache the engine version

### DIFF
--- a/gpgme/0002-gpgme-engine-cache-version.patch
+++ b/gpgme/0002-gpgme-engine-cache-version.patch
@@ -1,0 +1,25 @@
+diff --git a/src/engine.c b/src/engine.c
+index 69f1c150..252d8805 100644
+--- a/src/engine.c
++++ b/src/engine.c
+@@ -449,9 +449,16 @@ _gpgme_set_engine_info (gpgme_engine_info_t info, gpgme_protocol_t proto,
+         new_home_dir = NULL;
+     }
+ 
+-  new_version = engine_get_version (proto, new_file_name);
++  if (info && info->version
++      && ((!info->file_name && !new_file_name)
++          || (info->file_name && new_file_name
++              && !strcmp (info->file_name, new_file_name))))
++    new_version = strdup (info->version);
++  else
++    new_version = engine_get_version (proto, new_file_name);
+   if (!new_version)
+     {
++      /* Note that we also get here on a ENOMEM in strdup.  */
+       new_version = strdup ("1.0.0"); /* Fake one for dummy entries.  */
+       if (!new_version)
+         {
+-- 
+2.30.2
+

--- a/gpgme/PKGBUILD
+++ b/gpgme/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=gpgme
 pkgname=('libgpgme' 'libgpgme-devel' 'libgpgme-python')
 pkgver=1.23.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A C wrapper library for GnuPG"
 arch=('i686' 'x86_64')
 url="https://gnupg.org/related_software/gpgme/"
@@ -26,10 +26,12 @@ makedepends=(
   'python-wheel'
 )
 source=(https://gnupg.org/ftp/gcrypt/${pkgbase}/${pkgbase}-${pkgver}.tar.bz2{,.sig}
-        0001-fix-broken-version.patch)
+        0001-fix-broken-version.patch
+        0002-gpgme-engine-cache-version.patch)
 sha256sums=('9499e8b1f33cccb6815527a1bc16049d35a6198a6c5fae0185f2bd561bce5224'
             'SKIP'
-            '80771f9811ad809c8ff8977b05cfcc0d2d4a1c764c3df6ae5aa91c5aa7565a9a')
+            '80771f9811ad809c8ff8977b05cfcc0d2d4a1c764c3df6ae5aa91c5aa7565a9a'
+            '241206490b1f6dbb044c167525f8d1d85fc816be5f17a4b991664c7863a887bb')
 #These might be signed by any of these keys https://gnupg.org/signature_key.html
 validpgpkeys=('5B80C5754298F0CB55D8ED6ABCEF7E294B092E28'
               '6DAA6E64A76D2840571B4902528897B826403ADA'
@@ -40,6 +42,10 @@ prepare() {
 
   # otherwise it appends "unknown" to the version which isn't a valid python version
   patch -p1 -i "${srcdir}/0001-fix-broken-version.patch"
+
+  # https://github.com/msys2/msys2-pacman/issues/26
+  # https://dev.gnupg.org/T6369
+  patch -p1 -i "${srcdir}/0002-gpgme-engine-cache-version.patch"
 
   autoreconf -ivf
 }


### PR DESCRIPTION
See https://github.com/msys2/msys2-pacman/issues/26
See https://dev.gnupg.org/T6369

This saves a gpg spawn for every gpgme_get_key() call, for example around 100ms when starting pacman.