### PR TITLE
wget: don't depend on gpgme

### DIFF
--- a/wget/PKGBUILD
+++ b/wget/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=wget
 pkgver=1.24.5
-pkgrel=1
+pkgrel=2
 pkgdesc="A network utility to retrieve files from the Web"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/wget/"
@@ -12,8 +12,8 @@ msys2_references=(
   "cpe: cpe:2.3:a:wget:wget"
 )
 license=('GPL3')
-depends=('gcc-libs' 'libiconv' 'libidn2' 'libintl' 'libgpgme' 'libpcre2_8' 'libpsl' 'libuuid' 'libgnutls' 'zlib')
-makedepends=('autoconf-archive' 'gettext-devel' 'libidn2-devel' 'libgpgme-devel' 'libuuid-devel'
+depends=('gcc-libs' 'libiconv' 'libidn2' 'libintl' 'libpcre2_8' 'libpsl' 'libuuid' 'libgnutls' 'zlib')
+makedepends=('autoconf-archive' 'gettext-devel' 'libidn2-devel' 'libuuid-devel'
              'libpsl-devel' 'libgnutls-devel' 'pcre2-devel' 'zlib-devel' 'python' 'libunistring-devel' 'autotools' 'gcc')
 checkdepends=('perl-HTTP-Daemon' 'perl-IO-Socket-SSL')
 optdepends=('ca-certificates: HTTPS downloads')


### PR DESCRIPTION
wget 1's configure script only checks for and uses gpgme if metalink is enabled.  After b9f35e17d62e94d5ef3df3d9ece3b3aaff5f68ad, metalink is explicitly disabled, so gpgme was no longer used.