### PR TITLE
python-pyalpm: depend on libgpgme

### DIFF
--- a/python-pyalpm/PKGBUILD
+++ b/python-pyalpm/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pyalpm
 pkgbase="python-${_realname}"
 pkgname=("python-${_realname}")
 pkgver=0.10.9
-pkgrel=1
+pkgrel=2
 pkgdesc="Libalpm bindings for Python"
 arch=('i686' 'x86_64')
 license=('GPL')
@@ -13,7 +13,7 @@ msys2_references=(
   'archlinux: pyalpm'
   "pypi:pyalpm"
 )
-depends=("python" "libarchive")
+depends=("python" "libarchive" "libgpgme")
 makedepends=('gettext-devel'
              'heimdal-devel'
              'libarchive-devel'


### PR DESCRIPTION
The pyalpm dll is dynamically linked to msys-gpgme-11.dll, and now that wget will not depend on libgpgme it shouldn't be pulled into the base packages anymore.