### PR TITLE
CI: fix dll dependency check

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -65,7 +65,7 @@ install_packages() {
 list_dll_deps(){
     local target="${1}"
     echo "$(tput setaf 2)MSYS2 DLL dependencies:$(tput sgr0)"
-    find "$target" -regex ".*\.\(exe\|dll\)" -exec "echo '{}:' && ldd '{}';" | GREP_COLOR="1;35" grep --color=always "msys-.*\|" \
+    find "$target" -regex ".*\.\(exe\|dll\)" -printf '%p:\n' -exec ldd '{}' \; | GREP_COLOR="1;35" grep --color=always "msys-.*\|" \
     || echo "        None"
 }
 


### PR DESCRIPTION
The find expression was broken for a couple of reasons: it does not run in a subshell (so cannot use && like that), and it needs split arguments not one quoted argument.  Avoid having to call echo by using -printf argument.

Fixes #4611