### PR TITLE
Fixes #4640 openssl legacy provider missing

### DIFF
--- a/openssl/PKGBUILD
+++ b/openssl/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('openssl' 'libopenssl' 'openssl-devel' 'openssl-docs')
 pkgver=3.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc='The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
 arch=('i686' 'x86_64')
 url='https://www.openssl.org'
@@ -110,6 +110,9 @@ package_libopenssl() {
   mkdir -p ${pkgdir}/usr/lib/openssl
   cp -rf ${srcdir}/dest/usr/lib/openssl/engines-3 ${pkgdir}/usr/lib/openssl/
   chmod -R 755 ${pkgdir}/usr/lib/openssl/engines-3
+
+  cp -rf ${srcdir}/dest/usr/lib/ossl-modules ${pkgdir}/usr/lib/
+  chmod -R 755 ${pkgdir}/usr/lib/ossl-modules
 
   install -D -m644 ${srcdir}/openssl-${pkgver}/LICENSE.txt ${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.txt
 }


### PR DESCRIPTION
Should probably be in the other targets as well

I don't have the build tools installed so I am not certain of the change but it should be close