### PR TITLE
findutils: disable year 2038 check on 32-bit

### DIFF
--- a/findutils/PKGBUILD
+++ b/findutils/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=findutils
 pkgver=4.10.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU utilities to locate files"
 arch=('i686' 'x86_64')
 license=('GPL3')
@@ -32,12 +32,19 @@ build() {
   # sed -i '/^SUBDIRS/s/locate//' Makefile.in
 
   export CYGWIN_CHOST="${CHOST/-msys/-cygwin}"
+  local -a extra_config
+  # 32-bit cygwin only has 32-bit time_t
+  # https://github.com/msys2/MSYS2-packages/issues/4078
+  if [[ "$CARCH" == "i686" ]]; then
+    extra_config+=("--disable-year2038")
+  fi
 
   ./configure \
     --build=${CYGWIN_CHOST} \
     --prefix=/usr \
     --without-libiconv-prefix \
     --without-libintl-prefix \
+    "${extra_config[@]}" \
     DEFAULT_ARG_SIZE="(32u*1024)"
 
   make


### PR DESCRIPTION
As found in #4078, 32-bit cygwin only has 32-bit time_t.