### PR TITLE
pinentry: Update to 1.3.0

### DIFF
--- a/pinentry/1.1.0-w32.patch
+++ b/pinentry/1.1.0-w32.patch
@@ -1,7 +1,6 @@
-diff -ru pinentry-1.1.0-orig/configure.ac pinentry-1.1.0/configure.ac
---- pinentry-1.1.0-orig/configure.ac	2017-12-03 17:49:54.000000000 +0100
-+++ pinentry-1.1.0/configure.ac	2018-06-21 22:44:58.560006300 +0200
-@@ -576,7 +576,7 @@
+--- pinentry-1.3.0/configure.ac.orig	2024-03-18 12:13:19.000000000 +0100
++++ pinentry-1.3.0/configure.ac	2024-06-09 17:50:57.791957400 +0200
+@@ -762,7 +762,7 @@
  # Check whether we should build the W32 pinentry.  This is actually
  # the simplest check as we do this only for that platform.
  #
@@ -9,47 +8,4 @@ diff -ru pinentry-1.1.0-orig/configure.ac pinentry-1.1.0/configure.ac
 +pinentry_w32=yes
  test $have_w32_system = yes && pinentry_w32=yes
  AM_CONDITIONAL(BUILD_PINENTRY_W32, test "$pinentry_w32" = "yes")
- 
-diff -ru pinentry-1.1.0-orig/w32/main.c pinentry-1.1.0/w32/main.c
---- pinentry-1.1.0-orig/w32/main.c	2017-12-03 17:13:05.000000000 +0100
-+++ pinentry-1.1.0/w32/main.c	2018-06-21 22:44:34.529631800 +0200
-@@ -19,6 +19,7 @@
- #include <config.h>
- #include <stdio.h>
- #include <stdlib.h>
-+#include <unistd.h>
- #if WINVER < 0x0403
- # define WINVER 0x0403  /* Required for SendInput.  */
- #endif
-diff -ru pinentry-1.1.0-orig/w32/pinentry-w32.rc pinentry-1.1.0/w32/pinentry-w32.rc
---- pinentry-1.1.0-orig/w32/pinentry-w32.rc	2017-12-03 17:13:05.000000000 +0100
-+++ pinentry-1.1.0/w32/pinentry-w32.rc	2018-06-22 20:20:07.583469100 +0200
-@@ -51,20 +51,20 @@
- IDB_ICON_96    BITMAP   DISCARDABLE   "logo-96.bmp"
- IDB_ICON_128   BITMAP   DISCARDABLE   "logo-128.bmp"
- 
--IDD_PINENT DIALOG DISCARDABLE  0, 0, 186, 116
-+IDD_PINENT DIALOG DISCARDABLE  0, 0, 230, 125
- STYLE DS_MODALFRAME | DS_SYSMODAL | WS_POPUP | WS_CAPTION | WS_SYSMENU
- CAPTION "Pinentry"
- FONT 10, "MS Sans Serif"
- BEGIN
-     CONTROL         "", IDC_PINENT_ICON,
-                     "Static", SS_BITMAP|SS_CENTERIMAGE,
--                                           4,   6,  32, 32
--    LTEXT           "", IDC_PINENT_DESC,  40,   6, 140, 50
--    RTEXT           "", IDC_PINENT_PROMPT, 6,  60,  60, 12
--    EDITTEXT        IDC_PINENT_TEXT,      70,  59, 110, 12, ES_PASSWORD | ES_AUTOHSCROLL
--    CTEXT           "", IDC_PINENT_ERR,    6,  76, 174, 12
--    DEFPUSHBUTTON   "O&K", IDOK,          74,  96,  50, 14
--    PUSHBUTTON      "&Cancel", IDCANCEL, 130,  96,  50, 14
-+                                           5,   5,  32, 32
-+    LTEXT           "", IDC_PINENT_DESC,  45,   5, 180, 65
-+    RTEXT           "", IDC_PINENT_PROMPT, 5,  75,  60, 12
-+    EDITTEXT        IDC_PINENT_TEXT,      70,  75, 155, 12, ES_PASSWORD | ES_AUTOHSCROLL
-+    CTEXT           "", IDC_PINENT_ERR,    5,  90, 220, 12
-+    DEFPUSHBUTTON   "O&K", IDOK,          50,  105, 85, 14
-+    PUSHBUTTON      "&Cancel", IDCANCEL, 140,  105, 85, 14
- END
- 
  

--- a/pinentry/PKGBUILD
+++ b/pinentry/PKGBUILD
@@ -1,10 +1,11 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=pinentry
-pkgver=1.2.1
+pkgver=1.3.0
 pkgrel=1
 pkgdesc='A collection of simple PIN or passphrase entry dialogs which utilize the Assuan protocol'
 url='https://gnupg.org/related_software/pinentry/'
+msys2_repository_url="https://git.gnupg.org/cgi-bin/gitweb.cgi?p=pinentry.git"
 license=('GPL')
 arch=('i686' 'x86_64')
 makedepends=('ncurses-devel' 'libassuan-devel' 'libgpg-error-devel' 'autotools' 'gcc')
@@ -12,9 +13,9 @@ depends=('ncurses' 'libassuan' 'libgpg-error')
 source=(https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2{,.sig}
         1.1.0-w32.patch
         1.0.0-libiconv.patch)
-sha256sums=('457a185e5a85238fb945a955dc6352ab962dc8b48720b62fc9fa48c7540a4067'
+sha256sums=('9b3cd5226e7597f2fded399a3bc659923351536559e9db0826981bca316494de'
             'SKIP'
-            '0222e625b39f2acd75e718d65ee4eb86f90766cd36e26b9460676766738bc93d'
+            '81c44593f0886c6901ac90c0b83673394e03de62680facf3bbdefa5cb74068da'
             '7723a10cfc9f8a711b118ad9bd06e96c2acb9860f91b635b1253588c2a42811c')
 validpgpkeys=('D8692123C4065DEA5E0F3AB5249B39D24F25E3B6' # Werner Koch (dist sig)
               '6DAA6E64A76D2840571B4902528897B826403ADA' # Werner Koch (dist signing 2020)
@@ -39,6 +40,7 @@ build() {
     --disable-pinentry-curses \
     --disable-pinentry-gtk2 \
     --disable-pinentry-qt \
+    --disable-pinentry-fltk \
     --disable-libsecret \
     --without-libcap
 


### PR DESCRIPTION
* 1.1.0-w32.patch: removed hunks included in the release
* disable fltk, since that confused by a bit when the w32 patch wasn't applied locally. It would try to fall back to fltk otherwise.