### PR TITLE
psmisc: Update to 23.7

### DIFF
--- a/psmisc/0000-fix-build.patch
+++ b/psmisc/0000-fix-build.patch
@@ -10,3 +10,23 @@
  #include <fcntl.h>
  #include <getopt.h>
  #include <pwd.h>
+--- psmisc-v23.7/src/statx.c.orig	2024-06-09 20:06:35.559989500 +0200
++++ psmisc-v23.7/src/statx.c	2024-06-09 20:07:07.457617800 +0200
+@@ -26,6 +26,8 @@
+ #include <config.h>
+ #endif
+ 
++#ifdef WITH_STATX
++
+ #include <sys/sysmacros.h>
+ #include <sys/syscall.h>
+ #include <sys/types.h>
+@@ -33,7 +35,6 @@
+ #include <fcntl.h>		/* Definition of AT_* constants */
+ 
+ int stat_flags = AT_NO_AUTOMOUNT|AT_STATX_DONT_SYNC;
+-#ifdef WITH_STATX
+ 
+ #include <errno.h>
+ #ifndef HAVE_STATX
+

--- a/psmisc/PKGBUILD
+++ b/psmisc/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=psmisc
-pkgver=23.6
+pkgver=23.7
 pkgrel=1
 pkgdesc="Miscellaneous procfs tools"
 arch=('i686' 'x86_64')
@@ -12,8 +12,8 @@ depends=('gcc-libs' 'ncurses' 'libiconv' 'libintl')
 makedepends=('gcc' 'ncurses-devel' 'libiconv-devel' 'gettext-devel' 'autotools' 'gcc')
 source=(${pkgname}-${pkgver}.tar.gz::https://gitlab.com/psmisc/psmisc/-/archive/v${pkgver}/${pkgname}-v${pkgver}.tar.gz
         "0000-fix-build.patch")
-sha256sums=('58022dc47e0fb855468ba6c3c36af225b2caa79b61c8d68132438004fe8b79f3'
-            '99f27495fc1c4560246442e30f966b072d9209040dc6d98962d60ff52ce9b73c')
+sha256sums=('8f2526ce7ac6ef4976454cd63095fa10e467ef745cf33dc4f91df0bd7b10b905'
+            '76a8ae44d356ddce5d120ad71e880ac5d85e303f34a92a53d52be81aa583be97')
 
 prepare() {
   cd ${pkgname}-v${pkgver}
@@ -31,7 +31,8 @@ build() {
     --without-libiconv-prefix \
     --without-libintl-prefix \
     --disable-harden-flags \
-    CPPFLAGS="${CPPFLAGS} -I/usr/include/ncursesw"
+    --disable-statx
+
   make
 }
 

--- a/psmisc/PKGBUILD
+++ b/psmisc/PKGBUILD
@@ -18,6 +18,7 @@ sha256sums=('8f2526ce7ac6ef4976454cd63095fa10e467ef745cf33dc4f91df0bd7b10b905'
 prepare() {
   cd ${pkgname}-v${pkgver}
 
+  # https://gitlab.com/psmisc/psmisc/-/merge_requests/39
   patch -Np1 -i ../0000-fix-build.patch
 
   echo ${pkgver} > .tarball-version


### PR DESCRIPTION
* disable statx since we don't have it and fix the build despite that
* remove the ncurses hack, seems to work fine without