### PR TITLE
icu: fix build with cygwin < 3.5.0

### DIFF
--- a/icu/PKGBUILD
+++ b/icu/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=icu
 pkgname=('icu' 'icu-devel')
 pkgver=75.1
-pkgrel=1
+pkgrel=2
 pkgdesc="International Components for Unicode library"
 arch=('i686' 'x86_64')
 url="https://icu.unicode.org"
@@ -15,9 +15,11 @@ license=('spdx:ICU')
 depends=('gcc-libs' 'sh')
 makedepends=('autoconf-archive' 'autotools' 'gcc')
 source=("https://github.com/unicode-org/${pkgname}/releases/download/release-${pkgver//./-}/${pkgname}4c-${pkgver//./_}-src.tgz"{,.asc}
+        "https://github.com/unicode-org/${pkgname}/pull/3038.patch"
         icu-59.1-msys2.patch)
 sha512sums=('70ea842f0d5f1f6c6b65696ac71d96848c4873f4d794bebc40fd87af2ad4ef064c61a786bf7bc430ce4713ec6deabb8cc1a8cc0212eab148cee2d498a3683e45'
             'SKIP'
+            'ee83337e7bef34a2825e2e853db3b4ec9f83553eb29ab04edf44ffc1beae891961c9f9a611bd1164ccaa84b886417abd82306a73ed310fa9edad3867edc6830f'
             'd3e7c7a65c000bd283d9fd843566ce499edff6580ac8b8004bdba219e47d0dc71c156548df711a08ffae0cb699e2f73fb2800af1850131c37124b1107faf897a')
 validpgpkeys=('0E51E7F06EF719FBD072782A5F56E5AFA63CCD33'  # Craig Cornelius (For use with ICU releases) <ccornelius@google.com>
               '3DA35301A7C330257B8755754058F67406EAA6AB') # Craig Cornelius <ccornelius@google.com>
@@ -26,6 +28,7 @@ prepare() {
   cd ${srcdir}/icu/source
 
   patch -p2 -i ${srcdir}/icu-59.1-msys2.patch
+  patch -p3 -i ${srcdir}/3038.patch
 
   libtoolize --force --copy
   autoreconf -fi


### PR DESCRIPTION
This probably only matters for i686, which is stuck on 3.3.6.

I don't know if the upstream pull request (unicode-org/icu#3038) will go anywhere or not, feels like the kind of org that makes you jump through a lot of hoops to contribute anything.