### PR TITLE
python-markdown: Add 3.6

### DIFF
--- a/python-markdown/PKGBUILD
+++ b/python-markdown/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+_pyname=Markdown
+pkgname=python-markdown
+pkgver=3.6
+pkgrel=1
+pkgdesc="Python implementation of John Gruber's Markdown"
+arch=('any')
+url='https://python-markdown.github.io/'
+license=('spdx:BSD-3-Clause')
+depends=('python')
+makedepends=('git' 'python-build' 'python-installer' 'python-setuptools' 'python-wheel')
+optdepends=('python-yaml: parse Python in YAML metadata')
+checkdepends=('python-yaml')
+source=("${_pyname}-$pkgver.tar.gz"::"https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
+sha256sums=('ed4f41f6daecbeeb96e576ce414c41d2d876daa9a16cb35fa8ed8c2ddfad0224')
+
+build() {
+  cd "${_pyname}-$pkgver"
+
+  python -m build --wheel --no-isolation
+}
+
+check() {
+  cd "${_pyname}-$pkgver"
+
+  python -m unittest discover tests
+}
+
+package() {
+  cd "${_pyname}-$pkgver"
+
+  python -m installer --destdir="$pkgdir" dist/*.whl
+
+  install -Dm644 LICENSE.md "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.md"
+}


### PR DESCRIPTION
for gi-docgen