### PR TITLE
Update gdbinit

### DIFF
--- a/gdb/gdbinit
+++ b/gdb/gdbinit
@@ -1,6 +1,15 @@
 python
 import sys
-sys.path.insert(0, sys.path[0] + '/../../%GCC_NAME%/python')
+import os
+from os import path
+dir_of_gcc = list(filter(lambda x: x.startswith('gcc'), os.listdir('/usr/share')))
+if len(dir_of_gcc) > 0:
+  dir_of_gcc = path.join('/usr/share', dir_of_gcc[0], 'python')
+  if not path.exists(dir_of_gcc):
+    dir_of_gcc = sys.path[0]
+else:
+  dir_of_gcc = sys.path[0]
+sys.path.insert(0, dir_of_gcc)
 from libstdcxx.v6.printers import register_libstdcxx_printers
 register_libstdcxx_printers (None)
 end


### PR DESCRIPTION
fix wrong path of `libstdcxx` python script
If the version number of `gcc` was updated, but this script was not update the variable of `%GCC_NAME%` which will lead an error of missing `libstdcxx` module
This update use python script to search the real path of the `gcc` folder and insert it into the `sys.path` variable