### PR TITLE
mintty: default to BoldAsFont=no

### DIFF
--- a/mintty/PKGBUILD
+++ b/mintty/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=mintty
 pkgver=3.7.3
-pkgrel=1
+pkgrel=2
 epoch=1
 pkgdesc="Terminal emulator with native Windows look and feel"
 arch=('i686' 'x86_64')
@@ -18,7 +18,7 @@ backup=('etc/minttyrc')
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/mintty/mintty/archive/${pkgver}.tar.gz
         "minttyrc")
 sha256sums=('72c97c7bd63c2815238131e8915d6e0bf76f67be7e9533eb2b81814cd70ed008'
-            'aabad49568755a05e76b2581eb6061e27c3ab099aa0f4eb536dfdbcac99cac1f')
+            '9ba15549d8464b9b6711964e84bbf20e49bd57d7773503754fa9cdc42ba1e1d0')
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"

--- a/mintty/minttyrc
+++ b/mintty/minttyrc
@@ -1,2 +1,3 @@
 Columns=100
 Rows=27
+BoldAsFont=no


### PR DESCRIPTION
This is of course subjective, but at least on my low-dpi screen the default rendering of the bold font makes things harder to read.

On linux it looks nicer (not sure if rendering or font is the reason), and the Windows terminal doesn't do bold.

![Screenshot 2024-07-04 234328](https://github.com/msys2/MSYS2-packages/assets/991986/9ba2145b-0747-4c32-9adb-37f14e804df9)

![Screenshot 2024-07-04 234351](https://github.com/msys2/MSYS2-packages/assets/991986/601e9463-049d-47e9-b077-66b7b2de8a79)
