### PR TITLE
Rebuild gdb and libtool for new gcc version

### DIFF
--- a/gcc/PKGBUILD
+++ b/gcc/PKGBUILD
@@ -3,10 +3,12 @@
 # Contributor: Ray Donnelly <mingw.android@gmail.com>
 
 # toolchain build order: win32-api-headers->msys2-runtime->binutils->gcc->binutils->msys2-runtime
-# NOTE: libtool requires rebuilt with each new gcc version
 
 pkgbase=gcc
 pkgname=('gcc' 'gcc-libs')
+# NOTE: gdb must be rebuilt with each new gcc version.
+# NOTE: libtool must be rebuilt with each new gcc version.
+# FIXME: run compileall on /usr/share/gcc-${pkgver}/python/libstdcxx on the next version update
 pkgver=13.3.0
 pkgrel=1
 pkgdesc="The GNU Compiler Collection"

--- a/gdb/PKGBUILD
+++ b/gdb/PKGBUILD
@@ -4,8 +4,7 @@ pkgname=gdb
 pkgname=("gdb"
          "gdb-multiarch")
 pkgver=14.2
-pkgrel=2
-_gcc_ver=13.2.0
+pkgrel=3
 pkgdesc="GNU Debugger (MSYS2 version)"
 arch=('i686' 'x86_64')
 license=('spdx:GPL-3.0-or-later')
@@ -103,7 +102,7 @@ package_gdb() {
 
   # install "custom" system gdbinit
   install -D -m644 ${srcdir}/gdbinit ${pkgdir}/etc/gdbinit
-  sed -i 's|%GCC_NAME%|gcc-'${_gcc_ver}'|g' ${pkgdir}/etc/gdbinit
+  sed -i 's|%GCC_NAME%|gcc-'$(gcc -dumpversion)'|g' ${pkgdir}/etc/gdbinit
 
   # these are shipped by binutils
   rm -fr ${pkgdir}/usr/{include,lib}/ ${pkgdir}/usr/share/locale/

--- a/libtool/PKGBUILD
+++ b/libtool/PKGBUILD
@@ -2,8 +2,7 @@
 
 pkgname=('libtool' 'libltdl')
 pkgver=2.4.7
-_gccver=11.2.0
-pkgrel=3
+pkgrel=4
 pkgdesc="A generic library support script"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/libtool/"
@@ -11,7 +10,7 @@ msys2_references=(
   "cpe: cpe:/a:gnu:libtool"
 )
 license=('spdx:GPL-2.0-or-later')
-makedepends=("gcc>=${_gccver}" 'autotools' 'help2man')
+makedepends=("gcc" 'autotools' 'help2man')
 source=(https://ftp.gnu.org/pub/gnu/libtool/${pkgname}-${pkgver}.tar.xz{,.sig}
         #https://alpha.gnu.org/gnu/libtool/${pkgname}-${pkgver}.tar.xz{,.sig}
         #${pkgname}-${pkgver}::git+https://git.savannah.gnu.org/git/libtool.git


### PR DESCRIPTION
And add a note to gcc that this needs to happen on every version change