### PR TITLE
breezy: remove import for no longer existing module

### DIFF
--- a/breezy/0003-remove-unused-broken-import.patch
+++ b/breezy/0003-remove-unused-broken-import.patch
@@ -1,0 +1,10 @@
+--- breezy-brz-3.2.2/breezy/plugin.py.orig	2022-03-20 02:51:38.000000000 +0100
++++ breezy-brz-3.2.2/breezy/plugin.py	2024-07-06 09:50:36.944423900 +0200
+@@ -38,7 +38,6 @@
+ import re
+ import sys
+ 
+-import imp
+ from importlib import util as importlib_util
+ 
+ import breezy

--- a/breezy/PKGBUILD
+++ b/breezy/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=breezy
 pkgver=3.2.2
-pkgrel=4
+pkgrel=5
 pkgdesc='A decentralized revision control system with support for Bazaar and Git file formats'
 arch=('i686' 'x86_64')
 url='https://www.breezy-vcs.org/'
@@ -30,14 +30,17 @@ provides=(bzr)
 conflicts=(bzr)
 replaces=(bzr)
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/breezy-team/breezy/archive/brz-${pkgver}.tar.gz
-        '0002-add-msys2-certs-location.patch')
+        '0002-add-msys2-certs-location.patch'
+        '0003-remove-unused-broken-import.patch')
 sha256sums=('5661f2e2348a60db4af9c4c8f417a3da3f0bbc02f7a41ce988baba5e1100f3f1'
-            '8f3a1c151c9ceb8b2ace12dc1c80bd123810e2e77a2c784385d5ad039f0bd3bb')
+            '8f3a1c151c9ceb8b2ace12dc1c80bd123810e2e77a2c784385d5ad039f0bd3bb'
+            'a8b9707a9077b3c29e65ee5f89741dc2db92837d10a3041aca3d28032bfe7482')
 
 prepare(){
   cd "${srcdir}/${pkgname}-brz-${pkgver}"
 
   patch -p1 -i ${srcdir}/0002-add-msys2-certs-location.patch
+  patch -p1 -i ${srcdir}/0003-remove-unused-broken-import.patch
 }
 
 build() {


### PR DESCRIPTION
imp no longer exists with Python 3.12. Luckily this was an unused import