### PR TITLE
python: PEP 668 - mark as externally managed

### DIFF
--- a/python/EXTERNALLY-MANAGED
+++ b/python/EXTERNALLY-MANAGED
@@ -1,0 +1,8 @@
+[externally-managed]
+Error=To install Python packages system-wide, try 'pacman -S
+ python-xyz', where xyz is the package you are trying to
+ install.
+
+ If you wish to install a non-MSYS2-packaged Python package,
+ create a virtual environment using 'python -m venv path/to/venv'.
+ Then use path/to/venv/bin/python and path/to/venv/bin/pip.

--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=python
 pkgname=('python' 'python-devel')
 pkgver=3.12.4
-pkgrel=4
+pkgrel=5
 _pybasever=${pkgver%.*}
 pkgdesc="Next generation of the python high-level scripting language"
 arch=('i686' 'x86_64')
@@ -41,7 +41,8 @@ source=(https://www.python.org/ftp/python/${pkgver%rc*}/Python-${pkgver}.tar.xz
         940-rebase-python-dll.patch
         950-rebase-dlls.patch
         970-ossaudiodev.patch
-        980-fix-module-lib-dep.patch)
+        980-fix-module-lib-dep.patch
+        EXTERNALLY-MANAGED)
 sha256sums=('f6d419a6d8743ab26700801b4908d26d97e8b986e14f95de31b32de2b0e79554'
             '82cfafc5b31ad4c9bb4c9786044c39c75762dbc2656abdfdc433c23fee69c02f'
             'f0bb75ca69c63894fc43e0f8218c9dbcc746935bf5ea095a724e6fb2f5dcc566'
@@ -53,7 +54,8 @@ sha256sums=('f6d419a6d8743ab26700801b4908d26d97e8b986e14f95de31b32de2b0e79554'
             'b439ff4f0a1f13858f8fb596414b74ed2c14fc3103d90287bb8e461ee89288b9'
             'bcdb4e7922e30f7dfbd3993ffe6db2dfd0df29326bebd12203dce376ea3451d9'
             'ee109d91a1c7ea84d278d9a8b0e1feb397e691b8868d79f77ea7bb6b1b3b1968'
-            'e2861218f05741bfe99b05bb41cf88e14f57747aedec251626691b05482a50bd')
+            'e2861218f05741bfe99b05bb41cf88e14f57747aedec251626691b05482a50bd'
+            '2c8cdad18085b8736e985653c0f18523958f29b72125e15124806a0f3d1a20ee')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -129,6 +131,9 @@ package_python() {
   ln -sf pydoc3                "${pkgdir}"/usr/bin/pydoc
   ln -sf python${_pybasever}.1 "${pkgdir}"/usr/share/man/man1/python3.1
   ln -sf python${_pybasever}.1 "${pkgdir}"/usr/share/man/man1/python.1
+
+  # PEP668
+  install -Dm644 "$srcdir"/EXTERNALLY-MANAGED -t "${pkgdir}/usr/lib/python${_pybasever}/"
 
   # License
   install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"


### PR DESCRIPTION
See https://peps.python.org/pep-0668/

Similar to what Arch does.

```console
$ pip install pip
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try 'pacman -S
    python-xyz', where xyz is the package you are trying to
    install.

    If you wish to install a non-MSYS2-packaged Python package,
    create a virtual environment using 'python -m venv path/to/venv'.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```