### PR TITLE
msys2-runtime-3.4: synchronize with the `msys2-runtime-3.4.10` branch in the `msys2-runtime` repository

### DIFF
--- a/msys2-runtime-3.4/0052-Cygwin-try-to-avoid-recalling-offline-files.patch
+++ b/msys2-runtime-3.4/0052-Cygwin-try-to-avoid-recalling-offline-files.patch
@@ -1,0 +1,278 @@
+From 40793722b8ea98fcdf63533e10ebd28e84b7ffaa Mon Sep 17 00:00:00 2001
+From: Corinna Vinschen <corinna@vinschen.de>
+Date: Fri, 8 Mar 2024 20:57:06 +0100
+Subject: [PATCH 52/N] Cygwin: try to avoid recalling offline files
+
+Chances are high that Cygwin recalls offline files from remote
+storage, even if the file is only accessed during stat(2) or
+readdir(3).
+
+To avoid this
+- make sure Cygwin is placeholder-aware,
+- open files in path_conv handling, as well as in stat(2)/readdir(3)
+  scenarios with FILE_OPEN_NO_RECALL, and
+- during symlink checking or testing for executablility, don't even
+  try to open the file if one of the OFFLINE attributes is set.
+
+Reported-by: Marcin Wisnicki <mwisnicki@gmail.com>
+Signed-off-by: Corinna Vinschen <corinna@vinschen.de>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/autoload.cc              |  1 +
+ winsup/cygwin/dcrt0.cc                 |  3 +++
+ winsup/cygwin/fhandler/disk_file.cc    | 20 ++++++++++++++------
+ winsup/cygwin/local_includes/ntdll.h   |  8 ++++++++
+ winsup/cygwin/local_includes/path.h    | 16 +++++++++++++++-
+ winsup/cygwin/local_includes/winlean.h |  8 ++++++++
+ winsup/cygwin/path.cc                  | 17 +++++++++++++----
+ 7 files changed, 62 insertions(+), 11 deletions(-)
+
+diff --git a/winsup/cygwin/autoload.cc b/winsup/cygwin/autoload.cc
+index cdf6e75..c579bef 100644
+--- a/winsup/cygwin/autoload.cc
++++ b/winsup/cygwin/autoload.cc
+@@ -477,6 +477,7 @@ LoadDLLfuncEx (SetThreadDescription, 8, KernelBase, 1)
+ LoadDLLfunc (VirtualAlloc2, 28, KernelBase)
+ 
+ LoadDLLfunc (NtMapViewOfSectionEx, 36, ntdll)
++LoadDLLfuncEx (RtlSetProcessPlaceholderCompatibilityMode, 4, ntdll, 1)
+ 
+ LoadDLLfunc (ldap_bind_s, 0, wldap32)
+ LoadDLLfunc (ldap_count_entries, 0, wldap32)
+diff --git a/winsup/cygwin/dcrt0.cc b/winsup/cygwin/dcrt0.cc
+index d7a1b1a..a5b82b0 100644
+--- a/winsup/cygwin/dcrt0.cc
++++ b/winsup/cygwin/dcrt0.cc
+@@ -821,6 +821,9 @@ dll_crt0_1 (void *)
+   if (dynamically_loaded)
+     sigproc_init ();
+ 
++  /* Call this before accessing any files. */
++  RtlSetProcessPlaceholderCompatibilityMode (PHCM_EXPOSE_PLACEHOLDERS);
++
+   check_sanity_and_sync (user_data);
+ 
+   /* Initialize malloc and then call user_shared_initialize since it relies
+diff --git a/winsup/cygwin/fhandler/disk_file.cc b/winsup/cygwin/fhandler/disk_file.cc
+index 8528f7f..87c14df 100644
+--- a/winsup/cygwin/fhandler/disk_file.cc
++++ b/winsup/cygwin/fhandler/disk_file.cc
+@@ -175,7 +175,9 @@ readdir_check_reparse_point (POBJECT_ATTRIBUTES attr, bool remote)
+   bool ret = false;
+ 
+   status = NtOpenFile (&reph, READ_CONTROL, attr, &io, FILE_SHARE_VALID_FLAGS,
+-		       FILE_OPEN_FOR_BACKUP_INTENT | FILE_OPEN_REPARSE_POINT);
++		       FILE_OPEN_NO_RECALL
++		       | FILE_OPEN_FOR_BACKUP_INTENT
++		       | FILE_OPEN_REPARSE_POINT);
+   if (NT_SUCCESS (status))
+     {
+       PREPARSE_DATA_BUFFER rp = (PREPARSE_DATA_BUFFER) tp.c_get ();
+@@ -326,6 +328,7 @@ fhandler_base::fstat_by_name (struct stat *buf)
+       status = NtOpenFile (&dir, SYNCHRONIZE | FILE_LIST_DIRECTORY,
+ 			   &attr, &io, FILE_SHARE_VALID_FLAGS,
+ 			   FILE_SYNCHRONOUS_IO_NONALERT
++			   | FILE_OPEN_NO_RECALL
+ 			   | FILE_OPEN_FOR_BACKUP_INTENT
+ 			   | FILE_DIRECTORY_FILE);
+       if (!NT_SUCCESS (status))
+@@ -609,7 +612,8 @@ fhandler_disk_file::fstatvfs (struct statvfs *sfs)
+       opened = NT_SUCCESS (NtOpenFile (&fh, READ_CONTROL,
+ 				       pc.get_object_attr (attr, sec_none_nih),
+ 				       &io, FILE_SHARE_VALID_FLAGS,
+-				       FILE_OPEN_FOR_BACKUP_INTENT));
++				       FILE_OPEN_NO_RECALL
++				       | FILE_OPEN_FOR_BACKUP_INTENT));
+       if (!opened)
+ 	{
+ 	  /* Can't open file.  Try again with parent dir. */
+@@ -618,7 +622,8 @@ fhandler_disk_file::fstatvfs (struct statvfs *sfs)
+ 	  attr.ObjectName = &dirname;
+ 	  opened = NT_SUCCESS (NtOpenFile (&fh, READ_CONTROL, &attr, &io,
+ 					   FILE_SHARE_VALID_FLAGS,
+-					   FILE_OPEN_FOR_BACKUP_INTENT));
++					   FILE_OPEN_NO_RECALL
++					   | FILE_OPEN_FOR_BACKUP_INTENT));
+ 	  if (!opened)
+ 	    goto out;
+ 	}
+@@ -2054,7 +2059,8 @@ readdir_get_ino (const char *path, bool dot_dot)
+ 	   || NT_SUCCESS (NtOpenFile (&hdl, READ_CONTROL,
+ 				      pc.get_object_attr (attr, sec_none_nih),
+ 				      &io, FILE_SHARE_VALID_FLAGS,
+-				      FILE_OPEN_FOR_BACKUP_INTENT
++				      FILE_OPEN_NO_RECALL
++				      | FILE_OPEN_FOR_BACKUP_INTENT
+ 				      | (pc.is_known_reparse_point ()
+ 				      ? FILE_OPEN_REPARSE_POINT : 0)))
+ 	  )
+@@ -2103,8 +2109,9 @@ fhandler_disk_file::readdir_helper (DIR *dir, dirent *de, DWORD w32_err,
+      Mountpoints and unknown or unhandled reparse points will be treated
+      as normal file/directory/unknown. In all cases, returning the INO of
+      the reparse point (not of the target) matches behavior of posix systems.
++     Unless the file is OFFLINE. *.
+      */
+-  if (attr & FILE_ATTRIBUTE_REPARSE_POINT)
++  if ((attr & FILE_ATTRIBUTE_REPARSE_POINT) && !isoffline (attr))
+     {
+       OBJECT_ATTRIBUTES oattr;
+ 
+@@ -2345,7 +2352,8 @@ go_ahead:
+ 					 &nfs_aol_ffei, sizeof nfs_aol_ffei)
+ 			 : NtOpenFile (&hdl, READ_CONTROL, &attr, &io,
+ 				       FILE_SHARE_VALID_FLAGS,
+-				       FILE_OPEN_FOR_BACKUP_INTENT
++				       FILE_OPEN_NO_RECALL
++				       | FILE_OPEN_FOR_BACKUP_INTENT
+ 				       | FILE_OPEN_REPARSE_POINT);
+ 	      if (NT_SUCCESS (f_status))
+ 		{
+diff --git a/winsup/cygwin/local_includes/ntdll.h b/winsup/cygwin/local_includes/ntdll.h
+index a4e8b88..aa1f3b9 100644
+--- a/winsup/cygwin/local_includes/ntdll.h
++++ b/winsup/cygwin/local_includes/ntdll.h
+@@ -159,6 +159,13 @@ extern GUID __cygwin_socket_guid;
+ #define FILE_VC_QUOTAS_REBUILDING       0x00000200
+ #define FILE_VC_VALID_MASK              0x000003ff
+ 
++#define PHCM_APPLICATION_DEFAULT	 0
++#define PHCM_DISGUISE_PLACEHOLDER	 1
++#define PHCM_EXPOSE_PLACEHOLDERS	 2
++#define PHCM_MAX			 2
++#define PHCM_ERROR_INVALID_PARAMETER	-1
++#define PHCM_ERROR_NO_TEB		-2
++
+ /* IOCTL code to impersonate client of named pipe. */
+ 
+ #define FSCTL_PIPE_DISCONNECT	CTL_CODE(FILE_DEVICE_NAMED_PIPE, 1, \
+@@ -1605,6 +1612,7 @@ extern "C"
+ 					 BOOLEAN);
+   NTSTATUS RtlSetGroupSecurityDescriptor (PSECURITY_DESCRIPTOR, PSID, BOOLEAN);
+   NTSTATUS RtlSetOwnerSecurityDescriptor (PSECURITY_DESCRIPTOR, PSID, BOOLEAN);
++  CHAR RtlSetProcessPlaceholderCompatibilityMode (CHAR);
+   PUCHAR RtlSubAuthorityCountSid (PSID);
+   PULONG RtlSubAuthoritySid (PSID, ULONG);
+   ULONG RtlUnicodeStringToAnsiSize (PUNICODE_STRING);
+diff --git a/winsup/cygwin/local_includes/path.h b/winsup/cygwin/local_includes/path.h
+index 74f831e..8c97c42 100644
+--- a/winsup/cygwin/local_includes/path.h
++++ b/winsup/cygwin/local_includes/path.h
+@@ -23,6 +23,14 @@ has_attribute (DWORD attributes, DWORD attribs_to_test)
+ 	 && (attributes & attribs_to_test);
+ }
+ 
++extern inline bool
++isoffline (DWORD attributes)
++{
++  return has_attribute (attributes, FILE_ATTRIBUTE_OFFLINE
++				    | FILE_ATTRIBUTE_RECALL_ON_OPEN
++				    | FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS);
++}
++
+ enum executable_states
+ {
+   is_executable,
+@@ -230,6 +238,12 @@ class path_conv
+   bool exists () const {return fileattr != INVALID_FILE_ATTRIBUTES;}
+   bool has_attribute (DWORD x) const {return exists () && (fileattr & x);}
+   int isdir () const {return has_attribute (FILE_ATTRIBUTE_DIRECTORY);}
++  bool isoffline () const
++  {
++    return has_attribute (FILE_ATTRIBUTE_OFFLINE
++			  | FILE_ATTRIBUTE_RECALL_ON_OPEN
++			  | FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS);
++  }
+   executable_states exec_state ()
+   {
+     extern int _check_for_executable;
+@@ -237,7 +251,7 @@ class path_conv
+       return is_executable;
+     if (mount_flags & MOUNT_NOTEXEC)
+       return not_executable;
+-    if (!_check_for_executable)
++    if (isoffline () || !_check_for_executable)
+       return dont_care_if_executable;
+     return dont_know_if_executable;
+   }
+diff --git a/winsup/cygwin/local_includes/winlean.h b/winsup/cygwin/local_includes/winlean.h
+index 9b30b65..d4b4038 100644
+--- a/winsup/cygwin/local_includes/winlean.h
++++ b/winsup/cygwin/local_includes/winlean.h
+@@ -74,6 +74,14 @@ details. */
+ #undef CRITICAL
+ #endif
+ 
++/* Filesystem flags not yet supported by Mingw-w64 headers. */
++#ifndef FILE_ATTRIBUTE_RECALL_ON_OPEN
++#define FILE_ATTRIBUTE_RECALL_ON_OPEN		0x00040000
++#endif
++#ifndef FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS
++#define FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS	0x00400000
++#endif
++
+ /* So-called "Microsoft Account" SIDs (S-1-11-...) have a netbios domain name
+    "MicrosoftAccounts".  The new "Application Container SIDs" (S-1-15-...)
+    have a netbios domain name "APPLICATION PACKAGE AUTHORITY"
+diff --git a/winsup/cygwin/path.cc b/winsup/cygwin/path.cc
+index af88ecf..e61d370 100644
+--- a/winsup/cygwin/path.cc
++++ b/winsup/cygwin/path.cc
+@@ -577,6 +577,7 @@ getfileattr (const char *path, bool caseinsensitive) /* path has to be always ab
+       status = NtOpenFile (&dir, SYNCHRONIZE | FILE_LIST_DIRECTORY,
+ 			   &attr, &io, FILE_SHARE_VALID_FLAGS,
+ 			   FILE_SYNCHRONOUS_IO_NONALERT
++			   | FILE_OPEN_NO_RECALL
+ 			   | FILE_OPEN_FOR_BACKUP_INTENT
+ 			   | FILE_DIRECTORY_FILE);
+       if (NT_SUCCESS (status))
+@@ -3353,7 +3354,8 @@ restart:
+ 	    }
+ 	  status = NtOpenFile (&h, READ_CONTROL | FILE_READ_ATTRIBUTES,
+ 			       &attr, &io, FILE_SHARE_VALID_FLAGS,
+-			       FILE_OPEN_REPARSE_POINT
++			       FILE_OPEN_NO_RECALL
++			       | FILE_OPEN_REPARSE_POINT
+ 			       | FILE_OPEN_FOR_BACKUP_INTENT);
+ 	  debug_printf ("%y = NtOpenFile (no-EAs %S)", status, &upath);
+ 	}
+@@ -3481,6 +3483,7 @@ restart:
+ 	      status = NtOpenFile (&dir, SYNCHRONIZE | FILE_LIST_DIRECTORY,
+ 				   &dattr, &io, FILE_SHARE_VALID_FLAGS,
+ 				   FILE_SYNCHRONOUS_IO_NONALERT
++				   | FILE_OPEN_NO_RECALL
+ 				   | FILE_OPEN_FOR_BACKUP_INTENT
+ 				   | FILE_DIRECTORY_FILE);
+ 	      if (!NT_SUCCESS (status))
+@@ -3570,7 +3573,11 @@ restart:
+ 	 directory using a relative path, symlink evaluation goes totally
+ 	 awry.  We never want a virtual drive evaluated as symlink. */
+       if (upath.Length <= 14)
+-	  goto file_not_symlink;
++	goto file_not_symlink;
++
++      /* Offline files, even if reparse points, are not symlinks. */
++      if (isoffline (fileattr))
++	goto file_not_symlink;
+ 
+       /* Reparse points are potentially symlinks.  This check must be
+ 	 performed before checking the SYSTEM attribute for sysfile
+@@ -3616,7 +3623,8 @@ restart:
+ 
+ 	  status = NtOpenFile (&sym_h, SYNCHRONIZE | GENERIC_READ, &attr, &io,
+ 			       FILE_SHARE_VALID_FLAGS,
+-			       FILE_OPEN_FOR_BACKUP_INTENT
++			       FILE_OPEN_NO_RECALL
++			       | FILE_OPEN_FOR_BACKUP_INTENT
+ 			       | FILE_SYNCHRONOUS_IO_NONALERT);
+ 	  if (!NT_SUCCESS (status))
+ 	    res = 0;
+@@ -3660,7 +3668,8 @@ restart:
+ 
+ 	  status = NtOpenFile (&sym_h, SYNCHRONIZE | GENERIC_READ, &attr, &io,
+ 			       FILE_SHARE_VALID_FLAGS,
+-			       FILE_OPEN_FOR_BACKUP_INTENT
++			       FILE_OPEN_NO_RECALL
++			       | FILE_OPEN_FOR_BACKUP_INTENT
+ 			       | FILE_SYNCHRONOUS_IO_NONALERT);
+ 
+ 	  if (!NT_SUCCESS (status))

--- a/msys2-runtime-3.4/0053-Cygwin-get-set-security-descriptors-using-FILE_OPEN_.patch
+++ b/msys2-runtime-3.4/0053-Cygwin-get-set-security-descriptors-using-FILE_OPEN_.patch
@@ -1,0 +1,50 @@
+From 6f45a7c693dc4b723c24d4f28f038d551d492243 Mon Sep 17 00:00:00 2001
+From: Corinna Vinschen <corinna@vinschen.de>
+Date: Fri, 8 Mar 2024 21:30:57 +0100
+Subject: [PATCH 53/N] Cygwin: get/set security descriptors using
+ FILE_OPEN_NO_RECALL
+
+Add FILE_OPEN_NO_RECALL to NtOpenFile calls trying to fetch
+or write file security descriptors so as not to recall them
+from offline storage inadvertently.
+
+Signed-off-by: Corinna Vinschen <corinna@vinschen.de>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/sec/base.cc | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/winsup/cygwin/sec/base.cc b/winsup/cygwin/sec/base.cc
+index 8b04b40..0fc8699 100644
+--- a/winsup/cygwin/sec/base.cc
++++ b/winsup/cygwin/sec/base.cc
+@@ -65,7 +65,8 @@ get_file_sd (HANDLE fh, path_conv &pc, security_descriptor &sd,
+ 			   fh ? pc.init_reopen_attr (attr, fh)
+ 			      : pc.get_object_attr (attr, sec_none_nih),
+ 			   &io, FILE_SHARE_VALID_FLAGS,
+-			   FILE_OPEN_FOR_BACKUP_INTENT
++			   FILE_OPEN_NO_RECALL
++			   | FILE_OPEN_FOR_BACKUP_INTENT
+ 			   | pc.is_known_reparse_point ()
+ 			   ? FILE_OPEN_REPARSE_POINT : 0);
+       if (!NT_SUCCESS (status))
+@@ -129,7 +130,8 @@ get_file_sd (HANDLE fh, path_conv &pc, security_descriptor &sd,
+ 				  NULL, NULL);
+       status = NtOpenFile (&fh, READ_CONTROL, &attr, &io,
+ 			   FILE_SHARE_VALID_FLAGS,
+-			   FILE_OPEN_FOR_BACKUP_INTENT
++			   FILE_OPEN_NO_RECALL
++			   | FILE_OPEN_FOR_BACKUP_INTENT
+ 			   | FILE_OPEN_REPARSE_POINT);
+       if (!NT_SUCCESS (status))
+ 	{
+@@ -234,7 +236,8 @@ set_file_sd (HANDLE fh, path_conv &pc, security_descriptor &sd, bool is_chown)
+ 				  : pc.get_object_attr (attr, sec_none_nih),
+ 			       &io,
+ 			       FILE_SHARE_VALID_FLAGS,
+-			       FILE_OPEN_FOR_BACKUP_INTENT
++			       FILE_OPEN_NO_RECALL
++			       | FILE_OPEN_FOR_BACKUP_INTENT
+ 			       | pc.is_known_reparse_point ()
+ 			       ? FILE_OPEN_REPARSE_POINT : 0);
+ 	  if (!NT_SUCCESS (status))

--- a/msys2-runtime-3.4/0054-Cygwin-FILE_OPEN_NO_RECALL-is-incompatible-with-FILE.patch
+++ b/msys2-runtime-3.4/0054-Cygwin-FILE_OPEN_NO_RECALL-is-incompatible-with-FILE.patch
@@ -1,0 +1,51 @@
+From 260676cde0b49d30209387181a2371dd35ee364c Mon Sep 17 00:00:00 2001
+From: Corinna Vinschen <corinna@vinschen.de>
+Date: Thu, 4 Apr 2024 17:36:01 +0200
+Subject: [PATCH 54/N] Cygwin: FILE_OPEN_NO_RECALL is incompatible with
+ FILE_DIRECTORY_FILE
+
+If FILE_DIRECTORY_FILE is given, FILE_OPEN_NO_RECALL is not allowed,
+otherwise NtCreateFile returns STATUS_INVALID_PARAMETER.
+
+Drop FILE_OPEN_NO_RECALL where FILE_DIRECTORY_FILE is specified.
+
+Fixes: f6b56abec186 ("Cygwin: try to avoid recalling offline files")
+Reported-by: Bruce Jerrick <bmj001@gmail.com>
+Signed-off-by: Corinna Vinschen <corinna@vinschen.de>
+---
+ winsup/cygwin/fhandler/disk_file.cc | 1 -
+ winsup/cygwin/path.cc               | 2 --
+ 2 files changed, 3 deletions(-)
+
+diff --git a/winsup/cygwin/fhandler/disk_file.cc b/winsup/cygwin/fhandler/disk_file.cc
+index 87c14df..4df80dc 100644
+--- a/winsup/cygwin/fhandler/disk_file.cc
++++ b/winsup/cygwin/fhandler/disk_file.cc
+@@ -328,7 +328,6 @@ fhandler_base::fstat_by_name (struct stat *buf)
+       status = NtOpenFile (&dir, SYNCHRONIZE | FILE_LIST_DIRECTORY,
+ 			   &attr, &io, FILE_SHARE_VALID_FLAGS,
+ 			   FILE_SYNCHRONOUS_IO_NONALERT
+-			   | FILE_OPEN_NO_RECALL
+ 			   | FILE_OPEN_FOR_BACKUP_INTENT
+ 			   | FILE_DIRECTORY_FILE);
+       if (!NT_SUCCESS (status))
+diff --git a/winsup/cygwin/path.cc b/winsup/cygwin/path.cc
+index e61d370..46d1b8c 100644
+--- a/winsup/cygwin/path.cc
++++ b/winsup/cygwin/path.cc
+@@ -577,7 +577,6 @@ getfileattr (const char *path, bool caseinsensitive) /* path has to be always ab
+       status = NtOpenFile (&dir, SYNCHRONIZE | FILE_LIST_DIRECTORY,
+ 			   &attr, &io, FILE_SHARE_VALID_FLAGS,
+ 			   FILE_SYNCHRONOUS_IO_NONALERT
+-			   | FILE_OPEN_NO_RECALL
+ 			   | FILE_OPEN_FOR_BACKUP_INTENT
+ 			   | FILE_DIRECTORY_FILE);
+       if (NT_SUCCESS (status))
+@@ -3483,7 +3482,6 @@ restart:
+ 	      status = NtOpenFile (&dir, SYNCHRONIZE | FILE_LIST_DIRECTORY,
+ 				   &dattr, &io, FILE_SHARE_VALID_FLAGS,
+ 				   FILE_SYNCHRONOUS_IO_NONALERT
+-				   | FILE_OPEN_NO_RECALL
+ 				   | FILE_OPEN_FOR_BACKUP_INTENT
+ 				   | FILE_DIRECTORY_FILE);
+ 	      if (!NT_SUCCESS (status))

--- a/msys2-runtime-3.4/0055-Cygwin-console-Fix-exit-code-for-non-cygwin-process.patch
+++ b/msys2-runtime-3.4/0055-Cygwin-console-Fix-exit-code-for-non-cygwin-process.patch
@@ -1,0 +1,44 @@
+From 9fd76414684cfc137252b4a63a015dfc29e79fdb Mon Sep 17 00:00:00 2001
+From: Takashi Yano <takashi.yano@nifty.ne.jp>
+Date: Fri, 2 Feb 2024 13:59:19 +0900
+Subject: [PATCH 55/N] Cygwin: console: Fix exit code for non-cygwin process.
+
+If non-cygwin process is executed in console, the exit code is not
+set correctly. This is because the stub process for non-cygwin app
+crashes in fhandler_console::set_disable_master_thread() due to NULL
+pointer dereference. This bug was introduced by the commit:
+3721a756b0d8 ("Cygwin: console: Make the console accessible from
+other terminals."), that the pointer cons is accessed before fixing
+when it is NULL. This patch fixes the issue.
+
+Backported-from: aa73e11524 (Cygwin: console: Fix exit code for non-cygwin process., 2024-02-02)
+Fixes: 3721a756b0d8 ("Cygwin: console: Make the console accessible from other terminals.")
+Reported-by: Johannes Schindelin <Johannes.Schindelin@gmx.de>
+Signed-off-by: Takashi Yano <takashi.yano@nifty.ne.jp>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/fhandler/console.cc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/winsup/cygwin/fhandler/console.cc b/winsup/cygwin/fhandler/console.cc
+index c9b27c9..6c485f9 100644
+--- a/winsup/cygwin/fhandler/console.cc
++++ b/winsup/cygwin/fhandler/console.cc
+@@ -4328,8 +4328,6 @@ fhandler_console::need_console_handler ()
+ void
+ fhandler_console::set_disable_master_thread (bool x, fhandler_console *cons)
+ {
+-  if (con.disable_master_thread == x)
+-    return;
+   if (cons == NULL)
+     {
+       if (cygheap->ctty && cygheap->ctty->get_major () == DEV_CONS_MAJOR)
+@@ -4337,6 +4335,8 @@ fhandler_console::set_disable_master_thread (bool x, fhandler_console *cons)
+       else
+ 	return;
+     }
++  if (con.disable_master_thread == x)
++    return;
+   cons->acquire_input_mutex (mutex_timeout);
+   con.disable_master_thread = x;
+   cons->release_input_mutex ();

--- a/msys2-runtime-3.4/0056-Cygwin-console-Avoid-slipping-past-disable_master_th.patch
+++ b/msys2-runtime-3.4/0056-Cygwin-console-Avoid-slipping-past-disable_master_th.patch
@@ -1,0 +1,45 @@
+From fb060f79f664189f3b61a9d361dafbedf79e2441 Mon Sep 17 00:00:00 2001
+From: Takashi Yano <takashi.yano@nifty.ne.jp>
+Date: Sat, 3 Feb 2024 00:54:23 +0900
+Subject: [PATCH 56/N] Cygwin: console: Avoid slipping past
+ disable_master_thread check.
+
+If disable_master_thread flag is set between the code checking that
+flag not be set and the code acquiring input_mutex, input record is
+processed once after setting disable_master_thread flag. This patch
+prevents that.
+
+Backported-from: 9bcfd06045 (Cygwin: console: Avoid slipping past disable_master_thread check., 2024-02-03)
+Fixes: d4aacd50e6cf ("Cygwin: console: Add missing input_mutex guard.")
+Signed-off-by: Takashi Yano <takashi.yano@nifty.ne.jp>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/fhandler/console.cc | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/winsup/cygwin/fhandler/console.cc b/winsup/cygwin/fhandler/console.cc
+index 6c485f9..b415a0a 100644
+--- a/winsup/cygwin/fhandler/console.cc
++++ b/winsup/cygwin/fhandler/console.cc
+@@ -361,6 +361,12 @@ fhandler_console::cons_master_thread (handle_set_t *p, tty *ttyp)
+ 	}
+ 
+       WaitForSingleObject (p->input_mutex, mutex_timeout);
++      /* Ensure accessing input recored is not disabled. */
++      if (con.disable_master_thread)
++	{
++	  ReleaseMutex (p->input_mutex);
++	  continue;
++	}
+       total_read = 0;
+       switch (cygwait (p->input_handle, (DWORD) 0))
+ 	{
+@@ -4335,8 +4341,6 @@ fhandler_console::set_disable_master_thread (bool x, fhandler_console *cons)
+       else
+ 	return;
+     }
+-  if (con.disable_master_thread == x)
+-    return;
+   cons->acquire_input_mutex (mutex_timeout);
+   con.disable_master_thread = x;
+   cons->release_input_mutex ();

--- a/msys2-runtime-3.4/0057-Cygwin-pty-Fix-handle-leak-in-master-process.patch
+++ b/msys2-runtime-3.4/0057-Cygwin-pty-Fix-handle-leak-in-master-process.patch
@@ -1,0 +1,32 @@
+From f769444ad2f17709dfcb9c0067aa3b39b525abee Mon Sep 17 00:00:00 2001
+From: Takashi Yano <takashi.yano@nifty.ne.jp>
+Date: Tue, 13 Feb 2024 11:17:46 +0900
+Subject: [PATCH 57/N] Cygwin: pty: Fix handle leak in master process.
+
+If non-cygwin process is started in pty, closing from_master_nat
+pipe handle was missing in fhandler_pty_slave::input_transfer().
+This occured because the handle was duplicated but not closed.
+
+https://github.com/msys2/msys2-runtime/issues/198
+
+Backported-from: a6ac7b4138 (Cygwin: pty: Fix handle leak in master process., 2024-02-13)
+Fixes: 29431fcb5b14 ("Cygwin: pty: Inherit typeahead data between two input pipes.")
+Reported-by: Hakkin Lain
+Signed-off-by: Takashi Yano <takashi.yano@nifty.ne.jp>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/fhandler/pty.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/winsup/cygwin/fhandler/pty.cc b/winsup/cygwin/fhandler/pty.cc
+index dbeffc9..9d1a119 100644
+--- a/winsup/cygwin/fhandler/pty.cc
++++ b/winsup/cygwin/fhandler/pty.cc
+@@ -4066,6 +4066,7 @@ fhandler_pty_slave::transfer_input (tty::xfer_dir dir, HANDLE from, tty *ttyp,
+ 	    transfered = true;;
+ 	}
+     }
++  CloseHandle (to);
+ 
+   /* Fix input_available_event which indicates availability in cyg pipe. */
+   if (dir == tty::to_nat) /* all data is transfered to nat pipe,

--- a/msys2-runtime-3.4/0058-Cygwin-pty-Fix-potential-handle-leak-regarding-CallN.patch
+++ b/msys2-runtime-3.4/0058-Cygwin-pty-Fix-potential-handle-leak-regarding-CallN.patch
@@ -1,0 +1,64 @@
+From 85e89bbeff42c0195ec1f4cbbff063aeac145ad8 Mon Sep 17 00:00:00 2001
+From: Takashi Yano <takashi.yano@nifty.ne.jp>
+Date: Tue, 13 Feb 2024 11:36:05 +0900
+Subject: [PATCH 58/N] Cygwin: pty: Fix potential handle leak regarding
+ CallNamedPipe().
+
+In pty master_thread, 6 handles are duplicated when CallNamedPipe()
+requests that. Though some of them are not used so should be closed,
+they were not. This causes handle leak potentially.
+
+Backported-from: 73cd80c976 (Cygwin: pty: Fix potential handle leak regarding CallNamedPipe()., 2024-02-13)
+Signed-off-by: Takashi Yano <takashi.yano@nifty.ne.jp>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/fhandler/pty.cc | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/winsup/cygwin/fhandler/pty.cc b/winsup/cygwin/fhandler/pty.cc
+index 9d1a119..17b7b32 100644
+--- a/winsup/cygwin/fhandler/pty.cc
++++ b/winsup/cygwin/fhandler/pty.cc
+@@ -940,6 +940,8 @@ fhandler_pty_slave::open (int flags, mode_t)
+ 	  errmsg = "can't call master, %E";
+ 	  goto err;
+ 	}
++      CloseHandle (repl.to_slave_nat); /* not used. */
++      CloseHandle (repl.to_slave); /* not used. */
+       from_master_nat_local = repl.from_master_nat;
+       from_master_local = repl.from_master;
+       to_master_nat_local = repl.to_master_nat;
+@@ -1218,6 +1220,10 @@ fhandler_pty_slave::reset_switch_to_nat_pipe (void)
+ 		      if (!CallNamedPipe (pipe, &req, sizeof req,
+ 					  &repl, sizeof repl, &len, 500))
+ 			return; /* What can we do? */
++		      CloseHandle (repl.from_master); /* not used. */
++		      CloseHandle (repl.to_master); /* not used. */
++		      CloseHandle (repl.to_slave_nat); /* not used. */
++		      CloseHandle (repl.to_slave); /* not used. */
+ 		      CloseHandle (get_handle_nat ());
+ 		      set_handle_nat (repl.from_master_nat);
+ 		      CloseHandle (get_output_handle_nat ());
+@@ -3932,10 +3938,20 @@ fhandler_pty_slave::transfer_input (tty::xfer_dir dir, HANDLE from, tty *ttyp,
+       if (!CallNamedPipe (pipe, &req, sizeof req,
+ 			  &repl, sizeof repl, &len, 500))
+ 	return; /* What can we do? */
++      CloseHandle (repl.from_master_nat); /* not used. */
++      CloseHandle (repl.from_master); /* not used. */
++      CloseHandle (repl.to_master_nat); /* not used. */
++      CloseHandle (repl.to_master); /* not used. */
+       if (dir == tty::to_nat)
+-	to = repl.to_slave_nat;
++	{
++	  CloseHandle (repl.to_slave); /* not used. */
++	  to = repl.to_slave_nat;
++	}
+       else
+-	to = repl.to_slave;
++	{
++	  CloseHandle (repl.to_slave_nat); /* not used. */
++	  to = repl.to_slave;
++	}
+     }
+ 
+   UINT cp_from = 0, cp_to = 0;

--- a/msys2-runtime-3.4/0059-Cygwin-console-Make-VMIN-and-VTIME-work.patch
+++ b/msys2-runtime-3.4/0059-Cygwin-console-Make-VMIN-and-VTIME-work.patch
@@ -1,0 +1,74 @@
+From b3295b576d7662daf6e2c14761f50c5e05a21209 Mon Sep 17 00:00:00 2001
+From: Takashi Yano <takashi.yano@nifty.ne.jp>
+Date: Tue, 13 Feb 2024 11:42:42 +0900
+Subject: [PATCH 59/N] Cygwin: console: Make VMIN and VTIME work.
+
+Previously, VMIN and VTIME did not work at all. This patch fixes that.
+
+Backported-from: 73cd80c976 (Cygwin: pty: Fix potential handle leak regarding CallNamedPipe()., 2024-02-13)
+Signed-off-by: Takashi Yano <takashi.yano@nifty.ne.jp>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/fhandler/console.cc | 26 ++++++++++++++++++--------
+ 1 file changed, 18 insertions(+), 8 deletions(-)
+
+diff --git a/winsup/cygwin/fhandler/console.cc b/winsup/cygwin/fhandler/console.cc
+index b415a0a..f9a6946 100644
+--- a/winsup/cygwin/fhandler/console.cc
++++ b/winsup/cygwin/fhandler/console.cc
+@@ -1011,10 +1011,14 @@ fhandler_console::read (void *pv, size_t& buflen)
+ 
+   push_process_state process_state (PID_TTYIN);
+ 
+-  int copied_chars = 0;
++  size_t copied_chars = 0;
+ 
+-  DWORD timeout = is_nonblocking () ? 0 : INFINITE;
++  DWORD timeout = is_nonblocking () ? 0 :
++    (get_ttyp ()->ti.c_lflag & ICANON ? INFINITE :
++     (get_ttyp ()->ti.c_cc[VMIN] == 0 ? 0 :
++      (get_ttyp ()->ti.c_cc[VTIME]*100 ? : INFINITE)));
+ 
++read_more:
+   while (!input_ready && !get_cons_readahead_valid ())
+     {
+       int bgres;
+@@ -1037,6 +1041,11 @@ wait_retry:
+ 	  pthread::static_cancel_self ();
+ 	  /*NOTREACHED*/
+ 	case WAIT_TIMEOUT:
++	  if (copied_chars)
++	    {
++	      buflen = copied_chars;
++	      return;
++	    }
+ 	  set_sig_errno (EAGAIN);
+ 	  buflen = (size_t) -1;
+ 	  return;
+@@ -1082,19 +1091,20 @@ wait_retry:
+     }
+ 
+   /* Check console read-ahead buffer filled from terminal requests */
+-  while (con.cons_rapoi && *con.cons_rapoi && buflen)
+-    {
+-      buf[copied_chars++] = *con.cons_rapoi++;
+-      buflen --;
+-    }
++  while (con.cons_rapoi && *con.cons_rapoi && buflen > copied_chars)
++    buf[copied_chars++] = *con.cons_rapoi++;
+ 
+   copied_chars +=
+-    get_readahead_into_buffer (buf + copied_chars, buflen);
++    get_readahead_into_buffer (buf + copied_chars, buflen - copied_chars);
+ 
+   if (!con_ra.ralen)
+     input_ready = false;
+   release_input_mutex ();
+ 
++  if (buflen > copied_chars && !(get_ttyp ()->ti.c_lflag & ICANON)
++      && copied_chars < get_ttyp ()->ti.c_cc[VMIN])
++    goto read_more;
++
+ #undef buf
+ 
+   buflen = copied_chars;

--- a/msys2-runtime-3.4/0060-Cygwin-pipe-Give-up-to-use-query_hdl-for-non-cygwin-.patch
+++ b/msys2-runtime-3.4/0060-Cygwin-pipe-Give-up-to-use-query_hdl-for-non-cygwin-.patch
@@ -1,0 +1,43 @@
+From 436c8752437af86d24712a5a95b78fecde3ad35b Mon Sep 17 00:00:00 2001
+From: Takashi Yano <takashi.yano@nifty.ne.jp>
+Date: Sun, 3 Mar 2024 14:09:07 +0900
+Subject: [PATCH 60/N] Cygwin: pipe: Give up to use query_hdl for non-cygwin
+ apps.
+
+Non-cygwin app may call ReadFile() which makes NtQueryObject() for
+ObjectNameInformation block in fhandler_pipe::get_query_hdl_per_process.
+Therefore, stop to try to get query_hdl for non-cygwin apps.
+
+Addresses: https://github.com/msys2/msys2-runtime/issues/202
+
+Backported-from: https://inbox.sourceware.org/cygwin-patches/20240303050915.2024-1-takashi.yano@nifty.ne.jp/
+Fixes: b531d6b06eeb ("Cygwin: pipe: Introduce temporary query_hdl.")
+Reported-by: Alisa Sireneva, Johannes Schindelin <Johannes.Schindelin@gmx.de>
+Reviewed-by:
+Signed-off-by: Takashi Yano <takashi.yano@nifty.ne.jp>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/fhandler/pipe.cc | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/winsup/cygwin/fhandler/pipe.cc b/winsup/cygwin/fhandler/pipe.cc
+index 283319c..9319a57 100644
+--- a/winsup/cygwin/fhandler/pipe.cc
++++ b/winsup/cygwin/fhandler/pipe.cc
+@@ -1251,6 +1251,16 @@ fhandler_pipe::get_query_hdl_per_process (WCHAR *name,
+ 
+   for (LONG i = (LONG) n_process - 1; i >= 0; i--)
+     {
++      /* Non-cygwin app may call ReadFile() which makes NtQueryObject()
++	for ObjectNameInformation block. Therefore, stop to try to get
++	query_hdl for non-cygwin apps. */
++      pid_t cygpid;
++      if (!(cygpid = cygwin_pid (proc_pids[i])))
++	continue;
++      pinfo p (cygpid);
++      if (p && ISSTATE (p, PID_NOTCYGWIN))
++	continue;
++
+       HANDLE proc = OpenProcess (PROCESS_DUP_HANDLE
+ 				 | PROCESS_QUERY_INFORMATION,
+ 				 0, proc_pids[i]);

--- a/msys2-runtime-3.4/0061-Avoid-sharing-cygheaps-across-Cygwin-versions.patch
+++ b/msys2-runtime-3.4/0061-Avoid-sharing-cygheaps-across-Cygwin-versions.patch
@@ -1,0 +1,130 @@
+From a4222dbca4d1974f246f688d5f780a1d5f22c51a Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 30 Jan 2023 23:22:22 +0100
+Subject: [PATCH 61/N] Avoid sharing cygheaps across Cygwin versions
+
+It frequently leads to problems when trying, say, to call from MSYS2's
+Bash into Cygwin's or Git for Windows', merely because sharing that data
+is pretty finicky.
+
+For example, using the MSYS2' Bash using the MSYS2 runtime version that
+is current at time of writing, trying to call Cygwin's programs fails
+in manners like this:
+
+    $ /c/cygwin64/bin/uname -r
+      0 [main] uname (9540) child_copy: cygheap read copy failed, 0x800000000..0x800010BE0, done 0, windows pid 9540, Win32 error 6
+    680 [main] uname 880 C:\cygwin64\bin\uname.exe: *** fatal error - couldn't create signal pipe, Win32 error 5
+
+with the rather misleading exit code 127 (a code which is reserved to
+indicate that a command was not found).
+
+Let's just treat the MSYS2 runtime and the Cygwin runtime as completely
+incompatible with one another, by virtue of using a different
+magic constant than merely `CHILD_INFO_MAGIC`.
+
+By using the msys2-runtime commit to modify that magic constant, we can
+even spawn programs using a different MSYS2 runtime (such as Git for
+Windows') because the commit serves as the tell-tale whether two MSYS2
+runtime versions are compatible with each other. To support building in
+the MSYS2-packages repository (where we do not check out the
+`msys2-runtime` but instead check out Cygwin and apply patches on top),
+let's accept a hard-coded commit hash as `./configure` option.
+
+One consequence is that spawned MSYS processes using a different MSYS2
+runtime will not be visible as such to the parent process, i.e. they
+cannot share any resources such as pseudo terminals. But that's okay,
+they are simply treated as if they were regular Win32 programs.
+
+Note: We have to use a very rare form of encoding the brackets in the
+`expr` calls: quadrigraphs (for a thorough explanation, see
+https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.70/html_node/Quadrigraphs.html#Quadrigraphs).
+This is necessary because it is apparently impossible to encode brackets
+in `configure.ac` files otherwise.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/configure.ac       | 28 ++++++++++++++++++++++++++++
+ winsup/cygwin/Makefile.am |  3 +++
+ winsup/cygwin/dcrt0.cc    |  2 +-
+ winsup/cygwin/sigproc.cc  |  2 +-
+ 4 files changed, 33 insertions(+), 2 deletions(-)
+
+diff --git a/winsup/configure.ac b/winsup/configure.ac
+index 59b77fe..368a1db 100644
+--- a/winsup/configure.ac
++++ b/winsup/configure.ac
+@@ -57,6 +57,34 @@ AC_CHECK_TOOL(RANLIB, ranlib, ranlib)
+ AC_CHECK_TOOL(STRIP, strip, strip)
+ AC_CHECK_TOOL(WINDRES, windres, windres)
+ 
++# Record msys2-runtime commit
++AC_ARG_WITH([msys2-runtime-commit],
++  [AS_HELP_STRING([--with-msys2-runtime-commit=COMMIT],
++		  [indicate the msys2-runtime commit corresponding to this build])],
++  [MSYS2_RUNTIME_COMMIT=$withval], [MSYS2_RUNTIME_COMMIT=yes])
++case "$MSYS2_RUNTIME_COMMIT" in
++no)
++    MSYS2_RUNTIME_COMMIT=
++    MSYS2_RUNTIME_COMMIT_HEX=0
++    ;;
++yes|auto)
++    if MSYS2_RUNTIME_COMMIT="$(git --git-dir="$srcdir/../.git" rev-parse HEAD)"
++    then
++        MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
++    else
++        AC_MSG_WARN([Could not determine msys2-runtime commit"])
++        MSYS2_RUNTIME_COMMIT=
++        MSYS2_RUNTIME_COMMIT_HEX=0
++    fi
++    ;;
++*)
++    expr "$MSYS2_RUNTIME_COMMIT" : '@<:@0-9a-f@:>@\{6,64\}$' ||
++    AC_MSG_ERROR([Invalid commit name: "$MSYS2_RUNTIME_COMMIT"])
++    MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
++    ;;
++esac
++AC_SUBST(MSYS2_RUNTIME_COMMIT_HEX)
++
+ AC_ARG_ENABLE(debugging,
+ [AS_HELP_STRING([--enable-debugging],[Build a cygwin DLL which has more consistency checking for debugging])],
+ [case "${enableval}" in
+diff --git a/winsup/cygwin/Makefile.am b/winsup/cygwin/Makefile.am
+index ec782dc..038ae5a 100644
+--- a/winsup/cygwin/Makefile.am
++++ b/winsup/cygwin/Makefile.am
+@@ -17,6 +17,9 @@ if TARGET_X86_64
+ COMMON_CFLAGS+=-mcmodel=small
+ endif
+ 
++VERSION_CFLAGS = -DMSYS2_RUNTIME_COMMIT_HEX="@MSYS2_RUNTIME_COMMIT_HEX@"
++COMMON_CFLAGS += $(VERSION_CFLAGS)
++
+ AM_CFLAGS=$(cflags_common) $(COMMON_CFLAGS)
+ AM_CXXFLAGS=$(cxxflags_common) $(COMMON_CFLAGS) -fno-threadsafe-statics
+ 
+diff --git a/winsup/cygwin/dcrt0.cc b/winsup/cygwin/dcrt0.cc
+index a5b82b0..db79042 100644
+--- a/winsup/cygwin/dcrt0.cc
++++ b/winsup/cygwin/dcrt0.cc
+@@ -530,7 +530,7 @@ get_cygwin_startup_info ()
+   child_info *res = (child_info *) si.lpReserved2;
+ 
+   if (si.cbReserved2 < EXEC_MAGIC_SIZE || !res
+-      || res->intro != PROC_MAGIC_GENERIC || res->magic != CHILD_INFO_MAGIC)
++      || res->intro != PROC_MAGIC_GENERIC || res->magic != (CHILD_INFO_MAGIC ^ MSYS2_RUNTIME_COMMIT_HEX))
+     {
+       strace.activate (false);
+       res = NULL;
+diff --git a/winsup/cygwin/sigproc.cc b/winsup/cygwin/sigproc.cc
+index fd3291c..3d3f38f 100644
+--- a/winsup/cygwin/sigproc.cc
++++ b/winsup/cygwin/sigproc.cc
+@@ -811,7 +811,7 @@ int child_info::retry_count = 0;
+ child_info::child_info (unsigned in_cb, child_info_types chtype,
+ 			bool need_subproc_ready):
+   msv_count (0), cb (in_cb), intro (PROC_MAGIC_GENERIC),
+-  magic (CHILD_INFO_MAGIC), type (chtype), cygheap (::cygheap),
++  magic (CHILD_INFO_MAGIC ^ MSYS2_RUNTIME_COMMIT_HEX), type (chtype), cygheap (::cygheap),
+   cygheap_max (::cygheap_max), flag (0), retry (child_info::retry_count),
+   rd_proc_pipe (NULL), wr_proc_pipe (NULL), sigmask (_my_tls.sigmask)
+ {

--- a/msys2-runtime-3.4/0062-uname-report-msys2-runtime-commit-hash-too.patch
+++ b/msys2-runtime-3.4/0062-uname-report-msys2-runtime-commit-hash-too.patch
@@ -1,0 +1,159 @@
+From 6a583170a3215a133fbb763f464c87286fc1803d Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 21 Feb 2023 16:36:36 +0100
+Subject: [PATCH 62/N] uname: report msys2-runtime commit hash, too
+
+Having just Cygwin's version in the output of `uname` is not helpful, as
+both MSYS2 as well as Git for Windows release intermediate versions of
+the MSYS2 runtime much more often than Cygwin runtime versions are
+released.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/configure.ac             | 10 ++++++++--
+ winsup/cygwin/Makefile.am       |  6 ++++--
+ winsup/cygwin/scripts/mkvers.sh |  8 ++++++++
+ winsup/cygwin/uname.cc          | 16 +++++++++-------
+ 4 files changed, 29 insertions(+), 11 deletions(-)
+
+diff --git a/winsup/configure.ac b/winsup/configure.ac
+index 368a1db..bacff0b 100644
+--- a/winsup/configure.ac
++++ b/winsup/configure.ac
+@@ -65,24 +65,30 @@ AC_ARG_WITH([msys2-runtime-commit],
+ case "$MSYS2_RUNTIME_COMMIT" in
+ no)
+     MSYS2_RUNTIME_COMMIT=
++    MSYS2_RUNTIME_COMMIT_SHORT=
+     MSYS2_RUNTIME_COMMIT_HEX=0
+     ;;
+ yes|auto)
+     if MSYS2_RUNTIME_COMMIT="$(git --git-dir="$srcdir/../.git" rev-parse HEAD)"
+     then
+-        MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
++        MSYS2_RUNTIME_COMMIT_SHORT="$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')"
++        MSYS2_RUNTIME_COMMIT_HEX="0x${MSYS2_RUNTIME_COMMIT_SHORT}ul"
+     else
+         AC_MSG_WARN([Could not determine msys2-runtime commit"])
+         MSYS2_RUNTIME_COMMIT=
++        MSYS2_RUNTIME_COMMIT_SHORT=
+         MSYS2_RUNTIME_COMMIT_HEX=0
+     fi
+     ;;
+ *)
+     expr "$MSYS2_RUNTIME_COMMIT" : '@<:@0-9a-f@:>@\{6,64\}$' ||
+     AC_MSG_ERROR([Invalid commit name: "$MSYS2_RUNTIME_COMMIT"])
+-    MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
++    MSYS2_RUNTIME_COMMIT_SHORT="$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')"
++    MSYS2_RUNTIME_COMMIT_HEX="0x${MSYS2_RUNTIME_COMMIT_SHORT}ul"
+     ;;
+ esac
++AC_SUBST(MSYS2_RUNTIME_COMMIT)
++AC_SUBST(MSYS2_RUNTIME_COMMIT_SHORT)
+ AC_SUBST(MSYS2_RUNTIME_COMMIT_HEX)
+ 
+ AC_ARG_ENABLE(debugging,
+diff --git a/winsup/cygwin/Makefile.am b/winsup/cygwin/Makefile.am
+index 038ae5a..a7607b0 100644
+--- a/winsup/cygwin/Makefile.am
++++ b/winsup/cygwin/Makefile.am
+@@ -17,7 +17,9 @@ if TARGET_X86_64
+ COMMON_CFLAGS+=-mcmodel=small
+ endif
+ 
+-VERSION_CFLAGS = -DMSYS2_RUNTIME_COMMIT_HEX="@MSYS2_RUNTIME_COMMIT_HEX@"
++VERSION_CFLAGS = -DMSYS2_RUNTIME_COMMIT="\"@MSYS2_RUNTIME_COMMIT@\""
++VERSION_CFLAGS += -DMSYS2_RUNTIME_COMMIT_SHORT="\"@MSYS2_RUNTIME_COMMIT_SHORT@\""
++VERSION_CFLAGS += -DMSYS2_RUNTIME_COMMIT_HEX="@MSYS2_RUNTIME_COMMIT_HEX@"
+ COMMON_CFLAGS += $(VERSION_CFLAGS)
+ 
+ AM_CFLAGS=$(cflags_common) $(COMMON_CFLAGS)
+@@ -442,7 +444,7 @@ uname_version.c: .FORCE
+ version.cc: scripts/mkvers.sh include/cygwin/version.h winver.rc $(src_files)
+ 	@echo "Making version.cc and winver.o";\
+ 	export CC="$(CC)";\
+-	/bin/sh $(word 1,$^) $(word 2,$^) $(word 3,$^) $(WINDRES) $(CFLAGS)
++	/bin/sh $(word 1,$^) $(word 2,$^) $(word 3,$^) $(WINDRES) $(CFLAGS) $(VERSION_CFLAGS)
+ 
+ winver.o: version.cc
+ 
+diff --git a/winsup/cygwin/scripts/mkvers.sh b/winsup/cygwin/scripts/mkvers.sh
+index 98826f8..60586ad 100755
+--- a/winsup/cygwin/scripts/mkvers.sh
++++ b/winsup/cygwin/scripts/mkvers.sh
+@@ -16,6 +16,7 @@ incfile="$1"; shift
+ rcfile="$1"; shift
+ windres="$1"; shift
+ iflags=
++msys2_runtime_commit=
+ # Find header file locations
+ while [ -n "$*" ]; do
+   case "$1" in
+@@ -26,6 +27,9 @@ while [ -n "$*" ]; do
+     shift
+     iflags="$iflags -I$1"
+       ;;
++  -DMSYS2_RUNTIME_COMMIT=*)
++    msys2_runtime_commit="${1#*=}"
++    ;;
+   esac
+   shift
+ done
+@@ -168,6 +172,10 @@ then
+   cvs_tag="$(echo $wv_cvs_tag | sed -e 's/-branch.*//')"
+   cygwin_ver="$cygwin_ver-$cvs_tag"
+ fi
++if [ -n "$msys2_runtime_commit" ]
++then
++  cygwin_ver="$cygwin_ver-$msys2_runtime_commit"
++fi
+ 
+ echo "Version $cygwin_ver"
+ set -$- $builddate
+diff --git a/winsup/cygwin/uname.cc b/winsup/cygwin/uname.cc
+index a4ac0e3..a978363 100644
+--- a/winsup/cygwin/uname.cc
++++ b/winsup/cygwin/uname.cc
+@@ -76,18 +76,19 @@ uname_x (struct utsname *name)
+ #pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wformat-truncation="
+ #ifdef CYGPORT_RELEASE_INFO
+-      snprintf (name->release, _UTSNAME_LENGTH, "%s.%s",
+-		__XSTRING (CYGPORT_RELEASE_INFO), name->machine);
++      snprintf (name->release, _UTSNAME_LENGTH, "%s-%s.%s",
++		__XSTRING (CYGPORT_RELEASE_INFO), MSYS2_RUNTIME_COMMIT_SHORT, name->machine);
+ #else
+       extern const char *uname_dev_version;
+       if (uname_dev_version && uname_dev_version[0])
+-	snprintf (name->release, _UTSNAME_LENGTH, "%s.%s",
+-		  uname_dev_version, name->machine);
++	snprintf (name->release, _UTSNAME_LENGTH, "%s-%s.%s",
++		  uname_dev_version, MSYS2_RUNTIME_COMMIT_SHORT, name->machine);
+       else
+-	__small_sprintf (name->release, "%d.%d.%d-api-%d.%s",
++	__small_sprintf (name->release, "%d.%d.%d-%s-api-%d.%s",
+ 			 cygwin_version.dll_major / 1000,
+ 			 cygwin_version.dll_major % 1000,
+ 			 cygwin_version.dll_minor,
++			 MSYS2_RUNTIME_COMMIT_SHORT,
+ 			 cygwin_version.api_minor,
+ 			 name->machine);
+ #endif
+@@ -129,14 +130,15 @@ uname (struct utsname *in_name)
+       cygwin_gethostname (name->nodename, sizeof (name->nodename) - 1);
+ 
+       /* Cygwin dll release */
+-      __small_sprintf (name->release, "%d.%d.%d(%d.%d/%d/%d)",
++      __small_sprintf (name->release, "%d.%d.%d(%d.%d/%d/%d/%s)",
+ 		       cygwin_version.dll_major / 1000,
+ 		       cygwin_version.dll_major % 1000,
+ 		       cygwin_version.dll_minor,
+ 		       cygwin_version.api_major,
+ 		       cygwin_version.api_minor,
+ 		       cygwin_version.shared_data,
+-		       cygwin_version.mount_registry);
++		       cygwin_version.mount_registry,
++		       MSYS2_RUNTIME_COMMIT_SHORT);
+ 
+       /* Cygwin "version" aka build date */
+       strcpy (name->version, cygwin_version.dll_build_date);

--- a/msys2-runtime-3.4/0063-Cygwin-suppress-a-warning-generated-with-w32api-12.0.patch
+++ b/msys2-runtime-3.4/0063-Cygwin-suppress-a-warning-generated-with-w32api-12.0.patch
@@ -1,0 +1,34 @@
+From 62a586abfb7921f46ca53d3c6dd26f43ad6ab02e Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 8 Jul 2024 14:22:48 +0200
+Subject: [PATCH 63/N] Cygwin: suppress a warning generated with w32api >=
+ 12.0.0
+
+w32api 12.0.0 adds the returns_twice attribute to RtlCaptureContext().
+There's some data-flow interaction with using it inside a while loop
+which causes a maybe-uninitialized warning.
+
+../../../../winsup/cygwin/exceptions.cc: In member function 'int _cygtls::call_signal_handler()':
+../../../../winsup/cygwin/exceptions.cc:1720:33: error: '<anonymous>' may be used uninitialized in this function [-Werror=maybe-uninitialized]
+
+Backported-from: 7e3c833592 (Cygwin: suppress a warning generated with w32api >= 12.0.0, 2024-06-07)
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/exceptions.cc | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/winsup/cygwin/exceptions.cc b/winsup/cygwin/exceptions.cc
+index b843063..1faeda2 100644
+--- a/winsup/cygwin/exceptions.cc
++++ b/winsup/cygwin/exceptions.cc
+@@ -1646,7 +1646,10 @@ _cygtls::call_signal_handler ()
+ 		 context, unwind to the caller and in case we're called
+ 		 from sigdelayed, fix the instruction pointer accordingly. */
+ 	      context.uc_mcontext.ctxflags = CONTEXT_FULL;
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+ 	      RtlCaptureContext ((PCONTEXT) &context.uc_mcontext);
++#pragma GCC diagnostic pop
+ 	      __unwind_single_frame ((PCONTEXT) &context.uc_mcontext);
+ 	      if (stackptr > stack)
+ 		{

--- a/msys2-runtime-3.4/PKGBUILD
+++ b/msys2-runtime-3.4/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime-3.4
 pkgname=('msys2-runtime-3.4' 'msys2-runtime-3.4-devel')
 pkgver=3.4.10
-pkgrel=2
+pkgrel=3
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -79,8 +79,20 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0048-Handle-8-bit-characters-under-LOCALE-C.patch
         0049-fixup-path-conversion-Introduce-ability-to-switch-of.patch
         0050-pathconv-don-t-skip-arguments-with-double-quote.patch
-        0051-Work-around-fragile-include-in-binutils.patch)
-sha256sums=('SKIP'
+        0051-Work-around-fragile-include-in-binutils.patch
+        0052-Cygwin-try-to-avoid-recalling-offline-files.patch
+        0053-Cygwin-get-set-security-descriptors-using-FILE_OPEN_.patch
+        0054-Cygwin-FILE_OPEN_NO_RECALL-is-incompatible-with-FILE.patch
+        0055-Cygwin-console-Fix-exit-code-for-non-cygwin-process.patch
+        0056-Cygwin-console-Avoid-slipping-past-disable_master_th.patch
+        0057-Cygwin-pty-Fix-handle-leak-in-master-process.patch
+        0058-Cygwin-pty-Fix-potential-handle-leak-regarding-CallN.patch
+        0059-Cygwin-console-Make-VMIN-and-VTIME-work.patch
+        0060-Cygwin-pipe-Give-up-to-use-query_hdl-for-non-cygwin-.patch
+        0061-Avoid-sharing-cygheaps-across-Cygwin-versions.patch
+        0062-uname-report-msys2-runtime-commit-hash-too.patch
+        0063-Cygwin-suppress-a-warning-generated-with-w32api-12.0.patch)
+sha256sums=('a40476d03803bfa6875cde92221db4326b3479147e873fbeca2e4236d48fe875'
             '351bb1efdbdafe80c981e92d6b425c6ab71c85ce4e990db184e2118158eb2ab6'
             'd3d3a01feeae9f7d5e6cb32f4662df74fc9476ff11a1aac3dad2df3e43fd88e4'
             '2e50ecd65f2fd413baaf39e5058a6b252245abc7d34f4ebf17dd4f7ffed60ced'
@@ -131,7 +143,19 @@ sha256sums=('SKIP'
             '6c4cc6db864addb7ac78c5e2cbb0be41c7f853726c08b92fa33d573c8dcf0c16'
             'f9533f44a33f192716bdb7b613c66a675f37d3c613590d505737a76c80a3e75e'
             '1665c7654a3f5fbdf42fdc7c3b0bfeaa2f26a9534962ffece26da97122e3018e'
-            '164527ad2e289050ed336a6f1aa8e1af40fb864e7e4aed545bde2703d41203bd')
+            '164527ad2e289050ed336a6f1aa8e1af40fb864e7e4aed545bde2703d41203bd'
+            '9879a0fe09147b1e0d41f42211bb309dd08ea088186f413d4dec6e0300ef9fbc'
+            '677c013c456ca1ec239a694340ae36eae99a5700d0dda09e3679a29997234512'
+            '266db90ae4f67f2818d015272cdda3d751a62724149d035d1a04a4407a7dbcef'
+            '368c5a3c9df12d4fd0716979ec449890cb39690801b13121c06575a136727b5f'
+            '27b0596bea70532f0f1a017bda81a87e273ddcb76b638887adb3dd3171bdccf4'
+            '54afb4ad79fccdb1230181729edca861119b7668aa35715265461c0b0317a6a2'
+            '71d11ca9d0a39bb643ccff2c74e90fd2008453ef81361ddf00f3cc4429b2e687'
+            '43383dd8358ae49865f1856493f482eec1fa56710e990029028296888f50ac2c'
+            '45cf4e509845d27bf0d12bc6b878e8c2e33754e232a8d1de43ed7e19e451bfac'
+            '80119c6ee0e8c44260ead25f2e0a9d0aa9f6ae244521541db3a53c424f9f72fd'
+            'f8210e329bb0cac0028c25a415755fe8a0b4339eaeb6f4117d9a7c6d0559579e'
+            '2ba10495562b73a44d50526c923b523dd3b38071b49a19d02ab5223a3684ff2c')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -219,7 +243,19 @@ prepare() {
   0048-Handle-8-bit-characters-under-LOCALE-C.patch \
   0049-fixup-path-conversion-Introduce-ability-to-switch-of.patch \
   0050-pathconv-don-t-skip-arguments-with-double-quote.patch \
-  0051-Work-around-fragile-include-in-binutils.patch
+  0051-Work-around-fragile-include-in-binutils.patch \
+  0052-Cygwin-try-to-avoid-recalling-offline-files.patch \
+  0053-Cygwin-get-set-security-descriptors-using-FILE_OPEN_.patch \
+  0054-Cygwin-FILE_OPEN_NO_RECALL-is-incompatible-with-FILE.patch \
+  0055-Cygwin-console-Fix-exit-code-for-non-cygwin-process.patch \
+  0056-Cygwin-console-Avoid-slipping-past-disable_master_th.patch \
+  0057-Cygwin-pty-Fix-handle-leak-in-master-process.patch \
+  0058-Cygwin-pty-Fix-potential-handle-leak-regarding-CallN.patch \
+  0059-Cygwin-console-Make-VMIN-and-VTIME-work.patch \
+  0060-Cygwin-pipe-Give-up-to-use-query_hdl-for-non-cygwin-.patch \
+  0061-Avoid-sharing-cygheaps-across-Cygwin-versions.patch \
+  0062-uname-report-msys2-runtime-commit-hash-too.patch \
+  0063-Cygwin-suppress-a-warning-generated-with-w32api-12.0.patch
 }
 
 build() {

--- a/msys2-runtime-3.4/update-patches.sh
+++ b/msys2-runtime-3.4/update-patches.sh
@@ -75,6 +75,7 @@ then
 	exit 0
 fi
 
+GIT_CONFIG_PARAMETERS="${GIT_CONFIG_PARAMETERS+$GIT_CONFIG_PARAMETERS }'core.autocrlf=false'" \
 updpkgsums ||
 die "Could not update the patch set checksums in PKGBUILD"
 

--- a/msys2-runtime-3.4/update-patches.sh
+++ b/msys2-runtime-3.4/update-patches.sh
@@ -21,8 +21,10 @@ base_tag=refs/tags/cygwin-"$(sed -ne 's/^pkgver=//p' <PKGBUILD)"
 msys2_branch=refs/heads/msys2-${base_tag#refs/tags/cygwin-}
 url=https://github.com/msys2/msys2-runtime
 
-test -d msys2-runtime ||
-git clone --bare $url msys2-runtime ||
+test -d msys2-runtime || {
+	git clone --bare $url msys2-runtime &&
+	git --git-dir=msys2-runtime config remote.origin.url git://sourceware.org/git/newlib-cygwin.git # required by PKGBUILD
+} ||
 die "Could not clone msys2-runtime"
 
 git -C msys2-runtime fetch --no-tags $url $base_tag:$base_tag $msys2_branch:$msys2_branch


### PR DESCRIPTION
Seems that we haven't updated this package in a while...

NOTE: There seems to be [a compile error](https://github.com/msys2/msys2-runtime/actions/runs/9835525686/job/27149328693#step:4:1495) that I still need to look into, hence the draft status of this PR.