### PR TITLE
python: switch default mp start method to "spawn" and disable "forkserver"

### DIFF
--- a/python/990-cygwin-default-to-spawn-for-multiprocessing-and-disa.patch
+++ b/python/990-cygwin-default-to-spawn-for-multiprocessing-and-disa.patch
@@ -1,0 +1,61 @@
+From 735f8f1849b4c11ac05bcb6de3233f263cbb7490 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Mon, 8 Jul 2024 20:19:25 +0200
+Subject: [PATCH] cygwin: default to "spawn" for multiprocessing and disable
+ "forkserver"
+
+passing fds doesn't seem to be supported by cygwin, so the "forkserver"
+variant of multiprocessing fails.
+
+This was noticed because the default "fork" method is now deprecated and
+in internal tools, like compileall, it defaults to "forkserver" since 3.12.
+
+This switching code assumes that if "fork" works, also "forkserver" works,
+so we'd have to patch it too.
+
+Instead default to "spawn" like on macOS and disable "forkserver". This way
+we are not using deprecated things by defaults, and external code should
+hopefully not try to switch to "forkserver" then.
+---
+ Lib/multiprocessing/context.py   | 4 ++--
+ Lib/multiprocessing/reduction.py | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Lib/multiprocessing/context.py b/Lib/multiprocessing/context.py
+index de8a264829..63e467f166 100644
+--- a/Lib/multiprocessing/context.py
++++ b/Lib/multiprocessing/context.py
+@@ -262,7 +262,7 @@ def get_all_start_methods(self):
+         if sys.platform == 'win32':
+             return ['spawn']
+         else:
+-            methods = ['spawn', 'fork'] if sys.platform == 'darwin' else ['fork', 'spawn']
++            methods = ['spawn', 'fork'] if (sys.platform == 'darwin' or sys.platform == 'cygwin') else ['fork', 'spawn']
+             if reduction.HAVE_SEND_HANDLE:
+                 methods.append('forkserver')
+             return methods
+@@ -320,7 +320,7 @@ def _check_available(self):
+         'spawn': SpawnContext(),
+         'forkserver': ForkServerContext(),
+     }
+-    if sys.platform == 'darwin':
++    if sys.platform == 'darwin' or sys.platform == 'cygwin':
+         # bpo-33725: running arbitrary code after fork() is no longer reliable
+         # on macOS since macOS 10.14 (Mojave). Use spawn by default instead.
+         _default_context = DefaultContext(_concrete_contexts['spawn'])
+diff --git a/Lib/multiprocessing/reduction.py b/Lib/multiprocessing/reduction.py
+index 5593f0682f..a1b0429f89 100644
+--- a/Lib/multiprocessing/reduction.py
++++ b/Lib/multiprocessing/reduction.py
+@@ -24,7 +24,7 @@
+ HAVE_SEND_HANDLE = (sys.platform == 'win32' or
+                     (hasattr(socket, 'CMSG_LEN') and
+                      hasattr(socket, 'SCM_RIGHTS') and
+-                     hasattr(socket.socket, 'sendmsg')))
++                     hasattr(socket.socket, 'sendmsg'))) and sys.platform != 'cygwin'
+ 
+ #
+ # Pickler subclass
+-- 
+2.45.2
+

--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=python
 pkgname=('python' 'python-devel')
 pkgver=3.12.4
-pkgrel=5
+pkgrel=6
 _pybasever=${pkgver%.*}
 pkgdesc="Next generation of the python high-level scripting language"
 arch=('i686' 'x86_64')
@@ -42,6 +42,7 @@ source=(https://www.python.org/ftp/python/${pkgver%rc*}/Python-${pkgver}.tar.xz
         950-rebase-dlls.patch
         970-ossaudiodev.patch
         980-fix-module-lib-dep.patch
+        990-cygwin-default-to-spawn-for-multiprocessing-and-disa.patch
         EXTERNALLY-MANAGED)
 sha256sums=('f6d419a6d8743ab26700801b4908d26d97e8b986e14f95de31b32de2b0e79554'
             '82cfafc5b31ad4c9bb4c9786044c39c75762dbc2656abdfdc433c23fee69c02f'
@@ -55,6 +56,7 @@ sha256sums=('f6d419a6d8743ab26700801b4908d26d97e8b986e14f95de31b32de2b0e79554'
             'bcdb4e7922e30f7dfbd3993ffe6db2dfd0df29326bebd12203dce376ea3451d9'
             'ee109d91a1c7ea84d278d9a8b0e1feb397e691b8868d79f77ea7bb6b1b3b1968'
             'e2861218f05741bfe99b05bb41cf88e14f57747aedec251626691b05482a50bd'
+            'd04ca4778f150b880e23b9bc1fe5c5385e41228399093320c80ad4d5e29c6aab'
             '2c8cdad18085b8736e985653c0f18523958f29b72125e15124806a0f3d1a20ee')
 
 apply_patch_with_msg() {
@@ -80,6 +82,10 @@ prepare() {
     950-rebase-dlls.patch \
     970-ossaudiodev.patch \
     980-fix-module-lib-dep.patch
+
+  # https://github.com/msys2/MSYS2-packages/pull/4743#issuecomment-2213043559
+  apply_patch_with_msg \
+    990-cygwin-default-to-spawn-for-multiprocessing-and-disa.patch
 
   # Ensure that we are using the system copy of various libraries (expat, zlib and libffi),
   # rather than copies shipped in the tarball


### PR DESCRIPTION
"forkserver" doesn't work, and "fork" is deprecated, so give "spawn" a try See https://github.com/msys2/MSYS2-packages/pull/4743#issuecomment-2213043559