### PR TITLE
Prevent different msys2 runtime versions from sharing cygheaps (targeting msys2-runtime v3.5)

### DIFF
--- a/msys2-runtime/0040-Avoid-sharing-cygheaps-across-Cygwin-versions.patch
+++ b/msys2-runtime/0040-Avoid-sharing-cygheaps-across-Cygwin-versions.patch
@@ -1,0 +1,130 @@
+From 317fc51b3af5280d8d115cab17a502f7c37b204c Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 30 Jan 2023 23:22:22 +0100
+Subject: [PATCH 40/N] Avoid sharing cygheaps across Cygwin versions
+
+It frequently leads to problems when trying, say, to call from MSYS2's
+Bash into Cygwin's or Git for Windows', merely because sharing that data
+is pretty finicky.
+
+For example, using the MSYS2' Bash using the MSYS2 runtime version that
+is current at time of writing, trying to call Cygwin's programs fails
+in manners like this:
+
+    $ /c/cygwin64/bin/uname -r
+      0 [main] uname (9540) child_copy: cygheap read copy failed, 0x800000000..0x800010BE0, done 0, windows pid 9540, Win32 error 6
+    680 [main] uname 880 C:\cygwin64\bin\uname.exe: *** fatal error - couldn't create signal pipe, Win32 error 5
+
+with the rather misleading exit code 127 (a code which is reserved to
+indicate that a command was not found).
+
+Let's just treat the MSYS2 runtime and the Cygwin runtime as completely
+incompatible with one another, by virtue of using a different
+magic constant than merely `CHILD_INFO_MAGIC`.
+
+By using the msys2-runtime commit to modify that magic constant, we can
+even spawn programs using a different MSYS2 runtime (such as Git for
+Windows') because the commit serves as the tell-tale whether two MSYS2
+runtime versions are compatible with each other. To support building in
+the MSYS2-packages repository (where we do not check out the
+`msys2-runtime` but instead check out Cygwin and apply patches on top),
+let's accept a hard-coded commit hash as `./configure` option.
+
+One consequence is that spawned MSYS processes using a different MSYS2
+runtime will not be visible as such to the parent process, i.e. they
+cannot share any resources such as pseudo terminals. But that's okay,
+they are simply treated as if they were regular Win32 programs.
+
+Note: We have to use a very rare form of encoding the brackets in the
+`expr` calls: quadrigraphs (for a thorough explanation, see
+https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.70/html_node/Quadrigraphs.html#Quadrigraphs).
+This is necessary because it is apparently impossible to encode brackets
+in `configure.ac` files otherwise.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/configure.ac       | 28 ++++++++++++++++++++++++++++
+ winsup/cygwin/Makefile.am |  3 +++
+ winsup/cygwin/dcrt0.cc    |  2 +-
+ winsup/cygwin/sigproc.cc  |  2 +-
+ 4 files changed, 33 insertions(+), 2 deletions(-)
+
+diff --git a/winsup/configure.ac b/winsup/configure.ac
+index b88f3ad..eb9890a 100644
+--- a/winsup/configure.ac
++++ b/winsup/configure.ac
+@@ -57,6 +57,34 @@ AC_CHECK_TOOL(RANLIB, ranlib, ranlib)
+ AC_CHECK_TOOL(STRIP, strip, strip)
+ AC_CHECK_TOOL(WINDRES, windres, windres)
+ 
++# Record msys2-runtime commit
++AC_ARG_WITH([msys2-runtime-commit],
++  [AS_HELP_STRING([--with-msys2-runtime-commit=COMMIT],
++		  [indicate the msys2-runtime commit corresponding to this build])],
++  [MSYS2_RUNTIME_COMMIT=$withval], [MSYS2_RUNTIME_COMMIT=yes])
++case "$MSYS2_RUNTIME_COMMIT" in
++no)
++    MSYS2_RUNTIME_COMMIT=
++    MSYS2_RUNTIME_COMMIT_HEX=0
++    ;;
++yes|auto)
++    if MSYS2_RUNTIME_COMMIT="$(git --git-dir="$srcdir/../.git" rev-parse HEAD)"
++    then
++        MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
++    else
++        AC_MSG_WARN([Could not determine msys2-runtime commit"])
++        MSYS2_RUNTIME_COMMIT=
++        MSYS2_RUNTIME_COMMIT_HEX=0
++    fi
++    ;;
++*)
++    expr "$MSYS2_RUNTIME_COMMIT" : '@<:@0-9a-f@:>@\{6,64\}$' ||
++    AC_MSG_ERROR([Invalid commit name: "$MSYS2_RUNTIME_COMMIT"])
++    MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
++    ;;
++esac
++AC_SUBST(MSYS2_RUNTIME_COMMIT_HEX)
++
+ AC_ARG_ENABLE(debugging,
+ [AS_HELP_STRING([--enable-debugging],[Build a cygwin DLL which has more consistency checking for debugging])],
+ [case "${enableval}" in
+diff --git a/winsup/cygwin/Makefile.am b/winsup/cygwin/Makefile.am
+index 76b54eb..774e562 100644
+--- a/winsup/cygwin/Makefile.am
++++ b/winsup/cygwin/Makefile.am
+@@ -17,6 +17,9 @@ if TARGET_X86_64
+ COMMON_CFLAGS+=-mcmodel=small
+ endif
+ 
++VERSION_CFLAGS = -DMSYS2_RUNTIME_COMMIT_HEX="@MSYS2_RUNTIME_COMMIT_HEX@"
++COMMON_CFLAGS += $(VERSION_CFLAGS)
++
+ AM_CFLAGS=$(cflags_common) $(COMMON_CFLAGS)
+ AM_CXXFLAGS=$(cxxflags_common) $(COMMON_CFLAGS) -fno-threadsafe-statics
+ 
+diff --git a/winsup/cygwin/dcrt0.cc b/winsup/cygwin/dcrt0.cc
+index c1dbd5f..4759f8c 100644
+--- a/winsup/cygwin/dcrt0.cc
++++ b/winsup/cygwin/dcrt0.cc
+@@ -530,7 +530,7 @@ get_cygwin_startup_info ()
+   child_info *res = (child_info *) si.lpReserved2;
+ 
+   if (si.cbReserved2 < EXEC_MAGIC_SIZE || !res
+-      || res->intro != PROC_MAGIC_GENERIC || res->magic != CHILD_INFO_MAGIC)
++      || res->intro != PROC_MAGIC_GENERIC || res->magic != (CHILD_INFO_MAGIC ^ MSYS2_RUNTIME_COMMIT_HEX))
+     {
+       strace.activate (false);
+       res = NULL;
+diff --git a/winsup/cygwin/sigproc.cc b/winsup/cygwin/sigproc.cc
+index 86e4e60..2f5fd47 100644
+--- a/winsup/cygwin/sigproc.cc
++++ b/winsup/cygwin/sigproc.cc
+@@ -811,7 +811,7 @@ int child_info::retry_count = 0;
+ child_info::child_info (unsigned in_cb, child_info_types chtype,
+ 			bool need_subproc_ready):
+   msv_count (0), cb (in_cb), intro (PROC_MAGIC_GENERIC),
+-  magic (CHILD_INFO_MAGIC), type (chtype), cygheap (::cygheap),
++  magic (CHILD_INFO_MAGIC ^ MSYS2_RUNTIME_COMMIT_HEX), type (chtype), cygheap (::cygheap),
+   cygheap_max (::cygheap_max), flag (0), retry (child_info::retry_count),
+   rd_proc_pipe (NULL), wr_proc_pipe (NULL), sigmask (_my_tls.sigmask)
+ {

--- a/msys2-runtime/0041-uname-report-msys2-runtime-commit-hash-too.patch
+++ b/msys2-runtime/0041-uname-report-msys2-runtime-commit-hash-too.patch
@@ -1,0 +1,159 @@
+From 0ea583b9cb0326572ae1d446d4a5f41782d94b25 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 21 Feb 2023 16:36:36 +0100
+Subject: [PATCH 41/N] uname: report msys2-runtime commit hash, too
+
+Having just Cygwin's version in the output of `uname` is not helpful, as
+both MSYS2 as well as Git for Windows release intermediate versions of
+the MSYS2 runtime much more often than Cygwin runtime versions are
+released.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/configure.ac             | 10 ++++++++--
+ winsup/cygwin/Makefile.am       |  6 ++++--
+ winsup/cygwin/scripts/mkvers.sh |  8 ++++++++
+ winsup/cygwin/uname.cc          | 16 +++++++++-------
+ 4 files changed, 29 insertions(+), 11 deletions(-)
+
+diff --git a/winsup/configure.ac b/winsup/configure.ac
+index eb9890a..0fc607a 100644
+--- a/winsup/configure.ac
++++ b/winsup/configure.ac
+@@ -65,24 +65,30 @@ AC_ARG_WITH([msys2-runtime-commit],
+ case "$MSYS2_RUNTIME_COMMIT" in
+ no)
+     MSYS2_RUNTIME_COMMIT=
++    MSYS2_RUNTIME_COMMIT_SHORT=
+     MSYS2_RUNTIME_COMMIT_HEX=0
+     ;;
+ yes|auto)
+     if MSYS2_RUNTIME_COMMIT="$(git --git-dir="$srcdir/../.git" rev-parse HEAD)"
+     then
+-        MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
++        MSYS2_RUNTIME_COMMIT_SHORT="$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')"
++        MSYS2_RUNTIME_COMMIT_HEX="0x${MSYS2_RUNTIME_COMMIT_SHORT}ul"
+     else
+         AC_MSG_WARN([Could not determine msys2-runtime commit"])
+         MSYS2_RUNTIME_COMMIT=
++        MSYS2_RUNTIME_COMMIT_SHORT=
+         MSYS2_RUNTIME_COMMIT_HEX=0
+     fi
+     ;;
+ *)
+     expr "$MSYS2_RUNTIME_COMMIT" : '@<:@0-9a-f@:>@\{6,64\}$' ||
+     AC_MSG_ERROR([Invalid commit name: "$MSYS2_RUNTIME_COMMIT"])
+-    MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
++    MSYS2_RUNTIME_COMMIT_SHORT="$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')"
++    MSYS2_RUNTIME_COMMIT_HEX="0x${MSYS2_RUNTIME_COMMIT_SHORT}ul"
+     ;;
+ esac
++AC_SUBST(MSYS2_RUNTIME_COMMIT)
++AC_SUBST(MSYS2_RUNTIME_COMMIT_SHORT)
+ AC_SUBST(MSYS2_RUNTIME_COMMIT_HEX)
+ 
+ AC_ARG_ENABLE(debugging,
+diff --git a/winsup/cygwin/Makefile.am b/winsup/cygwin/Makefile.am
+index 774e562..abcb323 100644
+--- a/winsup/cygwin/Makefile.am
++++ b/winsup/cygwin/Makefile.am
+@@ -17,7 +17,9 @@ if TARGET_X86_64
+ COMMON_CFLAGS+=-mcmodel=small
+ endif
+ 
+-VERSION_CFLAGS = -DMSYS2_RUNTIME_COMMIT_HEX="@MSYS2_RUNTIME_COMMIT_HEX@"
++VERSION_CFLAGS = -DMSYS2_RUNTIME_COMMIT="\"@MSYS2_RUNTIME_COMMIT@\""
++VERSION_CFLAGS += -DMSYS2_RUNTIME_COMMIT_SHORT="\"@MSYS2_RUNTIME_COMMIT_SHORT@\""
++VERSION_CFLAGS += -DMSYS2_RUNTIME_COMMIT_HEX="@MSYS2_RUNTIME_COMMIT_HEX@"
+ COMMON_CFLAGS += $(VERSION_CFLAGS)
+ 
+ AM_CFLAGS=$(cflags_common) $(COMMON_CFLAGS)
+@@ -452,7 +454,7 @@ uname_version.c: .FORCE
+ version.cc: scripts/mkvers.sh include/cygwin/version.h winver.rc $(src_files)
+ 	@echo "Making version.cc and winver.o";\
+ 	export CC="$(CC)";\
+-	/bin/sh $(word 1,$^) $(word 2,$^) $(word 3,$^) $(WINDRES) $(CFLAGS)
++	/bin/sh $(word 1,$^) $(word 2,$^) $(word 3,$^) $(WINDRES) $(CFLAGS) $(VERSION_CFLAGS)
+ 
+ winver.o: version.cc
+ 
+diff --git a/winsup/cygwin/scripts/mkvers.sh b/winsup/cygwin/scripts/mkvers.sh
+index a3d45c5..34d8d6d 100755
+--- a/winsup/cygwin/scripts/mkvers.sh
++++ b/winsup/cygwin/scripts/mkvers.sh
+@@ -16,6 +16,7 @@ incfile="$1"; shift
+ rcfile="$1"; shift
+ windres="$1"; shift
+ iflags=
++msys2_runtime_commit=
+ # Find header file locations
+ while [ -n "$*" ]; do
+   case "$1" in
+@@ -26,6 +27,9 @@ while [ -n "$*" ]; do
+     shift
+     iflags="$iflags -I$1"
+       ;;
++  -DMSYS2_RUNTIME_COMMIT=*)
++    msys2_runtime_commit="${1#*=}"
++    ;;
+   esac
+   shift
+ done
+@@ -168,6 +172,10 @@ then
+   cvs_tag="$(echo $wv_cvs_tag | sed -e 's/-branch.*//')"
+   cygwin_ver="$cygwin_ver-$cvs_tag"
+ fi
++if [ -n "$msys2_runtime_commit" ]
++then
++  cygwin_ver="$cygwin_ver-$msys2_runtime_commit"
++fi
+ 
+ echo "Version $cygwin_ver"
+ set -$- $builddate
+diff --git a/winsup/cygwin/uname.cc b/winsup/cygwin/uname.cc
+index a4ac0e3..a978363 100644
+--- a/winsup/cygwin/uname.cc
++++ b/winsup/cygwin/uname.cc
+@@ -76,18 +76,19 @@ uname_x (struct utsname *name)
+ #pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wformat-truncation="
+ #ifdef CYGPORT_RELEASE_INFO
+-      snprintf (name->release, _UTSNAME_LENGTH, "%s.%s",
+-		__XSTRING (CYGPORT_RELEASE_INFO), name->machine);
++      snprintf (name->release, _UTSNAME_LENGTH, "%s-%s.%s",
++		__XSTRING (CYGPORT_RELEASE_INFO), MSYS2_RUNTIME_COMMIT_SHORT, name->machine);
+ #else
+       extern const char *uname_dev_version;
+       if (uname_dev_version && uname_dev_version[0])
+-	snprintf (name->release, _UTSNAME_LENGTH, "%s.%s",
+-		  uname_dev_version, name->machine);
++	snprintf (name->release, _UTSNAME_LENGTH, "%s-%s.%s",
++		  uname_dev_version, MSYS2_RUNTIME_COMMIT_SHORT, name->machine);
+       else
+-	__small_sprintf (name->release, "%d.%d.%d-api-%d.%s",
++	__small_sprintf (name->release, "%d.%d.%d-%s-api-%d.%s",
+ 			 cygwin_version.dll_major / 1000,
+ 			 cygwin_version.dll_major % 1000,
+ 			 cygwin_version.dll_minor,
++			 MSYS2_RUNTIME_COMMIT_SHORT,
+ 			 cygwin_version.api_minor,
+ 			 name->machine);
+ #endif
+@@ -129,14 +130,15 @@ uname (struct utsname *in_name)
+       cygwin_gethostname (name->nodename, sizeof (name->nodename) - 1);
+ 
+       /* Cygwin dll release */
+-      __small_sprintf (name->release, "%d.%d.%d(%d.%d/%d/%d)",
++      __small_sprintf (name->release, "%d.%d.%d(%d.%d/%d/%d/%s)",
+ 		       cygwin_version.dll_major / 1000,
+ 		       cygwin_version.dll_major % 1000,
+ 		       cygwin_version.dll_minor,
+ 		       cygwin_version.api_major,
+ 		       cygwin_version.api_minor,
+ 		       cygwin_version.shared_data,
+-		       cygwin_version.mount_registry);
++		       cygwin_version.mount_registry,
++		       MSYS2_RUNTIME_COMMIT_SHORT);
+ 
+       /* Cygwin "version" aka build date */
+       strcpy (name->version, cygwin_version.dll_build_date);

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.5.3
-pkgrel=4
+pkgrel=5
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -67,7 +67,9 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0036-build_env-respect-the-MSYS-environment-variable.patch
         0037-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch
         0038-proc-fix-error-the-address-of-iso15924-will-never-be.patch
-        0039-Cygwin-disable-high-entropy-VA-for-ldh.patch)
+        0039-Cygwin-disable-high-entropy-VA-for-ldh.patch
+        0040-Avoid-sharing-cygheaps-across-Cygwin-versions.patch
+        0041-uname-report-msys2-runtime-commit-hash-too.patch)
 sha256sums=('e395966060e0cf901f3cd4190b0b189bface69a2fec6ba93748387b61aa7dd5c'
             'a0de51b420ad7fc67b007adf4159e065a5beefc56e66735827fc9f39364e045f'
             '857830ffd5fe820e90e0f3b49b72c1f31c3c929be845e178eb3e6c7352181e18'
@@ -107,7 +109,9 @@ sha256sums=('e395966060e0cf901f3cd4190b0b189bface69a2fec6ba93748387b61aa7dd5c'
             'd472029276932e7df3da56347d1d09d5bd422f9f96f6f607fe8a28362ebe4a1b'
             '4683b3dca58af0fef7f704b3bcb199da1ddbce874e5fc69bfaaced9cc76d6be9'
             '853c6c41da7e188811dae2b3df9251ce84dbb81b39c8632173556132fcbd96c1'
-            'd038eec988844df56ac2ed183dddc73c3f4296c2606c818f2521d40eb2fa7500')
+            'd038eec988844df56ac2ed183dddc73c3f4296c2606c818f2521d40eb2fa7500'
+            'de9d29b6e889b64be316445529d03821473ad780e2950c72e1692975219483ae'
+            '26effe81ff2405d444845b484520a50ac6bdb1625474151b01835ba814a51a64')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -183,7 +187,9 @@ prepare() {
   0036-build_env-respect-the-MSYS-environment-variable.patch \
   0037-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch \
   0038-proc-fix-error-the-address-of-iso15924-will-never-be.patch \
-  0039-Cygwin-disable-high-entropy-VA-for-ldh.patch
+  0039-Cygwin-disable-high-entropy-VA-for-ldh.patch \
+  0040-Avoid-sharing-cygheaps-across-Cygwin-versions.patch \
+  0041-uname-report-msys2-runtime-commit-hash-too.patch
 }
 
 build() {

--- a/msys2-runtime/update-patches.sh
+++ b/msys2-runtime/update-patches.sh
@@ -75,6 +75,7 @@ then
 	exit 0
 fi
 
+GIT_CONFIG_PARAMETERS="${GIT_CONFIG_PARAMETERS+$GIT_CONFIG_PARAMETERS }'core.autocrlf=false'" \
 updpkgsums ||
 die "Could not update the patch set checksums in PKGBUILD"
 

--- a/msys2-runtime/update-patches.sh
+++ b/msys2-runtime/update-patches.sh
@@ -21,8 +21,10 @@ base_tag=refs/tags/cygwin-"$(sed -ne 's/^pkgver=//p' <PKGBUILD)"
 msys2_branch=refs/heads/msys2-${base_tag#refs/tags/cygwin-}
 url=https://github.com/msys2/msys2-runtime
 
-test -d msys2-runtime ||
-git clone --bare $url msys2-runtime ||
+test -d msys2-runtime || {
+	git clone --bare $url msys2-runtime &&
+	git --git-dir=msys2-runtime config remote.origin.url git://sourceware.org/git/newlib-cygwin.git # required by PKGBUILD
+} ||
 die "Could not clone msys2-runtime"
 
 git -C msys2-runtime fetch --no-tags $url $base_tag:$base_tag $msys2_branch:$msys2_branch


### PR DESCRIPTION
This corresponds to https://github.com/msys2/msys2-runtime/pull/219.