### PR TITLE
automake1.17: new package

### DIFF
--- a/automake1.17/PKGBUILD
+++ b/automake1.17/PKGBUILD
@@ -1,7 +1,8 @@
 # Maintainer: Yang Kun <ikspress@outlook.com>
 
+_basever=1.17
+pkgname=automake${_basever}
 pkgver=1.17
-pkgname=automake${pkgver}
 pkgrel=1
 pkgdesc="A GNU tool for automatically creating Makefiles"
 arch=('any')
@@ -86,5 +87,5 @@ package() {
   rm -rf ${pkgdir}/usr/share/doc
 
   # install the versioned info files
-  install -Dm644 ${srcdir}/automake-${pkgver}/doc/*${pkgver}.info* -t ${pkgdir}/usr/share/info/
+  install -Dm644 ${srcdir}/automake-${pkgver}/doc/*${_basever}.info* -t ${pkgdir}/usr/share/info/
 }

--- a/automake1.17/PKGBUILD
+++ b/automake1.17/PKGBUILD
@@ -1,0 +1,90 @@
+# Maintainer: Yang Kun <ikspress@outlook.com>
+
+pkgver=1.17
+pkgname=automake${pkgver}
+pkgrel=1
+pkgdesc="A GNU tool for automatically creating Makefiles"
+arch=('any')
+license=('spdx:GPL-2.0-or-later')
+url="https://www.gnu.org/software/automake"
+msys2_references=(
+  "cpe: cpe:/a:gnu:automake"
+)
+depends=('bash' 'perl')
+makedepends=('autoconf' 'make' 'texinfo')
+checkdepends=('bison' 'cscope' 'dejagnu' 'emacs' 'expect' 'flex' 'gcc' 'gettext'
+              'help2man' 'libtool' 'lzip' 'sharutils' 'texinfo-tex' 'zip')
+source=(https://ftp.gnu.org/gnu/automake/automake-${pkgver}.tar.xz{,.sig}
+        automake-1.17-documentation.patch
+        automake-1.17-msys2.patch)
+sha256sums=('8920c1fc411e13b90bf704ef9db6f29d540e76d232cb3b2c9f4dc4cc599bd990'
+            'SKIP'
+            '64874ff1f61a832b784a0cbd75f48d7e6b1fe5f7e9f5acb75134ad7c57c5d824'
+            'a6b3a7099fb23ddc3d1402b16df32cf8f21bb63ca6b9314ff7caff5869b6ed50')
+validpgpkeys=('E1622F96D2BB4E58018EEF9860F906016E407573'   # Stefano Lattarini
+              'F2A38D7EEB2B66405761070D0ADEE10094604D37'   # Mathieu Lirzin
+              '155D3FC500C834486D1EEA677FD9FCCB000BEEEE')  # Jim Meyering
+replace=('automake')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _fname in "$@"; do
+    msg2 "Applying ${_fname}"
+    patch -Nbp1 -i "${srcdir}"/${_fname}
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"; do
+    if [ -f $_fname ] || [ -d $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd ${srcdir}/automake-${pkgver}
+
+  apply_patch_with_msg \
+    automake-1.17-documentation.patch \
+    automake-1.17-msys2.patch
+}
+
+build() {
+  cd ${srcdir}/automake-${pkgver}
+  ./configure --prefix=/usr
+  make
+  # build versioned info files
+  cd doc
+  makeinfo automake.texi automake-history.texi
+}
+
+check() {
+  cd ${srcdir}/automake-${pkgver}
+
+  make -k check || warning "Tests failed"
+}
+
+package() {
+  cd ${srcdir}/automake-${pkgver}
+  make DESTDIR=${pkgdir} install
+
+  mv ${pkgdir}/usr/share/aclocal/README ${pkgdir}/usr/share/aclocal/README.am17
+
+  # remove the unversioned info files
+  rm -f ${pkgdir}/usr/share/info/automake{,-history}.info*
+
+  # remove the unversioned executables
+  rm -f ${pkgdir}/usr/bin/automake ${pkgdir}/usr/bin/aclocal
+
+  # remove the unversioned man pages
+  rm -f ${pkgdir}/usr/share/man/man1/automake.1 \
+    ${pkgdir}/usr/share/man/man1/aclocal.1
+
+  # remove amhello
+  rm -rf ${pkgdir}/usr/share/doc
+
+  # install the versioned info files
+  install -Dm644 ${srcdir}/automake-${pkgver}/doc/*${pkgver}.info* -t ${pkgdir}/usr/share/info/
+}

--- a/automake1.17/automake-1.17-documentation.patch
+++ b/automake1.17/automake-1.17-documentation.patch
@@ -1,0 +1,45 @@
+diff --git automake-1.17-orig/doc/automake-history.texi automake-1.17/doc/automake-history.texi
+index 6e8db83..8b9e212 100644
+--- automake-1.17-orig/doc/automake-history.texi
++++ automake-1.17/doc/automake-history.texi
+@@ -1,7 +1,7 @@
+ \input texinfo   @c -*-texinfo-*-
+ @c %**start of header
+-@setfilename automake-history.info
+-@settitle automake-history
++@setfilename automake-history1.17.info
++@settitle automake-history1.17
+ @setchapternewpage on
+ @c %**end of header
+ 
+diff --git automake-1.17-orig/doc/automake.texi automake-1.17/doc/automake.texi
+index 49ebfb2..fa7c03b 100644
+--- automake-1.17-orig/doc/automake.texi
++++ automake-1.17/doc/automake.texi
+@@ -1,7 +1,7 @@
+ \input texinfo   @c -*-texinfo-*-
+ @c %**start of header
+-@setfilename automake.info
+-@settitle automake
++@setfilename automake1.17.info
++@settitle automake1.17
+ @documentencoding UTF-8
+ @documentlanguage en
+ @setchapternewpage off
+@@ -40,13 +40,13 @@ section entitled ``GNU Free Documentation License.''
+ 
+ @dircategory Software development
+ @direntry
+-* Automake: (automake).         Making GNU standards-compliant Makefiles.
++* Automake1.17: (automake).         Making GNU standards-compliant Makefiles.
+ @end direntry
+ 
+ @dircategory Individual utilities
+ @direntry
+-* aclocal-invocation: (automake)aclocal Invocation.   Generating aclocal.m4.
+-* automake-invocation: (automake)automake Invocation. Generating Makefile.in.
++* aclocal-1.17-invocation: (automake)aclocal Invocation.   Generating aclocal.m4.
++* automake-1.17-invocation: (automake)automake Invocation. Generating Makefile.in.
+ @end direntry
+ 
+ @titlepage

--- a/automake1.17/automake-1.17-msys2.patch
+++ b/automake1.17/automake-1.17-msys2.patch
@@ -1,0 +1,18 @@
+diff --git automake-1.17-orig/t/compile5.sh automake-1.17/t/compile5.sh
+index 67c46cc..ddf9683 100644
+--- automake-1.17-orig/t/compile5.sh
++++ automake-1.17/t/compile5.sh
+@@ -47,11 +47,11 @@ case '@host_os@' in
+     ;;
+ esac
+ case @build_os@ in
+-  mingw* | cygwin*)
++  mingw* | cygwin* | msys*)
+     ;;
+   *)
+     winepath -w / \
+-      || skip_ "not on MinGW or Cygwin, and winepath not available"
++      || skip_ "not on MinGW, Cygwin or MSYS, and winepath not available"
+     ;;
+ esac
+ END

--- a/autotools-wrappers/PKGBUILD
+++ b/autotools-wrappers/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=autotools-wrappers
 pkgname=('automake-wrapper' 'autoconf-wrapper' )
 pkgver=20221207
-pkgrel=2
+pkgrel=3
 arch=('any')
 license=('spdx:GPL-2.0-only')
 makedepends=('git')
@@ -30,7 +30,8 @@ package_automake-wrapper() {
     'automake1.13'
     'automake1.14'
     'automake1.15'
-    'automake1.16')
+    'automake1.16'
+    'automake1.17')
   provides=("automake")
   conflicts=("automake")
 

--- a/autotools-wrappers/PKGBUILD
+++ b/autotools-wrappers/PKGBUILD
@@ -2,22 +2,17 @@
 
 pkgbase=autotools-wrappers
 pkgname=('automake-wrapper' 'autoconf-wrapper' )
-pkgver=20221207
-pkgrel=3
+pkgver=20240607
+pkgrel=1
 arch=('any')
 license=('spdx:GPL-2.0-only')
 makedepends=('git')
 url="https://gitweb.gentoo.org/proj/autotools-wrappers.git/"
-_commit="afe80def609c91d72df73837ce2c51fed8b69f28" # at-20221207
-source=("git+https://anongit.gentoo.org/git/proj/autotools-wrappers.git#commit=${_commit}"
-        "0001-bump-latest-autoconf-version.patch")
-sha256sums=('SKIP'
-            'facedfdd9a3520e58fb040d314dd64edc00c6e0e30dbcedb8dce20b347d6e73d')
+source=("git+https://anongit.gentoo.org/git/proj/autotools-wrappers.git#tag=at-${pkgver}")
+sha256sums=('79b07d06d8ea429a09719f57fce3d562dd92d00be4578ae0070af54408aada60')
 
 prepare() {
   cd "${srcdir}/${pkgbase}"
-
-  patch -Np1 -i "${srcdir}/0001-bump-latest-autoconf-version.patch"
 }
 
 package_automake-wrapper() {


### PR DESCRIPTION
This package is based on automake1.16
Difference between automake1.17 and 1.16
- Rename `README.am17` to `README.am1.17`
- Add more `checkdepends`

If you're not satisfied with any changes I've made, feel free to leave feedback.