### PR TITLE
fish PKGBUILD: remove ancient dependencies

### DIFF
--- a/fish/PKGBUILD
+++ b/fish/PKGBUILD
@@ -11,7 +11,7 @@ msys2_references=(
 )
 license=('GPL2')
 groups=()
-depends=('gcc-libs' 'gettext' 'libiconv' 'libpcre2_16' 'man-db' 'ncurses')
+depends=('gcc-libs' 'gettext' 'libpcre2_16' 'man-db' 'ncurses')
 makedepends=('gcc' 'gettext-devel' 'intltool' 'ncurses-devel' 'pcre2-devel' 'cmake')
 optdepends=('python: for manual page completion parser and web configuration tool')
 install=fish.install

--- a/fish/PKGBUILD
+++ b/fish/PKGBUILD
@@ -11,8 +11,8 @@ msys2_references=(
 )
 license=('GPL2')
 groups=()
-depends=('bc' 'gcc-libs' 'gettext' 'libiconv' 'libpcre2_16' 'man-db' 'ncurses')
-makedepends=('doxygen' 'gcc' 'gettext-devel' 'intltool' 'libiconv-devel' 'ncurses-devel' 'pcre2-devel' 'cmake')
+depends=('gcc-libs' 'gettext' 'libiconv' 'libpcre2_16' 'man-db' 'ncurses')
+makedepends=('gcc' 'gettext-devel' 'intltool' 'ncurses-devel' 'pcre2-devel' 'cmake')
 optdepends=('python: for manual page completion parser and web configuration tool')
 install=fish.install
 backup=('etc/fish/config.fish' 'etc/fish/msys2.fish' 'etc/fish/perlbin.fish')

--- a/fish/PKGBUILD
+++ b/fish/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=fish
 pkgver=3.7.1
-pkgrel=1
+pkgrel=2
 epoch=
 pkgdesc='Smart and user friendly shell intended mostly for interactive use'
 arch=('i686' 'x86_64')


### PR DESCRIPTION
There are a number of very old dependencies listed here, which should be able to be removed without any change in the function of the final binary.