### PR TITLE
gnutls: Update to 3.8.7

### DIFF
--- a/gnutls/PKGBUILD
+++ b/gnutls/PKGBUILD
@@ -24,8 +24,8 @@ makedepends=('gtk-doc'
              'libtasn1-devel'
              'libunistring-devel'
              'zlib-devel')
-source=(https://gnupg.org/ftp/gcrypt/gnutls/v${pkgver%.*}/${pkgname}-${pkgver}.tar.xz{,.sig})
-sha256sums=('fe302f2b6ad5a564bcb3678eb61616413ed5277aaf8e7bf7cdb9a95a18d9f477'
+source=(https://gnupg.org/ftp/gcrypt/gnutls/v${pkgver%.*}/${pkgname}-${pkgver}.1.tar.xz{,.sig})
+sha256sums=('9ca0ddaccce28a74fa18d738744190afb3b0daebef74e6ad686bf7bef99abd60'
             'SKIP')
 validpgpkeys=('0424D4EE81A0E3D119C6F835EDA21E94B565716F' # "Simon Josefsson <simon@josefsson.org>"
               '1F42418905D8206AA754CCDC29EE58B996865171' # "Nikos Mavrogiannopoulos <nmav@gnutls.org>

--- a/gnutls/PKGBUILD
+++ b/gnutls/PKGBUILD
@@ -2,8 +2,7 @@
 
 pkgbase=gnutls
 pkgname=('gnutls' 'libgnutls' 'libgnutls-devel')
-_base_ver=3.8.6
-pkgver=${_base_ver}
+pkgver=3.8.7
 pkgrel=1
 pkgdesc="A library which provides a secure layer over a reliable transport layer"
 arch=('x86_64' 'i686')
@@ -25,8 +24,8 @@ makedepends=('gtk-doc'
              'libtasn1-devel'
              'libunistring-devel'
              'zlib-devel')
-source=(https://gnupg.org/ftp/gcrypt/gnutls/v${_base_ver%.*}/${pkgname}-${pkgver}.tar.xz{,.sig})
-sha256sums=('2e1588aae53cb32d43937f1f4eca28febd9c0c7aa1734fc5dd61a7e81e0ebcdd'
+source=(https://gnupg.org/ftp/gcrypt/gnutls/v${pkgver%.*}/${pkgname}-${pkgver}.tar.xz{,.sig})
+sha256sums=('fe302f2b6ad5a564bcb3678eb61616413ed5277aaf8e7bf7cdb9a95a18d9f477'
             'SKIP')
 validpgpkeys=('0424D4EE81A0E3D119C6F835EDA21E94B565716F' # "Simon Josefsson <simon@josefsson.org>"
               '1F42418905D8206AA754CCDC29EE58B996865171' # "Nikos Mavrogiannopoulos <nmav@gnutls.org>
@@ -34,15 +33,13 @@ validpgpkeys=('0424D4EE81A0E3D119C6F835EDA21E94B565716F' # "Simon Josefsson <sim
               '5D46CB0F763405A7053556F47A75A648B3F9220C') # Zoltan Fridrich <zfridric at redhat.com>
 
 prepare() {
-  cd "${srcdir}"/${pkgname}-${_base_ver}
+  cd "${srcdir}"/${pkgname}-${pkgver}
 
   autoreconf -vfi
 }
 
 build() {
-  cd "${srcdir}/${pkgname}-${_base_ver}"
-
-  export gl_cv_have_weak=no
+  cd "${srcdir}/${pkgname}-${pkgver}"
 
   local CYGWIN_CHOST="${CHOST/-msys/-cygwin}"
   ./configure \
@@ -61,7 +58,7 @@ build() {
 }
 
 check() {
-  cd "${srcdir}"/${pkgname}-${_base_ver}
+  cd "${srcdir}"/${pkgname}-${pkgver}
   #make check
 }
 


### PR DESCRIPTION
the weak symbol check has been updated, so remove the workaround