### PR TITLE
mercurial: Update to 6.8.1

### DIFF
--- a/mercurial/PKGBUILD
+++ b/mercurial/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=mercurial
-pkgver=6.7.4
-pkgrel=4
+pkgver=6.8.1
+pkgrel=1
 pkgdesc="A scalable distributed SCM tool"
 arch=('i686' 'x86_64')
 url="https://www.mercurial-scm.org/"
@@ -24,14 +24,15 @@ makedepends=(
 backup=('etc/mercurial/hgrc')
 source=("https://mercurial-scm.org/release/${pkgname}-${pkgver}.tar.gz"{,.asc}
         'mercurial.profile')
-sha256sums=('74708f873405c12272fec116c6dd52862e8ed11c10011c7e575f5ea81263ea5e'
+sha256sums=('030e8a7a6d590e4eaeb403ee25675615cd80d236f3ab8a0b56dcc84181158b05'
             'SKIP'
             '87427151713e689cd87dc50d50c048e0e58285815e4eb61962b50583532cbde5')
 validpgpkeys=(2BCCE14F5C6725AA2EA8AEB7B9C9DC824AA5BDD5
               3A8155163D0E20A530FCB78647A67FFAA346AACE
               EB851395B4223EE2F7BA0B28DA54740BF08732BA
               818D87CD1AC180C394C86E633A33DE460D9EC39F  # Pulkit Goyal <7895pulkit@gmail.com>
-              1F66F8CDF654E905C11DA061A11E01CD0E05D956) # Raphaël Gomès <alphare@raphaelgomes.dev>
+              1F66F8CDF654E905C11DA061A11E01CD0E05D956  # Raphaël Gomès <alphare@raphaelgomes.dev>
+              ED213E486B23249BDC107B5945CAA92A71CA027B) # Pierre-Yves David <pierre-yves.david@ens-lyon.org>
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"


### PR DESCRIPTION
pgp key see: https://lists.mercurial-scm.org/pipermail/mercurial-packaging/2024-August/000737.html

Fixes https://github.com/msys2/MSYS2-packages/issues/4836