### PR TITLE
msys2-w32api: remove dependency on mingw-w64-cross-gcc

### DIFF
--- a/msys2-w32api-headers/PKGBUILD
+++ b/msys2-w32api-headers/PKGBUILD
@@ -2,13 +2,18 @@
 
 pkgname="msys2-w32api-headers"
 pkgver=12.0.0.r0.g819a6ec2e
-pkgrel=1
+pkgrel=2
 pkgdesc="Win32 API headers for MSYS2 32bit toolchain"
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
 license=('custom')
 depends=()
-makedepends=('git' 'mingw-w64-cross-gcc' 'autotools')
+makedepends=('git' 'autotools')
+if [[ "${CARCH}" == 'i686' ]]; then
+  makedepends+=('mingw-w64-cross-mingw32-gcc')
+else
+  makedepends+=('mingw-w64-cross-mingw64-gcc')
+fi
 options=('staticlibs' '!buildflags')
 _commit='819a6ec2ea87c19814b287e21d65e0dc7f05abba'
 source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit"

--- a/msys2-w32api-runtime/PKGBUILD
+++ b/msys2-w32api-runtime/PKGBUILD
@@ -2,14 +2,19 @@
 
 pkgname="msys2-w32api-runtime"
 pkgver=12.0.0.r0.g819a6ec2e
-pkgrel=1
+pkgrel=2
 pkgdesc="Win32 API import libs for MSYS2 toolchain"
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
 license=('custom')
 depends=('msys2-w32api-headers')
 options=('staticlibs' '!strip' '!buildflags')
-makedepends=('git' 'mingw-w64-cross-gcc' 'autotools')
+makedepends=('git' 'autotools')
+if [[ "${CARCH}" == 'i686' ]]; then
+  makedepends+=('mingw-w64-cross-mingw32-gcc')
+else
+  makedepends+=('mingw-w64-cross-mingw64-gcc')
+fi
 _commit='819a6ec2ea87c19814b287e21d65e0dc7f05abba'
 source=('mingw-w64'::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit")
 sha256sums=('41878f44fe3b6c347fc99ab8a90d384f61bd3ae25cfb2a62a7e24d4f0d14f720')


### PR DESCRIPTION
Instead depend on only the cross compiler that is needed.