### PR TITLE
mc: update to 4.8.32 and fix version bug

### DIFF
--- a/mc/0003-vfs-win32-absolute-paths.patch
+++ b/mc/0003-vfs-win32-absolute-paths.patch
@@ -1,6 +1,6 @@
---- lib/vfs/path.c.orig	2020-07-05 21:35:07.000000000 +0200
-+++ lib/vfs/path.c	2020-08-27 14:41:35.802799500 +0200
-@@ -142,11 +142,19 @@
+--- lib/vfs/path.c.orig	2024-08-23 13:22:35.000000000 -0400
++++ lib/vfs/path.c	2024-08-31 14:35:28.694195900 -0400
+@@ -147,12 +147,20 @@
  
      if (!IS_PATH_SEP (*path))
      {
@@ -8,7 +8,6 @@
 -
          char *local;
  
--        if (g_str_has_prefix (path, VFS_ENCODING_PREFIX))
 +        if (path[0] != NULL && isalpha (path[0]) &&
 +            path[1] != NULL && path[1] == ':' &&
 +            IS_PATH_SEP (path[2]))
@@ -19,13 +18,19 @@
 +            local[1] = local[0];
 +            local[0] = local[2];
 +        }
+ #ifdef HAVE_CHARSET
+-        if (g_str_has_prefix (path, VFS_ENCODING_PREFIX))
 +        else if (g_str_has_prefix (path, VFS_ENCODING_PREFIX))
          {
              /*
                 encoding prefix placed at start of string without the leading slash
-@@ -156,6 +164,8 @@
+@@ -160,9 +168,11 @@
+              */
+             local = mc_build_filename (PATH_SEP_STR, path, (char *) NULL);
          }
-         else
+-        else
+ #endif
++        else
          {
 +            /* Relative to current directory */
 +

--- a/mc/PKGBUILD
+++ b/mc/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=mc
-pkgver=4.8.31
+pkgver=4.8.32
 pkgrel=1
 pkgdesc="Midnight Commander is a text based filemanager/shell that emulates Norton Commander"
 arch=('i686' 'x86_64')
@@ -32,21 +32,24 @@ source=(${pkgname}-${pkgver}.tar.gz::"https://github.com/MidnightCommander/${pkg
         4.7.5.2-ncursesw-term.h.patch
         mc-4.8.19-msys2.patch
         0003-vfs-win32-absolute-paths.patch)
-sha256sums=('53be761b505f539ab1ba5d112734628667b8abb06de75a04953b0ffce71548b7'
+sha256sums=('5b8e6a66b53f67a430296e3e490c00af17cbbb449f6c56f406ff02a11d516ba1'
             '49e9a7d918088c8760b0090e99cd6257fa56efa3a4d3e6c9166270cda9c2e8e3'
             '513a015f237a6907bbbf92bcc13351d831740163a0b8a508a99ba647dea64981'
-            'dad59dada28d12d262389b23b7972703cb75da48e95f90102a9c30fc2174521a')
+            'fc33fcde6ead0406df9df2292804bd5f2d18fb05fc8b51a827f6abb1f6266b54')
 noextract=(${pkgname}-${pkgver}.tar.gz)
 
 prepare() {
   [[ -d ${srcdir}/${pkgname}-${pkgver} ]] && rm -rf ${srcdir}/${pkgname}-${pkgver}
   tar -xzf ${srcdir}/${pkgname}-${pkgver}.tar.gz -C ${srcdir} || true
-  
+
   cd "${srcdir}/${pkgname}-${pkgver}"
   cp -f doc/{INSTALL,NEWS,README} .
-  
+
+  sed -i "s/CURR_MC_VERSION=.*/CURR_MC_VERSION=${pkgver}/" version.sh
+  sed -i "s/SHOR_MC_VERSION=.*/SHOR_MC_VERSION=${pkgver}/" version.sh
+
   ./autogen.sh
-  
+
   patch -Np2 -i "${srcdir}/4.7.5.2-ncursesw-term.h.patch"
   patch -Np1 -i "${srcdir}/mc-4.8.19-msys2.patch"
   patch -Np0 -i "${srcdir}/0003-vfs-win32-absolute-paths.patch"

--- a/mc/PKGBUILD
+++ b/mc/PKGBUILD
@@ -45,6 +45,7 @@ prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   cp -f doc/{INSTALL,NEWS,README} .
 
+  # work around version.sh git repo dependencies so mc gets a version number
   sed -i "s/CURR_MC_VERSION=.*/CURR_MC_VERSION=${pkgver}/" version.sh
   sed -i "s/SHOR_MC_VERSION=.*/SHOR_MC_VERSION=${pkgver}/" version.sh
 


### PR DESCRIPTION
Updated mc to version 4..8.32, including updated absolute-paths patch to account for added preprocessor directives.

Also worked around existing issue where mc gets built without version info (verifiable with a `mc --version` or by looking at its F1 help dialog.  There's a versioning script that depends on some magic from the mc git repository, so I added a replacement to force the downloaded package version on it.  If there's a better way to get that info from PKGBUILD to the build process, do let me know.