### PR TITLE
mingw-w64-cross-headers: add aarch64 variant

### DIFF
--- a/mingw-w64-cross-headers/PKGBUILD
+++ b/mingw-w64-cross-headers/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=headers
 _mingw_suff=mingw-w64-cross
 pkgbase="${_mingw_suff}-${_realname}"
-_targetpkgs=("${_mingw_suff}-ucrt64-${_realname}" "${_mingw_suff}-mingw32-${_realname}" "${_mingw_suff}-mingw64-${_realname}")
+_targetpkgs=("${_mingw_suff}-mingwarm64-${_realname}" "${_mingw_suff}-ucrt64-${_realname}" "${_mingw_suff}-mingw32-${_realname}" "${_mingw_suff}-mingw64-${_realname}")
 pkgname=("${_mingw_suff}-${_realname}" "${_targetpkgs[@]}")
 pkgver=12.0.0.r0.g819a6ec2e
 pkgrel=4
@@ -37,6 +37,9 @@ _build() {
   if [[ "${_target}" == "x86_64-w64-mingw32ucrt" ]]; then
     _default_msvcrt=ucrt
     _default_win32_winnt=0x603  # Windows 8.1
+  elif [[ "${_target}" == "aarch64-w64-mingw32" ]]; then
+    _default_msvcrt=ucrt
+    _default_win32_winnt=0xA00  # Windows 10
   else
     _default_msvcrt=msvcrt
     _default_win32_winnt=0x601  # Windows 7
@@ -70,6 +73,7 @@ build() {
       "${_mingw_suff}-ucrt64-${_realname}") _build "x86_64-w64-mingw32ucrt" ;;
       "${_mingw_suff}-mingw32-${_realname}") _build "i686-w64-mingw32" ;;
       "${_mingw_suff}-mingw64-${_realname}") _build "x86_64-w64-mingw32" ;;
+      "${_mingw_suff}-mingwarm64-${_realname}") _build "aarch64-w64-mingw32" ;;
     esac
   done
 }
@@ -95,4 +99,9 @@ package_mingw-w64-cross-mingw32-headers() {
 package_mingw-w64-cross-mingw64-headers() {
   conflicts=("${_mingw_suff}-${_realname}<=12.0.0.r0.g819a6ec2e-1")
   _package "x86_64-w64-mingw32"
+}
+
+package_mingw-w64-cross-mingwarm64-headers() {
+  conflicts=("${_mingw_suff}-${_realname}<=12.0.0.r0.g819a6ec2e-1")
+  _package "aarch64-w64-mingw32"
 }


### PR DESCRIPTION
default to ucrt/win10 like we do for clangarm64