### PR TITLE
mingw-w64-cross-headers: split out mingwarm64

### DIFF
--- a/mingw-w64-cross-mingwarm64-headers/PKGBUILD
+++ b/mingw-w64-cross-mingwarm64-headers/PKGBUILD
@@ -3,32 +3,26 @@
 
 _realname=headers
 _mingw_suff=mingw-w64-cross
-pkgbase="${_mingw_suff}-${_realname}"
-_targetpkgs=("${_mingw_suff}-ucrt64-${_realname}" "${_mingw_suff}-mingw32-${_realname}" "${_mingw_suff}-mingw64-${_realname}")
-pkgname=("${_mingw_suff}-${_realname}" "${_targetpkgs[@]}")
-pkgver=12.0.0.r250.gc6bf4bdf6
+pkgbase="${_mingw_suff}-mingwarm64-${_realname}"
+_targetpkgs=("${_mingw_suff}-mingwarm64-${_realname}")
+pkgname=("${_targetpkgs[@]}")
+pkgver=12.0.0dev
 pkgrel=1
 pkgdesc="MinGW-w64 headers for cross-compiler"
 arch=('i686' 'x86_64')
 url="https://www.mingw-w64.org/"
-msys2_repository_url="https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-headers"
+msys2_repository_url="https://github.com/Windows-on-ARM-Experiments/mingw-woarm64"
 license=('custom')
 groups=("${_mingw_suff}-toolchain" "${_mingw_suff}")
 makedepends=('git' 'autotools')
 options=('!strip' '!libtool' '!emptydirs' '!buildflags')
-_commit='c6bf4bdf6572bfd530833ebd7e2dccb1133b602d'
-source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit")
-sha256sums=('3aafb8dadd7285254b9f6862bc359e99485c578d5bfb7ad9cad7d958547db291')
+_commit='bd5721da140a6a209e1ca53a2a0a207ac9ec9b0e'
+source=("mingw-w64"::"git+https://github.com/Windows-on-ARM-Experiments/mingw-woarm64.git#commit=$_commit")
+sha256sums=('165da7d2618f08859dfe3f2875845d8a73205d768aa79eb7f39a2d3685fbe98d')
 msys2_references=(
   'archlinux: mingw-w64-headers'
   'cpe: cpe:/a:mingw-w64:mingw-w64'
 )
-
-pkgver() {
-  cd "${srcdir}/mingw-w64"
-
-  git describe --long ${_commit} | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
-}
 
 _build() {
   _target=$1
@@ -78,25 +72,7 @@ build() {
   done
 }
 
-package_mingw-w64-cross-headers() {
-  pkgdesc+=" (meta package, for backward compatibility)"
-  provides=("${_mingw_suff}-${_realname}-git")
-  conflicts=("${_mingw_suff}-${_realname}-git")
-  replaces=("${_mingw_suff}-${_realname}-git")
-  depends=("${_targetpkgs[@]}")
-}
-
-package_mingw-w64-cross-ucrt64-headers() {
+package_mingw-w64-cross-mingwarm64-headers() {
   conflicts=("${_mingw_suff}-${_realname}<=12.0.0.r0.g819a6ec2e-1")
-  _package "x86_64-w64-mingw32ucrt"
-}
-
-package_mingw-w64-cross-mingw32-headers() {
-  conflicts=("${_mingw_suff}-${_realname}<=12.0.0.r0.g819a6ec2e-1")
-  _package "i686-w64-mingw32"
-}
-
-package_mingw-w64-cross-mingw64-headers() {
-  conflicts=("${_mingw_suff}-${_realname}<=12.0.0.r0.g819a6ec2e-1")
-  _package "x86_64-w64-mingw32"
+  _package "aarch64-w64-mingw32"
 }


### PR DESCRIPTION
We need to use the fork, so we can either backport patches, or keep things simple and use a different source for the mingwarm64 variant, which this tries to do.