### PR TITLE
libssh: update to 0.11.1

### DIFF
--- a/libssh/PKGBUILD
+++ b/libssh/PKGBUILD
@@ -1,6 +1,6 @@
 pkgbase=libssh
 pkgname=('libssh' 'libssh-devel')
-pkgver=0.11.0
+pkgver=0.11.1
 pkgrel=1
 pkgdesc='Library for accessing ssh client services through C libraries'
 url='https://www.libssh.org/'
@@ -12,20 +12,11 @@ license=('spdx:LGPL-2.1+')
 arch=('i686' 'x86_64')
 depends=('zlib' 'libopenssl')
 makedepends=('cmake' 'python' 'openssl-devel' 'gcc' 'zlib-devel')
-source=("https://www.libssh.org/files/${pkgver%.*}/$pkgname-$pkgver.tar.xz"{,.asc}
-        "https://gitlab.com/libssh/libssh-mirror/-/merge_requests/526.patch")
-sha256sums=('860e814579e7606f3fc3db98c5807bef2ab60f793ec871d81bcd23acdcdd3e91'
-            'SKIP'
-            '0933e3e3367adaafea01858eafd8aa240fcaf5c2c2b6a4fdc58ab3c06ce980f1')
+source=("https://www.libssh.org/files/${pkgver%.*}/$pkgname-$pkgver.tar.xz"{,.asc})
+sha256sums=('14b7dcc72e91e08151c58b981a7b570ab2663f630e7d2837645d5a9c612c1b79'
+            'SKIP')
 validpgpkeys=('8DFF53E18F2ABC8D8F3C92237EE0FC4DCC014E3D'  # Andreas Schneider <asn@cryptomilk.org>
               '88A228D89B07C2C77D0C780903D5DF8CFDD3E8E7') # libssh release key (release key) <libssh@libssh.org>
-
-prepare() {
-  cd $pkgname-$pkgver
-
-  # https://gitlab.com/libssh/libssh-mirror/-/merge_requests/526
-  patch -Np1 -i ../526.patch
-}
 
 build() {
   mkdir -p build && cd build


### PR DESCRIPTION
Patch applied upstream and no longer needed here.