### PR TITLE
openssl: Update to 3.3.2

### DIFF
--- a/ncurses/PKGBUILD
+++ b/ncurses/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=ncurses
 pkgname=('ncurses' 'ncurses-devel')
 pkgver=6.5
-pkgrel=1
+pkgrel=2
 pkgdesc="System V Release 4.0 curses emulation library"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/ncurses/"

--- a/ncurses/PKGBUILD
+++ b/ncurses/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=ncurses
 pkgname=('ncurses' 'ncurses-devel')
 pkgver=6.5
-pkgrel=2
+pkgrel=1
 pkgdesc="System V Release 4.0 curses emulation library"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/ncurses/"

--- a/openssl/PKGBUILD
+++ b/openssl/PKGBUILD
@@ -1,35 +1,32 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=('openssl' 'libopenssl' 'openssl-devel' 'openssl-docs')
-pkgver=3.3.1
+pkgver=3.3.2
 pkgrel=1
 pkgdesc='The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
 arch=('i686' 'x86_64')
-url='https://www.openssl.org'
+url='https://openssl-library.org'
+msys2_repository_url="https://github.com/openssl/openssl"
 msys2_references=(
   "cpe: cpe:/a:openssl:openssl"
 )
 license=('spdx:Apache-2.0')
 makedepends=('gcc' 'tar' 'perl' 'diffutils' 'nasm')
 noextract=(${pkgname}-${pkgver}.tar.gz)
-source=("https://www.openssl.org/source/${pkgname}-${pkgver}.tar.gz"{,.asc}
+source=("https://github.com/openssl/openssl/releases/download/${pkgname}-${pkgver}/${pkgname}-${pkgver}.tar.gz"{,.asc}
         '0001-Use-usr-ssl-as-ca-dir-instead-of-.-demoCA.patch'
         '0002-Support-MSYS2.patch'
         '0004-Override-engines-directory.patch'
         '0005-skip-dllmain-detach.patch')
-sha256sums=('777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e'
+sha256sums=('2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281'
             'SKIP'
             '7ff3213d8d085238695f076d254f16d15b16a9baca1f9393c1bed0057006da2c'
             'b73a45cf26830bbb3c110a8f9e042ea5c71a9627204d5d172b04c43aff5b0f1a'
             '345350546bf55dd069133e0c56b2c5f7e037db237a30f7ad38159bd61b6d4daf'
             '79b56c97da803493eb9bbc04dc67ddf3662a8486efb9ec7b15e668b8c0fa4e0f')
-# https://www.openssl.org/community/otc.html
+# https://openssl-library.org/source/index.html
 validpgpkeys=(
-  '8657ABB260F056B1E5190839D9C4D26D0E604491' # Matt Caswell <matt@openssl.org>
-  '7953AC1FBC3DC8B3B292393ED5E9E43F7DF9EE8C' # Richard Levitte <richard@levitte.org>
-  'A21FAB74B0088AA361152586B8EF1A6BA9DA2D5C' # Tomáš Mráz <tm@t8m.info>
-  'B7C1C14360F353A36862E4D5231C84CDDCC69C45' # Paul Dale <pauli@openssl.org>
-  'EFC0A467D613CB83C7ED6D30D894E2CE8B3D79F5' # OpenSSL security team <openssl-security@openssl.org>
+  'BA5473A2B0587B07FB27CF2D216094DFD0CB81EF' # openssl@openssl.org
 )
 
 prepare() {


### PR DESCRIPTION
new domain and new signing key (see https://openssl-library.org/source/index.html) and sources are now only hosted on github