### PR TITLE
ncurses: update to 6.5-20240831,enable term-driver

### DIFF
--- a/ncurses/PKGBUILD
+++ b/ncurses/PKGBUILD
@@ -2,7 +2,9 @@
 
 pkgbase=ncurses
 pkgname=('ncurses' 'ncurses-devel')
-pkgver=6.5
+_base_ver=6.5
+_date_rev=20240831
+pkgver=${_base_ver}.${_date_rev}
 pkgrel=1
 pkgdesc="System V Release 4.0 curses emulation library"
 arch=('i686' 'x86_64')
@@ -14,18 +16,17 @@ msys2_references=(
 )
 license=('spdx:MIT')
 makedepends=('autotools' 'gcc')
-source=(#"${pkgbase}-${pkgver}.tar.gz"::"https://invisible-mirror.net/archives/ncurses/current/${pkgbase}-${_basever}-${_date}.tgz"
-        https://ftp.gnu.org/pub/gnu/ncurses/ncurses-${pkgver}.tar.gz{,.sig}
+source=(https://invisible-island.net/archives/ncurses/current/${pkgbase}-${_base_ver}-${_date_rev}.tgz{,.asc}
         "ncurses-6.3-pkgconfig.patch"
         "ncurses-6.3-cflags-private.patch")
-sha256sums=('136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6'
+sha256sums=('685161fec9c20c0896f6d7569f8d1cba9124a1884d3d8be527253a773b787577'
             'SKIP'
             'b8544a607dfbeffaba2b087f03b57ed1fa81286afca25df65f61b04b5f3b3738'
             '3107029dfb807e338d34641d78329cd6725c58e6b873352621f4b9611a8380bf')
-validpgpkeys=('19882D92DDA4C400C22C0D56CC2AF4472167BE03')
+validpgpkeys=('19882D92DDA4C400C22C0D56CC2AF4472167BE03')  # "Thomas E. Dickey (self-signed w/o SHA1) <dickey@invisible-island.net>"
 
 prepare() {
-  cd ${srcdir}/${pkgbase}-${pkgver}
+  cd ${srcdir}/${pkgbase}-${_base_ver}-${_date_rev}
 
   # do not leak build-time LDFLAGS into the pkgconfig files:
   # https://bugs.archlinux.org/task/68523
@@ -35,7 +36,7 @@ prepare() {
 }
 
 build() {
-  cd ${srcdir}/${pkgbase}-${pkgver}
+  cd ${srcdir}/${pkgbase}-${_base_ver}-${_date_rev}
 
   ./configure \
     --build=${CHOST} \
@@ -55,7 +56,7 @@ build() {
     --enable-sp-funcs \
     --with-wrap-prefix=ncwrap_ \
     --enable-sigwinch \
-    --disable-term-driver \
+    --enable-term-driver \
     --enable-colorfgbg \
     --enable-tcap-names \
     --disable-termcap \
@@ -71,8 +72,8 @@ build() {
     --with-build-cflags=-D_XOPEN_SOURCE_EXTENDED \
     --with-pkg-config-libdir=/usr/lib/pkgconfig
 
-  make
-  make DESTDIR=${srcdir}/dest install
+  make -j$(nproc)
+  make -j$(nproc) DESTDIR=${srcdir}/dest install
 }
 
 package_ncurses() {
@@ -86,7 +87,7 @@ package_ncurses() {
   cp -rf $srcdir/dest/usr/share ${pkgdir}/usr/
 
   # install license, rip it from the readme
-  cd ${srcdir}/${pkgname}-${pkgver}
+  cd ${srcdir}/${pkgname}-${_base_ver}-${_date_rev}
   install -dm755 ${pkgdir}/usr/share/licenses/${pkgname}
   grep -B 100 '$Id' README > ${pkgdir}/usr/share/licenses/${pkgname}/license.txt
 }

--- a/ncurses/PKGBUILD
+++ b/ncurses/PKGBUILD
@@ -72,8 +72,8 @@ build() {
     --with-build-cflags=-D_XOPEN_SOURCE_EXTENDED \
     --with-pkg-config-libdir=/usr/lib/pkgconfig
 
-  make -j$(nproc)
-  make -j$(nproc) DESTDIR=${srcdir}/dest install
+  make
+  make DESTDIR=${srcdir}/dest install
 }
 
 package_ncurses() {


### PR DESCRIPTION
Update to the current dev version, as the last stable release was already two years ago.

This patch set includes a patch to enable the term-driver support for the Win32 console with TERM='#win32con' on the Cygwin runtime, like it does for MinGW, which does not require a terminfo database.

This does not change the regular terminfo-based functionality of ncurses otherwise.

You can verify that this works by running an ncurses program with TERM='#win32con' in a Windows Terminal session or similar. For example this one:

https://github.com/mtoyoda/sl
.