### PR TITLE
winpty: makedep only on the needed cross compiler

### DIFF
--- a/winpty/PKGBUILD
+++ b/winpty/PKGBUILD
@@ -6,18 +6,17 @@
 _realname=winpty
 pkgname="${_realname}"
 pkgver=0.4.3
-pkgrel=2
+pkgrel=3
 pkgdesc="A Windows software package providing an interface similar to a Unix pty-master for communicating with Windows console programs"
 arch=('i686' 'x86_64')
 url="https://github.com/rprichard/winpty"
 license=('MIT')
-
-# Explicitly reference the git version of the indirect dependency mingw-w64-cross-crt
-# for avoiding problems with its default provider mingw-w64-cross-crt-clang-git
-makedepends=(git tar 'autotools' xz gcc
-             mingw-w64-cross-gcc
-             mingw-w64-cross-crt)
-
+makedepends=(tar 'autotools' xz gcc)
+if [[ "${CARCH}" == 'i686' ]]; then
+  makedepends+=('mingw-w64-cross-mingw32-gcc')
+else
+  makedepends+=('mingw-w64-cross-mingw64-gcc')
+fi
 #depends=( "ncurses-devel" )
 replaces=("winpty-git")
 options=('staticlibs' 'strip')


### PR DESCRIPTION
and remove an outdated comment, the -git variants are gone