### PR TITLE
curl: Update to 8.10.0

### DIFF
--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=curl
 pkgname=('curl' 'libcurl' 'libcurl-devel')
-pkgver=8.9.1
+pkgver=8.10.0
 pkgrel=1
 pkgdesc="Multi-protocol file transfer utility"
 arch=('i686' 'x86_64')
@@ -21,9 +21,9 @@ makedepends=('brotli-devel' 'heimdal-devel' 'libidn2-devel' 'autotools'
              'libunistring-devel' 'libnghttp2-devel' 'libpsl-devel' 'libssh2-devel' 'openssl-devel' 'zlib-devel' 'libzstd-devel' 'gcc')
 source=("https://github.com/curl/curl/releases/download/${pkgbase}-${pkgver//./_}/${pkgbase}-${pkgver}.tar.xz"{,.asc}
         curl-7.60.0-gssapi-static-libs.patch)
-sha256sums=('f292f6cc051d5bbabf725ef85d432dfeacc8711dd717ea97612ae590643801e5'
+sha256sums=('e6b142f0e85e954759d37e26a3627e2278137595be80e3a860c4353e4335e5a0'
             'SKIP'
-            '2821fcb7238432992e7d99b327b40f08f7fa9823a86c13fa0203975aa3d25359')
+            'f85869319690a7e9b586a9b84d8c7e321f847709dff7572d09482ca3d9b92598')
 validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2')   # Daniel Stenberg
 
 prepare() {

--- a/curl/curl-7.60.0-gssapi-static-libs.patch
+++ b/curl/curl-7.60.0-gssapi-static-libs.patch
@@ -1,6 +1,6 @@
---- curl-7.82.0/configure.ac.orig	2022-04-03 13:21:15.513746700 +0200
-+++ curl-7.82.0/configure.ac	2022-04-03 13:27:03.712294600 +0200
-@@ -1704,15 +1704,15 @@
+--- curl-8.10.0/configure.ac.orig	2024-09-11 10:12:56.742850600 +0200
++++ curl-8.10.0/configure.ac	2024-09-11 10:24:56.074187600 +0200
+@@ -1846,15 +1846,15 @@
    AC_MSG_RESULT(yes)
  
    if test $GSSAPI_ROOT != "/usr"; then
@@ -11,18 +11,17 @@
 +    CURL_CHECK_PKGCONFIG(krb5-gssapi)
    fi
    if test -z "$GSSAPI_INCS"; then
-      if test -n "$host_alias" -a -f "$GSSAPI_ROOT/bin/$host_alias-krb5-config"; then
--        GSSAPI_INCS=`$GSSAPI_ROOT/bin/$host_alias-krb5-config --cflags gssapi`
-+        GSSAPI_INCS=`$GSSAPI_ROOT/bin/$host_alias-krb5-config --deps --libs --cflags gssapi`
-      elif test "$PKGCONFIG" != "no" ; then
--        GSSAPI_INCS=`$PKGCONFIG --cflags mit-krb5-gssapi`
-+        GSSAPI_INCS=`$PKGCONFIG --cflags krb5-gssapi`
-      elif test -f "$KRB5CONFIG"; then
-         GSSAPI_INCS=`$KRB5CONFIG --cflags gssapi`
-      elif test "$GSSAPI_ROOT" != "yes"; then
-@@ -1800,17 +1800,17 @@
+     if test -n "$host_alias" -a -f "$GSSAPI_ROOT/bin/$host_alias-krb5-config"; then
+       GSSAPI_INCS=`$GSSAPI_ROOT/bin/$host_alias-krb5-config --cflags gssapi`
+     elif test "$PKGCONFIG" != "no"; then
+-      GSSAPI_INCS=`$PKGCONFIG --cflags mit-krb5-gssapi`
++      GSSAPI_INCS=`$PKGCONFIG --cflags krb5-gssapi`
+     elif test -f "$KRB5CONFIG"; then
+       GSSAPI_INCS=`$KRB5CONFIG --cflags gssapi`
+     elif test "$GSSAPI_ROOT" != "yes"; then
+@@ -1938,17 +1938,17 @@
          ;;
-      *)
+       *)
          if test $GSSAPI_ROOT != "/usr"; then
 -          CURL_CHECK_PKGCONFIG(mit-krb5-gssapi, $GSSAPI_ROOT/lib/pkgconfig)
 +          CURL_CHECK_PKGCONFIG(krb5-gssapi, $GSSAPI_ROOT/lib/pkgconfig)
@@ -31,14 +30,14 @@
 +          CURL_CHECK_PKGCONFIG(krb5-gssapi)
          fi
          if test -n "$host_alias" -a -f "$GSSAPI_ROOT/bin/$host_alias-krb5-config"; then
-            dnl krb5-config doesn't have --libs-only-L or similar, put everything
-            dnl into LIBS
--           gss_libs=`$GSSAPI_ROOT/bin/$host_alias-krb5-config --libs gssapi`
-+           gss_libs=`$GSSAPI_ROOT/bin/$host_alias-krb5-config --deps --libs gssapi`
-            LIBS="$gss_libs $LIBS"
-         elif test "$PKGCONFIG" != "no" ; then
--           gss_libs=`$PKGCONFIG --libs mit-krb5-gssapi`
-+           gss_libs=`$PKGCONFIG --static --libs krb5-gssapi`
-            LIBS="$gss_libs $LIBS"
+           dnl krb5-config doesn't have --libs-only-L or similar, put everything
+           dnl into LIBS
+-          gss_libs=`$GSSAPI_ROOT/bin/$host_alias-krb5-config --libs gssapi`
++          gss_libs=`$GSSAPI_ROOT/bin/$host_alias-krb5-config --deps --libs gssapi`
+           LIBS="$gss_libs $LIBS"
+         elif test "$PKGCONFIG" != "no"; then
+-          gss_libs=`$PKGCONFIG --libs mit-krb5-gssapi`
++          gss_libs=`$PKGCONFIG --static --libs krb5-gssapi`
+           LIBS="$gss_libs $LIBS"
          elif test -f "$KRB5CONFIG"; then
-            dnl krb5-config doesn't have --libs-only-L or similar, put everything
+           dnl krb5-config doesn't have --libs-only-L or similar, put everything


### PR DESCRIPTION
Refresh the krb patch due to conflicts.
There was one case where it added libs to GSSAPI_INCS which seems weird, so I dropped it from the refresh.