### PR TITLE
Add cmake-bootstrap

### DIFF
--- a/cmake-bootstrap/PKGBUILD
+++ b/cmake-bootstrap/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+_realname=cmake
+pkgname="${_realname}-bootstrap"
+pkgver=3.30.3
+pkgrel=2
+pkgdesc="A cross-platform open-source make system"
+arch=('i686' 'x86_64')
+url="https://www.cmake.org/"
+msys2_repository_url="https://gitlab.kitware.com/cmake/cmake"
+msys2_references=(
+  "anitya: 306"
+  "cpe: cpe:2.3:a:cmake_project:cmake"
+)
+license=(spdx:MIT)
+makedepends=('gcc'
+             'make')
+depends=('gcc-libs')
+conflicts=('cmake' 'cmake-emacs' 'cmake-vim')
+provides=("cmake=$pkgver")
+source=(https://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz)
+sha256sums=('6d5de15b6715091df7f5441007425264bdd477809f80333fdf95f846aaff88e4')
+
+build() {
+  [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
+  mkdir -p ${srcdir}/build-${CARCH}
+  cd ${srcdir}/build-${CARCH}
+
+  "${srcdir}/${_realname}-${pkgver}/configure" \
+    --prefix=/usr \
+    --no-system-libs \
+    --no-qt-gui \
+    --parallel="$(nproc)" \
+    --mandir=share/man \
+    --docdir="share/doc/${_realname}" \
+    --datadir="share/${_realname}"
+
+  make
+}
+
+package() {
+  cd ${srcdir}/build-${CARCH}
+
+  make DESTDIR="${pkgdir}" install
+
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/Copyright.txt \
+    ${pkgdir}/usr/share/licenses/${pkgname}/LICENSE
+}


### PR DESCRIPTION
This adds a bootstrapped cmake, which does not depend on external
libraries and can be used to build makedepends for the real cmake
package which uses external dependencies.

It's mainly useful for bootstrapping.