### PR TITLE
pacman: Restore ja translations

### DIFF
--- a/pacman/0032-Translate-MSYS2-specific-messages-into-Japanese.patch
+++ b/pacman/0032-Translate-MSYS2-specific-messages-into-Japanese.patch
@@ -1,0 +1,47 @@
+From 2eabe53cc265d1a8c86e6621b40ca7250747d7bb Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Tue, 18 Jun 2024 13:50:19 +0900
+Subject: [PATCH 32/N] Translate MSYS2 specific messages into Japanese
+
+---
+ src/pacman/po/ja.po | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/src/pacman/po/ja.po b/src/pacman/po/ja.po
+index cf00c7cd..63e82e17 100644
+--- a/src/pacman/po/ja.po
++++ b/src/pacman/po/ja.po
+@@ -1498,6 +1498,30 @@ msgid "'%s' is a file, did you mean %s instead of %s?\n"
+ msgstr ""
+ "'%s' はファイルです、あなたが行いたいのは %s で %s ではありませんか？\n"
+ 
++#: src/pacman/sync.c:783
++#, c-format
++msgid "Starting core system upgrade...\n"
++msgstr "コアシステムの更新を開始...\n"
++
++#: src/pacman/sync.c:813
++#, c-format
++msgid "terminate other MSYS2 programs before proceeding\n"
++msgstr "続行する前に他の MSYS2 プログラムを終了してください\n"
++
++#: src/pacman/sync.c:818
++#, c-format
++msgid ""
++"To complete this update all MSYS2 processes including this terminal will be "
++"closed. Confirm to proceed"
++msgstr ""
++"更新を完了するために、この端末を含む全ての MSYS2 プロセスが閉じられます。続行"
++"しますか？"
++
++#: src/pacman/sync.c:822
++#, c-format
++msgid "terminating MSYS2 processes failed\n"
++msgstr "MSYS2 プロセスの終了に失敗しました\n"
++
+ #: src/pacman/sync.c:727
+ #, c-format
+ msgid "Starting full system upgrade...\n"
+-- 
+2.45.1
+

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.1.0
-pkgrel=6
+pkgrel=7
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -76,7 +76,8 @@ source=(pacman-${pkgver}::git+https://gitlab.archlinux.org/pacman/pacman.git#com
         0028-Fetch-signature-and-database-from-the-same-URL.patch
         0029-libmakepkg-remove-MAKEFLAGS-from-buildenv_vars.patch
         0030-libmakepkg-do-not-unset-CHOST-with-buildflags.patch
-        0031-repo-add-unconditionally-create-the-database-if-it-i.patch)
+        0031-repo-add-unconditionally-create-the-database-if-it-i.patch
+        0032-Translate-MSYS2-specific-messages-into-Japanese.patch)
 validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@archlinux.org>
               'B8151B117037781095514CA7BBDFFC92306B1121') # Andrew Gregory (pacman) <andrew@archlinux.org>
 sha256sums=('803cba087e713a59866797747c3c63abbc0e4354c45cc2c0467d11e78364d66f'
@@ -114,7 +115,8 @@ sha256sums=('803cba087e713a59866797747c3c63abbc0e4354c45cc2c0467d11e78364d66f'
             '56f660d747241514aee05a497be3924b41d2bf53a0ac77e2d6aee7c718ee7c03'
             '25229ab3f14460d14b58e37984262e26655110d3b2cdee74b345a3ccb8536cf1'
             'c4762de7bb589b5ed84f0474e7a2ba8bf3c6447db153099816cba9cf8cf01cee'
-            'f090e9c042c901c52f13a8639577f3a97fcac20fc4f2c21a27e7d9223f5dfe2c')
+            'f090e9c042c901c52f13a8639577f3a97fcac20fc4f2c21a27e7d9223f5dfe2c'
+            'b267d03ed6fd9fd2087084c35f303f0ece131ae9a2825e5d2764f7e98c6cf505')
 
 apply_git_with_msg() {
   for _patch in "$@"
@@ -161,7 +163,8 @@ prepare() {
   0028-Fetch-signature-and-database-from-the-same-URL.patch \
   0029-libmakepkg-remove-MAKEFLAGS-from-buildenv_vars.patch \
   0030-libmakepkg-do-not-unset-CHOST-with-buildflags.patch \
-  0031-repo-add-unconditionally-create-the-database-if-it-i.patch
+  0031-repo-add-unconditionally-create-the-database-if-it-i.patch \
+  0032-Translate-MSYS2-specific-messages-into-Japanese.patch
 }
 
 build() {


### PR DESCRIPTION
MSYS2-specific Japanese translations were removed in 1915a138c0796740f3eec33308d6d34644e78a86.
Restore them.

See: https://github.com/msys2/msys2-pacman/pull/53