### PR TITLE
ncurses: disable term-driver again to fix regressions

### DIFF
--- a/ncurses/PKGBUILD
+++ b/ncurses/PKGBUILD
@@ -5,7 +5,7 @@ pkgname=('ncurses' 'ncurses-devel')
 _base_ver=6.5
 _date_rev=20240831
 pkgver=${_base_ver}.${_date_rev}
-pkgrel=1
+pkgrel=2
 pkgdesc="System V Release 4.0 curses emulation library"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/ncurses/"
@@ -56,7 +56,7 @@ build() {
     --enable-sp-funcs \
     --with-wrap-prefix=ncwrap_ \
     --enable-sigwinch \
-    --enable-term-driver \
+    --disable-term-driver \
     --enable-colorfgbg \
     --enable-tcap-names \
     --disable-termcap \


### PR DESCRIPTION
It breaks colors with nano for some reason, see
https://github.com/msys2/MSYS2-packages/issues/4945

Fixes #4945