### PR TITLE
libpcap: Update to 1.10.5

### DIFF
--- a/libpcap/PKGBUILD
+++ b/libpcap/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=libpcap
 pkgname=('libpcap' 'libpcap-devel')
-pkgver=1.10.4
+pkgver=1.10.5
 pkgrel=1
 pkgdesc="A portable C/C++ library for network traffic capture"
 arch=('i686' 'x86_64')
@@ -15,7 +15,7 @@ msys2_references=(
 makedepends=('bison' 'cmake' 'flex' 'gcc' 'make' 'openssl-devel')
 source=(https://www.tcpdump.org/release/${pkgname}-${pkgver}.tar.gz
         0003-Disable-man-symlinks.patch)
-sha256sums=('ed19a0383fad72e3ad435fd239d7cd80d64916b87269550159d20e47160ebe5f'
+sha256sums=('37ced90a19a302a7f32e458224a00c365c117905c2cd35ac544b6880a81488f0'
             'cc3e4218937f5c75448ddcb3b09b1ad90c11ca2a01ade1defe900cba60893e8e')
 
 prepare() {
@@ -29,6 +29,7 @@ build() {
   cd build-${pkgbase}-${pkgver}-${CHOST}
   cmake \
     -DCMAKE_INSTALL_PREFIX="/usr" \
+    -DPCAP_TYPE=null \
     ../${pkgbase}-${pkgver}
   make DESTDIR=${srcdir}/dest install
 }


### PR DESCRIPTION
set PCAP_TYPE as suggested by the cmake build error