### PR TITLE
fix: nanorc.nanorc on nano-syntax-highlighting

### DIFF
--- a/nano-syntax-highlighting/001-nanorc.patch
+++ b/nano-syntax-highlighting/001-nanorc.patch
@@ -1,0 +1,12 @@
+diff -Naur a/nanorc.nanorc b/nanorc.nanorc
+--- a/nanorc.nanorc	2020-10-10 16:25:18.000000000 -0300
++++ b/nanorc.nanorc	2024-10-16 13:16:04.816910360 -0300
+@@ -23,7 +23,7 @@
+ icolor brightmagenta " brightmagenta"
+ icolor brightcyan " brightcyan"
+ icolor brightwhite " brightwhite"
+-icolor brightnormal " brightnormal"
++# icolor brightnormal " brightnormal"
+ icolor ,black ",black "
+ icolor ,red ",red "
+ icolor ,green ",green "

--- a/nano-syntax-highlighting/PKGBUILD
+++ b/nano-syntax-highlighting/PKGBUILD
@@ -4,7 +4,7 @@ pkgname=nano-syntax-highlighting
 conflicts=(${pkgname}-git)
 replaces=(${pkgname}-git)
 pkgver=2020.10.10
-pkgrel=3
+pkgrel=4
 pkgdesc="Nano editor syntax highlighting enhancements"
 arch=('any')
 depends=('nano')
@@ -12,14 +12,19 @@ url="https://github.com/scopatz/nanorc"
 license=('custom')
 install=nano-syntax-highlighting.install
 source=(https://github.com/scopatz/nanorc/releases/download/2020.10.10/nanorc-${pkgver}.tar.gz
+        '001-nanorc.patch'
         'nanorc.sample')
 sha256sums=('cd674e9eb230e4ba306b418c22d1891d93a3d2ffdf22234748d3398da50dfe64'
+            'd2eef37e950239e9c2d554fe058a1e06077513657bd19c3e4544dcb63b04b15d'
             '173e76e537261fc3633954e4ad4f807576f7cf2fc82edfdae205a721021bc805')
 noextract=(nanorc-${pkgver}.tar.gz)
 
 prepare() {
   [[ -d ${srcdir}/nanorc-${pkgver} ]] && rm -rf ${srcdir}/nanorc-${pkgver}
   tar -xzf ${srcdir}/nanorc-${pkgver}.tar.gz -C $srcdir || true
+
+  cd ${srcdir}/nanorc-${pkgver}
+  patch -Np1 -i ${srcdir}/001-nanorc.patch
 }
 
 package() {

--- a/nano-syntax-highlighting/PKGBUILD
+++ b/nano-syntax-highlighting/PKGBUILD
@@ -24,6 +24,7 @@ prepare() {
   tar -xzf ${srcdir}/nanorc-${pkgver}.tar.gz -C $srcdir || true
 
   cd ${srcdir}/nanorc-${pkgver}
+  # https://github.com/scopatz/nanorc/issues/410
   patch -Np1 -i ${srcdir}/001-nanorc.patch
 }
 


### PR DESCRIPTION
## Description

There is a mistake in the package ```nano-syntax-highlighting```, specifically at line 26 in the file ```/usr/share/nano-syntax-highlighting/nanorc.nanorc``` (brightnormal is not allowed as icolor).

This issue has been reported a few times upstream, and it is also cited on [arch wiki](https://wiki.archlinux.org/title/Nano#Syntax_highlighting), but maintainer seems to be unreachable (his last github activity was mid 2023).

## Solution

Even though arch wiki says to replace 'brightnormal' with 'normal', it would redefine icolor normal, which
was defined a few lines above on that file. Instead, I decided to keep the original value defined earlier.

Then, I just commented that offending line.

## Reproduction

1. Install the package ```nano-syntax-highlighting```:

```bash
pacman -S nano-syntax-highlighting
```

2. Open the file ```/usr/share/nano-syntax-highlighting/nanorc.nanorc``` with ```nano```
```bash
nano /usr/share/nano-syntax-highlighting/nanorc.nanorc
```

## Actual Behavior

![nanorc](https://github.com/user-attachments/assets/7e01f359-827a-4e33-8e9a-ed7e178e5338)

## Expected Behavior

After applying the fix:

![expected-nanorc](https://github.com/user-attachments/assets/bd67fb84-5b9c-43ea-ab97-f3715a6e624d)
