### PR TITLE
autoconf: Treat Flang as GNU-compatible Fortran compiler.

### DIFF
--- a/autoconf2.71/0004-LLVM-Flang.patch
+++ b/autoconf2.71/0004-LLVM-Flang.patch
@@ -1,0 +1,60 @@
+Treat LLVM Flang as GNU-compatible compiler for GNU targets.
+
+--- autoconf-2.71/lib/autoconf/fortran.m4.orig	2021-01-28 21:46:48.000000000 +0100
++++ autoconf-2.71/lib/autoconf/fortran.m4	2024-10-30 13:24:17.360461800 +0100
+@@ -286,6 +286,46 @@
+ 	 [m4_fatal([unknown Fortran dialect])])])
+ 
+ 
++# _AC_FC_COMPILER_GNU
++# ---------------------
++# Check whether the compiler for the current language is GNU.
++#
++# This is similar to _AC_LANG_COMPILER_GNU.  But also considers LLVM Flang
++# a GNU-compatible compiler.  Pay attention to the fact that the position
++# of 'choke me' on the seventh column is intentional: otherwise
++# some Fortran compilers (e.g., SGI) might consider it's a
++# continuation line, and warn instead of reporting an error.
++m4_define([_AC_FC_COMPILER_GNU],
++[AC_CACHE_CHECK([whether the compiler supports GNU _AC_LANG],
++		[ac_cv_[]_AC_LANG_ABBREV[]_compiler_gnu],
++		[_AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[#ifndef __GNUC__
++       choke me
++#endif
++]])],
++		  [ac_compiler_gnu=yes],
++		  [_AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[#ifndef __flang__
++       choke me
++#endif
++]])],
++		    [case `$[]_AC_FC[] $[]_AC_LANG_PREFIX[]FLAGS --print-target-triple < /dev/null 2>&1` in
++		      *mingw*|*-gnu)
++		        ac_compiler_gnu=yes
++		        ;;
++		      *-msvc)
++		        ac_compiler_gnu=no
++		        ;;
++		      *)
++		        ## assume Flang is GNU-compatible by default
++		        ac_compiler_gnu=yes
++		        ;;
++		    esac],
++		    [ac_compiler_gnu=no])])
++ac_cv_[]_AC_LANG_ABBREV[]_compiler_gnu=$ac_compiler_gnu
++])
++ac_compiler_gnu=$ac_cv_[]_AC_LANG_ABBREV[]_compiler_gnu
++])# _AC_FC_COMPILER_GNU
++
++
+ # _AC_PROG_FC([DIALECT], [COMPILERS...])
+ # --------------------------------------
+ # DIALECT is a Fortran dialect, given by Fortran [YY]YY or simply [YY]YY,
+@@ -346,7 +386,7 @@
+ # input file.  (Note that this only needs to work for GNU compilers.)
+ ac_save_ext=$ac_ext
+ ac_ext=F
+-_AC_LANG_COMPILER_GNU
++_AC_FC_COMPILER_GNU
+ ac_ext=$ac_save_ext
+ _AC_PROG_FC_G
+ ])# _AC_PROG_FC

--- a/autoconf2.71/PKGBUILD
+++ b/autoconf2.71/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=autoconf
 pkgname=${_realname}2.71
 pkgver=2.71
-pkgrel=3
+pkgrel=4
 pkgdesc="A GNU tool for automatically configuring source code"
 arch=('any')
 license=('spdx:GPL-2.0-or-later' 'spdx:GPL-3.0-or-later' 'spdx:Autoconf-exception-3.0')
@@ -15,6 +15,7 @@ source=(https://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.xz
         0001-autoconf-2.70-MSYS2-specifics-AC_CYGWIN.patch
         0002-autoconf-2.70-MSYS2-Autotest-Unify-EOLs-By-Default.patch
         0003-autoconf-2.70-MSYS2-specifics-config.guess.patch
+        0004-LLVM-Flang.patch
         0005-package.patch
         autoconf-2.71-AC_C_BIGENDIAN-lto.patch
         autoconf-2.71-AC_LANG_CALL_C_cxx.patch
@@ -25,6 +26,7 @@ sha256sums=('f14c83cfebcc9427f2c3cea7258bd90df972d92eb26752da4ddad81c87a0faa4'
             '3a5337e2269407405ee4c7feb12dbe2ae711610c3144c07cd085272676005db6'
             'c4e4952cc63a2ddaf7bf539f6e59353c4fadbf04cd48c3cfa789f8b175d0bd27'
             'a7671bef559a5f3edbd811a7cf9b557f216f1d3e9502dc046fd3a0ea665da7da'
+            'b055f013c85720dabe21947d2dbb67d0a282383d44b39d1a78ba05949834e649'
             '01894e38f901629373ff8ca6c55571b14450eacc625e717cd0da0ca65860f5e5'
             '1499271fa3004079bc2ce9db2697a7f4bd29666b2dfd7e1c39ad8fa397a4c08e'
             'befc2e2ae932e2247eee7fdd17d17e6b3065a741a47e0154670a009907d0860b'
@@ -32,21 +34,32 @@ sha256sums=('f14c83cfebcc9427f2c3cea7258bd90df972d92eb26752da4ddad81c87a0faa4'
             '65f2b02e96db437fc8fa974ba4b9db76eb9d053ceebcaf309c19f87eae3f8158'
             '402350041cbfb092321a5998f6abec6b0c59d3d03ae63735120e96a5a4a09d47')
 
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
+
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
 
   # MSYS2
-  patch -p1 -i ${srcdir}/0001-autoconf-2.70-MSYS2-specifics-AC_CYGWIN.patch
-  patch -p1 -i ${srcdir}/0002-autoconf-2.70-MSYS2-Autotest-Unify-EOLs-By-Default.patch
-  patch -p1 -i ${srcdir}/0003-autoconf-2.70-MSYS2-specifics-config.guess.patch
-  patch -p1 -i ${srcdir}/0005-package.patch
+  apply_patch_with_msg \
+    0001-autoconf-2.70-MSYS2-specifics-AC_CYGWIN.patch \
+    0002-autoconf-2.70-MSYS2-Autotest-Unify-EOLs-By-Default.patch \
+    0003-autoconf-2.70-MSYS2-specifics-config.guess.patch \
+    0004-LLVM-Flang.patch \
+    0005-package.patch
 
   # from gentoo: https://gitweb.gentoo.org/repo/gentoo.git/tree/sys-devel/autoconf/files
-  patch -p1 -i ${srcdir}/autoconf-2.71-AC_LANG_CALL_C_cxx.patch
-  patch -p1 -i ${srcdir}/autoconf-2.71-AC_C_BIGENDIAN-lto.patch
-  patch -p1 -i ${srcdir}/autoconf-2.71-K-R-decls-clang.patch
-  patch -p1 -i ${srcdir}/autoconf-2.71-make-4.4.patch
-  patch -p1 -i ${srcdir}/autoconf-2.71-K-R-decls-clang-deux.patch
+  apply_patch_with_msg \
+    autoconf-2.71-AC_LANG_CALL_C_cxx.patch \
+    autoconf-2.71-AC_C_BIGENDIAN-lto.patch \
+    autoconf-2.71-K-R-decls-clang.patch \
+    autoconf-2.71-make-4.4.patch \
+    autoconf-2.71-K-R-decls-clang-deux.patch
 }
 
 build() {

--- a/autoconf2.72/0004-LLVM-Flang.patch
+++ b/autoconf2.72/0004-LLVM-Flang.patch
@@ -1,0 +1,60 @@
+Treat LLVM Flang as GNU-compatible compiler for GNU targets.
+
+--- autoconf-2.71/lib/autoconf/fortran.m4.orig	2021-01-28 21:46:48.000000000 +0100
++++ autoconf-2.71/lib/autoconf/fortran.m4	2024-10-30 13:24:17.360461800 +0100
+@@ -286,6 +286,46 @@
+ 	 [m4_fatal([unknown Fortran dialect])])])
+ 
+ 
++# _AC_FC_COMPILER_GNU
++# ---------------------
++# Check whether the compiler for the current language is GNU.
++#
++# This is similar to _AC_LANG_COMPILER_GNU.  But also considers LLVM Flang
++# a GNU-compatible compiler.  Pay attention to the fact that the position
++# of 'choke me' on the seventh column is intentional: otherwise
++# some Fortran compilers (e.g., SGI) might consider it's a
++# continuation line, and warn instead of reporting an error.
++m4_define([_AC_FC_COMPILER_GNU],
++[AC_CACHE_CHECK([whether the compiler supports GNU _AC_LANG],
++		[ac_cv_[]_AC_LANG_ABBREV[]_compiler_gnu],
++		[_AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[#ifndef __GNUC__
++       choke me
++#endif
++]])],
++		  [ac_compiler_gnu=yes],
++		  [_AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[#ifndef __flang__
++       choke me
++#endif
++]])],
++		    [case `$[]_AC_FC[] $[]_AC_LANG_PREFIX[]FLAGS --print-target-triple < /dev/null 2>&1` in
++		      *mingw*|*-gnu)
++		        ac_compiler_gnu=yes
++		        ;;
++		      *-msvc)
++		        ac_compiler_gnu=no
++		        ;;
++		      *)
++		        ## assume Flang is GNU-compatible by default
++		        ac_compiler_gnu=yes
++		        ;;
++		    esac],
++		    [ac_compiler_gnu=no])])
++ac_cv_[]_AC_LANG_ABBREV[]_compiler_gnu=$ac_compiler_gnu
++])
++ac_compiler_gnu=$ac_cv_[]_AC_LANG_ABBREV[]_compiler_gnu
++])# _AC_FC_COMPILER_GNU
++
++
+ # _AC_PROG_FC([DIALECT], [COMPILERS...])
+ # --------------------------------------
+ # DIALECT is a Fortran dialect, given by Fortran [YY]YY or simply [YY]YY,
+@@ -346,7 +386,7 @@
+ # input file.  (Note that this only needs to work for GNU compilers.)
+ ac_save_ext=$ac_ext
+ ac_ext=F
+-_AC_LANG_COMPILER_GNU
++_AC_FC_COMPILER_GNU
+ ac_ext=$ac_save_ext
+ _AC_PROG_FC_G
+ ])# _AC_PROG_FC

--- a/autoconf2.72/PKGBUILD
+++ b/autoconf2.72/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=autoconf
 pkgname=${_realname}2.72
 pkgver=2.72
-pkgrel=1
+pkgrel=2
 pkgdesc="A GNU tool for automatically configuring source code"
 arch=('any')
 license=('spdx:GPL-2.0-or-later' 'spdx:GPL-3.0-or-later' 'spdx:Autoconf-exception-3.0')
@@ -14,24 +14,36 @@ source=(https://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.xz
         0001-autoconf-2.70-MSYS2-specifics-AC_CYGWIN.patch
         0002-autoconf-2.70-MSYS2-Autotest-Unify-EOLs-By-Default.patch
         0003-autoconf-2.70-MSYS2-specifics-config.guess.patch
+        0004-LLVM-Flang.patch
         0005-package.patch)
 sha256sums=('ba885c1319578d6c94d46e9b0dceb4014caafe2490e437a0dbca3f270a223f5a'
             '3a5337e2269407405ee4c7feb12dbe2ae711610c3144c07cd085272676005db6'
             'c4e4952cc63a2ddaf7bf539f6e59353c4fadbf04cd48c3cfa789f8b175d0bd27'
             'e3819dac51673591148e56872ad09d6c46527e7e48bc69fe9d49475fac2af179'
+            'b055f013c85720dabe21947d2dbb67d0a282383d44b39d1a78ba05949834e649'
             '5743a28cf0af0c10ec049c6d8df6801c675c9656ff623fbda5c2a29b3b15e8f4')
 msys2_references=(
   'archlinux: autoconf'
 )
 
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Np1 -i "${srcdir}/$_patch"
+  done
+}
+
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
 
   # MSYS2
-  patch -p1 -i ${srcdir}/0001-autoconf-2.70-MSYS2-specifics-AC_CYGWIN.patch
-  patch -p1 -i ${srcdir}/0002-autoconf-2.70-MSYS2-Autotest-Unify-EOLs-By-Default.patch
-  patch -p1 -i ${srcdir}/0003-autoconf-2.70-MSYS2-specifics-config.guess.patch
-  patch -p1 -i ${srcdir}/0005-package.patch
+  apply_patch_with_msg \
+    0001-autoconf-2.70-MSYS2-specifics-AC_CYGWIN.patch \
+    0002-autoconf-2.70-MSYS2-Autotest-Unify-EOLs-By-Default.patch \
+    0003-autoconf-2.70-MSYS2-specifics-config.guess.patch \
+    0004-LLVM-Flang.patch \
+    0005-package.patch
 }
 
 build() {


### PR DESCRIPTION
This allows building more projects with LLVM Flang as the Fortran compiler without needing additional (obscure) configure flags.

Note of caution: I've never used Classic Flang. I don't know if it also defines `__flang__`. And if it does, I don't know if it can be considered as a "drop-in replacement" of gfortran (or other GNU Fortran compilers).
