### PR TITLE
cross-crt: disable wildcard by default

### DIFF
--- a/mingw-w64-cross-crt/PKGBUILD
+++ b/mingw-w64-cross-crt/PKGBUILD
@@ -7,7 +7,7 @@ pkgbase="${_mingw_suff}-${_realname}"
 _targetpkgs=("${_mingw_suff}-ucrt64-${_realname}" "${_mingw_suff}-mingw32-${_realname}" "${_mingw_suff}-mingw64-${_realname}")
 pkgname=("${_mingw_suff}-${_realname}" "${_targetpkgs[@]}")
 pkgver=12.0.0.r250.gc6bf4bdf6
-pkgrel=1
+pkgrel=2
 pkgdesc='MinGW-w64 CRT for cross-compiler'
 arch=('i686' 'x86_64')
 url='https://www.mingw-w64.org'
@@ -55,7 +55,6 @@ _build() {
   --build=${CHOST} \
   --prefix=/opt/${_target} \
   --host=${_target} \
-  --enable-wildcard \
   --with-default-msvcrt=${_default_msvcrt} \
   --disable-dependency-tracking \
   ${_crt_configure_args}

--- a/mingw-w64-cross-mingwarm64-crt/PKGBUILD
+++ b/mingw-w64-cross-mingwarm64-crt/PKGBUILD
@@ -7,7 +7,7 @@ pkgbase="${_mingw_suff}-mingwarm64-${_realname}"
 _targetpkgs=("${_mingw_suff}-mingwarm64-${_realname}")
 pkgname=("${_targetpkgs[@]}")
 pkgver=12.0.0dev
-pkgrel=2
+pkgrel=3
 pkgdesc='MinGW-w64 CRT for cross-compiler'
 arch=('i686' 'x86_64')
 url='https://www.mingw-w64.org'
@@ -49,7 +49,6 @@ _build() {
   --build=${CHOST} \
   --prefix=/opt/${_target} \
   --host=${_target} \
-  --enable-wildcard \
   --with-default-msvcrt=${_default_msvcrt} \
   --disable-dependency-tracking \
   ${_crt_configure_args}


### PR DESCRIPTION
same as https://github.com/msys2/MINGW-packages/pull/22263 for the cross toolchain