### PR TITLE
msys2-runtime: update (arm64 canary crash fix backport)

### DIFF
--- a/msys2-runtime/0041-Cygwin-find_fast_cwd-don-t-run-assembler-checking-co.patch
+++ b/msys2-runtime/0041-Cygwin-find_fast_cwd-don-t-run-assembler-checking-co.patch
@@ -1,0 +1,71 @@
+From 16dfe943bcba396ac0b11c5b52cdbaeed4e03a8d Mon Sep 17 00:00:00 2001
+From: Corinna Vinschen <corinna@vinschen.de>
+Date: Tue, 13 Feb 2024 16:47:51 +0100
+Subject: [PATCH 41/N] Cygwin: find_fast_cwd: don't run assembler checking
+ code on ARM64
+
+https://cygwin.com/pipermail/cygwin/2024-February/255397.html
+reports a crash on ARM64 probably related to checking x86_64
+code on the x86_64 emulator on AArch64.
+
+At least for testing, pull the code checking the host HW
+up to be called before trying to evaluate assembler code.
+
+This fixes https://github.com/git-for-windows/git/issues/4808
+
+Backported from 4e77fa9b8b (Cygwin: find_fast_cwd: don't run assembler
+checking code on ARM64, 2024-02-13).
+
+Signed-off-by: Corinna Vinschen <corinna@vinschen.de>
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/path.cc | 28 +++++++++++++---------------
+ 1 file changed, 13 insertions(+), 15 deletions(-)
+
+diff --git a/winsup/cygwin/path.cc b/winsup/cygwin/path.cc
+index b0c45fa..f8afd4c 100644
+--- a/winsup/cygwin/path.cc
++++ b/winsup/cygwin/path.cc
+@@ -4826,29 +4826,27 @@ find_fast_cwd_pointer ()
+ static fcwd_access_t **
+ find_fast_cwd ()
+ {
++  USHORT emulated, hosted;
++  fcwd_access_t **f_cwd_ptr;
++
++  /* First check if we're running in WOW64 on ARM64 emulating AMD64.  Skip
++     fetching FAST_CWD pointer as long as there's no solution for finding
++     it on that system. */
++  if (IsWow64Process2 (GetCurrentProcess (), &emulated, &hosted)
++      && hosted == IMAGE_FILE_MACHINE_ARM64)
++    return NULL;
++
+   /* Fetch the pointer but don't set the global fast_cwd_ptr yet.  First
+      we have to make sure we know the version of the FAST_CWD structure
+      used on the system. */
+-  fcwd_access_t **f_cwd_ptr = find_fast_cwd_pointer ();
++  f_cwd_ptr = find_fast_cwd_pointer ();
+   if (!f_cwd_ptr)
+-    {
+-      bool warn = 1;
+-      USHORT emulated, hosted;
+-
+-      /* Check if we're running in WOW64 on ARM64 emulating AMD64.  Skip
+-	 warning as long as there's no solution for finding the FAST_CWD
+-	 pointer on that system. */
+-      if (IsWow64Process2 (GetCurrentProcess (), &emulated, &hosted)
+-	  && hosted == IMAGE_FILE_MACHINE_ARM64)
+-	warn = 0;
+-
+-      if (warn)
+-	small_printf ("Cygwin WARNING:\n"
++    small_printf ("Cygwin WARNING:\n"
+ "  Couldn't compute FAST_CWD pointer.  This typically occurs if you're using\n"
+ "  an older Cygwin version on a newer Windows.  Please update to the latest\n"
+ "  available Cygwin version from https://cygwin.com/.  If the problem persists,\n"
+ "  please see https://cygwin.com/problems.html\n\n");
+-    }
++
+   /* Eventually, after we set the version as well, set fast_cwd_ptr. */
+   return f_cwd_ptr;
+ }

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.5.4
-pkgrel=2
+pkgrel=3
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -68,7 +68,8 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0037-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch
         0038-Avoid-sharing-cygheaps-across-Cygwin-versions.patch
         0039-uname-report-msys2-runtime-commit-hash-too.patch
-        0040-Cygwin-pipe-Fix-a-regression-that-raw_write-slows-do.patch)
+        0040-Cygwin-pipe-Fix-a-regression-that-raw_write-slows-do.patch
+        0041-Cygwin-find_fast_cwd-don-t-run-assembler-checking-co.patch)
 sha256sums=('b8dce32fd9746506752d90ac3f30454fe1689100b08c41442016aaf244cc8584'
             '9f9e1b6b05cbc9a715fe9443740b25171e9c1a276a058e6ba7e4f6eada6872c8'
             'e5b2095e543a5d702cfce6da26cd17a78f40e17620315b1bcc434b94a007ae9b'
@@ -109,7 +110,8 @@ sha256sums=('b8dce32fd9746506752d90ac3f30454fe1689100b08c41442016aaf244cc8584'
             'f74cb189aafc9f8bf04cdad02531d9eca524c2dd12672e4e118bfdbb48926110'
             '344f108bc9e9ad597e07f1cc8e834e3d1a9fbd9972a1554c1c5de0fce0ae8506'
             'f93578a1150d724a60a7e8eb8491342aeb13f809e2ddb5193d8d126465f665cb'
-            '41e896036ea67c5d12a712554f4d53949c2dc809bb3545ac6be1fe619848f8af')
+            '41e896036ea67c5d12a712554f4d53949c2dc809bb3545ac6be1fe619848f8af'
+            '34035a411acb71c81a7f4a2367d2cf9f7f00572b6e92c7ba5506e6a48e4867ca')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -186,7 +188,8 @@ prepare() {
   0037-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch \
   0038-Avoid-sharing-cygheaps-across-Cygwin-versions.patch \
   0039-uname-report-msys2-runtime-commit-hash-too.patch \
-  0040-Cygwin-pipe-Fix-a-regression-that-raw_write-slows-do.patch
+  0040-Cygwin-pipe-Fix-a-regression-that-raw_write-slows-do.patch \
+  0041-Cygwin-find_fast_cwd-don-t-run-assembler-checking-co.patch
 }
 
 build() {


### PR DESCRIPTION
includes https://github.com/msys2/msys2-runtime/pull/233