### PR TITLE
base-devel: Remove pkgconf dependency.

### DIFF
--- a/base-devel/PKGBUILD
+++ b/base-devel/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
 
 pkgname=base-devel
-pkgver=2022.12
-pkgrel=2
+pkgver=2024.11
+pkgrel=1
 pkgdesc='Minimal package set for building packages with makepkg'
 url='https://www.msys2.org'
 arch=('any')
@@ -24,7 +24,6 @@ depends=(
   'make'
   'pacman'
   'patch'
-  'pkgconf'
   'sed'
   'tar'
 )


### PR DESCRIPTION
It interferes with mingw-w64-pkgconf.