### PR TITLE
msys2-runtime: integrate suspendthread fixup

### DIFF
--- a/msys2-runtime/0044-fixup-cygthread-suspend-thread-before-terminating.patch
+++ b/msys2-runtime/0044-fixup-cygthread-suspend-thread-before-terminating.patch
@@ -1,0 +1,64 @@
+From 7829673c0c6aad989084a9b72287988efe00a317 Mon Sep 17 00:00:00 2001
+From: Jeremy Drake <github@jdrake.com>
+Date: Tue, 19 Nov 2024 10:57:05 -0800
+Subject: [PATCH 44/N] fixup! cygthread: suspend thread before terminating.
+
+Address review comments:
+* add comments
+* change nested ifs to && conditions
+
+Added CancelSynchronousIo before another terminate_thread call, which
+was not the one that was causing issues, but still makes sense to avoid
+termination if possible.
+---
+ winsup/cygwin/pinfo.cc   |  3 +++
+ winsup/cygwin/sigproc.cc | 15 +++++++++++----
+ 2 files changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/winsup/cygwin/pinfo.cc b/winsup/cygwin/pinfo.cc
+index 43e0034..4bb1946 100644
+--- a/winsup/cygwin/pinfo.cc
++++ b/winsup/cygwin/pinfo.cc
+@@ -1268,6 +1268,9 @@ proc_waiter (void *arg)
+       if (!ReadFile (vchild.rd_proc_pipe, &buf, 1, &nb, NULL)
+ 	  && (err = GetLastError ()) != ERROR_BROKEN_PIPE)
+ 	{
++	  /* ERROR_OPERATION_ABORTED is expected due to the possibility that
++	     CancelSynchronousIo interruped the ReadFile call, so don't output
++	     that error */
+ 	  if (err != ERROR_OPERATION_ABORTED)
+ 	    system_printf ("error on read of child wait pipe %p, %E", vchild.rd_proc_pipe);
+ 	  break;
+diff --git a/winsup/cygwin/sigproc.cc b/winsup/cygwin/sigproc.cc
+index 0089626..19a2aec 100644
+--- a/winsup/cygwin/sigproc.cc
++++ b/winsup/cygwin/sigproc.cc
+@@ -409,9 +409,12 @@ proc_terminate ()
+ 	     to 1 iff it is a Cygwin process.  */
+ 	  if (!have_execed || !have_execed_cygwin)
+ 	    chld_procs[i]->ppid = 1;
+-	  if (chld_procs[i].wait_thread)
+-	    if (!CancelSynchronousIo (chld_procs[i].wait_thread->thread_handle ()))
+-	      chld_procs[i].wait_thread->terminate_thread ();
++	  /* Attempt to exit the wait_thread cleanly via CancelSynchronousIo
++	     before falling back to the (explicitly dangerous) cross-thread
++	     termination */
++	  if (chld_procs[i].wait_thread
++	      && !CancelSynchronousIo (chld_procs[i].wait_thread->thread_handle ()))
++	    chld_procs[i].wait_thread->terminate_thread ();
+ 	  /* Release memory associated with this process unless it is 'myself'.
+ 	     'myself' is only in the chld_procs table when we've execed.  We
+ 	     reach here when the next process has finished initializing but we
+@@ -1175,7 +1178,11 @@ remove_proc (int ci)
+ {
+   if (have_execed)
+     {
+-      if (_my_tls._ctinfo != chld_procs[ci].wait_thread)
++      /* Attempt to exit the wait_thread cleanly via CancelSynchronousIo
++	 before falling back to the (explicitly dangerous) cross-thread
++	 termination */
++      if (_my_tls._ctinfo != chld_procs[ci].wait_thread
++	  && !CancelSynchronousIo (chld_procs[ci].wait_thread->thread_handle ()))
+ 	chld_procs[ci].wait_thread->terminate_thread ();
+     }
+   else if (chld_procs[ci] && chld_procs[ci]->exists ())

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.5.4
-pkgrel=5
+pkgrel=6
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -71,7 +71,8 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0040-Cygwin-pipe-Fix-a-regression-that-raw_write-slows-do.patch
         0041-Cygwin-find_fast_cwd-don-t-run-assembler-checking-co.patch
         0042-cygthread-suspend-thread-before-terminating.patch
-        0043-fixup-cygthread-suspend-thread-before-terminating.patch)
+        0043-fixup-cygthread-suspend-thread-before-terminating.patch
+        0044-fixup-cygthread-suspend-thread-before-terminating.patch)
 sha256sums=('b8dce32fd9746506752d90ac3f30454fe1689100b08c41442016aaf244cc8584'
             '9f9e1b6b05cbc9a715fe9443740b25171e9c1a276a058e6ba7e4f6eada6872c8'
             'e5b2095e543a5d702cfce6da26cd17a78f40e17620315b1bcc434b94a007ae9b'
@@ -115,7 +116,8 @@ sha256sums=('b8dce32fd9746506752d90ac3f30454fe1689100b08c41442016aaf244cc8584'
             '41e896036ea67c5d12a712554f4d53949c2dc809bb3545ac6be1fe619848f8af'
             '34035a411acb71c81a7f4a2367d2cf9f7f00572b6e92c7ba5506e6a48e4867ca'
             '6ae29efcd4d17aad01eed252d166de4dd13c0bb2274905933152a1eb21c517dc'
-            '1c08c1c6ff588b8a3db23b8506c3e2c52c207f363d7c04b44da50640f176aab6')
+            '1c08c1c6ff588b8a3db23b8506c3e2c52c207f363d7c04b44da50640f176aab6'
+            'd40da853f11607c7c4bfe5abd95499a2042e520bb483b62fdae34182907f8d74')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -195,7 +197,8 @@ prepare() {
   0040-Cygwin-pipe-Fix-a-regression-that-raw_write-slows-do.patch \
   0041-Cygwin-find_fast_cwd-don-t-run-assembler-checking-co.patch \
   0042-cygthread-suspend-thread-before-terminating.patch \
-  0043-fixup-cygthread-suspend-thread-before-terminating.patch
+  0043-fixup-cygthread-suspend-thread-before-terminating.patch \
+  0044-fixup-cygthread-suspend-thread-before-terminating.patch
 }
 
 build() {


### PR DESCRIPTION
This corresponds to https://github.com/msys2/msys2-runtime/pull/239 and integrates one minor change of behavior where `remove_proc()` now _also_ tries `CancelSynchronousIo()` before using the big `terminate_thread()` hammer.

Probably not a very noticeable change of behavior. But still. Better stay aligned with Cygwin!