### PR TITLE
filesystem: fix HISTCONTROL list separator

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=filesystem
 pkgver=2023.02.07
-pkgrel=2
+pkgrel=3
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('spdx:BSD-3-Clause')
@@ -57,7 +57,7 @@ sha256sums=('742a7d66b7a5ebd2b8461728c5b44a46b2305fd2116208eecae5f45828938ea0'
             '99eae6e37081edd73b399009c85f4a67a0c14481241ee4937ab45c4178b540fb'
             '4330edf340394d0dae50afb04ac2a621f106fe67fb634ec81c4bfb98be2a1eb5'
             '00501046c301c5cb627b147e461217cda015aa109f673a9c1a67602891a26e88'
-            '602d7075b29cf5ed00de83fe010fcae4f0ad7c3321f5a2563a096b2eaf027c06'
+            '92b1d9ec2d3032fcfc6a54f09b944dfb02ca7be74763157fe54b24b7d6d5f730'
             '0e3f00cb2cc7778a1fb5440fc979cfeeafeca72c3059dd474f38ed6b99b46070'
             '387ca1e86c1a18a143eb077ca194ad44c0a2faf98795a0d437f2d210d5a6df18'
             'f8f1b5943d385e8a7e3b5a4a2c7d64004108c94c17b2f936016e2ae50bdb65af'

--- a/filesystem/dot.bashrc
+++ b/filesystem/dot.bashrc
@@ -58,7 +58,7 @@
 # History Options
 #
 # Don't put duplicate lines in the history.
-# export HISTCONTROL=$HISTCONTROL${HISTCONTROL+,}ignoredups
+# export HISTCONTROL=$HISTCONTROL${HISTCONTROL+:}ignoredups
 #
 # Ignore some controlling instructions
 # HISTIGNORE is a colon-delimited list of patterns which should be excluded.


### PR DESCRIPTION
HISTCONTROL is a colon-separated list, NOT a comma-separated one