### PR TITLE
autoconf2.72: Don't strip MinGW libraries from Fortran linker flags

### DIFF
--- a/autoconf2.72/0006-fortran-mingw-libs.patch
+++ b/autoconf2.72/0006-fortran-mingw-libs.patch
@@ -1,0 +1,14 @@
+Do not strip mingw libraries from list of Fortran standard linker flags.
+
+diff -urN autoconf-2.72/lib/autoconf/fortran.m4.orig autoconf-2.72/lib/autoconf/fortran.m4
+--- autoconf-2.72/lib/autoconf/fortran.m4.orig	2024-10-30 13:31:24.456674400 +0100
++++ autoconf-2.72/lib/autoconf/fortran.m4	2024-12-11 16:08:46.415095400 +0100
+@@ -705,7 +705,7 @@
+ 	-lang* | -lcrt*.o | -lc | -lgcc* | -lSystem | -libmil | -little \
+ 	  |-LANG:=* | -LIST:* | -LNO:* | -link)
+ 	  ;;
+-	-lkernel32 | -lmingw* | -lmoldname)
++	-lkernel32)
+ 	  # Ignore this library only on Windows-like systems.
+ 	  case $host_os in
+ 	  cygwin* | msys* | mingw* | windows*) ;;

--- a/autoconf2.72/PKGBUILD
+++ b/autoconf2.72/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=autoconf
 pkgname=${_realname}2.72
 pkgver=2.72
-pkgrel=2
+pkgrel=3
 pkgdesc="A GNU tool for automatically configuring source code"
 arch=('any')
 license=('spdx:GPL-2.0-or-later' 'spdx:GPL-3.0-or-later' 'spdx:Autoconf-exception-3.0')
@@ -15,13 +15,15 @@ source=(https://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.xz
         0002-autoconf-2.70-MSYS2-Autotest-Unify-EOLs-By-Default.patch
         0003-autoconf-2.70-MSYS2-specifics-config.guess.patch
         0004-LLVM-Flang.patch
-        0005-package.patch)
+        0005-package.patch
+        0006-fortran-mingw-libs.patch)
 sha256sums=('ba885c1319578d6c94d46e9b0dceb4014caafe2490e437a0dbca3f270a223f5a'
             '3a5337e2269407405ee4c7feb12dbe2ae711610c3144c07cd085272676005db6'
             'c4e4952cc63a2ddaf7bf539f6e59353c4fadbf04cd48c3cfa789f8b175d0bd27'
             'e3819dac51673591148e56872ad09d6c46527e7e48bc69fe9d49475fac2af179'
             'b055f013c85720dabe21947d2dbb67d0a282383d44b39d1a78ba05949834e649'
-            '5743a28cf0af0c10ec049c6d8df6801c675c9656ff623fbda5c2a29b3b15e8f4')
+            '5743a28cf0af0c10ec049c6d8df6801c675c9656ff623fbda5c2a29b3b15e8f4'
+            'bad3cffb9a4ebbef350227439b4e4bd1654b4cc9e2faf898971703779f4c113e')
 msys2_references=(
   'archlinux: autoconf'
 )
@@ -43,7 +45,8 @@ prepare() {
     0002-autoconf-2.70-MSYS2-Autotest-Unify-EOLs-By-Default.patch \
     0003-autoconf-2.70-MSYS2-specifics-config.guess.patch \
     0004-LLVM-Flang.patch \
-    0005-package.patch
+    0005-package.patch \
+    0006-fortran-mingw-libs.patch
 }
 
 build() {


### PR DESCRIPTION
Stripping `-lmingwex` from the Fortran standard linker flags can lead to a situation where the first `-lmsvcrt` appears before the first `-lmingwex` for a library that consists of Fortran and C++ sources. That means that the linker picks some functions from the Windows CRT that should instead be picked from `libmingwex.a`.

It took quite some time to figure out that this is causing an odd behavior when calling `std::asin` with a complex double precision value with a real part larger than 1 in such a library.
See also: https://octave.discourse.group/t/6026/75

Also don't strip `-lmoldname` from these flags because there is no reason to do that as far as I can tell.

This essentially reverts the upstream changes from: https://lists.gnu.org/r/autoconf-patches/2021-09/msg00000.html