### PR TITLE
guile: fix issue #5079

### DIFF
--- a/guile/0003-Fix-make-custom-port-in-case-encoding-is-f.patch
+++ b/guile/0003-Fix-make-custom-port-in-case-encoding-is-f.patch
@@ -1,0 +1,32 @@
+From 72b85f8e6a369e6aef4c6bd6bb233c0cacb80b03 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hannes=20M=C3=BCller?= <>
+Date: Sat, 21 Dec 2024 16:55:13 +0100
+Subject: [PATCH] Fix make-custom-port in case encoding is #f
+
+On MSYS2 readline support failed, ref.
+https://github.com/msys2/MSYS2-packages/issues/5079
+
+It turns out (fluid-ref %default-port-encoding) returns #f. The later code
+is prepared to handle #f for encoding, but not the assignment to encoding.
+---
+ module/ice-9/custom-ports.scm | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/module/ice-9/custom-ports.scm b/module/ice-9/custom-ports.scm
+index 6010fd94f..bc9de8f64 100644
+--- a/module/ice-9/custom-ports.scm
++++ b/module/ice-9/custom-ports.scm
+@@ -127,7 +127,9 @@
+           (id "custom-port")
+           (print (make-default-print #:id id))
+           (truncate default-truncate)
+-          (encoding (string->symbol (fluid-ref %default-port-encoding)))
++          (encoding (if (string? (fluid-ref %default-port-encoding))
++                        (string->symbol (fluid-ref %default-port-encoding))
++                        (fluid-ref %default-port-encoding)))
+           (conversion-strategy (fluid-ref %default-port-conversion-strategy))
+           (close-on-gc? #f))
+   "Create a custom port whose behavior is determined by the methods passed
+-- 
+2.45.2
+

--- a/guile/0004-libguile-scm.h-fix-BUILDING_LIBGUILE-for-Werror-unde.patch
+++ b/guile/0004-libguile-scm.h-fix-BUILDING_LIBGUILE-for-Werror-unde.patch
@@ -1,0 +1,32 @@
+From 696151ca382c7b166d349f704812dd73bc2fa7a7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hannes=20M=C3=BCller?= <>
+Date: Sat, 21 Dec 2024 19:20:17 +0100
+Subject: [PATCH] libguile/scm.h: fix BUILDING_LIBGUILE for -Werror=undef
+
+BUILDING_LIBGUILE is not always defined. This is
+signaled using -Werror=undef in code using libguile.
+
+This fixes commit dc3a3a84f908f4a16e95a2c3bb412861521960dc
+---
+ libguile/scm.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libguile/scm.h b/libguile/scm.h
+index 4d079b1a8..180b40159 100644
+--- a/libguile/scm.h
++++ b/libguile/scm.h
+@@ -718,9 +718,9 @@ enum scm_tc8_tags
+ 
+ /* SCM_API is a macro prepended to all function and data definitions
+    which should be exported from libguile. */
+-#if BUILDING_LIBGUILE && HAVE_VISIBILITY
++#if defined BUILDING_LIBGUILE && HAVE_VISIBILITY
+ # define SCM_API extern __attribute__((__visibility__("default")))
+-#elif BUILDING_LIBGUILE && (defined _WIN32 || defined __CYGWIN__)
++#elif defined BUILDING_LIBGUILE && (defined _WIN32 || defined __CYGWIN__)
+ # define SCM_API __declspec(dllexport) extern
+ #elif defined _WIN32 || defined __CYGWIN__
+ # define SCM_API __declspec(dllimport) extern
+-- 
+2.45.2
+

--- a/guile/PKGBUILD
+++ b/guile/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=guile
 pkgname=("${pkgbase}" "lib${pkgbase}" "lib${pkgbase}-devel")
 pkgver=3.0.10
-pkgrel=1
+pkgrel=2
 pkgdesc="a portable, embeddable Scheme implementation written in C"
 url="https://www.gnu.org/software/guile/"
 msys2_references=(
@@ -28,6 +28,8 @@ makedepends=('autotools'
 source=("https://ftp.gnu.org/pub/gnu/${pkgname}/${pkgbase}-${pkgver}.tar.xz"
         '0001-Fix-dynamic-library-guile-readline-name-on-Cygwin.patch'
         '0002-Fix-warning-if-libguile-is-used-with-compile-option-.patch'
+        '0003-Fix-make-custom-port-in-case-encoding-is-f.patch'
+        '0004-libguile-scm.h-fix-BUILDING_LIBGUILE-for-Werror-unde.patch'
         '0101-Add-convert-a-standard-shared-library-name-for-MSYS.patch'
         '0201-Activate-test-pthread-create-secondary-for-Cygwin.patch'
         '0202-Include-ITIMER_REAL-test-in-signals.test-for-Cygwin.patch'
@@ -39,6 +41,8 @@ source=("https://ftp.gnu.org/pub/gnu/${pkgname}/${pkgbase}-${pkgver}.tar.xz"
 sha256sums=('bd7168517fd526333446d4f7ab816527925634094fbd37322e17e2b8d8e76388'
             '76482f80bd2b2ade6cdc015230f95a34ef9e13d3798dcd88b881afb63f7bab44'
             '07c0dd3718b8edd8eef545c90b7bf013bdd9418f0eda662c29e31064c4870422'
+            '95ad8edc2ac1079e3959ce2a399aedf78b9b9d7d1b31d1aa49e0aba40bbece58'
+            '4b9fc785b5072c4bca978eabf4e30fe90bbb79d8ce89539a916af936e28a69a6'
             '7347d4008223245dfeeab04c7490b801d5989c30f263d73415848c6f113518e9'
             '61edb7c2f77aca3bdff316f0f72fe474c5a57b44be00a8fc3cd4209da1d7f33d'
             '60248b9055733309ff21372301e6af513aee7f2400b5681578c0fa509ee8763a'
@@ -53,6 +57,8 @@ prepare() {
 
   patch -p1 -i ${srcdir}/0001-Fix-dynamic-library-guile-readline-name-on-Cygwin.patch
   patch -p1 -i ${srcdir}/0002-Fix-warning-if-libguile-is-used-with-compile-option-.patch
+  patch -p1 -i ${srcdir}/0003-Fix-make-custom-port-in-case-encoding-is-f.patch
+  patch -p1 -i ${srcdir}/0004-libguile-scm.h-fix-BUILDING_LIBGUILE-for-Werror-unde.patch
 
   patch -p1 -i ${srcdir}/0101-Add-convert-a-standard-shared-library-name-for-MSYS.patch
 


### PR DESCRIPTION
guile 3.0.10 requires additional patch 0003 to enable readline support. Furthermore patch 0004 adds a minor fix.