### PR TITLE
ccache: unset CI env variable before running cmake

### DIFF
--- a/ccache/PKGBUILD
+++ b/ccache/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=ccache
 pkgver=4.10.2
-pkgrel=3
+pkgrel=4
 pkgdesc="A compiler cache (mingw-w64)"
 arch=('i686' 'x86_64')
 url="https://ccache.samba.org/"
@@ -33,6 +33,7 @@ build() {
   [[ -d build-${CHOST} ]] && rm -rf build-${CHOST}
   mkdir -p build-${CHOST}  && cd build-${CHOST}
 
+  unset CI
   /usr/bin/cmake \
     -GNinja \
     -DCMAKE_INSTALL_PREFIX=/usr \


### PR DESCRIPTION
ccache's cmake files will turn on a "dev mode" if CI is set in the environment, turning on -Werror among other things.  This was causing the build on i686 to fail due to a warning with fmt 11.  We don't really want ccache's dev mode, so unset it explicitly.