### PR TITLE
python: remove version from platform string and always use "cygwin"

### DIFF
--- a/python/900-msysize.patch
+++ b/python/900-msysize.patch
@@ -44,20 +44,25 @@
              print(find_library("crypt"))
          else:
              print(cdll.LoadLibrary("libm.so"))
-diff -Naur Python-3.8.2-orig/Lib/sysconfig.py Python-3.8.2/Lib/sysconfig.py
---- Python-3.8.2-orig/Lib/sysconfig.py	2020-02-25 00:36:25.000000000 +0300
-+++ Python-3.8.2/Lib/sysconfig.py	2020-04-16 11:24:20.643039800 +0300
-@@ -673,6 +673,13 @@
-         m = rel_re.match(release)
-         if m:
-             release = m.group()
-+    elif osname[:4] == "msys":
-+        osname = "msys"
-+        import re
-+        rel_re = re.compile (r'[\d.]+')
-+        m = rel_re.match(release)
-+        if m:
-+            release = m.group()
+--- Python-3.12.8/Lib/sysconfig.py.orig	2024-12-03 19:42:41.000000000 +0100
++++ Python-3.12.8/Lib/sysconfig.py	2025-01-24 20:14:10.834146500 +0100
+@@ -815,13 +815,13 @@
+     elif osname[:3] == "aix":
+         from _aix_support import aix_platform
+         return aix_platform()
+-    elif osname[:6] == "cygwin":
++    elif osname[:6] == "cygwin" or osname[:4] == "msys":
++        # https://github.com/msys2/MSYS2-packages/issues/5143
++        # Various build tools use the platform to derive the wheel tag
++        # and the wheel tag needs to be stable for a specific platform
++        # so we can't include a version here.
+         osname = "cygwin"
+-        import re
+-        rel_re = re.compile(r'[\d.]+')
+-        m = rel_re.match(release)
+-        if m:
+-            release = m.group()
++        return  f"{osname}-{machine}"
      elif osname[:6] == "darwin":
          import _osx_support
          osname, release, machine = _osx_support.get_platform_osx(

--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=python
 pkgname=('python' 'python-devel')
 pkgver=3.12.8
-pkgrel=1
+pkgrel=2
 _pybasever=${pkgver%.*}
 pkgdesc="Next generation of the python high-level scripting language"
 arch=('i686' 'x86_64')
@@ -50,7 +50,7 @@ sha256sums=('c909157bb25ec114e5869124cc2a9c4a4d4c1e957ca4ff553f1edc692101154e'
             '70f854f00de71372e49f2ebbff7491e09e9e036e8e3f3646fe2984e30fb4a9da'
             '24cc76e155b5e017d2e46e784eb3407de60f2f1fd26e691ef222bc2088bbb9d5'
             '9d0efb7e7e913e96b9f7953802311bbc2d046a7bfdcc3ffaf11fc509731b4d18'
-            '7ca289727bf714cccfe075c959f4907cf527b3e1d251020c9f0e8b21a2f1f365'
+            'b301ecb5ba9729d60c58a2e6d1dc38e3a1a31c7bf2f0654a73173821f40e94dd'
             '85d9d042e0fa3493ec54b364e6b4fb6d2b12ba09641e01047bc84a09605ef76b'
             'b439ff4f0a1f13858f8fb596414b74ed2c14fc3103d90287bb8e461ee89288b9'
             'bcdb4e7922e30f7dfbd3993ffe6db2dfd0df29326bebd12203dce376ea3451d9'


### PR DESCRIPTION
pip has recently started to compare wheel tags with system supported wheel tags, and as it turns out build tools just use sysconfig.get_platform() to generate a tag (in setuptools, wheel, packaging, etc) for non-official platforms. For official platforms they do various normalization steps and use other sources.

Since we can't really patch all those packages we need to provide a platform string that wont change between updates.

* Don't include the cygwin version in it anymore, since that can change on updates.
* Hardcode to "cygwin" since builing for cygwin can change the output of os.uname()

The later breaks detection of MSYS2 compared to cygwin, but ideally no one should depend on it, and we want to get rid of the differences there anyway.

Fixes #5143