### PR TITLE
python: fix sysconfig.get_platform when run in a mingw shell

### DIFF
--- a/python/900-msysize.patch
+++ b/python/900-msysize.patch
@@ -45,13 +45,13 @@
          else:
              print(cdll.LoadLibrary("libm.so"))
 --- Python-3.12.8/Lib/sysconfig.py.orig	2024-12-03 19:42:41.000000000 +0100
-+++ Python-3.12.8/Lib/sysconfig.py	2025-01-24 20:14:10.834146500 +0100
++++ Python-3.12.8/Lib/sysconfig.py	2025-02-01 17:39:28.925188300 +0100
 @@ -815,13 +815,13 @@
      elif osname[:3] == "aix":
          from _aix_support import aix_platform
          return aix_platform()
 -    elif osname[:6] == "cygwin":
-+    elif osname[:6] == "cygwin" or osname[:4] == "msys":
++    elif sys.platform == "cygwin":
 +        # https://github.com/msys2/MSYS2-packages/issues/5143
 +        # Various build tools use the platform to derive the wheel tag
 +        # and the wheel tag needs to be stable for a specific platform

--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=python
 pkgname=('python' 'python-devel')
 pkgver=3.12.8
-pkgrel=2
+pkgrel=3
 _pybasever=${pkgver%.*}
 pkgdesc="Next generation of the python high-level scripting language"
 arch=('i686' 'x86_64')
@@ -50,7 +50,7 @@ sha256sums=('c909157bb25ec114e5869124cc2a9c4a4d4c1e957ca4ff553f1edc692101154e'
             '70f854f00de71372e49f2ebbff7491e09e9e036e8e3f3646fe2984e30fb4a9da'
             '24cc76e155b5e017d2e46e784eb3407de60f2f1fd26e691ef222bc2088bbb9d5'
             '9d0efb7e7e913e96b9f7953802311bbc2d046a7bfdcc3ffaf11fc509731b4d18'
-            'b301ecb5ba9729d60c58a2e6d1dc38e3a1a31c7bf2f0654a73173821f40e94dd'
+            'a0acb9da960df3d509dfb530f548adeffbcab616e7f4f2fc92fc98659649d43b'
             '85d9d042e0fa3493ec54b364e6b4fb6d2b12ba09641e01047bc84a09605ef76b'
             'b439ff4f0a1f13858f8fb596414b74ed2c14fc3103d90287bb8e461ee89288b9'
             'bcdb4e7922e30f7dfbd3993ffe6db2dfd0df29326bebd12203dce376ea3451d9'


### PR DESCRIPTION
In a mingw shell it will call os.uname() which starts with MINGW.. resulting in bogus results. So just check for sys.platform which is always "cygwin".

See #5143