### PR TITLE
binutils: Update to 2.44

### DIFF
--- a/binutils/0100-binutils-2.37-msys2.patch
+++ b/binutils/0100-binutils-2.37-msys2.patch
@@ -429,17 +429,6 @@ diff -Naur binutils-2.37-orig/binutils/dllwrap.c binutils-2.37/binutils/dllwrap.
  	}
        dyn_string_append_cstr (step_pre1, " --output-def ");
        dyn_string_append_cstr (step_pre1, def_file_name);
-diff -Naur binutils-2.37-orig/binutils/testsuite/binutils-all/dlltool.exp binutils-2.37/binutils/testsuite/binutils-all/dlltool.exp
---- binutils-2.37-orig/binutils/testsuite/binutils-all/dlltool.exp	2021-11-30 08:19:29.712912800 +0100
-+++ binutils-2.37/binutils/testsuite/binutils-all/dlltool.exp	2021-11-30 08:31:03.111076800 +0100
-@@ -22,6 +22,7 @@
- 
- if {![istarget "i*86-*-*pe*"] \
-     && ![istarget "i*86-*-cygwin*"] \
-+    && ![istarget "i*86-*-msys*"] \
-     && ![istarget "i*86-*-mingw32*"] \
-     && ![istarget "arm-*-pe*"] \
-     && ![istarget "x86_64-*-mingw*"] } {
 diff -Naur binutils-2.37-orig/compile binutils-2.37/compile
 --- binutils-2.37-orig/compile	2021-11-30 08:19:41.276294300 +0100
 +++ binutils-2.37/compile	2021-11-30 08:56:44.916376000 +0100

--- a/binutils/2002-Allow-spaces-in-the-name-of-the-external-preprocesso.patch
+++ b/binutils/2002-Allow-spaces-in-the-name-of-the-external-preprocesso.patch
@@ -13,6 +13,22 @@ Subject: [PATCH 2/2] Allow spaces in the name of the external preprocessor
  2 files changed, 13 insertions(+), 1 deletion(-)
 
 diff --git a/binutils/windres.c b/binutils/windres.c
+index 3f691d3e829e..f0f6433160c3 100644
+--- a/binutils/windres.c
++++ b/binutils/windres.c
+@@ -885,10 +885,7 @@ main (int argc, char **argv)
+ 
+ 	case OPTION_PREPROCESSOR:
+ 	  if (strchr (optarg, ' '))
+-	    {
+-	      if (asprintf (& preprocessor, "\"%s\"", optarg) == -1)
+-		preprocessor = optarg;
+-	    }
++	    preprocessor = xasprintf ("\"%s\"", optarg);
+ 	  else
+ 	    preprocessor = optarg;	    
+ 	  break;
+diff --git a/binutils/windres.c b/binutils/windres.c
 index 5c83dab8fc0..df3e01fd941 100644
 --- a/binutils/windres.c
 +++ b/binutils/windres.c

--- a/binutils/PKGBUILD
+++ b/binutils/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=binutils
-pkgver=2.43.1
+pkgver=2.44
 pkgrel=1
 pkgdesc="A set of programs to assemble and manipulate binary and object files"
 arch=('i686' 'x86_64')
@@ -18,11 +18,11 @@ source=(https://ftp.gnu.org/gnu/binutils/binutils-${pkgver}.tar.xz{,.sig}
         0050-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
         0100-binutils-2.37-msys2.patch
         2002-Allow-spaces-in-the-name-of-the-external-preprocesso.patch)
-sha256sums=('13f74202a3c4c51118b797a39ea4200d3f6cfbe224da6d1d95bb938480132dfd'
+sha256sums=('ce2017e059d63e67ddb9240e9d4ec49c2893605035cd60e92ad53177f4377237'
             'SKIP'
             '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18'
-            '78a8fece3e244272bb3c52924ddcdeedc483631236cc71206a7f21b0949f5a49'
-            '57478b9971183d430c93701b1d533e3724dab5334bbf44db924777e4a93c1063')
+            'b6a04c9c77a6b5358564f01026431c9ff96430ee8b02d404644c8e9e54868a3b'
+            '699be1b01abec4bbb5a6fc649bee4da33048899c58e28d53ee9c97ba6b741114')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
 


### PR DESCRIPTION
* 0100-binutils-2.37-msys2.patch: remove hunk for removed code
* 2002-Allow-spaces-in-the-name-of-the-external-preprocesso.patch: also revert followup cleanup