### PR TITLE
msys2-runtime-3.3: build as msys2-runtime on i686

### DIFF
--- a/msys2-runtime-3.3/PKGBUILD
+++ b/msys2-runtime-3.3/PKGBUILD
@@ -2,9 +2,13 @@
 # Contributor: Ray Donnelly <mingw.android@gmail.com>
 
 pkgbase=msys2-runtime-3.3
-pkgname=('msys2-runtime-3.3' 'msys2-runtime-3.3-devel')
+if [ "$CARCH" == "i686" ]; then
+  pkgname=('msys2-runtime' 'msys2-runtime-devel')
+else
+  pkgname=('msys2-runtime-3.3' 'msys2-runtime-3.3-devel')
+fi
 pkgver=3.3.6
-pkgrel=13
+pkgrel=14
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -282,13 +286,7 @@ build() {
   rm -rf "${srcdir}"/dest/etc
 }
 
-package_msys2-runtime-3.3() {
-  pkgdesc="Posix emulation engine for Windows"
-  options=('!strip')
-  provides=("msys2-runtime=${pkgver}")
-  conflicts=('catgets' 'libcatgets' 'msys2-runtime' 'msys2-runtime-3.5')
-  replaces=('catgets' 'libcatgets')
-
+_package_msys2-runtime() {
   mkdir -p "${pkgdir}"/usr
   cp -rf "${srcdir}"/dest/usr/bin "${pkgdir}"/usr/
   cp -rf "${srcdir}"/dest/usr/libexec "${pkgdir}"/usr/
@@ -300,14 +298,26 @@ package_msys2-runtime-3.3() {
   cp -rf "${srcdir}"/dest/usr/share "${pkgdir}"/usr/
 }
 
-package_msys2-runtime-3.3-devel() {
-  pkgdesc="MSYS2 headers and libraries"
-  depends=("msys2-runtime-3.3=${pkgver}")
-  provides=("msys2-runtime-devel=${pkgver}")
-  options=('staticlibs' '!strip')
-  conflicts=('libcatgets-devel' 'msys2-runtime-devel' 'msys2-runtime-3.5-devel')
-  replaces=('libcatgets-devel')
+package_msys2-runtime-3.3() {
+  pkgdesc="Posix emulation engine for Windows"
+  options=('!strip')
+  provides=("msys2-runtime=${pkgver}")
+  conflicts=('catgets' 'libcatgets' 'msys2-runtime' 'msys2-runtime-3.5')
+  replaces=('catgets' 'libcatgets')
 
+  _package_msys2-runtime
+}
+
+package_msys2-runtime() {
+  pkgdesc="Posix emulation engine for Windows"
+  options=('!strip')
+  conflicts=('catgets' 'libcatgets' 'msys2-runtime-3.3')
+  replaces=('catgets' 'libcatgets' 'msys2-runtime-3.3')
+
+  _package_msys2-runtime
+}
+
+_package_msys2-runtime-devel() {
   mkdir -p "${pkgdir}"/usr/bin
   cp -f "${srcdir}"/dest/usr/bin/msys-2.0.dbg "${pkgdir}"/usr/bin/
   cp -rLf "${srcdir}"/dest/usr/${CHOST}/include "${pkgdir}"/usr/
@@ -317,4 +327,25 @@ package_msys2-runtime-3.3-devel() {
   rm -fr "${pkgdir}"/usr/include/rpc/
 
   cp -rLf "${srcdir}"/dest/usr/${CHOST}/lib "${pkgdir}"/usr/
+}
+
+package_msys2-runtime-3.3-devel() {
+  pkgdesc="MSYS2 headers and libraries"
+  depends=("msys2-runtime-3.3=${pkgver}")
+  provides=("msys2-runtime-devel=${pkgver}")
+  options=('staticlibs' '!strip')
+  conflicts=('libcatgets-devel' 'msys2-runtime-devel' 'msys2-runtime-3.5-devel')
+  replaces=('libcatgets-devel')
+
+  _package_msys2-runtime-devel
+}
+
+package_msys2-runtime-devel() {
+  pkgdesc="MSYS2 headers and libraries"
+  depends=("msys2-runtime=${pkgver}")
+  options=('staticlibs' '!strip')
+  conflicts=('libcatgets-devel' 'msys2-runtime-3.3-devel')
+  replaces=('libcatgets-devel' 'msys2-runtime-3.3-devel')
+
+  _package_msys2-runtime-devel
 }


### PR DESCRIPTION
So there is an automated upgrade path and users don't have to manually switch to msys2-runtime-3.3.