### PR TITLE
mintty: default to Term=xterm-256color

### DIFF
--- a/mintty/PKGBUILD
+++ b/mintty/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=mintty
 pkgver=3.7.7
-pkgrel=1
+pkgrel=2
 epoch=1
 pkgdesc="Terminal emulator with native Windows look and feel"
 arch=('i686' 'x86_64')
@@ -18,7 +18,7 @@ backup=('etc/minttyrc')
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/mintty/mintty/archive/${pkgver}.tar.gz
         "minttyrc")
 sha256sums=('6f1a03e3fdab51927a1eb7415a1478f694aeb57d37edcee8eca50ed3a7e044a0'
-            'aabad49568755a05e76b2581eb6061e27c3ab099aa0f4eb536dfdbcac99cac1f')
+            'ce43a9b0c8eb01a695d0543ceb56c9281708a02aaf92021b72d0f0b69a7feeb9')
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"

--- a/mintty/minttyrc
+++ b/mintty/minttyrc
@@ -1,2 +1,3 @@
 Columns=100
 Rows=27
+Term=xterm-256color


### PR DESCRIPTION
instead of plain xterm. xterm-256color is the default on most modern systems, so give it a try.

Fixes #4973