### PR TITLE
gettext: update to 0.22.5

### DIFF
--- a/gettext/PKGBUILD
+++ b/gettext/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=gettext
 pkgname=('gettext' 'gettext-devel' 'libgettextpo' 'libasprintf' 'libintl')
-pkgver=0.22.4
+pkgver=0.22.5
 pkgrel=1
 pkgdesc="GNU internationalization library"
 arch=('i686' 'x86_64')
@@ -19,25 +19,37 @@ source=(https://ftp.gnu.org/pub/gnu/gettext/${pkgname}-${pkgver}.tar.gz{,.sig}
         gettext-0.21.1-cygwin-ftm.patch
         gettext-0.22-no-woe32dll-gettext-tools-configure-ac.patch
         gettext-0.22-no-woe32dll-m4-woe32-dll-m4.patch
-        gettext-0.22-gettext-runtime-gnulib-lib-localename-c.patch
-        gettext-0.22-gettext-runtime-intl-gnulib-lib-localename-c.patch
-        gettext-0.22-gettext-tools-gnulib-lib-localename-c.patch
+        gettext-0.22.5-gettext-runtime-gnulib-lib-localcharset-c.patch
+        gettext-0.22.5-gettext-runtime-gnulib-lib-localename-h.patch
+        gettext-0.22.5-gettext-runtime-gnulib-lib-localename-unsafe-c.patch
+        gettext-0.22.5-gettext-runtime-intl-gnulib-lib-localcharset-c.patch
+        gettext-0.22.5-gettext-runtime-intl-gnulib-lib-localename-h.patch
+        gettext-0.22.5-gettext-runtime-intl-gnulib-lib-localename-unsafe-c.patch
+        gettext-0.22.5-gettext-tools-gnulib-lib-localcharset-c.patch
+        gettext-0.22.5-gettext-tools-gnulib-lib-localename-h.patch
+        gettext-0.22.5-gettext-tools-gnulib-lib-localename-unsafe-c.patch
         gettext-0.22-disable-libtextstyle.patch
         gettext-0.19.8.1-msys2.patch
         gettext-0.19.7-archive.patch)
-sha256sums=('c1e0bb2a4427a9024390c662cd532d664c4b36b8ff444ed5e54b115fdb7a1aea'
+sha256sums=('ec1705b1e969b83a9f073144ec806151db88127f5e40fe5a94cb6c8fa48996a0'
             'SKIP'
             'a83c2e89aa799232847d120ce3da856fbee2fda87245233d336c5de044465321'
             '2a8ea083abf7278b3b6157e6f3eed4e6a90b803308396e30b1302085b840c8e9'
             '62c0cf906df4c0196e2e3e4f79b91486f6a95d29bf9de8aed8c92b5075058497'
             '71f26d49ddabf400ee14ea574495a5d3b3055957d81fecfb4cb5cb99dab3cd47'
             'd5b14b03ca609764f1c646efa9e85dedafe69f967f37b8db194fcddc199f2d97'
-            'd618348b44a4b19466707edf195aa84ca6825d7e4b4459f4c2c64fe47388b24c'
-            '1e5af27a1c29e1595696c899e0cc411a54acd9b7f8aef186c1640d79434f30f7'
-            '42edf54a3d63a57ba80ae7e65c641dd13276141ae4657002e70da1078ade354f'
+            'b65bbf78a55a3b8a048a89f8351b3daeff79058d8c45318f8642f07b7cb74f5a'
+            'e1e5a2e50d23d9e16b4f33dfeeab33f193d7f7678a560db9a84fcad81dd33369'
+            'd05a8da45d4aa90e5c412554d198b84845d34c60aa5ae1fa1167b5a551828f3f'
+            '9774ca475c280ba6641807063b79420a7a350a363154b7e20fb6307096f031ed'
+            '5060b449ac30fe3699e284bd633644d8a82faaa2b4e6516fb38b69b616972ca9'
+            'd15bd9341df9653603b6cb7de962ce47eff3a557368508c7f57240acca7057e1'
+            'b43e41f10e123ce449b0fc7224dfde18da122cb95897198f54175fe30f41f05e'
+            '082edeacdea36bad6f8901e276ee38876667ed79366d6745264cf905f1031042'
+            '5a5ee0d8a72eb056489c1881c8e2b183e128e96a6dc5cc9619286626223c226e'
             'a28a27192f336f0b0908bdbf840d3b19d7b587c4ac52cad635cb43e95eb3c78d'
             '1f6d2a340676543f1565416307ecf00d0c4ce68b2b3519f4ba9499d37c045a91'
-            '180ae8287158fd11214fa79c65f0b0880057fa8361f0055090218a0730927cbc')
+            '5e0851e372d78aac8ec20be40b13b2c010e45c1703d676711d793ae86ca82fd5')
 validpgpkeys=('462225C3B46F34879FC8496CD605848ED7E69871'  # Daiki Ueno
               '9001B85AF9E1B83DF1BDA942F5BE8B267C6A406D') # Bruno Haible (Open Source Development)
 
@@ -50,9 +62,15 @@ prepare() {
   patch -p1 -i $srcdir/gettext-0.21.1-cygwin-ftm.patch
   patch -p1 -i $srcdir/gettext-0.22-no-woe32dll-gettext-tools-configure-ac.patch
   patch -p1 -i $srcdir/gettext-0.22-no-woe32dll-m4-woe32-dll-m4.patch
-  patch -p1 -i $srcdir/gettext-0.22-gettext-runtime-gnulib-lib-localename-c.patch
-  patch -p1 -i $srcdir/gettext-0.22-gettext-runtime-intl-gnulib-lib-localename-c.patch
-  patch -p1 -i $srcdir/gettext-0.22-gettext-tools-gnulib-lib-localename-c.patch
+  patch -p1 -i $srcdir/gettext-0.22.5-gettext-runtime-gnulib-lib-localcharset-c.patch
+  patch -p1 -i $srcdir/gettext-0.22.5-gettext-runtime-gnulib-lib-localename-h.patch
+  patch -p1 -i $srcdir/gettext-0.22.5-gettext-runtime-gnulib-lib-localename-unsafe-c.patch
+  patch -p1 -i $srcdir/gettext-0.22.5-gettext-runtime-intl-gnulib-lib-localcharset-c.patch
+  patch -p1 -i $srcdir/gettext-0.22.5-gettext-runtime-intl-gnulib-lib-localename-h.patch
+  patch -p1 -i $srcdir/gettext-0.22.5-gettext-runtime-intl-gnulib-lib-localename-unsafe-c.patch
+  patch -p1 -i $srcdir/gettext-0.22.5-gettext-tools-gnulib-lib-localcharset-c.patch
+  patch -p1 -i $srcdir/gettext-0.22.5-gettext-tools-gnulib-lib-localename-h.patch
+  patch -p1 -i $srcdir/gettext-0.22.5-gettext-tools-gnulib-lib-localename-unsafe-c.patch
   patch -p1 -i $srcdir/gettext-0.22-disable-libtextstyle.patch
 
   # MSYS2 patch

--- a/gettext/gettext-0.19.7-archive.patch
+++ b/gettext/gettext-0.19.7-archive.patch
@@ -2300,3 +2300,14 @@ diff -Nur archive-orig/gettext-0.21/config.rpath archive/gettext-0.21/config.rpa
        case "$host_os" in
          mingw*)
            gl_final_[$1]=`cygpath -w "$gl_final_[$1]"` ;;
+--- archive-orig/gettext-0.22.5/m4/build-to-host.m4     2025-02-08 19:55:55.356513500 -0300
++++ archive/gettext-0.22.5/m4/build-to-host.m4  2025-02-08 19:57:37.912654100 -0300
+@@ -39,7 +39,7 @@
+   gl_final_[$1]="$[$1]"
+   dnl Translate it from build syntax to host syntax.
+   case "$build_os" in
+-    cygwin*)
++    cygwin* | msys*)
+       case "$host_os" in
+         mingw* | windows*)
+           gl_final_[$1]=`cygpath -w "$gl_final_[$1]"` ;;

--- a/gettext/gettext-0.22.5-gettext-runtime-gnulib-lib-localcharset-c.patch
+++ b/gettext/gettext-0.22.5-gettext-runtime-gnulib-lib-localcharset-c.patch
@@ -1,0 +1,91 @@
+--- origsrc/gettext-runtime/gnulib-lib/localcharset.c	2024-02-21 03:43:51.000000000 -0700
++++ src/gettext-runtime/gnulib-lib/localcharset.c	2024-02-26 07:33:50.105393100 -0700
+@@ -51,10 +51,6 @@
+ #   include <locale.h>
+ #  endif
+ # endif
+-# ifdef __CYGWIN__
+-#  define WIN32_LEAN_AND_MEAN
+-#  include <windows.h>
+-# endif
+ #elif defined WINDOWS_NATIVE
+ # define WIN32_LEAN_AND_MEAN
+ # include <windows.h>
+@@ -351,7 +347,7 @@ static const struct table_entry alias_ta
+     { "646", "ASCII" }
+ #   define alias_table_defined
+ #  endif
+-#  if defined WINDOWS_NATIVE || defined __CYGWIN__          /* Windows */
++#  if defined WINDOWS_NATIVE                                /* Windows */
+     { "CP1361",  "JOHAB" },
+     { "CP20127", "ASCII" },
+     { "CP20866", "KOI8-R" },
+@@ -846,68 +842,6 @@ locale_charset (void)
+   /* Most systems support nl_langinfo (CODESET) nowadays.  */
+   codeset = nl_langinfo (CODESET);
+ 
+-#  ifdef __CYGWIN__
+-  /* Cygwin < 1.7 does not have locales.  nl_langinfo (CODESET) always
+-     returns "US-ASCII".  Return the suffix of the locale name from the
+-     environment variables (if present) or the codepage as a number.  */
+-  if (codeset != NULL && strcmp (codeset, "US-ASCII") == 0)
+-    {
+-      const char *locale;
+-      static char resultbuf[2 + 10 + 1];
+-
+-      locale = getenv ("LC_ALL");
+-      if (locale == NULL || locale[0] == '\0')
+-        {
+-          locale = getenv ("LC_CTYPE");
+-          if (locale == NULL || locale[0] == '\0')
+-            locale = getenv ("LANG");
+-        }
+-      if (locale != NULL && locale[0] != '\0')
+-        {
+-          /* If the locale name contains an encoding after the dot, return
+-             it.  */
+-          const char *dot = strchr (locale, '.');
+-
+-          if (dot != NULL)
+-            {
+-              const char *modifier;
+-
+-              dot++;
+-              /* Look for the possible @... trailer and remove it, if any.  */
+-              modifier = strchr (dot, '@');
+-              if (modifier == NULL)
+-                return dot;
+-              if (modifier - dot < sizeof (resultbuf))
+-                {
+-                  /* This way of filling resultbuf is multithread-safe.  */
+-                  memcpy (resultbuf, dot, modifier - dot);
+-                  resultbuf [modifier - dot] = '\0';
+-                  return resultbuf;
+-                }
+-            }
+-        }
+-
+-      /* The Windows API has a function returning the locale's codepage as a
+-         number: GetACP().  This encoding is used by Cygwin, unless the user
+-         has set the environment variable CYGWIN=codepage:oem (which very few
+-         people do).
+-         Output directed to console windows needs to be converted (to
+-         GetOEMCP() if the console is using a raster font, or to
+-         GetConsoleOutputCP() if it is using a TrueType font).  Cygwin does
+-         this conversion transparently (see winsup/cygwin/fhandler_console.cc),
+-         converting to GetConsoleOutputCP().  This leads to correct results,
+-         except when SetConsoleOutputCP has been called and a raster font is
+-         in use.  */
+-      {
+-        char buf[2 + 10 + 1];
+-
+-        sprintf (buf, "CP%u", GetACP ());
+-        strcpy (resultbuf, buf);
+-        codeset = resultbuf;
+-      }
+-    }
+-#  endif
+-
+   if (codeset == NULL)
+     /* The canonical name cannot be determined.  */
+     codeset = "";

--- a/gettext/gettext-0.22.5-gettext-runtime-gnulib-lib-localename-h.patch
+++ b/gettext/gettext-0.22.5-gettext-runtime-gnulib-lib-localename-h.patch
@@ -1,0 +1,11 @@
+--- origsrc/gettext-runtime/gnulib-lib/localename.h	2024-02-21 03:43:51.000000000 -0700
++++ src/gettext-runtime/gnulib-lib/localename.h	2024-02-26 07:40:54.664851300 -0700
+@@ -91,7 +91,7 @@ extern const char * gl_locale_name_envir
+ 
+    The result must not be freed; it is statically allocated.  */
+ extern const char * gl_locale_name_default (void)
+-#if !(HAVE_CFPREFERENCESCOPYAPPVALUE || defined _WIN32 || defined __CYGWIN__)
++#if !(HAVE_CFPREFERENCESCOPYAPPVALUE || defined _WIN32)
+   _GL_ATTRIBUTE_CONST
+ #endif
+   ;

--- a/gettext/gettext-0.22.5-gettext-runtime-gnulib-lib-localename-unsafe-c.patch
+++ b/gettext/gettext-0.22.5-gettext-runtime-gnulib-lib-localename-unsafe-c.patch
@@ -1,0 +1,112 @@
+--- origsrc/gettext-runtime/gnulib-lib/localename-unsafe.c	2024-02-21 03:43:51.000000000 -0700
++++ src/gettext-runtime/gnulib-lib/localename-unsafe.c	2024-02-25 09:16:19.293294900 -0700
+@@ -77,7 +77,7 @@ extern char * getlocalename_l(int, local
+ # include "thread-optim.h"
+ #endif
+ 
+-#if defined WINDOWS_NATIVE || defined __CYGWIN__ /* Native Windows or Cygwin */
++#if defined WINDOWS_NATIVE /* Native Windows */
+ # define WIN32_LEAN_AND_MEAN
+ # include <windows.h>
+ # include <winnls.h>
+@@ -1461,7 +1461,7 @@ gl_locale_name_canonicalize (char *name)
+ #endif
+ 
+ 
+-#if defined WINDOWS_NATIVE || defined __CYGWIN__ /* Native Windows or Cygwin */
++#if defined WINDOWS_NATIVE /* Native Windows */
+ 
+ /* Canonicalize a Windows native locale name to a Unix locale name.
+    NAME is a sufficiently large buffer.
+@@ -3117,19 +3117,6 @@ gl_locale_name_thread_unsafe (int catego
+ #  endif
+ # elif defined _AIX && HAVE_NAMELESS_LOCALES
+         return get_locale_t_name (category, thread_locale);
+-# elif defined __CYGWIN__
+-        /* Cygwin < 2.6 lacks uselocale and thread-local locales altogether.
+-           Cygwin <= 2.6.1 lacks NL_LOCALE_NAME, requiring peeking inside
+-           an opaque struct.  */
+-#  ifdef NL_LOCALE_NAME
+-        return nl_langinfo_l (NL_LOCALE_NAME (category), thread_locale);
+-#  else
+-        /* FIXME: Remove when we can assume new-enough Cygwin.  */
+-        struct __locale_t {
+-          char categories[7][32];
+-        };
+-        return ((struct __locale_t *) thread_locale)->categories[category];
+-#  endif
+ # elif defined __HAIKU__
+         /* Since 2022, Haiku has per-thread locales.  locale_t is 'void *',
+            but in fact a 'LocaleBackendData *'.  */
+@@ -3219,9 +3206,10 @@ gl_locale_name_thread_unsafe (int catego
+      - musl libc,
+      - FreeBSD, NetBSD,
+      - Solaris,
+-     - Haiku.
++     - Haiku,
++     - Cygwin.
+    We cannot use it on
+-     - macOS, Cygwin (because these systems have a facility for customizing the
++     - macOS (because these systems have a facility for customizing the
+        default locale, and setlocale (category, NULL) ignores it and merely
+        returns "C" or "C.UTF-8"),
+      - OpenBSD (because on OpenBSD ≤ 6.1, LC_ALL does not set the LC_NUMERIC,
+@@ -3232,7 +3220,7 @@ gl_locale_name_thread_unsafe (int catego
+      - native Windows (because it has locale names such as French_France.1252),
+      - Android (because it only supports the C and C.UTF-8 locales).
+  */
+-#if defined _LIBC || ((defined __GLIBC__ && __GLIBC__ >= 2) && !defined __UCLIBC__) || MUSL_LIBC || defined __FreeBSD__ || defined __NetBSD__ || defined __sun || defined __HAIKU__
++#if defined _LIBC || ((defined __GLIBC__ && __GLIBC__ >= 2) && !defined __UCLIBC__) || MUSL_LIBC || defined __FreeBSD__ || defined __NetBSD__ || defined __sun || defined __HAIKU__ || defined CYGWIN
+ # define HAVE_LOCALE_NULL
+ #endif
+ 
+@@ -3273,8 +3261,8 @@ gl_locale_name_posix_unsafe (int categor
+     /* On other systems we ignore what setlocale reports and instead look at the
+        environment variables directly.  This is necessary
+          1. on systems which have a facility for customizing the default locale
+-            (macOS, native Windows, Cygwin) and where the system's setlocale()
+-            function ignores this default locale (macOS, Cygwin), in two cases:
++            (macOS, native Windows) and where the system's setlocale()
++            function ignores this default locale (macOS), in two cases:
+             a. when the user missed to use the setlocale() override from libintl
+                (for example by not including <libintl.h>),
+             b. when setlocale supports only the "C" locale, such as on Cygwin
+@@ -3329,11 +3317,6 @@ gl_locale_name_environ (_GL_UNUSED int c
+          Ignore invalid LANG value set by the Terminal application.  */
+       if (strcmp (retval, "UTF-8") != 0)
+ #endif
+-#if defined __CYGWIN__
+-      /* Cygwin.
+-         Ignore dummy LANG value set by ~/.profile.  */
+-      if (strcmp (retval, "C.UTF-8") != 0)
+-#endif
+         return retval;
+     }
+ 
+@@ -3362,16 +3345,11 @@ gl_locale_name_default (void)
+        - On native Windows, by default, none of LC_* or LANG are set.
+          When no environment variable is set, setlocale (LC_ALL, "") uses the
+          locale chosen by the user.
+-       - On Cygwin 1.5.x, by default, none of LC_* or LANG are set.
+-         When no environment variable is set, setlocale (LC_ALL, "") uses the
+-         "C" locale.
+-       - On Cygwin 1.7, by default, LANG is set to "C.UTF-8" when the default
+-         ~/.profile is executed.
+          When no environment variable is set, setlocale (LC_ALL, "") uses the
+          "C.UTF-8" locale, which operates in the same way as the "C" locale.
+   */
+ 
+-#if !(HAVE_CFPREFERENCESCOPYAPPVALUE || defined WINDOWS_NATIVE || defined __CYGWIN__)
++#if !(HAVE_CFPREFERENCESCOPYAPPVALUE || defined WINDOWS_NATIVE)
+ 
+   /* The system does not have a way of setting the locale, other than the
+      POSIX specified environment variables.  We use C as default locale.  */
+@@ -3424,7 +3402,7 @@ gl_locale_name_default (void)
+ 
+ # endif
+ 
+-# if defined WINDOWS_NATIVE || defined __CYGWIN__ /* Native Windows or Cygwin */
++# if defined WINDOWS_NATIVE /* Native Windows */
+   {
+     LCID lcid;
+ 

--- a/gettext/gettext-0.22.5-gettext-runtime-intl-gnulib-lib-localcharset-c.patch
+++ b/gettext/gettext-0.22.5-gettext-runtime-intl-gnulib-lib-localcharset-c.patch
@@ -1,0 +1,91 @@
+--- origsrc/gettext-runtime/intl/gnulib-lib/localcharset.c	2024-02-21 03:43:51.000000000 -0700
++++ src/gettext-runtime/intl/gnulib-lib/localcharset.c	2024-02-26 07:33:50.105393100 -0700
+@@ -51,10 +51,6 @@
+ #   include <locale.h>
+ #  endif
+ # endif
+-# ifdef __CYGWIN__
+-#  define WIN32_LEAN_AND_MEAN
+-#  include <windows.h>
+-# endif
+ #elif defined WINDOWS_NATIVE
+ # define WIN32_LEAN_AND_MEAN
+ # include <windows.h>
+@@ -351,7 +347,7 @@ static const struct table_entry alias_ta
+     { "646", "ASCII" }
+ #   define alias_table_defined
+ #  endif
+-#  if defined WINDOWS_NATIVE || defined __CYGWIN__          /* Windows */
++#  if defined WINDOWS_NATIVE                                /* Windows */
+     { "CP1361",  "JOHAB" },
+     { "CP20127", "ASCII" },
+     { "CP20866", "KOI8-R" },
+@@ -846,68 +842,6 @@ locale_charset (void)
+   /* Most systems support nl_langinfo (CODESET) nowadays.  */
+   codeset = nl_langinfo (CODESET);
+ 
+-#  ifdef __CYGWIN__
+-  /* Cygwin < 1.7 does not have locales.  nl_langinfo (CODESET) always
+-     returns "US-ASCII".  Return the suffix of the locale name from the
+-     environment variables (if present) or the codepage as a number.  */
+-  if (codeset != NULL && strcmp (codeset, "US-ASCII") == 0)
+-    {
+-      const char *locale;
+-      static char resultbuf[2 + 10 + 1];
+-
+-      locale = getenv ("LC_ALL");
+-      if (locale == NULL || locale[0] == '\0')
+-        {
+-          locale = getenv ("LC_CTYPE");
+-          if (locale == NULL || locale[0] == '\0')
+-            locale = getenv ("LANG");
+-        }
+-      if (locale != NULL && locale[0] != '\0')
+-        {
+-          /* If the locale name contains an encoding after the dot, return
+-             it.  */
+-          const char *dot = strchr (locale, '.');
+-
+-          if (dot != NULL)
+-            {
+-              const char *modifier;
+-
+-              dot++;
+-              /* Look for the possible @... trailer and remove it, if any.  */
+-              modifier = strchr (dot, '@');
+-              if (modifier == NULL)
+-                return dot;
+-              if (modifier - dot < sizeof (resultbuf))
+-                {
+-                  /* This way of filling resultbuf is multithread-safe.  */
+-                  memcpy (resultbuf, dot, modifier - dot);
+-                  resultbuf [modifier - dot] = '\0';
+-                  return resultbuf;
+-                }
+-            }
+-        }
+-
+-      /* The Windows API has a function returning the locale's codepage as a
+-         number: GetACP().  This encoding is used by Cygwin, unless the user
+-         has set the environment variable CYGWIN=codepage:oem (which very few
+-         people do).
+-         Output directed to console windows needs to be converted (to
+-         GetOEMCP() if the console is using a raster font, or to
+-         GetConsoleOutputCP() if it is using a TrueType font).  Cygwin does
+-         this conversion transparently (see winsup/cygwin/fhandler_console.cc),
+-         converting to GetConsoleOutputCP().  This leads to correct results,
+-         except when SetConsoleOutputCP has been called and a raster font is
+-         in use.  */
+-      {
+-        char buf[2 + 10 + 1];
+-
+-        sprintf (buf, "CP%u", GetACP ());
+-        strcpy (resultbuf, buf);
+-        codeset = resultbuf;
+-      }
+-    }
+-#  endif
+-
+   if (codeset == NULL)
+     /* The canonical name cannot be determined.  */
+     codeset = "";

--- a/gettext/gettext-0.22.5-gettext-runtime-intl-gnulib-lib-localename-h.patch
+++ b/gettext/gettext-0.22.5-gettext-runtime-intl-gnulib-lib-localename-h.patch
@@ -1,0 +1,11 @@
+--- origsrc/gettext-runtime/intl/gnulib-lib/localename.h	2024-02-21 03:43:51.000000000 -0700
++++ src/gettext-runtime/intl/gnulib-lib/localename.h	2024-02-26 07:40:54.664851300 -0700
+@@ -91,7 +91,7 @@ extern const char * gl_locale_name_envir
+ 
+    The result must not be freed; it is statically allocated.  */
+ extern const char * gl_locale_name_default (void)
+-#if !(HAVE_CFPREFERENCESCOPYAPPVALUE || defined _WIN32 || defined __CYGWIN__)
++#if !(HAVE_CFPREFERENCESCOPYAPPVALUE || defined _WIN32)
+   _GL_ATTRIBUTE_CONST
+ #endif
+   ;

--- a/gettext/gettext-0.22.5-gettext-runtime-intl-gnulib-lib-localename-unsafe-c.patch
+++ b/gettext/gettext-0.22.5-gettext-runtime-intl-gnulib-lib-localename-unsafe-c.patch
@@ -1,0 +1,112 @@
+--- origsrc/gettext-runtime/intl/gnulib-lib/localename-unsafe.c	2024-02-21 03:43:51.000000000 -0700
++++ src/gettext-runtime/intl/gnulib-lib/localename-unsafe.c	2024-02-25 09:16:19.293294900 -0700
+@@ -77,7 +77,7 @@ extern char * getlocalename_l(int, local
+ # include "thread-optim.h"
+ #endif
+ 
+-#if defined WINDOWS_NATIVE || defined __CYGWIN__ /* Native Windows or Cygwin */
++#if defined WINDOWS_NATIVE /* Native Windows */
+ # define WIN32_LEAN_AND_MEAN
+ # include <windows.h>
+ # include <winnls.h>
+@@ -1461,7 +1461,7 @@ gl_locale_name_canonicalize (char *name)
+ #endif
+ 
+ 
+-#if defined WINDOWS_NATIVE || defined __CYGWIN__ /* Native Windows or Cygwin */
++#if defined WINDOWS_NATIVE /* Native Windows */
+ 
+ /* Canonicalize a Windows native locale name to a Unix locale name.
+    NAME is a sufficiently large buffer.
+@@ -3117,19 +3117,6 @@ gl_locale_name_thread_unsafe (int catego
+ #  endif
+ # elif defined _AIX && HAVE_NAMELESS_LOCALES
+         return get_locale_t_name (category, thread_locale);
+-# elif defined __CYGWIN__
+-        /* Cygwin < 2.6 lacks uselocale and thread-local locales altogether.
+-           Cygwin <= 2.6.1 lacks NL_LOCALE_NAME, requiring peeking inside
+-           an opaque struct.  */
+-#  ifdef NL_LOCALE_NAME
+-        return nl_langinfo_l (NL_LOCALE_NAME (category), thread_locale);
+-#  else
+-        /* FIXME: Remove when we can assume new-enough Cygwin.  */
+-        struct __locale_t {
+-          char categories[7][32];
+-        };
+-        return ((struct __locale_t *) thread_locale)->categories[category];
+-#  endif
+ # elif defined __HAIKU__
+         /* Since 2022, Haiku has per-thread locales.  locale_t is 'void *',
+            but in fact a 'LocaleBackendData *'.  */
+@@ -3219,9 +3206,10 @@ gl_locale_name_thread_unsafe (int catego
+      - musl libc,
+      - FreeBSD, NetBSD,
+      - Solaris,
+-     - Haiku.
++     - Haiku,
++     - Cygwin.
+    We cannot use it on
+-     - macOS, Cygwin (because these systems have a facility for customizing the
++     - macOS (because these systems have a facility for customizing the
+        default locale, and setlocale (category, NULL) ignores it and merely
+        returns "C" or "C.UTF-8"),
+      - OpenBSD (because on OpenBSD ≤ 6.1, LC_ALL does not set the LC_NUMERIC,
+@@ -3232,7 +3220,7 @@ gl_locale_name_thread_unsafe (int catego
+      - native Windows (because it has locale names such as French_France.1252),
+      - Android (because it only supports the C and C.UTF-8 locales).
+  */
+-#if defined _LIBC || ((defined __GLIBC__ && __GLIBC__ >= 2) && !defined __UCLIBC__) || MUSL_LIBC || defined __FreeBSD__ || defined __NetBSD__ || defined __sun || defined __HAIKU__
++#if defined _LIBC || ((defined __GLIBC__ && __GLIBC__ >= 2) && !defined __UCLIBC__) || MUSL_LIBC || defined __FreeBSD__ || defined __NetBSD__ || defined __sun || defined __HAIKU__ || defined CYGWIN
+ # define HAVE_LOCALE_NULL
+ #endif
+ 
+@@ -3273,8 +3261,8 @@ gl_locale_name_posix_unsafe (int categor
+     /* On other systems we ignore what setlocale reports and instead look at the
+        environment variables directly.  This is necessary
+          1. on systems which have a facility for customizing the default locale
+-            (macOS, native Windows, Cygwin) and where the system's setlocale()
+-            function ignores this default locale (macOS, Cygwin), in two cases:
++            (macOS, native Windows) and where the system's setlocale()
++            function ignores this default locale (macOS), in two cases:
+             a. when the user missed to use the setlocale() override from libintl
+                (for example by not including <libintl.h>),
+             b. when setlocale supports only the "C" locale, such as on Cygwin
+@@ -3329,11 +3317,6 @@ gl_locale_name_environ (_GL_UNUSED int c
+          Ignore invalid LANG value set by the Terminal application.  */
+       if (strcmp (retval, "UTF-8") != 0)
+ #endif
+-#if defined __CYGWIN__
+-      /* Cygwin.
+-         Ignore dummy LANG value set by ~/.profile.  */
+-      if (strcmp (retval, "C.UTF-8") != 0)
+-#endif
+         return retval;
+     }
+ 
+@@ -3362,16 +3345,11 @@ gl_locale_name_default (void)
+        - On native Windows, by default, none of LC_* or LANG are set.
+          When no environment variable is set, setlocale (LC_ALL, "") uses the
+          locale chosen by the user.
+-       - On Cygwin 1.5.x, by default, none of LC_* or LANG are set.
+-         When no environment variable is set, setlocale (LC_ALL, "") uses the
+-         "C" locale.
+-       - On Cygwin 1.7, by default, LANG is set to "C.UTF-8" when the default
+-         ~/.profile is executed.
+          When no environment variable is set, setlocale (LC_ALL, "") uses the
+          "C.UTF-8" locale, which operates in the same way as the "C" locale.
+   */
+ 
+-#if !(HAVE_CFPREFERENCESCOPYAPPVALUE || defined WINDOWS_NATIVE || defined __CYGWIN__)
++#if !(HAVE_CFPREFERENCESCOPYAPPVALUE || defined WINDOWS_NATIVE)
+ 
+   /* The system does not have a way of setting the locale, other than the
+      POSIX specified environment variables.  We use C as default locale.  */
+@@ -3424,7 +3402,7 @@ gl_locale_name_default (void)
+ 
+ # endif
+ 
+-# if defined WINDOWS_NATIVE || defined __CYGWIN__ /* Native Windows or Cygwin */
++# if defined WINDOWS_NATIVE /* Native Windows */
+   {
+     LCID lcid;
+ 

--- a/gettext/gettext-0.22.5-gettext-tools-gnulib-lib-localcharset-c.patch
+++ b/gettext/gettext-0.22.5-gettext-tools-gnulib-lib-localcharset-c.patch
@@ -1,0 +1,91 @@
+--- origsrc/gettext-tools/gnulib-lib/localcharset.c	2024-02-21 03:43:51.000000000 -0700
++++ src/gettext-tools/gnulib-lib/localcharset.c	2024-02-26 07:33:50.105393100 -0700
+@@ -51,10 +51,6 @@
+ #   include <locale.h>
+ #  endif
+ # endif
+-# ifdef __CYGWIN__
+-#  define WIN32_LEAN_AND_MEAN
+-#  include <windows.h>
+-# endif
+ #elif defined WINDOWS_NATIVE
+ # define WIN32_LEAN_AND_MEAN
+ # include <windows.h>
+@@ -351,7 +347,7 @@ static const struct table_entry alias_ta
+     { "646", "ASCII" }
+ #   define alias_table_defined
+ #  endif
+-#  if defined WINDOWS_NATIVE || defined __CYGWIN__          /* Windows */
++#  if defined WINDOWS_NATIVE                                /* Windows */
+     { "CP1361",  "JOHAB" },
+     { "CP20127", "ASCII" },
+     { "CP20866", "KOI8-R" },
+@@ -846,68 +842,6 @@ locale_charset (void)
+   /* Most systems support nl_langinfo (CODESET) nowadays.  */
+   codeset = nl_langinfo (CODESET);
+ 
+-#  ifdef __CYGWIN__
+-  /* Cygwin < 1.7 does not have locales.  nl_langinfo (CODESET) always
+-     returns "US-ASCII".  Return the suffix of the locale name from the
+-     environment variables (if present) or the codepage as a number.  */
+-  if (codeset != NULL && strcmp (codeset, "US-ASCII") == 0)
+-    {
+-      const char *locale;
+-      static char resultbuf[2 + 10 + 1];
+-
+-      locale = getenv ("LC_ALL");
+-      if (locale == NULL || locale[0] == '\0')
+-        {
+-          locale = getenv ("LC_CTYPE");
+-          if (locale == NULL || locale[0] == '\0')
+-            locale = getenv ("LANG");
+-        }
+-      if (locale != NULL && locale[0] != '\0')
+-        {
+-          /* If the locale name contains an encoding after the dot, return
+-             it.  */
+-          const char *dot = strchr (locale, '.');
+-
+-          if (dot != NULL)
+-            {
+-              const char *modifier;
+-
+-              dot++;
+-              /* Look for the possible @... trailer and remove it, if any.  */
+-              modifier = strchr (dot, '@');
+-              if (modifier == NULL)
+-                return dot;
+-              if (modifier - dot < sizeof (resultbuf))
+-                {
+-                  /* This way of filling resultbuf is multithread-safe.  */
+-                  memcpy (resultbuf, dot, modifier - dot);
+-                  resultbuf [modifier - dot] = '\0';
+-                  return resultbuf;
+-                }
+-            }
+-        }
+-
+-      /* The Windows API has a function returning the locale's codepage as a
+-         number: GetACP().  This encoding is used by Cygwin, unless the user
+-         has set the environment variable CYGWIN=codepage:oem (which very few
+-         people do).
+-         Output directed to console windows needs to be converted (to
+-         GetOEMCP() if the console is using a raster font, or to
+-         GetConsoleOutputCP() if it is using a TrueType font).  Cygwin does
+-         this conversion transparently (see winsup/cygwin/fhandler_console.cc),
+-         converting to GetConsoleOutputCP().  This leads to correct results,
+-         except when SetConsoleOutputCP has been called and a raster font is
+-         in use.  */
+-      {
+-        char buf[2 + 10 + 1];
+-
+-        sprintf (buf, "CP%u", GetACP ());
+-        strcpy (resultbuf, buf);
+-        codeset = resultbuf;
+-      }
+-    }
+-#  endif
+-
+   if (codeset == NULL)
+     /* The canonical name cannot be determined.  */
+     codeset = "";

--- a/gettext/gettext-0.22.5-gettext-tools-gnulib-lib-localename-h.patch
+++ b/gettext/gettext-0.22.5-gettext-tools-gnulib-lib-localename-h.patch
@@ -1,0 +1,11 @@
+--- origsrc/gettext-tools/gnulib-lib/localename.h	2024-02-21 03:43:51.000000000 -0700
++++ src/gettext-tools/gnulib-lib/localename.h	2024-02-26 07:40:54.664851300 -0700
+@@ -91,7 +91,7 @@ extern const char * gl_locale_name_envir
+ 
+    The result must not be freed; it is statically allocated.  */
+ extern const char * gl_locale_name_default (void)
+-#if !(HAVE_CFPREFERENCESCOPYAPPVALUE || defined _WIN32 || defined __CYGWIN__)
++#if !(HAVE_CFPREFERENCESCOPYAPPVALUE || defined _WIN32)
+   _GL_ATTRIBUTE_CONST
+ #endif
+   ;

--- a/gettext/gettext-0.22.5-gettext-tools-gnulib-lib-localename-unsafe-c.patch
+++ b/gettext/gettext-0.22.5-gettext-tools-gnulib-lib-localename-unsafe-c.patch
@@ -1,0 +1,112 @@
+--- origsrc/gettext-tools/gnulib-lib/localename-unsafe.c	2024-02-21 03:43:51.000000000 -0700
++++ src/gettext-tools/gnulib-lib/localename-unsafe.c	2024-02-25 09:16:19.293294900 -0700
+@@ -77,7 +77,7 @@ extern char * getlocalename_l(int, local
+ # include "thread-optim.h"
+ #endif
+ 
+-#if defined WINDOWS_NATIVE || defined __CYGWIN__ /* Native Windows or Cygwin */
++#if defined WINDOWS_NATIVE /* Native Windows */
+ # define WIN32_LEAN_AND_MEAN
+ # include <windows.h>
+ # include <winnls.h>
+@@ -1461,7 +1461,7 @@ gl_locale_name_canonicalize (char *name)
+ #endif
+ 
+ 
+-#if defined WINDOWS_NATIVE || defined __CYGWIN__ /* Native Windows or Cygwin */
++#if defined WINDOWS_NATIVE /* Native Windows */
+ 
+ /* Canonicalize a Windows native locale name to a Unix locale name.
+    NAME is a sufficiently large buffer.
+@@ -3117,19 +3117,6 @@ gl_locale_name_thread_unsafe (int catego
+ #  endif
+ # elif defined _AIX && HAVE_NAMELESS_LOCALES
+         return get_locale_t_name (category, thread_locale);
+-# elif defined __CYGWIN__
+-        /* Cygwin < 2.6 lacks uselocale and thread-local locales altogether.
+-           Cygwin <= 2.6.1 lacks NL_LOCALE_NAME, requiring peeking inside
+-           an opaque struct.  */
+-#  ifdef NL_LOCALE_NAME
+-        return nl_langinfo_l (NL_LOCALE_NAME (category), thread_locale);
+-#  else
+-        /* FIXME: Remove when we can assume new-enough Cygwin.  */
+-        struct __locale_t {
+-          char categories[7][32];
+-        };
+-        return ((struct __locale_t *) thread_locale)->categories[category];
+-#  endif
+ # elif defined __HAIKU__
+         /* Since 2022, Haiku has per-thread locales.  locale_t is 'void *',
+            but in fact a 'LocaleBackendData *'.  */
+@@ -3219,9 +3206,10 @@ gl_locale_name_thread_unsafe (int catego
+      - musl libc,
+      - FreeBSD, NetBSD,
+      - Solaris,
+-     - Haiku.
++     - Haiku,
++     - Cygwin.
+    We cannot use it on
+-     - macOS, Cygwin (because these systems have a facility for customizing the
++     - macOS (because these systems have a facility for customizing the
+        default locale, and setlocale (category, NULL) ignores it and merely
+        returns "C" or "C.UTF-8"),
+      - OpenBSD (because on OpenBSD ≤ 6.1, LC_ALL does not set the LC_NUMERIC,
+@@ -3232,7 +3220,7 @@ gl_locale_name_thread_unsafe (int catego
+      - native Windows (because it has locale names such as French_France.1252),
+      - Android (because it only supports the C and C.UTF-8 locales).
+  */
+-#if defined _LIBC || ((defined __GLIBC__ && __GLIBC__ >= 2) && !defined __UCLIBC__) || MUSL_LIBC || defined __FreeBSD__ || defined __NetBSD__ || defined __sun || defined __HAIKU__
++#if defined _LIBC || ((defined __GLIBC__ && __GLIBC__ >= 2) && !defined __UCLIBC__) || MUSL_LIBC || defined __FreeBSD__ || defined __NetBSD__ || defined __sun || defined __HAIKU__ || defined CYGWIN
+ # define HAVE_LOCALE_NULL
+ #endif
+ 
+@@ -3273,8 +3261,8 @@ gl_locale_name_posix_unsafe (int categor
+     /* On other systems we ignore what setlocale reports and instead look at the
+        environment variables directly.  This is necessary
+          1. on systems which have a facility for customizing the default locale
+-            (macOS, native Windows, Cygwin) and where the system's setlocale()
+-            function ignores this default locale (macOS, Cygwin), in two cases:
++            (macOS, native Windows) and where the system's setlocale()
++            function ignores this default locale (macOS), in two cases:
+             a. when the user missed to use the setlocale() override from libintl
+                (for example by not including <libintl.h>),
+             b. when setlocale supports only the "C" locale, such as on Cygwin
+@@ -3329,11 +3317,6 @@ gl_locale_name_environ (_GL_UNUSED int c
+          Ignore invalid LANG value set by the Terminal application.  */
+       if (strcmp (retval, "UTF-8") != 0)
+ #endif
+-#if defined __CYGWIN__
+-      /* Cygwin.
+-         Ignore dummy LANG value set by ~/.profile.  */
+-      if (strcmp (retval, "C.UTF-8") != 0)
+-#endif
+         return retval;
+     }
+ 
+@@ -3362,16 +3345,11 @@ gl_locale_name_default (void)
+        - On native Windows, by default, none of LC_* or LANG are set.
+          When no environment variable is set, setlocale (LC_ALL, "") uses the
+          locale chosen by the user.
+-       - On Cygwin 1.5.x, by default, none of LC_* or LANG are set.
+-         When no environment variable is set, setlocale (LC_ALL, "") uses the
+-         "C" locale.
+-       - On Cygwin 1.7, by default, LANG is set to "C.UTF-8" when the default
+-         ~/.profile is executed.
+          When no environment variable is set, setlocale (LC_ALL, "") uses the
+          "C.UTF-8" locale, which operates in the same way as the "C" locale.
+   */
+ 
+-#if !(HAVE_CFPREFERENCESCOPYAPPVALUE || defined WINDOWS_NATIVE || defined __CYGWIN__)
++#if !(HAVE_CFPREFERENCESCOPYAPPVALUE || defined WINDOWS_NATIVE)
+ 
+   /* The system does not have a way of setting the locale, other than the
+      POSIX specified environment variables.  We use C as default locale.  */
+@@ -3424,7 +3402,7 @@ gl_locale_name_default (void)
+ 
+ # endif
+ 
+-# if defined WINDOWS_NATIVE || defined __CYGWIN__ /* Native Windows or Cygwin */
++# if defined WINDOWS_NATIVE /* Native Windows */
+   {
+     LCID lcid;
+ 


### PR DESCRIPTION
## Description

This update was born as an attempt to solve build issues for nano 8.3 ( [https://github.com/msys2/MSYS2-packages/pull/5110#issuecomment-2646155381](https://github.com/msys2/MSYS2-packages/pull/5110#issuecomment-2646155381) ).

Changes:
* All the added patches ( gettext-0.22.5-* ) came from Cygwin sources for gettext;
* The patches that were disabled ( gettext-0.22-gettext-* ) no longer applies for 0.22.5;
* The addition on ```gettext-0.19.7-archive.patch``` followed the idea from the last update.

> [!NOTE]
> 
> I have no experience with gettext at all (I was trying to solve build issues on nano 8.3), so someone skilled enough on it should run their tests