### PR TITLE
nano: follow git-for-windows and paint interface elements

### DIFF
--- a/nano/0002-paint-interface-elements.patch
+++ b/nano/0002-paint-interface-elements.patch
@@ -1,0 +1,32 @@
+diff -Naur nano-8.3-orig/doc/sample.nanorc.in nano-8.3/doc/sample.nanorc.in
+--- nano-8.3-orig/doc/sample.nanorc.in	2024-12-20 07:38:10.000000000 -0300
++++ nano-8.3/doc/sample.nanorc.in	2025-02-21 11:33:55.337769515 -0300
+@@ -219,17 +219,17 @@
+ 
+ ## Paint the interface elements of nano.  These are examples; there are
+ ## no colors by default, except for errorcolor and spotlightcolor.
+-# set titlecolor bold,white,blue
+-# set promptcolor lightwhite,grey
+-# set statuscolor bold,white,green
+-# set errorcolor bold,white,red
+-# set spotlightcolor black,lightyellow
+-# set selectedcolor lightwhite,magenta
+-# set stripecolor ,#444
+-# set scrollercolor cyan
+-# set numbercolor cyan
+-# set keycolor cyan
+-# set functioncolor green
++set titlecolor bold,white,magenta
++set promptcolor lightwhite,grey
++set statuscolor bold,white,#770
++set errorcolor bold,white,red
++set spotlightcolor black,lightgreen
++set selectedcolor lightwhite,blue
++set stripecolor ,#444
++set scrollercolor orange
++set numbercolor orange
++set keycolor orange
++set functioncolor yellow
+ 
+ ## In root's .nanorc you might want to use:
+ # set titlecolor bold,white,magenta

--- a/nano/PKGBUILD
+++ b/nano/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=nano
 pkgver=8.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Pico editor clone with enhancements"
 arch=('i686' 'x86_64')
 license=('spdx:GPL-3.0-or-later')
@@ -20,10 +20,12 @@ makedepends=('autotools'
              'gettext-devel')
 backup=('etc/nanorc')
 source=(https://www.nano-editor.org/dist/v8/${pkgname}-${pkgver}.tar.xz{,.asc}
-        "0001-fix-link-order.patch")
+        "0001-fix-link-order.patch"
+        "0002-paint-interface-elements.patch")
 sha256sums=('551b717b2e28f7e90f749323686a1b5bbbd84cfa1390604d854a3ca3778f111e'
             'SKIP'
-            'fd89f31bd8813db14587241ef4526f929dcee17b97572b70e92f2db40b53c859')
+            'fd89f31bd8813db14587241ef4526f929dcee17b97572b70e92f2db40b53c859'
+            '9df1a720de5cbcd6fa93e257afbc0ccf92d5c841c24a0a9c666df3b1d63399f2')
 validpgpkeys=(
   '168E6F4297BFD7A79AFD4496514BBE2EB8E1961F' # Benno Schulenberg <bensberg@telfort.nl>
 )
@@ -32,6 +34,7 @@ prepare() {
   cd "${pkgname}-${pkgver}"
 
   patch -Np1 -i "${srcdir}/0001-fix-link-order.patch"
+  patch -Np1 -i "${srcdir}/0002-paint-interface-elements.patch"
 
   autoreconf -vfi
 }


### PR DESCRIPTION
## Description

As the title says: follow git-for-windows and paint interface elements of nano

[https://github.com/git-for-windows/git-sdk-64/blob/869fd0088bed870075a3a8e109367c0920625b57/etc/nanorc#L219-L233](https://github.com/git-for-windows/git-sdk-64/blob/869fd0088bed870075a3a8e109367c0920625b57/etc/nanorc#L219-L233)

> [!NOTE]
> 
> I did not use the same colors as git-for-windows to differentiate the MSYS2 shells. The ```titlecolor``` was set as magenta (resembles MSYS2 icon color), and orange / yellow on other parts to resemble the recommended environment (UCRT64) icon color.

## Screenshots

Once this PR is merged, a file opened on nano through any MSYS2 shell would look like the following image

![Screenshot from 2025-02-21 11-58-12](https://github.com/user-attachments/assets/ff327bb5-fb29-49fb-99b9-868aae559524)

## Wishes

In my opinion, MSYS2 should go even further enabling the default syntax highlighting files by uncommenting the line 252

