### PR TITLE
enscript: new package

### DIFF
--- a/enscript/PKGBUILD
+++ b/enscript/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc="Convert ASCII files to PostScript suitable for printing"
 arch=('x86_64')
 url="https://git.savannah.gnu.org/cgit/enscript.git"
 license=('sdpx:GPL-3.0-or-later')
-depends=('perl' 'gcc-libs' 'cygutils')
+depends=('perl' 'gcc-libs')
 
 makedepends=('autotools' 'gcc')
 optdepends=('cygutils: Send the output to a physical printer instead of stdout.')

--- a/enscript/PKGBUILD
+++ b/enscript/PKGBUILD
@@ -3,10 +3,14 @@
 
 pkgname=enscript
 pkgver=1.6.6
-pkgrel=6
+pkgrel=1
 pkgdesc="Convert ASCII files to PostScript suitable for printing"
-arch=('x86_64')
+arch=('i686' 'x86_64')
 url="https://git.savannah.gnu.org/cgit/enscript.git"
+msys2_references=(
+  "anitya: 699"
+  "cpe: cpe:/a:gnu:enscript"
+)
 license=('sdpx:GPL-3.0-or-later')
 depends=('perl')
 

--- a/enscript/PKGBUILD
+++ b/enscript/PKGBUILD
@@ -18,9 +18,10 @@ makedepends=('autotools' 'gcc' 'perl')
 optdepends=('cygutils: Send the output to a physical printer instead of stdout.')
 source=(
         "https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.gz"
-        "300ecf85a8fe166a39f9dd818945c7b8a970db39.patch"::"https://git.savannah.gnu.org/cgit/enscript.git/patch/id=300ecf85a8fe166a39f9dd818945c7b8a970db39"
+        "300ecf85a8fe166a39f9dd818945c7b8a970db39.patch"::"https://git.savannah.gnu.org/cgit/enscript.git/patch/?id=300ecf85a8fe166a39f9dd818945c7b8a970db39"
 )
-sha256sums=(`updpkgsums`)
+sha256sums=('6d56bada6934d055b34b6c90399aa85975e66457ac5bf513427ae7fc77f5c0bb'
+            '53705eb99a11fbc4277140534331813fff526e5380f5d5a2046484ae92900186')
 
 # To avoid a mess with lpr, the config file will be patched to send to stdout by default.
 prepare() {

--- a/enscript/PKGBUILD
+++ b/enscript/PKGBUILD
@@ -10,7 +10,7 @@ url="https://git.savannah.gnu.org/cgit/enscript.git"
 license=('sdpx:GPL-3.0-or-later')
 depends=('perl')
 
-makedepends=('autotools' 'gcc', 'perl')
+makedepends=('autotools' 'gcc' 'perl')
 optdepends=('cygutils: Send the output to a physical printer instead of stdout.')
 source=(https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.gz)
 sha256sums=('6d56bada6934d055b34b6c90399aa85975e66457ac5bf513427ae7fc77f5c0bb')

--- a/enscript/PKGBUILD
+++ b/enscript/PKGBUILD
@@ -1,0 +1,35 @@
+# This was copied from the arch linux PKGBUILD.
+# GNU Enscript is more or less feature complete, so it's a drop in file.
+
+pkgname=enscript
+pkgver=1.6.6
+pkgrel=6
+pkgdesc="Convert ASCII files to PostScript suitable for printing"
+arch=('x86_64')
+url="https://git.savannah.gnu.org/cgit/enscript.git"
+license=('sdpx:GPL-3.0-or-later')
+depends=('perl' 'gcc-libs' 'cygutils') # Without lpr, it reports back an error. Maybe compile it out?
+# In addition, the config file defaults to a physical printer with it allowed to set to STDOUT. Perhaps
+# make this with the STDOUT setting by default?
+
+makedepends=('autotools' 'gcc')
+optdepends=()
+source=(https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.gz)
+sha256sums=('6d56bada6934d055b34b6c90399aa85975e66457ac5bf513427ae7fc77f5c0bb')
+
+build() {
+  cd $pkgname-$pkgver
+  ./configure --prefix=/usr --sysconfdir=/etc/enscript
+  make
+}
+
+# Is the check truly necessary? Last stable release was 2012.
+check() {
+  cd $pkgname-$pkgver
+  make check
+}
+
+package() {
+  cd $pkgname-$pkgver
+  make DESTDIR="$pkgdir" install
+}

--- a/enscript/PKGBUILD
+++ b/enscript/PKGBUILD
@@ -8,14 +8,18 @@ pkgdesc="Convert ASCII files to PostScript suitable for printing"
 arch=('x86_64')
 url="https://git.savannah.gnu.org/cgit/enscript.git"
 license=('sdpx:GPL-3.0-or-later')
-depends=('perl' 'gcc-libs' 'cygutils') # Without lpr, it reports back an error. Maybe compile it out?
-# In addition, the config file defaults to a physical printer with it allowed to set to STDOUT. Perhaps
-# make this with the STDOUT setting by default?
+depends=('perl' 'gcc-libs' 'cygutils')
 
 makedepends=('autotools' 'gcc')
-optdepends=()
+optdepends=('cygutils: Send the output to a physical printer instead of stdout.')
 source=(https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.gz)
 sha256sums=('6d56bada6934d055b34b6c90399aa85975e66457ac5bf513427ae7fc77f5c0bb')
+
+# To avoid a mess with lpr, the config file will be patched to send to stdout by default.
+prepare() {
+  cd $pkgname-$pkgver
+  sed -i '52s/DefaultOutputMethod: printer/DefaultOutputMethod: stdout/' lib/enscript.cfg.in
+}
 
 build() {
   cd $pkgname-$pkgver
@@ -23,7 +27,6 @@ build() {
   make
 }
 
-# Is the check truly necessary? Last stable release was 2012.
 check() {
   cd $pkgname-$pkgver
   make check

--- a/enscript/PKGBUILD
+++ b/enscript/PKGBUILD
@@ -8,9 +8,9 @@ pkgdesc="Convert ASCII files to PostScript suitable for printing"
 arch=('x86_64')
 url="https://git.savannah.gnu.org/cgit/enscript.git"
 license=('sdpx:GPL-3.0-or-later')
-depends=('perl' 'gcc-libs')
+depends=('perl')
 
-makedepends=('autotools' 'gcc')
+makedepends=('autotools' 'gcc', 'perl')
 optdepends=('cygutils: Send the output to a physical printer instead of stdout.')
 source=(https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.gz)
 sha256sums=('6d56bada6934d055b34b6c90399aa85975e66457ac5bf513427ae7fc77f5c0bb')

--- a/enscript/PKGBUILD
+++ b/enscript/PKGBUILD
@@ -35,4 +35,9 @@ check() {
 package() {
   cd $pkgname-$pkgver
   make DESTDIR="$pkgdir" install
+  # There is a conflict between the gettext locale.alias and the encsript supplied one.
+  # The elinks PKGBUILD script for example, removes the installed one from the tarball, I'll do the same.
+  rm -f "$pkgdir/usr/share/locale/locale.alias"
+  # Also this one as well, can't hurt.
+  rm -f "$pkgdir/usr/lib/charset.alias"
 }

--- a/enscript/PKGBUILD
+++ b/enscript/PKGBUILD
@@ -23,6 +23,9 @@ sha256sums=('6d56bada6934d055b34b6c90399aa85975e66457ac5bf513427ae7fc77f5c0bb')
 prepare() {
   cd $pkgname-$pkgver
   sed -i '52s/DefaultOutputMethod: printer/DefaultOutputMethod: stdout/' lib/enscript.cfg.in
+
+  # Also, tiny additional modification to fix issue with compilation warning fixed in the upstream git, but not stable tarball yet.
+  sed -i '37s/^$/#include <string.h>/' compat/getopt.c
 }
 
 build() {

--- a/enscript/PKGBUILD
+++ b/enscript/PKGBUILD
@@ -16,8 +16,11 @@ depends=('perl')
 
 makedepends=('autotools' 'gcc' 'perl')
 optdepends=('cygutils: Send the output to a physical printer instead of stdout.')
-source=(https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.gz)
-sha256sums=('6d56bada6934d055b34b6c90399aa85975e66457ac5bf513427ae7fc77f5c0bb')
+source=(
+        "https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.gz"
+        "300ecf85a8fe166a39f9dd818945c7b8a970db39.patch"::"https://git.savannah.gnu.org/cgit/enscript.git/patch/id=300ecf85a8fe166a39f9dd818945c7b8a970db39"
+)
+sha256sums=(`updpkgsums`)
 
 # To avoid a mess with lpr, the config file will be patched to send to stdout by default.
 prepare() {
@@ -25,7 +28,7 @@ prepare() {
   sed -i '52s/DefaultOutputMethod: printer/DefaultOutputMethod: stdout/' lib/enscript.cfg.in
 
   # Also, tiny additional modification to fix issue with compilation warning fixed in the upstream git, but not stable tarball yet.
-  sed -i '37s/^$/#include <string.h>/' compat/getopt.c
+  patch -Nbp1 -i "${srcdir}/300ecf85a8fe166a39f9dd818945c7b8a970db39.patch"
 }
 
 build() {


### PR DESCRIPTION
GNU enscript is a somewhat lesser known package (It is a GNU package meant to replace the adobe enscript from the late 80s) that prints to PostScript ASCII files suitable for printing to a physical printer or to STDOUT. It seems to want to use lpr by default, so some patches might be required. The config file lets you specify if a physical printer or STDOUT should be delivered to. Or maybe patch out lpr usage. Or both? I'll let you make the call.