### PR TITLE
pcre2: Update to 10.45

### DIFF
--- a/pcre2/PKGBUILD
+++ b/pcre2/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=pcre2
 pkgname=('pcre2' 'libpcre2_8' 'libpcre2_16' 'libpcre2_32' 'libpcre2posix' 'pcre2-devel')
-pkgver=10.44
+pkgver=10.45
 pkgrel=1
 pkgdesc="A library that implements Perl 5-style regular expressions"
 arch=('i686' 'x86_64')
@@ -15,9 +15,9 @@ msys2_references=(
 license=('BSD')
 makedepends=('libreadline-devel' 'libbz2-devel' 'zlib-devel' 'autotools' 'gcc')
 source=(https://github.com/PCRE2Project/pcre2/releases/download/${pkgname}-${pkgver}/${pkgname}-${pkgver}.tar.bz2{,.sig})
-sha256sums=('d34f02e113cf7193a1ebf2770d3ac527088d485d4e047ed10e5d217c6ef5de96'
+sha256sums=('21547f3516120c75597e5b30a992e27a592a31950b5140e7b8bfde3f192033c4'
             'SKIP')
-validpgpkeys=('45F68D54BBE23FB3039B46E59766E084FB0F43D8') # Philip Hazel <ph10@hermes.cam.ac.uk>
+validpgpkeys=('A95536204A3BB489715231282A98E77EB6F24CA8') # Nicholas Wilson <nicholas@nicholaswilson.me.uk>
 
 prepare() {
   cd "${srcdir}"/${pkgname}-${pkgver}
@@ -60,7 +60,7 @@ package_pcre2() {
   mkdir -p ${pkgdir}/usr/bin
   cp -f ${srcdir}/dest/usr/bin/*.exe ${pkgdir}/usr/bin/
   cp -rf ${srcdir}/dest/usr/share ${pkgdir}/usr/
-  install -Dm644 ${srcdir}/${pkgname}-${pkgver}/LICENCE "${pkgdir}"/usr/share/licenses/${pkgname}/LICENSE
+  install -Dm644 ${srcdir}/${pkgname}-${pkgver}/LICENCE.md "${pkgdir}"/usr/share/licenses/${pkgname}/LICENSE.md
 }
 
 package_libpcre2_8() {


### PR DESCRIPTION
See https://github.com/PCRE2Project/pcre2/blob/c421b939e7e1e7caf8a3de89b86f8e3fa83317e4/SECURITY.md for the signing key change