### PR TITLE
genromfs: close() fds after use

### DIFF
--- a/genromfs/0001-genromfs.c-alignnode-close-fd-after-read.patch
+++ b/genromfs/0001-genromfs.c-alignnode-close-fd-after-read.patch
@@ -1,0 +1,35 @@
+From 5c995f8ebf22a790374bf1964c1cf135c132842d Mon Sep 17 00:00:00 2001
+From: nkhan <nkhan@nvidia.com>
+Date: Tue, 11 Feb 2025 15:47:02 -0800
+Subject: [PATCH] * genromfs.c (alignnode): close(fd) after read
+
+Issue:
+In MSYS2, when processing a large set of files (approximately 9,000), genromfs
+displays the error:
+
+"Too many open files"
+
+Fix:
+To resolve this, the open file handles are now explicitly closed after reading,
+preventing the system from exceeding the file descriptor limit.
+
+Signed-off-by: Noman Khan <nkhan@nvidia.com>
+---
+ genromfs.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/genromfs.c b/genromfs.c
+index a804d37..e81dbfc 100644
+--- a/genromfs.c
++++ b/genromfs.c
+@@ -632,6 +632,7 @@ int alignnode(struct filenode *node, int curroffset, int extraspace)
+ 			if ((fd = open(node->realname, O_RDBIN)) >= 0) {
+ 				memset(bigbuf, 0, 16);
+ 				read(fd, bigbuf, 16);
++				close(fd);
+ 				checkpos = 0;
+ 			}
+ 		} else if (S_ISLNK(node->modes)) {
+-- 
+2.47.1
+

--- a/genromfs/PKGBUILD
+++ b/genromfs/PKGBUILD
@@ -2,14 +2,22 @@
 
 pkgname=genromfs
 pkgver=0.5.7
-pkgrel=1
+pkgrel=2
 pkgdesc="Creates ROMFS images"
 arch=('any')
 url="https://romfs.sourceforge.net/"
 license=("GPL-2+")
 makedepends=("gcc")
-source=("${pkgname}-${pkgver}.tar.gz::https://github.com/chexum/${pkgname}/archive/refs/tags/${pkgver}.tar.gz")
-sha256sums=("2d16d217b11a28809454ddab0cd7c1c0865af8ea79ac0e86af03ab82320f02ab")
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/chexum/${pkgname}/archive/refs/tags/${pkgver}.tar.gz"
+        "0001-genromfs.c-alignnode-close-fd-after-read.patch")
+
+sha256sums=("2d16d217b11a28809454ddab0cd7c1c0865af8ea79ac0e86af03ab82320f02ab"
+            "25a0514f4c9218359647bb3e6fa353115a3a738d166f6349f874cdc51a5be4ac")
+
+prepare() {
+    cd "genromfs-${pkgver}"
+    patch -Np1 -i ../0001-genromfs.c-alignnode-close-fd-after-read.patch
+}
 
 build() {
   make -C "${srcdir}"/${pkgname}-${pkgver}


### PR DESCRIPTION
The current version of genromfs has a bug whereby it leaks fd handles by not closing them after use. This results in the tool failing with large sets of files (approximately 9,000) displaying an error: `Too many open files`.

Linux users are typically less affected by this bug because the operating system in most cases allows a far greater number of simultaneously open file handles than is allowed on Windows.

A patch to correct the issue has been provided by @NomanKhan777 [here](https://github.com/chexum/genromfs/pull/5)

However, the maintainer does not appear to be very responsive. The most recent commit in the repository was made in 2011. Unless and until this patch is accepted upstream, or a new maintainer is found for the project, this commit adds the patch to MSYS2-packages to correct the issue.