### PR TITLE
genromfs: downgrade to 0.5.2 - the most recent true release

### DIFF
--- a/genromfs/PKGBUILD
+++ b/genromfs/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Joel Holdsworth <jholdsworth@nvidia.com>
 
 pkgname=genromfs
-pkgver=0.5.7
+pkgver=0.5.2
 pkgrel=1
 pkgdesc="Creates ROMFS images"
 arch=('any')
@@ -9,7 +9,7 @@ url="https://romfs.sourceforge.net/"
 license=("GPL-2+")
 makedepends=("gcc")
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/chexum/${pkgname}/archive/refs/tags/${pkgver}.tar.gz")
-sha256sums=("2d16d217b11a28809454ddab0cd7c1c0865af8ea79ac0e86af03ab82320f02ab")
+sha256sums=("a96953ff6a2ce96b9c9aca99faaa43fda0e25e0012f3855cd6b988a12895467b")
 
 build() {
   make -C "${srcdir}"/${pkgname}-${pkgver}

--- a/genromfs/PKGBUILD
+++ b/genromfs/PKGBUILD
@@ -3,6 +3,7 @@
 pkgname=genromfs
 pkgver=0.5.2
 pkgrel=1
+epoch=1
 pkgdesc="Creates ROMFS images"
 arch=('any')
 url="https://romfs.sourceforge.net/"


### PR DESCRIPTION
The current package version is 0.5.7. This version number comes from a tag in the GitHub repository at commit [2bdc5f9](https://github.com/chexum/genromfs/commit/2bdc5f933f5aa1451252d36f10bd376992affe24) - a commit made in 2009. However, this tag was never released as a true package release and the commit has the label:

> Update to version 0.5.7 (not released)

Repology [reports](https://repology.org/project/genromfs/versions) that the vast majority of package distributions are shipping the 0.5.2 release, which is the most recent true release made in 2007.

One bug that was found with the 0.5.7 non-release is that the genromfs tool opens file handles without then closing them which eventually causes a "Too many open files" error. A patch has been submitted to fix the issue [here](https://github.com/chexum/genromfs/pull/5).

However, it seems unlikely that acceptance of this patch, or a new release are going to be forthcoming because no commits have been added to the GitHub repository since 2011.

Therefore, this patch sets the version number to 0.5.2.