### PR TITLE
Upgrade GNU Privacy Guard to v2.5.5

### DIFF
--- a/gnupg/0001-gnupg-2.2.8-msys2.patch
+++ b/gnupg/0001-gnupg-2.2.8-msys2.patch
@@ -1,7 +1,7 @@
 diff -ru gnupg-2.2.8-orig/g10/gpg.c gnupg-2.2.8/g10/gpg.c
 --- gnupg-2.2.8-orig/g10/gpg.c	2018-06-06 11:59:06.000000000 +0200
 +++ gnupg-2.2.8/g10/gpg.c	2018-06-21 01:00:49.167416100 +0200
-@@ -1508,7 +1508,7 @@
+@@ -1676,7 +1676,7 @@ check_permissions (const char *path, int item)
  	{
  	  if(statbuf.st_uid==getuid())
  	    {

--- a/gnupg/PKGBUILD
+++ b/gnupg/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=gnupg
-pkgver=2.4.7
+pkgver=2.5.5
 pkgrel=1
 pkgdesc='Complete and free implementation of the OpenPGP standard'
 provides=('dirmngr' "gnupg2=${pkgver}")
@@ -60,13 +60,15 @@ source=("https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2"{,
         '0001-gnupg-2.2.8-msys2.patch'
         'gnupg-2.4-avoid_beta_warning.patch'
         'gnupg-2.4-drop_import_clean.patch'
-        'gnupg-2.4-revert_default_rfc4880bis.patch')
-sha256sums=('7b24706e4da7e0e3b06ca068231027401f238102c41c909631349dcc3b85eb46'
+        'gnupg-2.4-revert_default_rfc4880bis.patch'
+        'gnupg-2.5-Avoid-looking-for-SOCKET.patch')
+sha256sums=('7afa71d72ff9aaff75a6810b87b486bc492fd752e4f77b07c41759ce4ef36b31'
             'SKIP'
-            '902563c91c72ed9222343de3482f4ca7b141775235625af5ad790f3d86419370'
-            '243c3a79295519b3931f9d846cf2af5caa064a78de812ee336dc786c1567b4d0'
-            '6ade15b536c50a88efc2d9dc958433b0ccfaf2908025b7672753e6bfce51c3c6'
-            'ef2267eecd9eb59bbbbdb97d55cbfe10236b4979a125c6683a840830bc202905')
+            '1cf11adb8d6942a0fc0cc53b690167162976fd03e529a94c70b3310ebd62812a'
+            '599f19263d56855f50ec0913a3bde589b17e9828960e6f813aac4c7b16f79c40'
+            '3da55ad697f1eab22353dfe2c6c72f0a38b0b3f48945db11f7daf00db39facee'
+            '2c84b6106c835d9274e2dc4e6848f74095db2487643e0d5cf15c62c8d120843a'
+            '7266098ffe88d61e06affdac52821eb62c14e9da27452bc1e33e7abc55e88c98')
 validpgpkeys=(
   '5B80C5754298F0CB55D8ED6ABCEF7E294B092E28' # Andre Heinecke (Release Signing Key)
   '6DAA6E64A76D2840571B4902528897B826403ADA' # Werner Koch (dist signing 2020)
@@ -80,6 +82,7 @@ prepare() {
 
   # MSYS2 patches
   patch -p1 -i ${srcdir}/0001-gnupg-2.2.8-msys2.patch
+  patch -p1 -i ${srcdir}/gnupg-2.5-Avoid-looking-for-SOCKET.patch
 
   # Arch Linux patches
   patch -p1 -i ${srcdir}/gnupg-2.4-avoid_beta_warning.patch
@@ -103,15 +106,15 @@ build() {
     --disable-libdns \
     --enable-maintainer-mode
 
-  make
+  make MAKEINFO=true
 }
 
 check() {
   cd "${srcdir}/${pkgname}-${pkgver}"
-  make check
+  make MAKEINFO=true check
 }
 
 package() {
   cd "${srcdir}/${pkgname}-${pkgver}"
-  make DESTDIR="${pkgdir}" install
+  make MAKEINFO=true DESTDIR="${pkgdir}" install
 }

--- a/gnupg/gnupg-2.4-avoid_beta_warning.patch
+++ b/gnupg/gnupg-2.4-avoid_beta_warning.patch
@@ -21,19 +21,19 @@ See discussion at:
 Patch-Source: https://sources.debian.org/data/main/g/gnupg2/2.2.27-2/debian/patches/debian-packaging/avoid-beta-warning.patch
 
 diff --git a/autogen.sh b/autogen.sh
-index b238550..9b86d3f 100755
+index 0b08e8b..5728473 100755
 --- a/autogen.sh
 +++ b/autogen.sh
-@@ -229,7 +229,7 @@ if [ "$myhost" = "find-version" ]; then
-     esac
+@@ -258,7 +258,7 @@ if [ "$myhost" = "find-version" ]; then
+     fi
  
      beta=no
 -    if [ -e .git ]; then
 +    if false; then
        ingit=yes
        tmp=$(git describe --match "${matchstr1}" --long 2>/dev/null)
-       tmp=$(echo "$tmp" | sed s/^"$package"//)
-@@ -245,8 +245,8 @@ if [ "$myhost" = "find-version" ]; then
+       if [ -n "$tmp" ]; then
+@@ -284,8 +284,8 @@ if [ "$myhost" = "find-version" ]; then
        rvd=$((0x$(echo ${rev} | dd bs=1 count=4 2>/dev/null)))
      else
        ingit=no
@@ -41,6 +41,6 @@ index b238550..9b86d3f 100755
 -      tmp="-unknown"
 +      beta=no
 +      tmp=""
+       cid="0000000"
        rev="0000000"
        rvd="0"
-     fi

--- a/gnupg/gnupg-2.4-drop_import_clean.patch
+++ b/gnupg/gnupg-2.4-drop_import_clean.patch
@@ -23,10 +23,10 @@ Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>
 Patch-Source: https://sources.debian.org/data/main/g/gnupg2/2.2.27-2/debian/patches/gpg-drop-import-clean-from-default-keyserver-import-optio.patch
 
 diff --git a/doc/gpg.texi b/doc/gpg.texi
-index 804ecf9..b238278 100644
+index 5f93e9f..9576ab4 100644
 --- a/doc/gpg.texi
 +++ b/doc/gpg.texi
-@@ -2047,7 +2047,7 @@ are available for all keyserver types, some common options are:
+@@ -2169,7 +2169,7 @@ are available for all keyserver types, some common options are:
  
  @end table
  
@@ -36,10 +36,10 @@ index 804ecf9..b238278 100644
  the actual used source is an LDAP server "no-self-sigs-only" is
  assumed unless "self-sigs-only" has been explicitly configured.
 diff --git a/g10/gpg.c b/g10/gpg.c
-index 68c0454..205de60 100644
+index b9c43e5..2509f64 100644
 --- a/g10/gpg.c
 +++ b/g10/gpg.c
-@@ -2441,8 +2441,7 @@ main (int argc, char **argv)
+@@ -2501,8 +2501,7 @@ main (int argc, char **argv)
  					    | IMPORT_REPAIR_PKS_SUBKEY_BUG
                                              | IMPORT_SELF_SIGS_ONLY
                                              | IMPORT_COLLAPSE_UIDS

--- a/gnupg/gnupg-2.4-revert_default_rfc4880bis.patch
+++ b/gnupg/gnupg-2.4-revert_default_rfc4880bis.patch
@@ -12,10 +12,10 @@ This reverts commit 4583f4fe2 (gpg: Merge --rfc4880bis features into
  2 files changed, 50 insertions(+), 15 deletions(-)
 
 diff --git a/g10/gpg.c b/g10/gpg.c
-index dcab0a11a..796888013 100644
+index 2509f64..a569ba5 100644
 --- a/g10/gpg.c
 +++ b/g10/gpg.c
-@@ -247,6 +247,7 @@ enum cmd_and_opt_values
+@@ -254,6 +254,7 @@ enum cmd_and_opt_values
      oGnuPG,
      oRFC2440,
      oRFC4880,
@@ -23,7 +23,7 @@ index dcab0a11a..796888013 100644
      oOpenPGP,
      oPGP7,
      oPGP8,
-@@ -636,6 +637,7 @@ static gpgrt_opt_t opts[] = {
+@@ -653,6 +654,7 @@ static gpgrt_opt_t opts[] = {
    ARGPARSE_s_n (oGnuPG, "no-pgp8", "@"),
    ARGPARSE_s_n (oRFC2440, "rfc2440", "@"),
    ARGPARSE_s_n (oRFC4880, "rfc4880", "@"),
@@ -31,7 +31,7 @@ index dcab0a11a..796888013 100644
    ARGPARSE_s_n (oOpenPGP, "openpgp", N_("use strict OpenPGP behavior")),
    ARGPARSE_s_n (oPGP7, "pgp6", "@"),
    ARGPARSE_s_n (oPGP7, "pgp7", "@"),
-@@ -978,7 +980,6 @@ static gpgrt_opt_t opts[] = {
+@@ -1006,7 +1008,6 @@ static gpgrt_opt_t opts[] = {
    ARGPARSE_s_n (oNoop, "no-allow-multiple-messages", "@"),
    ARGPARSE_s_s (oNoop, "aead-algo", "@"),
    ARGPARSE_s_s (oNoop, "personal-aead-preferences","@"),
@@ -39,7 +39,7 @@ index dcab0a11a..796888013 100644
    ARGPARSE_s_n (oNoop, "override-compliance-check", "@"),
  
  
-@@ -2227,7 +2228,7 @@ static struct gnupg_compliance_option compliance_options[] =
+@@ -2261,7 +2262,7 @@ static struct gnupg_compliance_option compliance_options[] =
    {
      { "gnupg",      oGnuPG },
      { "openpgp",    oOpenPGP },
@@ -48,7 +48,7 @@ index dcab0a11a..796888013 100644
      { "rfc4880",    oRFC4880 },
      { "rfc2440",    oRFC2440 },
      { "pgp6",       oPGP7 },
-@@ -2243,8 +2244,28 @@ static struct gnupg_compliance_option compliance_options[] =
+@@ -2277,11 +2278,32 @@ static struct gnupg_compliance_option compliance_options[] =
  static void
  set_compliance_option (enum cmd_and_opt_values option)
  {
@@ -74,26 +74,22 @@ index dcab0a11a..796888013 100644
 +      opt.s2k_digest_algo = DIGEST_ALGO_SHA256;
 +      opt.s2k_cipher_algo = CIPHER_ALGO_AES256;
 +      break;
-     case oOpenPGP:
-     case oRFC4880:
-       /* This is effectively the same as RFC2440, but with
-@@ -2288,6 +2309,7 @@ set_compliance_option (enum cmd_and_opt_values option)
-     case oPGP8:  opt.compliance = CO_PGP8;  break;
      case oGnuPG:
+       /* set up default options affected by policy compliance: */
        opt.compliance = CO_GNUPG;
 +      opt.flags.rfc4880bis = 1;
-       break;
- 
-     case oDE_VS:
-@@ -2491,6 +2513,7 @@ main (int argc, char **argv)
-     opt.emit_version = 0;
+       opt.flags.dsa2 = 0;
+       opt.flags.require_cross_cert = 1;
+       opt.rfc2440_text = 0;
+@@ -2528,6 +2550,7 @@ main (int argc, char **argv)
      opt.weak_digests = NULL;
-     opt.compliance = CO_GNUPG;
+     opt.with_subkey_fingerprint = 1;
+     set_compliance_option (oGnuPG);
 +    opt.flags.rfc4880bis = 1;
  
      /* Check special options given on the command line.  */
      orig_argc = argc;
-@@ -3033,6 +3056,7 @@ main (int argc, char **argv)
+@@ -3087,6 +3110,7 @@ main (int argc, char **argv)
            case oOpenPGP:
            case oRFC2440:
            case oRFC4880:
@@ -101,7 +97,7 @@ index dcab0a11a..796888013 100644
            case oPGP7:
            case oPGP8:
            case oGnuPG:
-@@ -3862,6 +3886,11 @@ main (int argc, char **argv)
+@@ -3989,6 +4013,11 @@ main (int argc, char **argv)
      if( may_coredump && !opt.quiet )
  	log_info(_("WARNING: program may create a core file!\n"));
  
@@ -113,7 +109,7 @@ index dcab0a11a..796888013 100644
      if (eyes_only) {
        if (opt.set_filename)
  	  log_info(_("WARNING: %s overrides %s\n"),
-@@ -4078,7 +4107,7 @@ main (int argc, char **argv)
+@@ -4211,7 +4240,7 @@ main (int argc, char **argv)
      /* Check our chosen algorithms against the list of legal
         algorithms. */
  
@@ -123,10 +119,10 @@ index dcab0a11a..796888013 100644
  	const char *badalg=NULL;
  	preftype_t badtype=PREFTYPE_NONE;
 diff --git a/g10/keygen.c b/g10/keygen.c
-index a2cfe3ccf..2a1dd1f81 100644
+index 2f1541d..dabb8e2 100644
 --- a/g10/keygen.c
 +++ b/g10/keygen.c
-@@ -404,7 +404,7 @@ keygen_set_std_prefs (const char *string,int personal)
+@@ -489,7 +489,7 @@ keygen_set_std_prefs (const char *string,int personal)
  	      strcat(dummy_string,"S7 ");
  	    strcat(dummy_string,"S2 "); /* 3DES */
  
@@ -135,7 +131,7 @@ index a2cfe3ccf..2a1dd1f81 100644
  	      strcat(dummy_string,"A2 ");
  
              if (personal)
-@@ -889,7 +889,7 @@ keygen_upd_std_prefs (PKT_signature *sig, void *opaque)
+@@ -974,7 +974,7 @@ keygen_upd_std_prefs (PKT_signature *sig, void *opaque)
    /* Make sure that the MDC feature flag is set if needed.  */
    add_feature_mdc (sig,mdc_available);
    add_feature_aead (sig, aead_available);
@@ -144,7 +140,7 @@ index a2cfe3ccf..2a1dd1f81 100644
    add_keyserver_modify (sig,ks_modify);
    keygen_add_keyserver_url(sig,NULL);
  
-@@ -3382,7 +3382,10 @@ parse_key_parameter_part (ctrl_t ctrl,
+@@ -4118,7 +4118,10 @@ parse_key_parameter_part (ctrl_t ctrl,
                  }
              }
            else if (!ascii_strcasecmp (s, "v5"))
@@ -156,7 +152,7 @@ index a2cfe3ccf..2a1dd1f81 100644
            else if (!ascii_strcasecmp (s, "v4"))
              keyversion = 4;
            else
-@@ -3641,7 +3644,7 @@ parse_key_parameter_part (ctrl_t ctrl,
+@@ -4379,7 +4382,7 @@ parse_key_parameter_part (ctrl_t ctrl,
   *   ecdsa := Use algorithm ECDSA.
   *   eddsa := Use algorithm EdDSA.
   *   ecdh  := Use algorithm ECDH.
@@ -165,7 +161,7 @@ index a2cfe3ccf..2a1dd1f81 100644
   *
   * There are several defaults and fallbacks depending on the
   * algorithm.  PART can be used to select which part of STRING is
-@@ -4513,9 +4516,9 @@ read_parameter_file (ctrl_t ctrl, const char *fname )
+@@ -5353,9 +5356,9 @@ read_parameter_file (ctrl_t ctrl, const char *fname )
  	    }
  	}
  
@@ -178,9 +174,9 @@ index a2cfe3ccf..2a1dd1f81 100644
          else
            {
              r = xmalloc_clear( sizeof *r + strlen( value ) );
-@@ -4610,11 +4613,14 @@ quickgen_set_para (struct para_data_s *para, int for_subkey,
-       para = r;
-     }
+@@ -5450,11 +5453,14 @@ quickgen_set_para (struct para_data_s *para, int for_subkey,
+   r->next = para;
+   para = r;
  
 -  r = xmalloc_clear (sizeof *r + 20);
 -  r->key = for_subkey? pSUBVERSION : pVERSION;

--- a/gnupg/gnupg-2.5-Avoid-looking-for-SOCKET.patch
+++ b/gnupg/gnupg-2.5-Avoid-looking-for-SOCKET.patch
@@ -1,0 +1,46 @@
+From eee7eff3d4011ffe1c40bd5b95d9b66367f7cbdf Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 10 Mar 2025 11:59:44 +0100
+Subject: [PATCH] Avoid looking for `SOCKET`
+
+This is not actually used in the MSYS2 build.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ agent/command-ssh.c | 4 ----
+ configure.ac        | 3 ---
+ 2 files changed, 7 deletions(-)
+
+diff --git a/agent/command-ssh.c b/agent/command-ssh.c
+index 8e812a6..ce38545 100644
+--- a/agent/command-ssh.c
++++ b/agent/command-ssh.c
+@@ -3958,11 +3958,7 @@ start_command_handler_ssh (ctrl_t ctrl, gnupg_fd_t sock_client)
+   es_syshd_t syshd;
+ 
+   syshd.type = ES_SYSHD_SOCK;
+-#ifdef HAVE_SOCKET
+-  syshd.u.sock = (SOCKET)sock_client;
+-#else
+   syshd.u.sock = sock_client;
+-#endif
+ 
+   get_client_info (sock_client, &peer_info);
+   ctrl->client_pid = peer_info.pid;
+diff --git a/configure.ac b/configure.ac
+index eb2b437..f38c77d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1370,9 +1370,6 @@ AC_CHECK_SIZEOF(time_t,,[[
+ ]])
+ GNUPG_TIME_T_UNSIGNED
+ 
+-# Check SOCKET type for Windows.
+-AC_CHECK_TYPES([SOCKET], [], [], [[#include "winsock2.h"]])
+-
+ if test "$ac_cv_sizeof_unsigned_short" = "0" \
+    || test "$ac_cv_sizeof_unsigned_int" = "0" \
+    || test "$ac_cv_sizeof_unsigned_long" = "0"; then
+-- 
+2.49.0.rc1.windows.1
+

--- a/libassuan/PKGBUILD
+++ b/libassuan/PKGBUILD
@@ -54,6 +54,14 @@ package_libassuan() {
   cp -rf ${srcdir}/dest/usr/share/info ${pkgdir}/usr/share/
 
   install -D -m644 ${srcdir}/${pkgname}-${pkgver}/COPYING ${pkgdir}/usr/share/licenses/${pkgname}/COPYING
+
+  # UTTER HACK; REMOVE after gnupg and pinentry are rebuilt!!!
+  # Work-around to avoid `dirmngr.exe`/`gpg.exe` from no longer finding their
+  # dependent DLL file by copying the new DLL to the old name.
+  if test ! -f /usr/bin/msys-assuan-9.dll
+  then
+    cp ${srcdir}/dest/usr/bin/msys-assuan-9.dll ${pkgdir}/usr/bin/msys-assuan-0.dll
+  fi
 }
 
 package_libassuan-devel() {

--- a/libassuan/PKGBUILD
+++ b/libassuan/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=libassuan
 pkgname=('libassuan' 'libassuan-devel')
-pkgver=2.5.7
+pkgver=3.0.2
 pkgrel=1
 pkgdesc="A IPC library used by some GnuPG related software"
 arch=('i686' 'x86_64')
@@ -13,9 +13,10 @@ license=('GPL')
 makedepends=('libgpg-error-devel' 'autotools' 'gcc')
 options=('strip' 'libtool')
 source=(https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2{,.sig})
-sha256sums=('0103081ffc27838a2e50479153ca105e873d3d65d8a9593282e9c94c7e6afb76'
+sha256sums=('d2931cdad266e633510f9970e1a2f346055e351bb19f9b78912475b8074c36f6'
             'SKIP')
-validpgpkeys=('AC8E115BF73E2D8D47FA9908E98E9B2D19C6C8BD') # Niibe Yutaka (GnuPG Release Key)
+validpgpkeys=('AC8E115BF73E2D8D47FA9908E98E9B2D19C6C8BD'  # Niibe Yutaka (GnuPG Release Key)
+              '6DAA6E64A76D2840571B4902528897B826403ADA') # Werner Koch (dist signing 2020)
 
 prepare() {
   cd "${pkgname}-${pkgver}"

--- a/pinentry/PKGBUILD
+++ b/pinentry/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=pinentry
 pkgver=1.3.1
-pkgrel=1
+pkgrel=2
 pkgdesc='A collection of simple PIN or passphrase entry dialogs which utilize the Assuan protocol'
 url='https://gnupg.org/related_software/pinentry/'
 msys2_repository_url="https://git.gnupg.org/cgi-bin/gitweb.cgi?p=pinentry.git"


### PR DESCRIPTION
This makes the big jump from v2.4.* to v2.5.*.

This requires an upgrade of `libassuan`, too. Which might cause some problems, as the current DLL is called `msys-assuan-0.dll` whereas the new DLL is called `msys-assuan-9.dll` (which means that e.g. `dirmngr.exe` simply won't start anymore if `libassuan` is upgraded in isolation...).