### PR TITLE
msys2-runtime: adjust CWD magic to accommodate for the latest Windows previews

### DIFF
--- a/msys2-runtime/0054-Cygwin-Adjust-CWD-magic-to-accommodate-for-the-lates.patch
+++ b/msys2-runtime/0054-Cygwin-Adjust-CWD-magic-to-accommodate-for-the-lates.patch
@@ -1,0 +1,67 @@
+From 7878787624144cd3b9cbd8a41b25d7d266b7173c Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 22 May 2023 13:36:27 +0200
+Subject: [PATCH 54/N] Cygwin: Adjust CWD magic to accommodate for the latest
+ Windows previews
+
+Reportedly a very recent internal build of Windows 11 once again changed
+the current working directory logic a bit, and Cygwin's "magic" (or:
+"technologically sufficiently advanced") code needs to be adjusted
+accordingly.
+
+In particular, the following assembly code can be seen:
+
+ntdll!RtlpReferenceCurrentDirectory
+
+  598 00000001`800c6925 488d0db4cd0f00  lea     rcx,[ntdll!FastPebLock (00000001`801c36e0)]
+  583 00000001`800c692c 4c897810        mov     qword ptr [rax+10h],r15
+  588 00000001`800c6930 0f1140c8        movups  xmmword ptr [rax-38h],xmm0
+  598 00000001`800c6934 e82774f4ff      call    ntdll!RtlEnterCriticalSection
+
+The change necessarily looks a bit different than 4840a56325 (Cygwin:
+Adjust CWD magic to accommodate for the latest Windows previews,
+2023-05-22): The needle `\x48\x8d\x0d` is already present, as the first
+version of the hack after Windows 8.1 was released. In that code,
+though, the `call` to `RtlEnterCriticalSection` followed the `lea`
+instruction immediately, but now there are two more instructions
+separating them.
+
+Note: In the long run, we may very well want to follow the insightful
+suggestion by a helpful Windows kernel engineer who pointed out that it
+may be less fragile to implement kind of a disassembler that has a
+better chance to adapt to the ever-changing code of
+`ntdll!RtlpReferenceCurrentDirectory` by skipping uninteresting
+instructions such as `mov %rsp,%rax`, `mov %rbx,0x20(%rax)`, `push %rsi`
+`sub $0x70,%rsp`, etc, and focuses on finding the `lea`, `call
+ntdll!RtlEnterCriticalSection` and `mov ..., rbx` instructions, much
+like it was prototyped out for ARM64 at
+https://gist.github.com/jeremyd2019/aa167df0a0ae422fa6ebaea5b60c80c9
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/path.cc | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/winsup/cygwin/path.cc b/winsup/cygwin/path.cc
+index 33eb644..2ca929b 100644
+--- a/winsup/cygwin/path.cc
++++ b/winsup/cygwin/path.cc
+@@ -4883,6 +4883,18 @@ find_fast_cwd_pointer ()
+          %rcx for the subsequent RtlEnterCriticalSection call. */
+       lock = (const uint8_t *) memmem ((const char *) use_cwd, 80,
+                                        "\x48\x8d\x0d", 3);
++      if (lock)
++	{
++	  /* A recent Windows 11 Preview calls `lea rel(rip),%rcx' then
++	     a `mov` and a `movups` instruction, and only then
++	     `callq RtlEnterCriticalSection'.
++	     */
++	  if (memmem (lock + 7, 8, "\x4c\x89\x78\x10\x0f\x11\x40\xc8", 8))
++	    {
++	      call_rtl_offset = 15;
++	    }
++	}
++
+       if (!lock)
+ 	{
+ 	  /* Windows 8.1 Preview calls `lea rel(rip),%r12' then some unrelated

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.5.7
-pkgrel=3
+pkgrel=4
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -81,7 +81,8 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0050-fixup-Instead-of-creating-Cygwin-symlinks-use-deep-c.patch
         0051-fixup-Instead-of-creating-Cygwin-symlinks-use-deep-c.patch
         0052-amend-Instead-of-creating-Cygwin-symlinks-use-deep-c.patch
-        0053-Cygwin-console-Redesign-mode-set-strategy-on-close.patch)
+        0053-Cygwin-console-Redesign-mode-set-strategy-on-close.patch
+        0054-Cygwin-Adjust-CWD-magic-to-accommodate-for-the-lates.patch)
 sha256sums=('e78e129eed8e2dd4a2600fe6df8cb6f3beb9dca786574823ed55951adecb7064'
             '87d86c95008274731cf560d929ae5fb319d962591303b2690e11bfd60f4818e7'
             'c6d091cb51440638eb9fc59b35ba40f2b63e9e32a31a56c51a2aaec2445aa88e'
@@ -135,7 +136,8 @@ sha256sums=('e78e129eed8e2dd4a2600fe6df8cb6f3beb9dca786574823ed55951adecb7064'
             'e24911a237886d043959ccf64a4f862e91b0d9e322f200d255355040aae3ea16'
             '54e01260a3b481f2e178f2d603442d206b497b554a530c85d365febb11b12488'
             '086916ec5e3f038d6b815f268880bdda39b574efaa1c9a53fdc08ce46a57ba20'
-            '9ffbb094aa5d9616cae3fc8df6aaf4db64cd5dbe80144147b6aa68ba6e99b25c')
+            '9ffbb094aa5d9616cae3fc8df6aaf4db64cd5dbe80144147b6aa68ba6e99b25c'
+            '0a878a8b9a4ec43316bebcf67832b91104c8598b3a7eb7d6c9b9fb33da8114e3')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -225,7 +227,8 @@ prepare() {
   0050-fixup-Instead-of-creating-Cygwin-symlinks-use-deep-c.patch \
   0051-fixup-Instead-of-creating-Cygwin-symlinks-use-deep-c.patch \
   0052-amend-Instead-of-creating-Cygwin-symlinks-use-deep-c.patch \
-  0053-Cygwin-console-Redesign-mode-set-strategy-on-close.patch
+  0053-Cygwin-console-Redesign-mode-set-strategy-on-close.patch \
+  0054-Cygwin-Adjust-CWD-magic-to-accommodate-for-the-lates.patch
 }
 
 build() {


### PR DESCRIPTION
This is a companion of https://github.com/msys2/msys2-runtime/pull/264.