### PR TITLE
libblake3: use windows asm under cygwin; disable avx512

### DIFF
--- a/libblake3/0001-use-windows-asm.patch
+++ b/libblake3/0001-use-windows-asm.patch
@@ -1,0 +1,11 @@
+--- BLAKE3-1.6.1/c/CMakeLists.txt.orig	2025-03-15 08:06:05.461612600 +0100
++++ BLAKE3-1.6.1/c/CMakeLists.txt	2025-03-15 08:06:15.407136700 +0100
+@@ -45,7 +45,7 @@
+   set(BLAKE3_CFLAGS_AVX2 "-mavx2" CACHE STRING "the compiler flags to enable AVX2")
+   set(BLAKE3_CFLAGS_AVX512 "-mavx512f -mavx512vl" CACHE STRING "the compiler flags to enable AVX512")
+ 
+-  if (WIN32)
++  if (WIN32 OR CYGWIN)
+     set(BLAKE3_AMD64_ASM_SOURCES
+       blake3_avx2_x86-64_windows_gnu.S
+       blake3_avx512_x86-64_windows_gnu.S

--- a/libblake3/PKGBUILD
+++ b/libblake3/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=BLAKE3
 pkgname=libblake3
 pkgver=1.6.1
-pkgrel=1
+pkgrel=2
 pkgdesc='The official C implementation of BLAKE3'
 arch=(x86_64 i686)
 url=https://github.com/BLAKE3-team/BLAKE3
@@ -19,10 +19,22 @@ makedepends=(
   cmake
   ninja
 )
-source=("https://github.com/BLAKE3-team/BLAKE3/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('1f2fbd93790694f1ad66eef26e23c42260a1916927184d78d8395ff1a512d285')
+source=("https://github.com/BLAKE3-team/BLAKE3/archive/${pkgver}/${_realname}-${pkgver}.tar.gz"
+        0001-use-windows-asm.patch)
+sha256sums=('1f2fbd93790694f1ad66eef26e23c42260a1916927184d78d8395ff1a512d285'
+            'ae47916bb5b5ae870718ffe09e58539513379ca2f1161d79f3cf28d4230d8e36')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  patch -Np1 -i ../0001-use-windows-asm.patch
+}
 
 build() {
+
+  # FIXME: fails to link otherwise
+  CFLAGS+=" -DBLAKE3_NO_AVX512"
+
   cmake \
     -GNinja \
     -DCMAKE_INSTALL_PREFIX=/usr \


### PR DESCRIPTION
the first one made it crash when using asm, the later avoids it failing to link at build time

This fixes ccache segfaulting in some cases.