### PR TITLE
udis86: new package

### DIFF
--- a/udis86/PKGBUILD
+++ b/udis86/PKGBUILD
@@ -1,0 +1,60 @@
+# Maintainer: Jeremy Drake
+
+pkgname='udis86'
+pkgver=1.7.2
+pkgrel=1
+pkgdesc="Minimalistic disassembler library"
+arch=('i686' 'x86_64')
+url="http://sourceforge.net/projects/udis86"
+msys2_references=(
+  "anitya: 5026"
+  "cpe: cpe:2.3:a:vmt:udis86"
+)
+license=('BSD')
+options=('staticlibs')
+makedepends=('autotools' 'gcc' 'python')
+checkdepends=('yasm')
+source=(https://downloads.sourceforge.net/${pkgname}/${pkgname}-${pkgver}.tar.gz
+        'udis86-1.7.2-cygwin-msys.patch'
+        'udis86-1.7.2-docdir.patch'
+        'udis86-1.7.2-python3.patch'
+        'udis86-1.7.2-uninitialized-variable.patch')
+sha256sums=('9c52ac626ac6f531e1d6828feaad7e797d0f3cce1e9f34ad4e84627022b3c2f4'
+            'a351a8f242d74367a822a321309aae76fc4ad57d34027690296d09398845de49'
+            '48813d19cba7797abafc247c6463c501062be4120e4c52d26b168265d683737e'
+            'f307ff6c02aba6cbc53e231ba15a121435a08c9525fff2cedc58762ac5d4ca09'
+            'ca3b9b5d767b9de39dbc175ab782036bcc7967bec490df35c0d3d7de3630dc33')
+
+prepare() {
+  cd ${pkgname}-${pkgver}
+  patch -p1 -i ${srcdir}/udis86-1.7.2-cygwin-msys.patch
+
+  # These patches came from Gentoo
+  patch -p1 -i ${srcdir}/udis86-1.7.2-docdir.patch
+  patch -p1 -i ${srcdir}/udis86-1.7.2-python3.patch
+  patch -p1 -i ${srcdir}/udis86-1.7.2-uninitialized-variable.patch
+
+  autoreconf -fiv
+}
+
+build() {
+  mkdir -p build-${CARCH} && cd build-${CARCH}
+  local CYGWIN_CHOST="${CHOST/-msys/-cygwin}"
+  ../${pkgname}-${pkgver}/configure \
+    --prefix=/usr \
+    --enable-static \
+    --enable-shared \
+    --build="${CYGWIN_CHOST}"
+  make
+}
+
+check() {
+  cd build-${CARCH}
+  make check
+}
+
+package() {
+  cd build-${CARCH}
+  make DESTDIR="${pkgdir}" install
+  install -Dm644 "${srcdir}/${pkgname}-${pkgver}/README" "${pkgdir}/usr/share/doc/${pkgname}"
+}

--- a/udis86/udis86-1.7.2-cygwin-msys.patch
+++ b/udis86/udis86-1.7.2-cygwin-msys.patch
@@ -1,0 +1,11 @@
+--- udis86-1.7.2.orig/configure.ac	2013-09-01 21:08:39.000000000 -0700
++++ udis86-1.7.2/configure.ac	2025-03-17 11:37:21.151093000 -0700
+@@ -24,7 +24,7 @@
+ AC_CANONICAL_HOST
+ 
+ case "$host_os" in
+-	mingw32* )
++	mingw32* | cygwin* | msys* )
+ 		TARGET_OS=windows
+ 		AC_LIBTOOL_WIN32_DLL
+ 		;;

--- a/udis86/udis86-1.7.2-docdir.patch
+++ b/udis86/udis86-1.7.2-docdir.patch
@@ -1,0 +1,18 @@
+diff -ur a/docs/manual/Makefile.am b/docs/manual/Makefile.am
+--- a/docs/manual/Makefile.am	2013-09-02 05:46:56.000000000 +0200
++++ b/docs/manual/Makefile.am	2015-03-05 11:22:03.645828113 +0100
+@@ -1,4 +1,4 @@
+-docdir = ${datadir}/docs/udis86/manual
++docdir = @docdir@/manual
+ 
+ rst_sources = \
+ 	index.rst \
+diff -ur a/docs/x86/Makefile.am b/docs/x86/Makefile.am
+--- a/docs/x86/Makefile.am	2013-06-29 21:58:38.000000000 +0200
++++ b/docs/x86/Makefile.am	2015-03-05 11:22:30.477826105 +0100
+@@ -1,4 +1,4 @@
+-docdir = ${datadir}/docs/udis86/x86
++docdir = @docdir@/x86
+ dist_doc_DATA = optable.xml optable.xsl
+ 
+ MAINTAINERCLEANFILES = Makefile.in

--- a/udis86/udis86-1.7.2-python3.patch
+++ b/udis86/udis86-1.7.2-python3.patch
@@ -1,0 +1,42 @@
+--- a/scripts/ud_opcode.py
++++ b/scripts/ud_opcode.py
+@@ -130,8 +130,8 @@
+             '/mod'   : lambda v: '00' if v == '!11' else '01',
+             # Mode extensions:
+             # (16, 32, 64) => (00, 01, 02)
+-            '/o'     : lambda v: "%02x" % (int(v) / 32),
+-            '/a'     : lambda v: "%02x" % (int(v) / 32),
++            '/o'     : lambda v: "%02x" % (int(v) // 32),
++            '/a'     : lambda v: "%02x" % (int(v) // 32),
+             '/m'     : lambda v: '00' if v == '!64' else '01',
+             # SSE
+             '/sse'   : lambda v: UdOpcodeTables.OpcExtIndex['sse'][v],
+@@ -227,7 +227,7 @@
+ 
+     def print_table( self, table, pfxs ):
+         print("%s   |" % pfxs)
+-        keys = table[ 'entries' ].keys()
++        keys = list(table[ 'entries' ].keys())
+         if ( len( keys ) ):
+             keys.sort()
+         for idx in keys:
+--- a/tests/oprgen.py
++++ b/tests/oprgen.py
+@@ -686,7 +686,7 @@
+     def generate_yasm( self, mode, seed ):
+         opr_combos = {}
+         random.seed( seed )
+-        print "[bits %s]" % mode
++        print("[bits %s]" % mode)
+         for insn in self.InsnTable:
+             if insn[ 'mnemonic' ] in self.ExcludeList:
+                 continue
+@@ -728,7 +728,7 @@
+                 else:
+                     operands = None
+             if operands is not None:
+-                print "\t%s %s" % (insn['mnemonic'], operands)
++                print("\t%s %s" % (insn['mnemonic'], operands))
+                 opr_combos[fusedName]['covered'] = True
+ 
+         # stats

--- a/udis86/udis86-1.7.2-uninitialized-variable.patch
+++ b/udis86/udis86-1.7.2-uninitialized-variable.patch
@@ -1,0 +1,22 @@
+From cce390dd61996e569bd8a3bca78e7aa4b286d6df Mon Sep 17 00:00:00 2001
+From: Vivek Thampi <vivek.mt@gmail.com>
+Date: Sun, 22 Sep 2013 12:13:05 -0700
+Subject: [PATCH] Minor fix for an uninitialized var
+
+---
+ libudis86/decode.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libudis86/decode.c b/libudis86/decode.c
+index 3dab9ad..55638bd 100644
+--- a/libudis86/decode.c
++++ b/libudis86/decode.c
+@@ -228,7 +228,7 @@ static int
+ decode_prefixes(struct ud *u)
+ {
+   int done = 0;
+-  uint8_t curr, last = 0;
++  uint8_t curr = 0, last = 0;
+   UD_RETURN_ON_ERROR(u);
+ 
+   do {


### PR DESCRIPTION
There was a suggestion at one point that udis86 could be used for walking machine code in cygwin/msys2-runtime when looking for fast cwd.  This builds the library for prototype purposes.