### PR TITLE
zsh: fix performance issues related to PATH

### DIFF
--- a/zsh/PKGBUILD
+++ b/zsh/PKGBUILD
@@ -23,6 +23,7 @@ source=("https://www.zsh.org/pub/zsh-${pkgver}.tar.xz"{,.asc}
         msysize.patch
         zsh-5.0.6-1.patch
         msys-symlink-hack.patch
+        path-performance-issues.patch
         0004-pcre2.patch)
 sha256sums=('9b8d1ecedd5b5e81fbf1918e876752a7dd948e05c1a0dba10ab863842d45acd5'
             'SKIP'
@@ -35,6 +36,7 @@ sha256sums=('9b8d1ecedd5b5e81fbf1918e876752a7dd948e05c1a0dba10ab863842d45acd5'
             'b879d33cc60fc0c44361189eef1ee95a3bd0b8f9e8b32c81e439950483c151aa'
             '336a8e6e93b778e7aec27348619b7200e0a75e5cf14dce720afd9dd6f836ea2c'
             'de515b0d86c13c29a663b4ba0fdb338dea83f82f145cf8c4da78d30369f963e4'
+            '339a45c0c2d1f8d9e51a12b6ea24947c606c158b2785b6075172e08c19af2282'
             'ea68214d5be0514aa1b19e93fc9f44de878b9428e920227230a8fa3a75b0bd18')
 validpgpkeys=('F7B2754C7DE2830914661F0EA71D9A9D4BDB27B3'
               'E96646BE08C0AF0AA0F90788A5FEEE3AC7937444'
@@ -47,6 +49,7 @@ prepare() {
   patch -p1 -i "${srcdir}/msysize.patch"
   patch -p1 -i "${srcdir}/zsh-5.0.6-1.patch"
   patch -p1 -i "${srcdir}/msys-symlink-hack.patch"
+  patch -p0 -i "${srcdir}/path-performance-issues.patch"
 
   # pcre2 backport from Arch:
   # https://gitlab.archlinux.org/archlinux/packaging/packages/zsh/-/blob/main/0004-pcre2.patch

--- a/zsh/path-performance-issues.patch
+++ b/zsh/path-performance-issues.patch
@@ -1,0 +1,64 @@
+diff --git Src/exec.c Src/exec.c
+index c1181c5eb..4313124e6 100644
+--- Src/exec.c
++++ Src/exec.c
+@@ -707,7 +707,8 @@ search_defpath(char *cmd, char *pbuf, int plen)
+ 		    continue;
+ 		strucpy(&s, ps);
+ 	    }
+-	    *s++ = '/';
++	    if (s == pbuf || s[-1] != '/')
++		*s++ = '/';
+ 	    if ((s - pbuf) + strlen(cmd) >= plen)
+ 		continue;
+ 	    strucpy(&s, cmd);
+@@ -841,7 +842,8 @@ execute(LinkList args, int flags, int defpath)
+ 		    } else if (**pp != '/') {
+ 			z = buf;
+ 			strucpy(&z, *pp);
+-			*z++ = '/';
++			if (z[-1] != '/')
++			    *z++ = '/';
+ 			strcpy(z, arg0);
+ 			ee = zexecve(buf, argv, newenvp);
+ 			if (isgooderr(ee, *pp))
+@@ -866,7 +868,8 @@ execute(LinkList args, int flags, int defpath)
+ 	    } else {
+ 		z = buf;
+ 		strucpy(&z, *pp);
+-		*z++ = '/';
++		if (z[-1] != '/')
++		    *z++ = '/';
+ 		strcpy(z, arg0);
+ 		ee = zexecve(buf, argv, newenvp);
+ 		if (isgooderr(ee, *pp))
+@@ -935,7 +938,8 @@ findcmd(char *arg0, int docopy, int default_path)
+ 		    z = buf;
+ 		    if (**pp) {
+ 			strucpy(&z, *pp);
+-			*z++ = '/';
++			if (z[-1] != '/')
++			    *z++ = '/';
+ 		    }
+ 		    strcpy(z, arg0);
+ 		    RET_IF_COM(buf);
+@@ -950,7 +954,8 @@ findcmd(char *arg0, int docopy, int default_path)
+ 	z = buf;
+ 	if (**pp) {
+ 	    strucpy(&z, *pp);
+-	    *z++ = '/';
++	    if (z[-1] != '/')
++		*z++ = '/';
+ 	}
+ 	strcpy(z, arg0);
+ 	RET_IF_COM(buf);
+@@ -1025,7 +1030,8 @@ hashcmd(char *arg0, char **pp)
+ 	if (**pp == '/') {
+ 	    s = buf;
+ 	    struncpy(&s, *pp, PATH_MAX);
+-	    *s++ = '/';
++	    if (s[-1] != '/')
++		*s++ = '/';
+ 	    if ((s - buf) + strlen(arg0) >= PATH_MAX)
+ 		continue;
+ 	    strcpy(s, arg0);


### PR DESCRIPTION
When `$PATH` contains `/` and command `foo` is run, zsh will try to execute `//foo` instead of `/foo`, which will attempt to contact a network share on server `foo`, causing DNS and CIFS requests that will greatly slow down the shell. And if `/foo` actually exists, it will not be found.

As a workaround, we do not insert the additional `'/'` if the path element already ends with a slash.

Another workaround for the users would be to put `/.` instead of `/` in `$PATH`.