### PR TITLE
mintty: build with configured_glyph_shift option set

### DIFF
--- a/mintty/PKGBUILD
+++ b/mintty/PKGBUILD
@@ -22,6 +22,7 @@ sha256sums=('ab477a693e922cdee06738bb47cc8274dd05de5d283334dda6142143b058e21f'
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
+  CFLAGS+=" -D configured_glyph_shift"
   make
 }
 


### PR DESCRIPTION
The new `configued_glyph_shift` option, introduced in version 3.7.8, was designed to address the issue of misaligned CJK characters. While this feature primarily benefits users working with CJK in their terminal, it should, I think, not negatively impact other users. It's turned off by default.

Related discussions are:
+ https://github.com/mintty/mintty/commit/4c73970ce9263a0eda1c81d529df3cd0ac90844a
+ https://github.com/mintty/mintty/issues/1313
