### PR TITLE
msys2-runtime: backport pipe hang fix

### DIFF
--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.6.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -29,6 +29,7 @@ makedepends=('cocom'
 # re zipman: https://github.com/msys2/MSYS2-packages/pull/2687#issuecomment-965714874
 options=('!zipman')
 source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-${pkgver}
+        https://patch-diff.githubusercontent.com/raw/msys2/msys2-runtime/pull/271.patch
         msys2-runtime.commit
         0001-Add-MSYS2-triplet.patch
         0002-Fix-msys-library-name-in-import-libraries.patch
@@ -72,6 +73,7 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0040-Cygwin-Adjust-CWD-magic-to-accommodate-for-the-lates.patch
         0041-Cygwin-console-tty-restore-really-restores-the-previ.patch)
 sha256sums=('89d856fbf9f8d753a644651f95ccd769a43135d93b1bc322582f6fb87ebf4cea'
+            '875c09c99cfa98b7480e7ec37ee211315f3f60b59c14a70760a4f8e2b9cc3c17'
             '564998f09ca51148aba183e52ac8e78169c98d3e1a92e163f56a00cd7c840a68'
             '5945b95c6b3caf18cc8356802e9af1770746a76c27d0931b897d48d072603fcf'
             '8f2def0add5397487e2470fd7219bd80233e4d43e9f78d92d042907fede0570a'
@@ -151,6 +153,9 @@ prepare() {
   fi
   del_file_exists winsup/cygwin/msys2_path_conv.cc \
     winsup/cygwin/msys2_path_conv.h
+
+  apply_git_am_with_msg 271.patch
+
  apply_git_am_with_msg 0001-Add-MSYS2-triplet.patch \
   0002-Fix-msys-library-name-in-import-libraries.patch \
   0003-Rename-dll-from-cygwin-to-msys.patch \


### PR DESCRIPTION
See https://github.com/msys2/msys2-runtime/pull/271

So we can build GIMP until we have an upstream fix