### PR TITLE
cmake: move various packages to ninja; fixes for cmake 4

### DIFF
--- a/brotli/PKGBUILD
+++ b/brotli/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=brotli
 pkgname=('brotli' 'brotli-devel' 'brotli-testdata')
 pkgver=1.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Brotli compression library'
 arch=('i686' 'x86_64')
 license=('MIT')
@@ -15,6 +15,7 @@ depends=('gcc-libs')
 makedepends=(
   'cmake'
   'gcc'
+  'ninja'
 )
 source=("${pkgbase}-${pkgver}.tar.gz::https://github.com/google/$pkgbase/archive/v${pkgver}.tar.gz")
 sha256sums=('e720a6ca29428b803f4ad165371771f5398faba397edf6778837a18599ea13ff')
@@ -27,12 +28,12 @@ prepare() {
 build() {
   cd brotli-${pkgver}
 
-  cmake -B "build-static" \
+  cmake -GNinja -B "build-static" \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DBUILD_SHARED_LIBS=OFF
   cmake --build "build-static"
 
-  cmake -B "build-shared" \
+  cmake -GNinja -B "build-shared" \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DBUILD_SHARED_LIBS=ON
   cmake --build "build-shared"
@@ -48,11 +49,11 @@ package_brotli() {
   cd brotli-${pkgver}
 
   cd build-static
-  make DESTDIR=${pkgdir} install
+  DESTDIR="${pkgdir}" cmake --install .
   rm -rf ${pkgdir}/usr/{include,lib}
   cd -
   cd build-shared
-  make DESTDIR=${pkgdir} install
+  DESTDIR="${pkgdir}" cmake --install .
   rm -rf ${pkgdir}/usr/{include,lib}
 
   install -D -m644 "${srcdir}"/brotli-${pkgver}/LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
@@ -64,11 +65,11 @@ package_brotli-devel() {
   cd brotli-${pkgver}
 
   cd build-static
-  make DESTDIR=${pkgdir} install
+  DESTDIR="${pkgdir}" cmake --install .
   rm -rf ${pkgdir}/usr/bin
   cd -
   cd build-shared
-  make DESTDIR=${pkgdir} install
+  DESTDIR="${pkgdir}" cmake --install .
   rm -rf ${pkgdir}/usr/bin
 }
 

--- a/c-ares/PKGBUILD
+++ b/c-ares/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase="c-ares"
 pkgname=("libcares" "libcares-devel")
 pkgver=1.34.4
-pkgrel=1
+pkgrel=2
 pkgdesc="C library that performs DNS requests and name resolves asynchronously (libraries)"
 arch=('i686' 'x86_64')
 url="https://c-ares.haxx.se/"
@@ -13,7 +13,7 @@ msys2_references=(
   "cpe: cpe:/a:daniel_stenberg:c-ares"
 )
 license=("spdx:MIT")
-makedepends=("cmake" 'gcc')
+makedepends=("cmake" 'gcc' 'ninja')
 depends=("gcc-libs")
 source=("https://github.com/c-ares/c-ares/releases/download/v${pkgver}/c-ares-${pkgver}.tar.gz"{,.asc})
 sha256sums=('fa38dbed659ee4cc5a32df5e27deda575fa6852c79a72ba1af85de35a6ae222f'
@@ -25,14 +25,14 @@ validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2' # Daniel Stenberg <dani
 build() {
   cd "${srcdir}/${pkgbase}-${pkgver}"
 
-  cmake -B "build-static" \
+  cmake -GNinja -B "build-static" \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCARES_STATIC=ON \
     -DCARES_SHARED=OFF
   cmake --build "build-static"
   DESTDIR="${srcdir}/dest" cmake --install "build-static"
 
-  cmake -B "build-shared" \
+  cmake -GNinja -B "build-shared" \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCARES_STATIC=OFF \
     -DCARES_SHARED=ON

--- a/doctest/PKGBUILD
+++ b/doctest/PKGBUILD
@@ -22,6 +22,7 @@ build() {
         -DCMAKE_BUILD_TYPE=Release \
         -DDOCTEST_WITH_TESTS=off \
         -GNinja \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         ../
   
   cmake --build .

--- a/doctest/PKGBUILD
+++ b/doctest/PKGBUILD
@@ -2,12 +2,12 @@
 
 pkgname=doctest
 pkgver=2.4.11
-pkgrel=1
+pkgrel=2
 pkgdesc='The lightest feature rich C++ single header testing framework'
 arch=('any')
 url='https://github.com/onqtam/doctest'
 license=('spdx:MIT')
-makedepends=('cmake' 'gcc' 'make')
+makedepends=('cmake' 'gcc' 'ninja')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/${pkgname}/${pkgname}/archive/refs/tags/v${pkgver}.tar.gz")
 sha256sums=('632ed2c05a7f53fa961381497bf8069093f0d6628c5f26286161fbd32a560186')
 
@@ -21,13 +21,14 @@ build() {
   cmake -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_BUILD_TYPE=Release \
         -DDOCTEST_WITH_TESTS=off \
-        -G"Unix Makefiles" \
+        -GNinja \
         ../
-  make
+  
+  cmake --build .
 }
 
 package() {
   cd "${srcdir}/${pkgname}-${pkgver}/build"
-  make DESTDIR="${pkgdir}" install
+  DESTDIR="${pkgdir}" cmake --install .
   install -Dm 0644 ../LICENSE.txt "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/libpcap/PKGBUILD
+++ b/libpcap/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=libpcap
 pkgname=('libpcap' 'libpcap-devel')
 pkgver=1.10.5
-pkgrel=1
+pkgrel=2
 pkgdesc="A portable C/C++ library for network traffic capture"
 arch=('i686' 'x86_64')
 license=('spdx:BSD-3-Clause')
@@ -12,7 +12,7 @@ msys2_repository_url="https://github.com/the-tcpdump-group/libpcap"
 msys2_references=(
   "cpe: cpe:/a:tcpdump:libpcap"
 )
-makedepends=('bison' 'cmake' 'flex' 'gcc' 'make' 'openssl-devel')
+makedepends=('bison' 'cmake' 'flex' 'gcc' 'ninja' 'openssl-devel')
 source=(https://www.tcpdump.org/release/${pkgname}-${pkgver}.tar.gz
         0003-Disable-man-symlinks.patch)
 sha256sums=('37ced90a19a302a7f32e458224a00c365c117905c2cd35ac544b6880a81488f0'
@@ -27,11 +27,13 @@ prepare() {
 build() {
   mkdir -p build-${pkgbase}-${pkgver}-${CHOST}
   cd build-${pkgbase}-${pkgver}-${CHOST}
-  cmake \
+  cmake -GNinja \
     -DCMAKE_INSTALL_PREFIX="/usr" \
     -DPCAP_TYPE=null \
     ../${pkgbase}-${pkgver}
-  make DESTDIR=${srcdir}/dest install
+  
+  cmake --build .
+  DESTDIR="${srcdir}/dest" cmake --install .
 }
 
 package_libpcap() {

--- a/libssh/PKGBUILD
+++ b/libssh/PKGBUILD
@@ -1,7 +1,7 @@
 pkgbase=libssh
 pkgname=('libssh' 'libssh-devel')
 pkgver=0.11.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Library for accessing ssh client services through C libraries'
 url='https://www.libssh.org/'
 msys2_repository_url="https://git.libssh.org/projects/libssh.git"
@@ -11,7 +11,7 @@ msys2_references=(
 license=('spdx:LGPL-2.1+')
 arch=('i686' 'x86_64')
 depends=('zlib' 'libopenssl')
-makedepends=('cmake' 'python' 'openssl-devel' 'gcc' 'zlib-devel')
+makedepends=('cmake' 'python' 'openssl-devel' 'gcc' 'zlib-devel' 'ninja')
 source=("https://www.libssh.org/files/${pkgver%.*}/$pkgname-$pkgver.tar.xz"{,.asc})
 sha256sums=('14b7dcc72e91e08151c58b981a7b570ab2663f630e7d2837645d5a9c612c1b79'
             'SKIP')
@@ -21,12 +21,13 @@ validpgpkeys=('8DFF53E18F2ABC8D8F3C92237EE0FC4DCC014E3D'  # Andreas Schneider <a
 build() {
   mkdir -p build && cd build
 
-  cmake ../$pkgname-$pkgver \
+  cmake -GNinja ../$pkgname-$pkgver \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DWITH_GSSAPI=OFF \
     -DUNIT_TESTING=OFF
-  make
-  make DESTDIR="$srcdir/dest" install
+
+  cmake --build .
+  DESTDIR="$srcdir/dest" cmake --install .
 }
 
 package_libssh() {

--- a/msgpack-c/PKGBUILD
+++ b/msgpack-c/PKGBUILD
@@ -3,28 +3,28 @@
 pkgbase=msgpack-c
 pkgname=('msgpack-c' 'msgpack-c-devel')
 pkgver=6.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="MessagePack implementation for C"
 arch=('i686' 'x86_64')
 url="https://msgpack.org"
 msys2_repository_url="https://github.com/msgpack/msgpack-c"
 license=('Boost')
-makedepends=('cmake' 'gcc' 'make')
+makedepends=('cmake' 'gcc' 'ninja')
 source=("https://github.com/msgpack/msgpack-c/releases/download/c-${pkgver}/${pkgbase}-${pkgver}.tar.gz")
 sha256sums=('674119f1a85b5f2ecc4c7d5c2859edf50c0b05e0c10aa0df85eefa2c8c14b796')
 
 build() {
   cd "${srcdir}/${pkgbase}-${pkgver}"
 
-  cmake -DCMAKE_INSTALL_PREFIX=/usr \
+  cmake -GNinja -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_BUILD_TYPE=None \
     -DBUILD_SHARED_LIBS=ON \
     -DMSGPACK_ENABLE_STATIC=OFF \
     -DMSGPACK_BUILD_EXAMPLES=OFF \
     .
 
-  make
-  make DESTDIR="${srcdir}/dest" install
+  cmake --build .
+  DESTDIR="${srcdir}/dest" cmake --install .
 }
 
 package_msgpack-c() {

--- a/re2c/PKGBUILD
+++ b/re2c/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=re2c
 pkgver=3.1
-pkgrel=2
+pkgrel=3
 arch=('i686' 'x86_64')
 pkgdesc='A tool for generating C-based recognizers from regular expressions'
 url='https://re2c.org/'
@@ -14,13 +14,13 @@ msys2_references=(
 )
 license=('public domain')
 depends=('gcc-libs')
-makedepends=('cmake' 'gcc' 'python')
+makedepends=('cmake' 'gcc' 'python' 'ninja')
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/skvadrik/re2c/archive/${pkgver}.tar.gz)
 sha256sums=('087c44de0400fb15caafde09fd72edc7381e688a35ef505ee65e0e3d2fac688b')
 
 build() {
   cd ${pkgname}-${pkgver}
-  cmake -B build -DCMAKE_INSTALL_PREFIX=/usr
+  cmake -GNinja -B build -DCMAKE_INSTALL_PREFIX=/usr
   cmake --build build
 }
 

--- a/upx/PKGBUILD
+++ b/upx/PKGBUILD
@@ -17,7 +17,7 @@ msys2_references=(
 )
 license=('GPL')
 depends=('ucl' 'zlib')
-makedepends=('ucl-devel' 'zlib-devel' 'gcc' 'make' 'cmake' 'ninja')
+makedepends=('ucl-devel' 'zlib-devel' 'gcc' 'cmake' 'ninja')
 source=("https://github.com/${pkgname}/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}-src.tar.xz")
 sha256sums=('e0eb96f9c50aefdb02eca445f8ed76aca5cd70b6b132bf61bea3ba4b8ebb64cc')
 

--- a/znc/PKGBUILD
+++ b/znc/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=znc
 pkgver=1.9.1
-pkgrel=1
+pkgrel=2
 pkgdesc='An IRC bouncer with modules & scripts support'
 url='https://znc.in/'
 msys2_repository_url="https://github.com/znc/znc"
@@ -25,6 +25,7 @@ makedepends=('cmake'
              'swig'
              'gcc'
              #'tcl'
+             'ninja'
              )
 optdepends=('tcl: modtcl module'
             'python: modpython module'
@@ -44,6 +45,7 @@ build() {
   mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
 
   cmake \
+    -GNinja \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DBUILD_SHARED_LIBS=OFF \
     -DCMAKE_BUILD_TYPE=Release \
@@ -52,12 +54,12 @@ build() {
     -DWANT_PYTHON=ON \
     -DWANT_I18N=OFF \
     ../${pkgname}-${pkgver}
-  make
+  cmake --build .
 }
 
 package() {
   cd "${srcdir}/build-${CARCH}"
-  make DESTDIR="${pkgdir}" install
+  DESTDIR="${pkgdir}" cmake --install .
 
   python3 -m compileall -o 0 -o 1 -s "${pkgdir}" "${pkgdir}/usr/lib/znc"
 


### PR DESCRIPTION
To get some cmake 4.0 testing rebuild a few things, and while at it move those packages to ninja.