### PR TITLE
openssh: Update to 10.0p1 (v2)

### DIFF
--- a/openssh/PKGBUILD
+++ b/openssh/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=openssh
-pkgver=9.9p2
-pkgrel=1
+pkgver=10.0p1
+pkgrel=2
 pkgdesc='Free version of the SSH connectivity tools'
 url='https://www.openssh.com/portable.html'
 msys2_changelog_url="https://www.openssh.com/releasenotes.html"
@@ -18,7 +18,7 @@ source=("https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/${pkgname}-${pkgve
         openssh-7.3p1-msys2.patch
         openssh-7.3p1-msys2-setkey.patch
         openssh-7.3p1-msys2-drive-name-in-path.patch)
-sha256sums=('91aadb603e08cc285eddf965e1199d02585fa94d994d6cae5b41e1721e215673'
+sha256sums=('021a2e709a0edf4250b1256bd5a9e500411a90dddabea830ed59cef90eb9d85c'
             'SKIP'
             '4ac8da8f0933eae61e3b973e627c0c152ea4168c28cdc27066f9a5d54432f578'
             '25079cf4a10c1ab70d60302bccaabee513762520dffd7c35285f7aae3ea36087'
@@ -38,6 +38,10 @@ prepare() {
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
+
+  # setproctitle is new in Cygwin 3.6, and we want openssh
+  # to work with older Cygwin versions too.
+  export ac_cv_func_setproctitle=no
 
   local CYGWIN_CHOST="${CHOST/-msys/-cygwin}"
   export MSYSTEM=CYGWIN


### PR DESCRIPTION
I had to pull the last update, f97d8e521886b021d868 because it was no longer working with cygwin 3.5