### PR TITLE
llvm: build with clang

### DIFF
--- a/llvm/PKGBUILD
+++ b/llvm/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Mateusz Mikuła <oss@mateuszmikula.dev>
 
-_compiler=gcc
+_compiler=clang
 
 pkgbase=llvm
 pkgname=("llvm"
@@ -12,7 +12,7 @@ _version=20.1.2
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM"
 arch=('i686' 'x86_64')
 url="https://llvm.org/"
@@ -21,7 +21,7 @@ msys2_references=(
 )
 license=("spdx:Apache-2.0 WITH LLVM-exception")
 makedepends=('cmake'
-             'gcc'
+             "$_compiler"
              'ninja'
              'pkgconf'
              'python'


### PR DESCRIPTION
This allows building dynamic libraries, making the package *much* smaller.