### PR TITLE
gdbm: Update to 1.25

### DIFF
--- a/gdbm/0001-missing-include.patch
+++ b/gdbm/0001-missing-include.patch
@@ -1,0 +1,10 @@
+--- gdbm-1.25/tools/gdbmapp.h.orig	2025-03-06 16:51:59.000000000 +0100
++++ gdbm-1.25/tools/gdbmapp.h	2025-04-17 09:00:24.952369600 +0200
+@@ -14,6 +14,7 @@
+    You should have received a copy of the GNU General Public License
+    along with GDBM. If not, see <http://www.gnu.org/licenses/>.   */
+ 
++#include <sys/types.h>
+ #include <stdlib.h>
+ #include <stdarg.h>
+ #include "gettext.h"

--- a/gdbm/PKGBUILD
+++ b/gdbm/PKGBUILD
@@ -1,25 +1,29 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=('gdbm' 'libgdbm' 'libgdbm-devel')
-pkgver=1.24
+pkgver=1.25
 pkgrel=1
 pkgdesc="GNU database library"
 url="https://www.gnu.org/software/gdbm/gdbm.html"
+msys2_repository_url="https://git.savannah.gnu.org/cgit/gdbm.git"
 license=('GPL3')
 arch=('i686' 'x86_64')
 makedepends=('libreadline-devel' 'autotools' 'gcc' 'gettext-devel' 'libiconv-devel' 'ncurses-devel')
 source=(https://ftp.gnu.org/gnu/gdbm/${pkgname}-${pkgver}.tar.gz{,.sig}
-        1.10-no-undefined.patch)
+        1.10-no-undefined.patch
+        0001-missing-include.patch)
 options=('!makeflags')
-sha256sums=('695e9827fdf763513f133910bc7e6cfdb9187943a4fec943e57449723d2b8dbf'
+sha256sums=('d02db3c5926ed877f8817b81cd1f92f53ef74ca8c6db543fbba0271b34f393ec'
             'SKIP'
-            'b2d661b1365fde38e4ed1796433767ed61b3be72f3b6c48b3d27e4004db01877')
-validpgpkeys=('325F650C4C2B6AD58807327A3602B07F55D0C732') # Sergey Poznyakoff <gray@gnu.org>
+            'b2d661b1365fde38e4ed1796433767ed61b3be72f3b6c48b3d27e4004db01877'
+            '9fbde56f54e5e27e7c4c244f588224d3fba90dc6fb456a34db57e37ccf10f028')
+validpgpkeys=('4BE4E62655488EB92ABB468F79FFD94BFCE230B1') # Sergey Poznyakoff <gray@gnu.org>
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
 
   patch -Np2 -i ${srcdir}/1.10-no-undefined.patch
+  patch -Np1 -i ${srcdir}/0001-missing-include.patch
 
   autoreconf -fiv
 }


### PR DESCRIPTION
new key, as pointed out here:
https://www.gnu.org.ua/software/gdbm/download.html