### PR TITLE
perl: build for msys2

### DIFF
--- a/perl/0006-perl-5.36.0-msys2.patch
+++ b/perl/0006-perl-5.36.0-msys2.patch
@@ -1,21 +1,187 @@
+From badb6df6fd00b343b810886a647fa793ab2ef539 Mon Sep 17 00:00:00 2001
+From: Alexey Pavlov <alexpux@gmail.com>
+Date: Tue, 5 Nov 2013 00:30:05 +0400
+Subject: [PATCH 6/7] perl-5.36.0-msys2
+
+---
+ Configure                                     | 20 +++-
+ Cross/Makefile-cross-SH                       |  8 +-
+ Makefile.SH                                   |  6 +-
+ configpm                                      |  4 +-
+ cpan/Archive-Tar/t/02_methods.t               |  2 +-
+ cpan/CPAN-Meta/t/data-fail/META-1_4.yml       |  3 +
+ cpan/CPAN-Meta/t/data-fixable/META-1_4.yml    |  3 +
+ .../invalid-meta-spec-version.yml             |  3 +
+ .../meta-spec-version-trailing-zeros.yml      |  3 +
+ cpan/CPAN-Meta/t/data-test/META-1_4.yml       |  3 +
+ .../CPAN-Meta/t/data-test/restrictive-1_4.yml |  3 +
+ cpan/CPAN-Meta/t/data-test/unicode.yml        |  3 +
+ cpan/Compress-Raw-Zlib/Makefile.PL            |  2 +-
+ cpan/DB_File/t/db-btree.t                     |  5 +-
+ cpan/DB_File/t/db-hash.t                      |  4 +-
+ cpan/DB_File/t/db-recno.t                     |  4 +-
+ cpan/Digest-SHA/shasum                        |  2 +-
+ cpan/ExtUtils-Install/lib/ExtUtils/Install.pm |  4 +-
+ .../lib/ExtUtils/Liblist/Kid.pm               |  2 +
+ cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm    |  2 +-
+ .../lib/ExtUtils/MM_Cygwin.pm                 |  6 +-
+ cpan/ExtUtils-MakeMaker/t/03-xsstatic.t       |  2 +-
+ cpan/ExtUtils-MakeMaker/t/MM_Cygwin.t         |  2 +-
+ cpan/ExtUtils-MakeMaker/t/MM_Unix.t           |  2 +-
+ cpan/ExtUtils-MakeMaker/t/Mkbootstrap.t       |  2 +-
+ cpan/ExtUtils-MakeMaker/t/eu_command.t        |  4 +-
+ cpan/ExtUtils-MakeMaker/t/fixin.t             |  2 +-
+ cpan/ExtUtils-Manifest/t/Manifest.t           |  2 +-
+ cpan/File-Path/t/Path.t                       |  2 +-
+ cpan/File-Temp/lib/File/Temp.pm               |  4 +-
+ cpan/IO-Compress/t/cz-14gzopen.t              |  4 +-
+ cpan/IO-Socket-IP/t/11sockopts.t              |  2 +-
+ cpan/IPC-Cmd/t/03_run-forked.t                |  2 +-
+ cpan/IPC-SysV/t/ipcsysv.t                     |  6 +-
+ cpan/Pod-Perldoc/lib/Pod/Perldoc.pm           |  2 +-
+ cpan/Pod-Perldoc/lib/Pod/Perldoc/BaseTo.pm    |  2 +-
+ cpan/Socket/t/socketpair.t                    |  2 +-
+ cpan/Sys-Syslog/t/syslog.t                    |  2 +-
+ cpan/Sys-Syslog/win32/Win32.pm                |  2 +-
+ cpan/Sys-Syslog/win32/compile.pl              |  2 +-
+ cpan/Win32/Makefile.PL                        |  5 +-
+ cpan/Win32/t/GetCurrentThreadId.t             |  2 +-
+ cpan/Win32/t/Unicode.t                        | 16 +--
+ cpan/Win32API-File/File.pm                    |  2 +-
+ cpan/Win32API-File/Makefile.PL                |  2 +-
+ cpan/Win32API-File/t/file.t                   |  8 +-
+ cpan/autodie/t/chown.t                        |  2 +-
+ cpan/autodie/t/version_tag.t                  |  2 +-
+ cpan/libnet/lib/Net/Domain.pm                 |  2 +-
+ cpan/libnet/lib/Net/Netrc.pm                  |  1 +
+ cpan/libnet/t/netrc.t                         |  2 +-
+ .../lib/ExtUtils/CBuilder/Platform/msys.pm    | 33 +++++++
+ dist/IO/t/cachepropagate-unix.t               |  4 +-
+ dist/IO/t/io_xs.t                             |  2 +
+ dist/Net-Ping/lib/Net/Ping.pm                 | 10 +-
+ dist/Net-Ping/t/001_new.t                     |  2 +-
+ dist/Net-Ping/t/450_service.t                 |  4 +-
+ dist/Net-Ping/t/510_ping_udp.t                |  2 +-
+ dist/PathTools/Cwd.pm                         | 13 ++-
+ dist/PathTools/lib/File/Spec.pm               |  1 +
+ dist/PathTools/lib/File/Spec/Cygwin.pm        |  4 +-
+ dist/PathTools/lib/File/Spec/Unix.pm          |  2 +-
+ dist/PathTools/t/crossplatform.t              |  2 +-
+ dist/PathTools/t/cwd.t                        |  2 +-
+ dist/PathTools/t/cwd_enoent.t                 |  4 +-
+ dist/Storable/stacksize                       |  2 +-
+ dist/Term-ReadLine/t/ReadLine-STDERR.t        |  3 +-
+ dist/Time-HiRes/Makefile.PL                   |  4 +-
+ dist/Time-HiRes/t/stat.t                      |  2 +-
+ dist/Time-HiRes/t/utime.t                     |  2 +-
+ dist/XSLoader/XSLoader_pm.PL                  |  2 +-
+ ext/DynaLoader/DynaLoader_pm.PL               |  3 +
+ ext/DynaLoader/t/DynaLoader.t                 |  2 +-
+ ext/File-Find/t/find.t                        |  2 +-
+ ext/File-Glob/t/basic.t                       |  2 +-
+ ext/NDBM_File/Makefile.PL                     |  2 +-
+ ext/ODBM_File/Makefile.PL                     |  2 +-
+ ext/POSIX/Makefile.PL                         |  2 +-
+ ext/POSIX/t/sysconf.t                         |  2 +-
+ ext/POSIX/t/time.t                            |  2 +-
+ ext/POSIX/t/wrappers.t                        |  2 +
+ ext/Win32CORE/t/win32core.t                   |  4 +-
+ ext/XS-APItest/t/call_checker.t               |  2 +-
+ haiku/Haiku/Makefile.PL                       |  2 +-
+ hints/msys.sh                                 | 98 +++++++++++++++++++
+ install_lib.pl                                |  2 +-
+ installman                                    |  2 +-
+ lib/AnyDBM_File.t                             |  3 +-
+ lib/ExtUtils/t/Embed.t                        |  4 +-
+ lib/File/Compare.t                            |  2 +-
+ lib/File/Copy.t                               |  2 +-
+ lib/Net/hostent.t                             |  2 +-
+ lib/User/grent.t                              |  2 +-
+ lib/User/pwent.t                              |  4 +-
+ lib/locale.t                                  |  2 +-
+ lib/perl5db.pl                                |  2 +-
+ regen/regen_lib.pl                            |  2 +-
+ t/io/eintr.t                                  |  2 +-
+ t/io/fs.t                                     | 11 ++-
+ t/io/pvbm.t                                   |  2 +-
+ t/io/tell.t                                   |  4 +-
+ t/lib/cygwin.t                                |  4 +-
+ t/lib/dbmt_common.pl                          |  2 +-
+ t/op/groups.t                                 |  2 +-
+ t/op/magic.t                                  |  2 +-
+ t/op/require_errors.t                         |  3 +-
+ t/op/sigdispatch.t                            |  6 +-
+ t/op/stat.t                                   | 11 ++-
+ t/op/taint.t                                  |  2 +-
+ t/op/time.t                                   |  2 +-
+ t/porting/exec-bit.t                          |  2 +-
+ t/porting/extrefs.t                           |  2 +-
+ t/porting/globvar.t                           |  2 +-
+ t/run/locale.t                                |  2 +-
+ t/test.pl                                     |  2 +-
+ utils/perlbug.PL                              |  4 +-
+ win32/FindExt.pm                              |  2 +-
+ 117 files changed, 354 insertions(+), 155 deletions(-)
+ create mode 100644 dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/msys.pm
+ create mode 100644 hints/msys.sh
+
 diff --git a/Configure b/Configure
 index 24366f6..368f7ad 100755
 --- a/Configure
 +++ b/Configure
-@@ -8731,10 +8731,10 @@
- 			dflt=libperl.$so
+@@ -1440,7 +1440,7 @@ elif test -f /kern/cookiejar; then
+ : MiNT
+     _exe=""
+ elif test -d c:/. -o -n "$is_os2" ; then
+-: OS/2 or cygwin
++: OS/2 or cygwin or msys
+     _exe=".exe"
+ fi
+ 
+@@ -3480,6 +3480,9 @@ EOM
+ 		cygwin*) osname=cygwin
+ 			osvers="$3"
  			;;
- 		cygwin*) # ld links now against the dll directly
--			majmin="cygperl5_${patchlevel}_${subversion}.${so}"
-+			majmin="msys-perl5_${patchlevel}_${subversion}.${so}"
- 			majonly=`echo $patchlevel $subversion |
- 				$awk '{printf "%03d%03d", $1, $2}'`
--			majonly=cygperl5.$majonly.$so
-+			majonly=msys-perl5.$majonly.$so
++		msys*) osname=msys
++			osvers="$3"
++			;;
+ 		*dc.osx) osname=dcosx
+ 			osvers="$3"
+ 			;;
+@@ -8705,7 +8708,7 @@ $undef)
+ 	;;
+ *)	case "$useshrplib" in
+ 	'')	case "$osname" in
+-		svr4*|nonstopux|dgux|dynixptx|esix|powerux|haiku|cygwin*)
++		svr4*|nonstopux|dgux|dynixptx|esix|powerux|haiku|cygwin*|msys*)
+ 			dflt=y
+ 			also='Building a shared libperl is required for dynamic loading to work on your system.'
+ 			;;
+@@ -8776,6 +8779,13 @@ true)
+ 			majonly=cygperl5.$majonly.$so
  			dflt=$majmin
  			;;
++		msys*) # ld links now against the dll directly
++			majmin="msys-perl5_${patchlevel}_${subversion}.${so}"
++			majonly=`echo $patchlevel $subversion |
++				$awk '{printf "%03d%03d", $1, $2}'`
++			majonly=msys-perl5.$majonly.$so
++			dflt=$majmin
++			;;
  		*)	# Try to guess based on whether libc has major.minor.
-@@ -23651,7 +23651,7 @@
+ 			case "$libc" in
+ 			*libc.$so.[0-9]*.[0-9]*) dflt=$majmin ;;
+@@ -8867,6 +8877,9 @@ if "$useshrplib"; then
+ 	cygwin)
+ 		# cygwin needs only ldlibpth
+ 		;;
++	msys)
++		# cygwin needs only ldlibpth
++		;;
+ 	*)
+ 		tmp_shrpenv="env LD_RUN_PATH=$shrpdir"
+ 		;;
+@@ -23537,7 +23550,7 @@ BeOS BIG_ENDIAN BIT_MSF BSD bsd bsd43 bsd4_2 BSD4_3 bsd4_3 bsd4_4
  BSDCOMPAT bsdi BSD_4_3 BSD_4_4 BSD_NET2 BSD_TIME BSD_TYPES bull
  byteorder byte_order
  c cadmus clang clipper CMU COFF COMPILER_VERSION concurrent
@@ -24,25 +190,44 @@ index 24366f6..368f7ad 100755
  DECC DGUX DGUX_SOURCE DJGPP dmert DOLPHIN DPX2 DSO Dynix DynixPTX
  ELF encore EPI EXTENSIONS
  FAVOR_BSD FILE_OFFSET_BITS FORTIFY_SOURCE FreeBSD
+@@ -24163,6 +24176,7 @@ for xxx in $xs_extensions ; do
+ 	Win32*)
+ 		case "$osname" in
+ 		cygwin) avail_ext="$avail_ext $xxx" ;;
++		msys) avail_ext="$avail_ext $xxx" ;;
+ 		esac
+ 		;;
+ 	XS/APItest|xs/apitest)
 diff --git a/Cross/Makefile-cross-SH b/Cross/Makefile-cross-SH
 index a774f4a..26d4d61 100644
 --- a/Cross/Makefile-cross-SH
 +++ b/Cross/Makefile-cross-SH
-@@ -56,7 +56,7 @@
+@@ -55,8 +55,8 @@ true)
+ 				${revision}.${patchlevel}.${subversion} \
  			     -install_name \$(shrpdir)/\$@"
  		;;
- 	cygwin*)
+-	cygwin*)
 -		linklibperl="-lperl"
++	cygwin* | msys*)
 +		linklibperl="-L. -lperl"
  		;;
  	sunos*)
  		linklibperl="-lperl"
-@@ -948,7 +948,7 @@
+@@ -461,7 +461,7 @@ perlmain.c: miniperlmain.c config.sh $(FIRSTMAKEFILE)
+ 
+ !NO!SUBS!
+ case "$osname" in
+-cygwin)
++cygwin | msys)
+ 	;; # Let cygwin/Makefile.SHs do its work.
+ *)
+ 	$spitshell >>$Makefile <<'!NO!SUBS!'
+@@ -948,7 +948,7 @@ _mopup:
  	-rm -f perl.third lib*.so.perl.third perl.3log t/perl.third t/perl.3log
  	-rm -f perl.pixie lib*.so.perl.pixie lib*.so.Addrs
  	-rm -f perl.Addrs perl.Counts t/perl.Addrs t/perl.Counts *perl.xok
 -	-rm -f cygwin.c libperl*.def libperl*.dll cygperl*.dll *.exe.stackdump
-+	-rm -f cygwin.c libperl*.def libperl*.dll cygperl*.dll msys-perl*.dll *.exe.stackdump
++	-rm -f cygwin.c libperl*.def libperl*.dll msys-perl*.dll *.exe.stackdump
  	-rm -f perl$(EXE_EXT) miniperl$(EXE_EXT) $(LIBPERL) libperl.* microperl
  	-rm -f config.over
  
@@ -50,6 +235,15 @@ diff --git a/Makefile.SH b/Makefile.SH
 index e2490da..547bd49 100755
 --- a/Makefile.SH
 +++ b/Makefile.SH
+@@ -72,7 +72,7 @@ true)
+ 			;;
+ 		esac
+ 		;;
+-	cygwin*)
++	cygwin*|msys*)
+ 		shrpldflags="$shrpldflags -Wl,--out-implib=libperl.dll.a"
+ 		linklibperl="-L. -lperl"
+ 		;;
 @@ -1360,7 +1360,7 @@ _mopup:
  	-rm -f perl.exp ext.libs $(generated_pods) uni.data $(mini_only_objs) pod/roffitall
  	-rm -f perl.export perl.dll perl.libexp perl.map perl.def
@@ -78,16 +272,483 @@ index 94a4778..284e322 100755
  my $from = $osname eq 'VMS' ? 'PERLSHR image' : 'binary (from libperl)';
 -my $env_cygwin = $osname eq 'cygwin'
 -    ? 'push @env, "CYGWIN=\"$ENV{CYGWIN}\"" if $ENV{CYGWIN};' . "\n" : "";
-+my $env_cygwin = $osname eq 'cygwin'
++my $env_cygwin = ($^O eq 'cygwin' || $^O eq 'msys')
 +    ? 'push @env, "MSYS=\"$ENV{MSYS}\"" if $ENV{MSYS};' . "\n" : "";
  
  $heavy_txt .= sprintf <<'ENDOFBEG', $osname, $osname, $from, $osname, $env_cygwin;
  # This file was created by configpm when Perl was built. Any changes
+diff --git a/cpan/Archive-Tar/t/02_methods.t b/cpan/Archive-Tar/t/02_methods.t
+index 19d9212..e0e73b5 100644
+--- a/cpan/Archive-Tar/t/02_methods.t
++++ b/cpan/Archive-Tar/t/02_methods.t
+@@ -60,7 +60,7 @@ my @EXPECTX = (
+ my $LONG_FILE = qq[directory/really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-long-directory-name/myfile];
+ 
+ ### wintendo can't deal with too long paths, so we might have to skip tests ###
+-my $TOO_LONG    =   ($^O eq 'MSWin32' or $^O eq 'cygwin' or $^O eq 'VMS')
++my $TOO_LONG    =   ($^O eq 'MSWin32' or $^O eq 'cygwin' or $^O eq 'msys' or $^O eq 'VMS')
+                     && length( cwd(). $LONG_FILE ) > 247;
+ 
+ if(!$TOO_LONG) {
+diff --git a/cpan/CPAN-Meta/t/data-fail/META-1_4.yml b/cpan/CPAN-Meta/t/data-fail/META-1_4.yml
+index cec4d11..b04c410 100644
+--- a/cpan/CPAN-Meta/t/data-fail/META-1_4.yml
++++ b/cpan/CPAN-Meta/t/data-fail/META-1_4.yml
+@@ -77,6 +77,9 @@ provides:
+   Module::Build::Platform::cygwin:
+     file: lib/Module/Build/Platform/cygwin.pm
+     version: 0.36_08
++  Module::Build::Platform::msys:
++    file: lib/Module/Build/Platform/msys.pm
++    version: 0.36_08
+   Module::Build::Platform::darwin:
+     file: lib/Module/Build/Platform/darwin.pm
+     version: 0.36_08
+diff --git a/cpan/CPAN-Meta/t/data-fixable/META-1_4.yml b/cpan/CPAN-Meta/t/data-fixable/META-1_4.yml
+index 1336f10..7944d8f 100644
+--- a/cpan/CPAN-Meta/t/data-fixable/META-1_4.yml
++++ b/cpan/CPAN-Meta/t/data-fixable/META-1_4.yml
+@@ -76,6 +76,9 @@ provides:
+   Module::Build::Platform::cygwin:
+     file: lib/Module/Build/Platform/cygwin.pm
+     version: 0.36_08
++  Module::Build::Platform::msys:
++    file: lib/Module/Build/Platform/msys.pm
++    version: 0.36_08
+   Module::Build::Platform::darwin:
+     file: lib/Module/Build/Platform/darwin.pm
+     version: 0.36_08
+diff --git a/cpan/CPAN-Meta/t/data-fixable/invalid-meta-spec-version.yml b/cpan/CPAN-Meta/t/data-fixable/invalid-meta-spec-version.yml
+index d74cde6..c360ca1 100644
+--- a/cpan/CPAN-Meta/t/data-fixable/invalid-meta-spec-version.yml
++++ b/cpan/CPAN-Meta/t/data-fixable/invalid-meta-spec-version.yml
+@@ -77,6 +77,9 @@ provides:
+   Module::Build::Platform::cygwin:
+     file: lib/Module/Build/Platform/cygwin.pm
+     version: 0.36_08
++  Module::Build::Platform::msys:
++    file: lib/Module/Build/Platform/msys.pm
++    version: 0.36_08
+   Module::Build::Platform::darwin:
+     file: lib/Module/Build/Platform/darwin.pm
+     version: 0.36_08
+diff --git a/cpan/CPAN-Meta/t/data-fixable/meta-spec-version-trailing-zeros.yml b/cpan/CPAN-Meta/t/data-fixable/meta-spec-version-trailing-zeros.yml
+index 92445cb..94156d0 100644
+--- a/cpan/CPAN-Meta/t/data-fixable/meta-spec-version-trailing-zeros.yml
++++ b/cpan/CPAN-Meta/t/data-fixable/meta-spec-version-trailing-zeros.yml
+@@ -77,6 +77,9 @@ provides:
+   Module::Build::Platform::cygwin:
+     file: lib/Module/Build/Platform/cygwin.pm
+     version: 0.36_08
++  Module::Build::Platform::msys:
++    file: lib/Module/Build/Platform/msys.pm
++    version: 0.36_08
+   Module::Build::Platform::darwin:
+     file: lib/Module/Build/Platform/darwin.pm
+     version: 0.36_08
+diff --git a/cpan/CPAN-Meta/t/data-test/META-1_4.yml b/cpan/CPAN-Meta/t/data-test/META-1_4.yml
+index 801f579..60f598f 100644
+--- a/cpan/CPAN-Meta/t/data-test/META-1_4.yml
++++ b/cpan/CPAN-Meta/t/data-test/META-1_4.yml
+@@ -77,6 +77,9 @@ provides:
+   Module::Build::Platform::cygwin:
+     file: lib/Module/Build/Platform/cygwin.pm
+     version: 0.36_08
++  Module::Build::Platform::msys:
++    file: lib/Module/Build/Platform/msys.pm
++    version: 0.36_08
+   Module::Build::Platform::darwin:
+     file: lib/Module/Build/Platform/darwin.pm
+     version: 0.36_08
+diff --git a/cpan/CPAN-Meta/t/data-test/restrictive-1_4.yml b/cpan/CPAN-Meta/t/data-test/restrictive-1_4.yml
+index b780016..ee2ceac 100644
+--- a/cpan/CPAN-Meta/t/data-test/restrictive-1_4.yml
++++ b/cpan/CPAN-Meta/t/data-test/restrictive-1_4.yml
+@@ -77,6 +77,9 @@ provides:
+   Module::Build::Platform::cygwin:
+     file: lib/Module/Build/Platform/cygwin.pm
+     version: 0.36_08
++  Module::Build::Platform::msys:
++    file: lib/Module/Build/Platform/msys.pm
++    version: 0.36_08
+   Module::Build::Platform::darwin:
+     file: lib/Module/Build/Platform/darwin.pm
+     version: 0.36_08
+diff --git a/cpan/CPAN-Meta/t/data-test/unicode.yml b/cpan/CPAN-Meta/t/data-test/unicode.yml
+index 8aa5bca..b902e0b 100644
+--- a/cpan/CPAN-Meta/t/data-test/unicode.yml
++++ b/cpan/CPAN-Meta/t/data-test/unicode.yml
+@@ -77,6 +77,9 @@ provides:
+   Module::Build::Platform::cygwin:
+     file: lib/Module/Build/Platform/cygwin.pm
+     version: 0.36_08
++  Module::Build::Platform::msys:
++    file: lib/Module/Build/Platform/msys.pm
++    version: 0.36_08
+   Module::Build::Platform::darwin:
+     file: lib/Module/Build/Platform/darwin.pm
+     version: 0.36_08
+diff --git a/cpan/Compress-Raw-Zlib/Makefile.PL b/cpan/Compress-Raw-Zlib/Makefile.PL
+index bf3681b..1aa5cc5 100644
+--- a/cpan/Compress-Raw-Zlib/Makefile.PL
++++ b/cpan/Compress-Raw-Zlib/Makefile.PL
+@@ -32,7 +32,7 @@ my $ZLIB_LIBRARY_NAME = $^O eq 'MSWin32' ? 'zlib' : 'z' ;
+ # ExtUtils::Install.
+ 
+ # Don't ask if MM_USE_DEFAULT is set -- enables perl core building on cygwin
+-if ($^O =~ /cygwin/i and $ExtUtils::Install::VERSION < 1.39
++if (($^O =~ /cygwin/i or $^O =~ /msys/i) and $ExtUtils::Install::VERSION < 1.39
+         and not ($ENV{PERL_MM_USE_DEFAULT} or $ENV{PERL_CORE}))
+ {
+     print <<EOM ;
+diff --git a/cpan/DB_File/t/db-btree.t b/cpan/DB_File/t/db-btree.t
+index fc19e99..88cbcea 100644
+--- a/cpan/DB_File/t/db-btree.t
++++ b/cpan/DB_File/t/db-btree.t
+@@ -106,7 +106,8 @@ sub normalise
+ {
+     my $data = shift ;
+     $data =~ s#\r\n#\n#g
+-        if $^O eq 'cygwin' ;
++        if ($^O eq 'cygwin' or $^O eq 'msys') ;
++:cn
+ 
+     return $data ;
+ }
+@@ -179,7 +180,7 @@ die "Could not tie: $!" unless $X;
+ my ($dev,$ino,$mode,$nlink,$uid,$gid,$rdev,$size,$atime,$mtime,$ctime,
+    $blksize,$blocks) = stat($Dfile);
+ 
+-my %noMode = map { $_, 1} qw( amigaos MSWin32 NetWare cygwin ) ;
++my %noMode = map { $_, 1} qw( amigaos MSWin32 NetWare cygwin msys ) ;
+ 
+ ok(18, ($mode & 0777) == (($^O eq 'os2' || $^O eq 'MacOS') ? 0666 : 0640)
+    || $noMode{$^O} );
+diff --git a/cpan/DB_File/t/db-hash.t b/cpan/DB_File/t/db-hash.t
+index cc10bfc..4b18f21 100644
+--- a/cpan/DB_File/t/db-hash.t
++++ b/cpan/DB_File/t/db-hash.t
+@@ -70,7 +70,7 @@ sub normalise
+ {
+     my $data = shift ;
+     $data =~ s#\r\n#\n#g
+-        if $^O eq 'cygwin' ;
++        if ($^O eq 'cygwin' or $^O eq 'msys') ;
+     return $data ;
+ }
+ 
+@@ -140,7 +140,7 @@ die "Could not tie: $!" unless defined $X;
+ my ($dev,$ino,$mode,$nlink,$uid,$gid,$rdev,$size,$atime,$mtime,$ctime,
+    $blksize,$blocks) = stat($Dfile);
+ 
+-my %noMode = map { $_, 1} qw( amigaos MSWin32 NetWare cygwin ) ;
++my %noMode = map { $_, 1} qw( amigaos MSWin32 NetWare cygwin msys ) ;
+ 
+ ok(16, ($mode & 0777) == (($^O eq 'os2' || $^O eq 'MacOS') ? 0666 : 0640) ||
+    $noMode{$^O} );
+diff --git a/cpan/DB_File/t/db-recno.t b/cpan/DB_File/t/db-recno.t
+index 4b80e93..8caca08 100644
+--- a/cpan/DB_File/t/db-recno.t
++++ b/cpan/DB_File/t/db-recno.t
+@@ -127,7 +127,7 @@ EOM
+ 
+ sub normalise
+ {
+-    return unless $^O eq 'cygwin' ;
++    return unless ($^O eq 'cygwin' || $^O eq 'msys') ;
+     foreach (@_)
+       { s#\r\n#\n#g }
+ }
+@@ -202,7 +202,7 @@ my $X  ;
+ my @h ;
+ ok(17, $X = tie @h, 'DB_File', $Dfile, O_RDWR|O_CREAT, 0640, $DB_RECNO ) ;
+ 
+-my %noMode = map { $_, 1} qw( amigaos MSWin32 NetWare cygwin ) ;
++my %noMode = map { $_, 1} qw( amigaos MSWin32 NetWare cygwin msys ) ;
+ 
+ ok(18, ((stat($Dfile))[2] & 0777) == (($^O eq 'os2' || $^O eq 'MacOS') ? 0666 : 0640)
+         ||  $noMode{$^O} );
+diff --git a/cpan/Digest-SHA/shasum b/cpan/Digest-SHA/shasum
+index 46a7162..4d7f0b0 100644
+--- a/cpan/Digest-SHA/shasum
++++ b/cpan/Digest-SHA/shasum
+@@ -201,7 +201,7 @@ if ($version) {
+ 	## explicitly overridden by command line "--text" or
+ 	## "--UNIVERSAL" options.
+ 
+-my $isDOSish = ($^O =~ /^(MSWin\d\d|os2|dos|mint|cygwin)$/);
++my $isDOSish = ($^O =~ /^(MSWin\d\d|os2|dos|mint|cygwin|msys)$/);
+ if ($isDOSish) { $binary = 1 unless $text || $UNIVERSAL }
+ 
+ my $modesym = $binary ? '*' : ($UNIVERSAL ? 'U' : ($BITS ? '^' : ' '));
+diff --git a/cpan/ExtUtils-Install/lib/ExtUtils/Install.pm b/cpan/ExtUtils-Install/lib/ExtUtils/Install.pm
+index 9608180..e748ece 100644
+--- a/cpan/ExtUtils-Install/lib/ExtUtils/Install.pm
++++ b/cpan/ExtUtils-Install/lib/ExtUtils/Install.pm
+@@ -88,8 +88,8 @@ Dies with a special message.
+ BEGIN {
+     *_Is_VMS        = $^O eq 'VMS'     ? sub(){1} : sub(){0};
+     *_Is_Win32      = $^O eq 'MSWin32' ? sub(){1} : sub(){0};
+-    *_Is_cygwin     = $^O eq 'cygwin'  ? sub(){1} : sub(){0};
+-    *_CanMoveAtBoot = ($^O eq 'MSWin32' || $^O eq 'cygwin') ? sub(){1} : sub(){0};
++    *_Is_cygwin     = ($^O eq 'cygwin' || $^O eq 'msys') ? sub(){1} : sub(){0};
++    *_CanMoveAtBoot = ($^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys') ? sub(){1} : sub(){0};
+ }
+ 
+ my $Inc_uninstall_warn_handler;
+diff --git a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Liblist/Kid.pm b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Liblist/Kid.pm
+index 01a4a48..7e9416e 100644
+--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Liblist/Kid.pm
++++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Liblist/Kid.pm
+@@ -188,6 +188,8 @@ sub _unix_os2_ext {
+             }
+             elsif ( $^O eq 'cygwin' && -f ( $fullname = "$thispth/$thislib.dll" ) ) {
+             }
++            elsif ( $^O eq 'msys' && -f ( $fullname = "$thispth/$thislib.dll" ) ) {
++            }
+             elsif ( -f ( $fullname = "$thispth/Slib$thislib$Config_libext" ) ) {
+             }
+             elsif ($^O eq 'dgux'
+diff --git a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm
+index a9d8d26..16a1c15 100644
+--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm
++++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm
+@@ -59,7 +59,7 @@ if( $^O eq 'MSWin32' ) {
+     _is_win95() ? $Is{Win95} = 1 : $Is{Win32} = 1;
+ }
+ $Is{UWIN}   = $^O =~ /^uwin(-nt)?$/;
+-$Is{Cygwin} = $^O eq 'cygwin';
++$Is{Cygwin} = ($^O eq 'cygwin' or $^O eq 'msys');
+ $Is{NW5}    = $Config{osname} eq 'NetWare';  # intentional
+ $Is{BeOS}   = ($^O =~ /beos/i or $^O eq 'haiku');
+ $Is{DOS}    = $^O eq 'dos';
+diff --git a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Cygwin.pm b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Cygwin.pm
+index 91d2094..992e6b9 100644
+--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Cygwin.pm
++++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Cygwin.pm
+@@ -35,7 +35,7 @@ We're Unix and Cygwin.
+ =cut
+ 
+ sub os_flavor {
+-    return('Unix', 'Cygwin');
++    return('Unix', 'Msys');
+ }
+ 
+ =item cflags
+@@ -145,7 +145,7 @@ sub dynamic_lib {
+     return $s unless %{$self->{XS}};
+ 
+     # do an ephemeral rebase so the new DLL fits to the current rebase map
+-    $s .= "\t/bin/find \$\(INST_ARCHLIB\)/auto -xdev -name \\*.$self->{DLEXT} | /bin/rebase -sOT -" if (( $Config{myarchname} eq 'i686-cygwin' ) and not ( exists $ENV{CYGPORT_PACKAGE_VERSION} ));
++    $s .= "\t/bin/find \$\(INST_ARCHLIB\)/auto -xdev -name \\*.$self->{DLEXT} | /bin/rebase -sOT -" if (( $Config{myarchname} eq 'i686-msys' ) and not ( exists $ENV{CYGPORT_PACKAGE_VERSION} ));
+     $s;
+ }
+ 
+@@ -165,7 +165,7 @@ sub install {
+     my $INSTALLLIB = $self->{"INSTALL". ($INSTALLDIRS eq 'perl' ? 'ARCHLIB' : uc($INSTALLDIRS)."ARCH")};
+     my $dop = "\$\(DESTDIR\)$INSTALLLIB/auto/";
+     my $dll = "$dop/$self->{FULLEXT}/$self->{BASEEXT}.$self->{DLEXT}";
+-    $s =~ s|^(pure_install :: pure_\$\(INSTALLDIRS\)_install\n\t)\$\(NOECHO\) \$\(NOOP\)\n|$1\$(CHMOD) \$(PERM_RWX) $dll\n\t/bin/find $dop -xdev -name \\*.$self->{DLEXT} \| /bin/rebase -sOT -\n|m if (( $Config{myarchname} eq 'i686-cygwin') and not ( exists $ENV{CYGPORT_PACKAGE_VERSION} ));
++    $s =~ s|^(pure_install :: pure_\$\(INSTALLDIRS\)_install\n\t)\$\(NOECHO\) \$\(NOOP\)\n|$1\$(CHMOD) \$(PERM_RWX) $dll\n\t/bin/find $dop -xdev -name \\*.$self->{DLEXT} \| /bin/rebase -sOT -\n|m if (( $Config{myarchname} eq 'i686-msys') and not ( exists $ENV{CYGPORT_PACKAGE_VERSION} ));
+     $s;
+ }
+ 
+diff --git a/cpan/ExtUtils-MakeMaker/t/03-xsstatic.t b/cpan/ExtUtils-MakeMaker/t/03-xsstatic.t
+index dceed52..3c22c84 100644
+--- a/cpan/ExtUtils-MakeMaker/t/03-xsstatic.t
++++ b/cpan/ExtUtils-MakeMaker/t/03-xsstatic.t
+@@ -19,7 +19,7 @@ use Test::More;
+ plan skip_all => "ExtUtils::CBuilder not installed or couldn't find a compiler"
+   unless have_compiler();
+ plan skip_all => 'Shared perl library' if $Config{useshrplib} eq 'true';
+-plan skip_all => $^O if $^O =~ m!^(MSWin32|cygwin|haiku|darwin)$!;
++plan skip_all => $^O if $^O =~ m!^(MSWin32|cygwin|msys|haiku|darwin)$!;
+ plan skip_all => 'Skipped when not PERL_CORE nor in git repo' unless $ENV{PERL_CORE} or $release;
+ plan skip_all => 'Skipped as perl.exp is not in scope' if -s '../../../perl.exp' && $ENV{PERL_CORE};
+ my @tests = list_static();
+diff --git a/cpan/ExtUtils-MakeMaker/t/MM_Cygwin.t b/cpan/ExtUtils-MakeMaker/t/MM_Cygwin.t
+index 5a7f8b3..d34c5ec 100644
+--- a/cpan/ExtUtils-MakeMaker/t/MM_Cygwin.t
++++ b/cpan/ExtUtils-MakeMaker/t/MM_Cygwin.t
+@@ -10,7 +10,7 @@ use warnings;
+ use Test::More;
+ 
+ BEGIN {
+-	if ($^O =~ /cygwin/i) {
++	if ($^O =~ /cygwin|msys/i) {
+ 		plan tests => 14;
+ 	} else {
+ 		plan skip_all => "This is not cygwin";
+diff --git a/cpan/ExtUtils-MakeMaker/t/MM_Unix.t b/cpan/ExtUtils-MakeMaker/t/MM_Unix.t
+index b3175f4..73adc79 100644
+--- a/cpan/ExtUtils-MakeMaker/t/MM_Unix.t
++++ b/cpan/ExtUtils-MakeMaker/t/MM_Unix.t
+@@ -8,7 +8,7 @@ chdir 't';
+ BEGIN {
+     use Test::More;
+ 
+-    if( $^O =~ /^VMS|os2|MacOS|MSWin32|cygwin|beos|netware$/i ) {
++    if( $^O =~ /^VMS|os2|MacOS|MSWin32|cygwin|msys|beos|netware$/i ) {
+         plan skip_all => 'Non-Unix platform';
+     }
+     else {
+diff --git a/cpan/ExtUtils-MakeMaker/t/Mkbootstrap.t b/cpan/ExtUtils-MakeMaker/t/Mkbootstrap.t
+index c0edfda..4f6857c 100644
+--- a/cpan/ExtUtils-MakeMaker/t/Mkbootstrap.t
++++ b/cpan/ExtUtils-MakeMaker/t/Mkbootstrap.t
+@@ -78,7 +78,7 @@ SKIP: {
+ 	chmod 0444, 'dasboot.bs';
+ 
+ 	SKIP: {
+-	    skip("cannot write readonly files", 1) if -w 'dasboot.bs' || $^O eq 'cygwin';
++	    skip("cannot write readonly files", 1) if -w 'dasboot.bs' || $^O eq 'cygwin' ||  $^O eq 'msys';
+ 
+ 	    eval{ Mkbootstrap('dasboot', 1) };
+ 	    like( $@, qr/Unable to open dasboot\.bs/, 'should die given bad filename' );
+diff --git a/cpan/ExtUtils-MakeMaker/t/eu_command.t b/cpan/ExtUtils-MakeMaker/t/eu_command.t
+index 0233c2f..ace9885 100644
+--- a/cpan/ExtUtils-MakeMaker/t/eu_command.t
++++ b/cpan/ExtUtils-MakeMaker/t/eu_command.t
+@@ -100,7 +100,7 @@ BEGIN {
+     SKIP: {
+         if ($^O eq 'amigaos' || $^O eq 'os2' || $^O eq 'MSWin32' ||
+             $^O eq 'NetWare' || $^O eq 'dos' || $^O eq 'cygwin'  ||
+-            $^O eq 'MacOS'
++            $^O eq 'msys'    || $^O eq 'MacOS'
+            ) {
+             skip( "different file permission semantics on $^O", 3);
+         }
+@@ -140,7 +140,7 @@ BEGIN {
+     SKIP: {
+         if ($^O eq 'amigaos' || $^O eq 'os2' || $^O eq 'MSWin32' ||
+             $^O eq 'NetWare' || $^O eq 'dos' || $^O eq 'cygwin'  ||
+-            $^O eq 'MacOS'   || $^O eq 'haiku'
++            $^O eq 'msys'    || $^O eq 'MacOS'   || $^O eq 'haiku'
+            ) {
+             skip( "different file permission semantics on $^O", 5);
+         }
+diff --git a/cpan/ExtUtils-MakeMaker/t/fixin.t b/cpan/ExtUtils-MakeMaker/t/fixin.t
+index b942a5f..711fa79 100644
+--- a/cpan/ExtUtils-MakeMaker/t/fixin.t
++++ b/cpan/ExtUtils-MakeMaker/t/fixin.t
+@@ -130,7 +130,7 @@ END
+ SKIP: {
+     eval { chmod(0755, "usrbin/interp") }
+         or skip "no chmod", 8;
+-    skip "Not relevant on VMS or MSWin32", 8 if $^O eq 'VMS' || $^O eq 'MSWin32' || $^O eq 'cygwin';
++    skip "Not relevant on VMS or MSWin32", 8 if $^O eq 'VMS' || $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys';
+ 
+     my $dir = getcwd();
+     local $ENV{PATH} = join $Config{path_sep}, map "$dir/$_", qw(usrbin bin);
+diff --git a/cpan/ExtUtils-Manifest/t/Manifest.t b/cpan/ExtUtils-Manifest/t/Manifest.t
+index 183786b..327a218 100644
+--- a/cpan/ExtUtils-Manifest/t/Manifest.t
++++ b/cpan/ExtUtils-Manifest/t/Manifest.t
+@@ -455,7 +455,7 @@ is_deeply( $files, \%expect, 'maniadd() vs MANIFEST without trailing newline');
+ 
+ SKIP: {
+     chmod( 0400, 'MANIFEST' );
+-    skip "Can't make MANIFEST read-only", 2 if -w 'MANIFEST' or $Config{osname} eq 'cygwin';
++    skip "Can't make MANIFEST read-only", 2 if -w 'MANIFEST' or $Config{osname} eq 'cygwin' or $Config{osname} eq 'msys';
+ 
+     eval {
+         maniadd({ 'foo' => 'bar' });
+diff --git a/cpan/File-Path/t/Path.t b/cpan/File-Path/t/Path.t
+index b265aee..5341cb8 100644
+--- a/cpan/File-Path/t/Path.t
++++ b/cpan/File-Path/t/Path.t
+@@ -499,7 +499,7 @@ SKIP : {
+         $octal_input = sprintf "%04o", S_IMODE($input);
+         SKIP: {
+ 	    skip "permissions are not fully supported by the filesystem", 1
+-                if (($^O eq 'MSWin32' || $^O eq 'cygwin') && ((Win32::FsType())[1] & 8) == 0);
++                if (($^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys') && ((Win32::FsType())[1] & 8) == 0);
+             is($octal_mode,$input, "create a new directory with chmod $input ($octal_input)");
+ 	    }
+         rmtree( $dir );
+diff --git a/cpan/File-Temp/lib/File/Temp.pm b/cpan/File-Temp/lib/File/Temp.pm
+index 570f25a..a6668d3 100644
+--- a/cpan/File-Temp/lib/File/Temp.pm
++++ b/cpan/File-Temp/lib/File/Temp.pm
+@@ -828,7 +828,7 @@ sub _can_do_level {
+   return 1 if $level == STANDARD;
+ 
+   # Currently, the systems that can do HIGH or MEDIUM are identical
+-  if ( $^O eq 'MSWin32' || $^O eq 'os2' || $^O eq 'cygwin' || $^O eq 'dos' || $^O eq 'MacOS' || $^O eq 'mpeix') {
++  if ( $^O eq 'MSWin32' || $^O eq 'os2' || $^O eq 'cygwin' || $^O eq 'msys' || $^O eq 'dos' || $^O eq 'MacOS' || $^O eq 'mpeix') {
+     return 0;
+   } else {
+     return 1;
+@@ -2157,7 +2157,7 @@ sub unlink0 {
+     # On NFS the link count may still be 1 but we can't know that
+     # we are on NFS.  Since we can't be sure, we'll defer it
+ 
+-    return 1 if $fh[3] == 0 || $^O eq 'cygwin';
++    return 1 if $fh[3] == 0 || $^O eq 'cygwin' || $^O eq 'msys';
+   }
+   # fall-through if we can't unlink now
+   _deferred_unlink($fh, $path, 0);
+diff --git a/cpan/IO-Compress/t/cz-14gzopen.t b/cpan/IO-Compress/t/cz-14gzopen.t
+index 59a4d82..7406551 100644
+--- a/cpan/IO-Compress/t/cz-14gzopen.t
++++ b/cpan/IO-Compress/t/cz-14gzopen.t
+@@ -490,7 +490,7 @@ foreach my $stdio ( ['-', '-'], [*STDIN, *STDOUT])
+     SKIP:
+     {
+         skip "Cannot create non-writable file", 3
+-            if $^O eq 'cygwin';
++            if ($^O eq 'cygwin' or $^O eq 'msys');
+ 
+         my $lex = LexFile->new( my $name );
+         writeFile($name, "abc");
+@@ -514,7 +514,7 @@ foreach my $stdio ( ['-', '-'], [*STDIN, *STDOUT])
+     {
+         my $lex = LexFile->new( my $name );
+         skip "Cannot create non-readable file", 3
+-            if $^O eq 'cygwin';
++            if ($^O eq 'cygwin' or $^O eq 'msys');
+ 
+         writeFile($name, "abc");
+         chmod 0222, $name ;
+diff --git a/cpan/IO-Socket-IP/t/11sockopts.t b/cpan/IO-Socket-IP/t/11sockopts.t
+index e3bbd08..1ae1a67 100644
+--- a/cpan/IO-Socket-IP/t/11sockopts.t
++++ b/cpan/IO-Socket-IP/t/11sockopts.t
+@@ -12,7 +12,7 @@ use Errno qw( EACCES );
+ use Socket qw( SOL_SOCKET SO_REUSEADDR SO_REUSEPORT SO_BROADCAST );
+ 
+ TODO: {
+-   local $TODO = "SO_REUSEADDR doesn't appear to work on cygwin smokers" if $^O eq "cygwin";
++   local $TODO = "SO_REUSEADDR doesn't appear to work on cygwin smokers" if ($^O eq "cygwin" || $^O eq 'msys');
+    # I honestly have no idea why this fails, and people don't seem to be able
+    # to reproduce it on a development box. I'll mark it TODO for now until we
+    # can gain any more insight into it.
+diff --git a/cpan/IPC-Cmd/t/03_run-forked.t b/cpan/IPC-Cmd/t/03_run-forked.t
+index 42e7709..3f651e2 100644
+--- a/cpan/IPC-Cmd/t/03_run-forked.t
++++ b/cpan/IPC-Cmd/t/03_run-forked.t
+@@ -44,7 +44,7 @@ $r = run_forked("$sleep 5", {'timeout' => 2});
+ ok($r->{'timeout'}, "[$sleep 5] runs longer than 2 seconds");
+ 
+ SKIP: {
+-  skip "Exhibits problems on Cygwin", 4 if $^O eq 'cygwin';
++  skip "Exhibits problems on Cygwin", 4 if ($^O eq 'cygwin' || $^O eq 'msys');
+   # https://rt.cpan.org/Ticket/Display.html?id=85912
+   sub runSub {
+        my $blah = "blahblah";
 diff --git a/cpan/IPC-SysV/t/ipcsysv.t b/cpan/IPC-SysV/t/ipcsysv.t
 index 8bbea07..a1a0b4e 100644
 --- a/cpan/IPC-SysV/t/ipcsysv.t
 +++ b/cpan/IPC-SysV/t/ipcsysv.t
-@@ -49,11 +49,11 @@
+@@ -42,18 +42,18 @@ use IPC::SysV qw(IPC_PRIVATE IPC_NOWAIT IPC_STAT IPC_RMID S_IRWXU);
+   {
+     return if $did_diag++;
+ 
+-    if ($^O eq 'cygwin') {
++    if ($^O eq 'cygwin' or $^O eq 'msys') {
+       diag(<<EOM);
+ 
+ It may be that the cygserver service isn't running.
  
  EOM
  
@@ -101,25 +762,125 @@ index 8bbea07..a1a0b4e 100644
  
  EOM
      }
+diff --git a/cpan/Pod-Perldoc/lib/Pod/Perldoc.pm b/cpan/Pod-Perldoc/lib/Pod/Perldoc.pm
+index bb6ffc8..5fc5002 100644
+--- a/cpan/Pod-Perldoc/lib/Pod/Perldoc.pm
++++ b/cpan/Pod-Perldoc/lib/Pod/Perldoc.pm
+@@ -66,7 +66,7 @@ BEGIN {
+  *is_mswin32 = $^O eq 'MSWin32' ? \&TRUE : \&FALSE unless defined &is_mswin32;
+  *is_dos     = $^O eq 'dos'     ? \&TRUE : \&FALSE unless defined &is_dos;
+  *is_os2     = $^O eq 'os2'     ? \&TRUE : \&FALSE unless defined &is_os2;
+- *is_cygwin  = $^O eq 'cygwin'  ? \&TRUE : \&FALSE unless defined &is_cygwin;
++ *is_cygwin  = ($^O eq 'cygwin' || $^O eq 'msys')  ? \&TRUE : \&FALSE unless defined &is_cygwin;
+  *is_linux   = $^O eq 'linux'   ? \&TRUE : \&FALSE unless defined &is_linux;
+  *is_hpux    = $^O =~ m/hpux/   ? \&TRUE : \&FALSE unless defined &is_hpux;
+  *is_amigaos = $^O eq 'amigaos' ? \&TRUE : \&FALSE unless defined &is_amigaos;
+diff --git a/cpan/Pod-Perldoc/lib/Pod/Perldoc/BaseTo.pm b/cpan/Pod-Perldoc/lib/Pod/Perldoc/BaseTo.pm
+index 37f6510..7ae4af5 100644
+--- a/cpan/Pod-Perldoc/lib/Pod/Perldoc/BaseTo.pm
++++ b/cpan/Pod-Perldoc/lib/Pod/Perldoc/BaseTo.pm
+@@ -29,7 +29,7 @@ BEGIN {
+  *is_mswin32 = $^O eq 'MSWin32'  ? \&TRUE : \&FALSE unless defined &is_mswin32;
+  *is_dos     = $^O eq 'dos'      ? \&TRUE : \&FALSE unless defined &is_dos;
+  *is_os2     = $^O eq 'os2'      ? \&TRUE : \&FALSE unless defined &is_os2;
+- *is_cygwin  = $^O eq 'cygwin'   ? \&TRUE : \&FALSE unless defined &is_cygwin;
++ *is_cygwin  = ($^O eq 'cygwin' || $^O eq 'msys')   ? \&TRUE : \&FALSE unless defined &is_cygwin;
+  *is_linux   = $^O eq 'linux'    ? \&TRUE : \&FALSE unless defined &is_linux;
+  *is_hpux    = $^O =~ m/hpux/    ? \&TRUE : \&FALSE unless defined &is_hpux;
+  *is_openbsd = $^O =~ m/openbsd/ ? \&TRUE : \&FALSE unless defined &is_openbsd;
+diff --git a/cpan/Socket/t/socketpair.t b/cpan/Socket/t/socketpair.t
+index a803302..ac7d78b 100644
+--- a/cpan/Socket/t/socketpair.t
++++ b/cpan/Socket/t/socketpair.t
+@@ -40,7 +40,7 @@ BEGIN {
+ 	    }
+ 	    warn "Something unexpectedly hung during testing";
+ 	    kill "INT", $parent or die "Kill failed: $!";
+-	    if( $^O eq "cygwin" ) {
++	    if( $^O eq "cygwin" || $^O eq "msys" ) {
+ 		# sometimes the above isn't enough on cygwin
+ 		sleep 1; # wait a little, it might have worked after all
+ 		system( "/bin/kill -f $parent; echo die $parent" );
+diff --git a/cpan/Sys-Syslog/t/syslog.t b/cpan/Sys-Syslog/t/syslog.t
+index 6802ace..89efba5 100644
+--- a/cpan/Sys-Syslog/t/syslog.t
++++ b/cpan/Sys-Syslog/t/syslog.t
+@@ -18,7 +18,7 @@ use warnings qw(closure deprecated exiting glob io misc numeric once overflow
+ $^W = 0 if $] < 5.006;
+ 
+ my $is_Win32  = $^O =~ /win32/i;
+-my $is_Cygwin = $^O =~ /cygwin/i;
++my $is_Cygwin = $^O =~ /cygwin|msys/i;
+ 
+ # if testing in core, check that the module is at least available
+ if ($ENV{PERL_CORE}) {
+diff --git a/cpan/Sys-Syslog/win32/Win32.pm b/cpan/Sys-Syslog/win32/Win32.pm
+index 70caf33..d589aa1 100644
+--- a/cpan/Sys-Syslog/win32/Win32.pm
++++ b/cpan/Sys-Syslog/win32/Win32.pm
+@@ -39,7 +39,7 @@ use Win32::TieRegistry 0.20 (
+     ),
+ );    
+ 
+-my $is_Cygwin = $^O =~ /Cygwin/i;
++my $is_Cygwin = $^O =~ /Cygwin|Msys/i;
+ my $is_Win32  = $^O =~ /Win32/i;
+ 
+ my %const = (
+diff --git a/cpan/Sys-Syslog/win32/compile.pl b/cpan/Sys-Syslog/win32/compile.pl
+index 3a8cf4f..8e9cd52 100644
+--- a/cpan/Sys-Syslog/win32/compile.pl
++++ b/cpan/Sys-Syslog/win32/compile.pl
+@@ -127,7 +127,7 @@ use Win32::TieRegistry 0.20 (
+     ),
+ );    
+ 
+-my $is_Cygwin = $^O =~ /Cygwin/i;
++my $is_Cygwin = $^O =~ /Cygwin|Msys/i;
+ my $is_Win32  = $^O =~ /Win32/i;
+ 
+ my %const = (
 diff --git a/cpan/Win32/Makefile.PL b/cpan/Win32/Makefile.PL
 index 90ad660..f11de75 100644
 --- a/cpan/Win32/Makefile.PL
 +++ b/cpan/Win32/Makefile.PL
-@@ -22,7 +22,7 @@
- $param{NO_META} = 1 if eval "$ExtUtils::MakeMaker::VERSION" >= 6.10_03;
+@@ -3,7 +3,7 @@ use strict;
+ use warnings;
+ use ExtUtils::MakeMaker;
  
- if ($^O eq 'cygwin') {
--    $param{LIBS} = ['-L/lib/w32api -lole32 -lversion -luserenv -lnetapi32 -lwinhttp']
-+    $param{LIBS} = ['-L/usr/lib/w32api -lole32 -lversion -luserenv -lnetapi32 -lwinhttp']
+-unless ($^O eq "MSWin32" || $^O eq "cygwin") {
++unless ($^O eq "MSWin32" || $^O eq "cygwin" || $^O eq "msys") {
+     die "OS unsupported\n";
  }
+ 
+@@ -24,6 +24,9 @@ $param{NO_META} = 1 if eval "$ExtUtils::MakeMaker::VERSION" >= 6.10_03;
+ if ($^O eq 'cygwin') {
+     $param{LIBS} = ['-L/lib/w32api -lole32 -lversion -luserenv -lnetapi32 -lwinhttp']
+ }
++elsif ($^O eq 'msys') {
++    $param{LIBS} = ['-L/usr/lib/w32api -lole32 -lversion -luserenv -lnetapi32 -lwinhttp']
++}
  else {
      $param{LIBS} = ['-luserenv -lwinhttp']
-
+ }
+diff --git a/cpan/Win32/t/GetCurrentThreadId.t b/cpan/Win32/t/GetCurrentThreadId.t
+index ce98f3e..aa0720c 100644
+--- a/cpan/Win32/t/GetCurrentThreadId.t
++++ b/cpan/Win32/t/GetCurrentThreadId.t
+@@ -10,7 +10,7 @@ plan tests => $tests;
+ 
+ my $pid = $$+0; # make sure we don't copy any magic to $pid
+ 
+-if ($^O eq "cygwin") {
++if ($^O eq "cygwin" or $^O eq "msys") {
+     skip(!defined &Cygwin::pid_to_winpid,
+ 	 Cygwin::pid_to_winpid($pid),
+ 	 Win32::GetCurrentProcessId());
 diff --git a/cpan/Win32/t/Unicode.t b/cpan/Win32/t/Unicode.t
 index fa05188..c0f854d 100644
 --- a/cpan/Win32/t/Unicode.t
 +++ b/cpan/Win32/t/Unicode.t
-@@ -47,7 +47,7 @@
+@@ -47,7 +47,7 @@ sub cleanup {
  cleanup();
  END { cleanup() }
  
@@ -128,24 +889,94 @@ index fa05188..c0f854d 100644
  
  # Create Unicode directory
  Win32::CreateDirectory($dir8);
-@@ -91,9 +91,11 @@
+@@ -87,13 +87,15 @@ ok(Win32::GetLongPathName($w32dir), $long);
+ 
+ # cwd() on Cygwin returns a mapped path that we need to translate
+ # back to a Windows path. Invoking `cygpath` on $subdir doesn't work.
+-if ($^O eq "cygwin") {
++if ($^O eq "cygwin" or $^O eq "msys") {
      $subdir = decode "UTF-8", Cygwin::posix_to_win_path($subdir, 1);
  }
  $subdir =~ s,/,\\,g;
 -# Cygwin64 no longer returns an ANSI name
 -skip($^O eq "cygwin", Win32::GetLongPathName($subdir), $long);
--
--# We can chdir() into the Unicode directory if we use the ANSI name
--ok(chdir(Win32::GetANSIPathName($dir)));
--ok(Win32::GetLongPathName(Win32::GetCwd()), $long);
 +# 
 +SKIP: {
 +    skip("Cygwin64 no longer returns an ANSI name", 2) if $^O eq "cygwin";
-+
+ 
+-# We can chdir() into the Unicode directory if we use the ANSI name
+-ok(chdir(Win32::GetANSIPathName($dir)));
+-ok(Win32::GetLongPathName(Win32::GetCwd()), $long);
 +    # We can chdir() into the Unicode directory if we use the ANSI name
 +    ok(chdir(Win32::GetANSIPathName($dir)));
 +    ok(Win32::GetLongPathName(Win32::GetCwd()), $long);
 +}
+diff --git a/cpan/Win32API-File/File.pm b/cpan/Win32API-File/File.pm
+index 804a7f6..504cb1e 100644
+--- a/cpan/Win32API-File/File.pm
++++ b/cpan/Win32API-File/File.pm
+@@ -738,7 +738,7 @@ sub FILENO {
+ 
+ 	return $self->_fileno() if defined $self->_fileno();
+ 
+-	return -1 if $^O eq 'cygwin';
++	return -1 if ($^O eq 'cygwin' or $^O eq 'msys');
+ 
+ # FIXME: We don't always open the handle, better to query the handle or to set
+ # the right access info at TIEHANDLE time.
+diff --git a/cpan/Win32API-File/Makefile.PL b/cpan/Win32API-File/Makefile.PL
+index b0a0dc0..8e0894d 100644
+--- a/cpan/Win32API-File/Makefile.PL
++++ b/cpan/Win32API-File/Makefile.PL
+@@ -5,7 +5,7 @@ use Config;
+ use strict;
+ # See lib/ExtUtils/MakeMaker.pm for details of how to influence
+ # the contents of the Makefile that is written.
+-unless ($^O eq "MSWin32" || $^O eq "cygwin" || $^O eq "interix") { #not tested on Interix
++unless ($^O eq "MSWin32" || $^O eq "cygwin" || $^O eq "msys" || $^O eq "interix") { #not tested on Interix
+     die "OS unsupported\n";
+ }
+ 
+diff --git a/cpan/Win32API-File/t/file.t b/cpan/Win32API-File/t/file.t
+index 25450a5..119b69a 100644
+--- a/cpan/Win32API-File/t/file.t
++++ b/cpan/Win32API-File/t/file.t
+@@ -151,7 +151,7 @@ $ok= print APP "is enough\n";
+ $ok or print "# ",fileLastError(),"\n";
+ print $ok ? "" : "not ", "ok ", ++$test, "\n";	# ok 19
+ 
+-SetFilePointer($h1, 0, [], FILE_BEGIN) if $^O eq 'cygwin';
++SetFilePointer($h1, 0, [], FILE_BEGIN) if ($^O eq 'cygwin' or $^O eq 'msys');
+ 
+ $ok= ReadFile( $h1, $text, 0, [], [] );
+ $ok or print "# ",fileLastError(),"\n";
+@@ -166,7 +166,7 @@ if( !$ok ) {
+ print $ok ? "" : "not ", "ok ", ++$test, "\n";	# ok 21
+ 
+ $skip = "";
+-if ($^O eq 'cygwin') {
++if ($^O eq 'cygwin' or $^O eq 'msys') {
+     $ok = 1;
+     $skip = " # skip cygwin can delete open files";
+ }
+@@ -247,7 +247,7 @@ $ok= ! DeleteFile( "Moved.cp" )
+ $ok or print "# ",fileLastError(),"\n";
+ print $ok ? "" : "not ", "ok ", ++$test, "\n";	# ok 35
+ 
+-if ($^O eq 'cygwin') {
++if ($^O eq 'cygwin' or $^O eq 'msys') {
+     chmod( 0200 | 07777 & (stat("Moved.cp"))[2], "Moved.cp" );
+ }
+ else {
+@@ -343,7 +343,7 @@ if( !$ok  ) {
+ print $ok ? "" : "not ", "ok ", ++$test, "\n";	# ok 49
+ 
+ my $path = $ENV{WINDIR};
+-$ok= -f $let.substr($path,$^O eq 'cygwin'?2:3)."/win.ini";
++$ok= -f $let.substr($path,($^O eq 'cygwin' || $^O eq 'msys')?2:3)."/win.ini";
+ $ok or print "# ",$let.substr($path,3)."/win.ini ",fileLastError(),"\n";
+ print $ok ? "" : "not ", "ok ", ++$test, "\n";	# ok 50
+ 
 diff --git a/cpan/autodie/t/chown.t b/cpan/autodie/t/chown.t
 index 90c4d3b..7d118d4 100644
 --- a/cpan/autodie/t/chown.t
@@ -155,7 +986,7 @@ index 90c4d3b..7d118d4 100644
  use autodie;
  
 -if ($^O eq 'MSWin32') {
-+if ($^O eq 'MSWin32' or $^O eq 'cygwin') {
++if ($^O eq 'MSWin32' or $^O eq 'msys') {
      plan skip_all => 'chown() seems to always succeed on Windows';
  }
  
@@ -168,10 +999,176 @@ index 4860a49..54c9e79 100644
  SKIP: {
  
 -    if ($^O eq "MSWin32") { skip("chown() on Windows always succeeds.", 1) }
-+    if ($^O eq "MSWin32" or $^O eq 'cygwin') { skip("chown() on Windows always succeeds.", 1) }
++    if ($^O eq "MSWin32" or $^O eq 'msys') { skip("chown() on Windows always succeeds.", 1) }
  
      eval {
          use autodie;
+diff --git a/cpan/libnet/lib/Net/Domain.pm b/cpan/libnet/lib/Net/Domain.pm
+index 7c017f2..19f5695 100644
+--- a/cpan/libnet/lib/Net/Domain.pm
++++ b/cpan/libnet/lib/Net/Domain.pm
+@@ -171,7 +171,7 @@ sub _hostdomain {
+     }
+ 
+     chop($dom = `domainname 2>/dev/null`)
+-      unless (defined $dom || $^O =~ /^(?:cygwin|MSWin32|android)/);
++      unless (defined $dom || $^O =~ /^(?:cygwin|msys|MSWin32|android)/);
+ 
+     if (defined $dom) {
+       my @h = ();
+diff --git a/cpan/libnet/lib/Net/Netrc.pm b/cpan/libnet/lib/Net/Netrc.pm
+index 3dec11e..7040f50 100644
+--- a/cpan/libnet/lib/Net/Netrc.pm
++++ b/cpan/libnet/lib/Net/Netrc.pm
+@@ -57,6 +57,7 @@ sub _readrc {
+   unless ($^O eq 'os2'
+     || $^O eq 'MSWin32'
+     || $^O eq 'MacOS'
++    || $^O =~ /^msys/
+     || $^O =~ /^cygwin/)
+   {
+     my @stat = stat($file);
+diff --git a/cpan/libnet/t/netrc.t b/cpan/libnet/t/netrc.t
+index ba0183c..8e7c335 100644
+--- a/cpan/libnet/t/netrc.t
++++ b/cpan/libnet/t/netrc.t
+@@ -48,7 +48,7 @@ $Net::Netrc::TESTING=$Net::Netrc::TESTING=1;
+ 
+ SKIP: {
+         skip('incompatible stat() handling for OS', 4), next SKIP 
+-                if $^O =~ /os2|win32|macos|cygwin/i;
++                if $^O =~ /os2|win32|macos|cygwin|msys/i;
+ 
+         my $warn;
+         local $SIG{__WARN__} = sub {
+diff --git a/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/msys.pm b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/msys.pm
+new file mode 100644
+index 0000000..dd060cd
+--- /dev/null
++++ b/dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/msys.pm
+@@ -0,0 +1,33 @@
++package ExtUtils::CBuilder::Platform::msys;
++
++use warnings;
++use strict;
++use File::Spec;
++use ExtUtils::CBuilder::Platform::Unix;
++
++our $VERSION = '0.280230'; # VERSION
++our @ISA = qw(ExtUtils::CBuilder::Platform::Unix);
++
++# TODO: If a specific exe_file name is requested, if the exe created
++# doesn't have that name, we might want to rename it.  Apparently asking
++# for an exe of "foo" might result in "foo.exe".  Alternatively, we should
++# make sure the return value is correctly "foo.exe".
++# C.f http://rt.cpan.org/Public/Bug/Display.html?id=41003
++sub link_executable {
++  my $self = shift;
++  return $self->SUPER::link_executable(@_);
++}
++
++sub link {
++  my ($self, %args) = @_;
++
++  my $lib = $self->{config}{useshrplib} ? 'libperl.dll.a' : 'libperl.a';
++  $args{extra_linker_flags} = [
++    File::Spec->catfile($self->perl_inc(), $lib),
++    $self->split_like_shell($args{extra_linker_flags})
++  ];
++
++  return $self->SUPER::link(%args);
++}
++
++1;
+diff --git a/dist/IO/t/cachepropagate-unix.t b/dist/IO/t/cachepropagate-unix.t
+index 718d01d..df1f3ad 100644
+--- a/dist/IO/t/cachepropagate-unix.t
++++ b/dist/IO/t/cachepropagate-unix.t
+@@ -50,7 +50,7 @@ my $p = $listener->protocol();
+     # This is a TODO instead of a skip so if these ever implement SO_PROTOCOL
+     # we'll be notified about the passing TODO so the test can be updated.
+     local $TODO = "$^O doesn't support SO_PROTOCOL on AF_UNIX"
+-        if $^O =~ /^(netbsd|darwin|cygwin|hpux|solaris|dragonfly|os390|gnu)$/;
++        if $^O =~ /^(netbsd|darwin|cygwin|msys|hpux|solaris|dragonfly|os390|gnu)$/;
+     ok(defined($p), 'protocol defined');
+ }
+ my $d = $listener->sockdomain();
+@@ -105,7 +105,7 @@ SKIP: {
+     {
+         # see comment above
+         local $TODO = "$^O doesn't support SO_PROTOCOL on AF_UNIX"
+-            if $^O =~ /^(netbsd|darwin|cygwin|hpux|solaris|dragonfly|os390|gnu)$/;
++            if $^O =~ /^(netbsd|darwin|cygwin|msys|hpux|solaris|dragonfly|os390|gnu)$/;
+         ok(defined($p), 'protocol defined');
+     }
+     $d = $listener->sockdomain();
+diff --git a/dist/IO/t/io_xs.t b/dist/IO/t/io_xs.t
+index c9b8836..e21e9d3 100644
+--- a/dist/IO/t/io_xs.t
++++ b/dist/IO/t/io_xs.t
+@@ -52,6 +52,8 @@ SKIP:
+       and skip "fsync() documented to fail on non-writable handles on $^O", 1;
+     $^O eq 'cygwin'
+       and skip "fsync() on cygwin uses FlushFileBuffers which requires a writable handle", 1;
++    $^O eq 'msys'
++      and skip "fsync() on msys uses FlushFileBuffers which requires a writable handle", 1;
+     $^O eq 'VMS'
+       and skip "fsync() not allowed on a read-only handle on $^O", 1;
+     open my $fh, "<", "t/io_xs.t"
+diff --git a/dist/Net-Ping/lib/Net/Ping.pm b/dist/Net-Ping/lib/Net/Ping.pm
+index 19bb51e..ef10b04 100644
+--- a/dist/Net-Ping/lib/Net/Ping.pm
++++ b/dist/Net-Ping/lib/Net/Ping.pm
+@@ -420,15 +420,15 @@ sub retrans
+ }
+ 
+ sub _IsAdminUser {
+-  return unless $^O eq 'MSWin32' or $^O eq "cygwin";
++  return unless $^O eq 'MSWin32' or $^O eq "cygwin" or $^O eq "msys";
+   return unless eval { require Win32 };
+   return unless defined &Win32::IsAdminUser;
+   return Win32::IsAdminUser();
+ }
+ 
+ sub _isroot {
+-  if (($> and $^O ne 'VMS' and $^O ne 'cygwin')
+-    or (($^O eq 'MSWin32' or $^O eq 'cygwin')
++  if (($> and $^O ne 'VMS' and $^O ne 'cygwin' and $^O ne 'msys')
++    or (($^O eq 'MSWin32' or $^O eq 'cygwin' or $^O eq 'msys')
+         and !_IsAdminUser())
+     or ($^O eq 'VMS'
+         and (`write sys\$output f\$privilege("SYSPRV")` =~ m/FALSE/))) {
+@@ -974,7 +974,7 @@ sub tcp_connect
+             # This should set $! to the correct error.
+             my $char;
+             sysread($self->{fh},$char,1);
+-            $! = ECONNREFUSED if ($! == EAGAIN && $^O =~ /cygwin/i);
++            $! = ECONNREFUSED if ($! == EAGAIN && $^O =~ /cygwin|msys/i);
+ 
+             $ret = 1 if (!$self->{econnrefused}
+                          && $! == ECONNREFUSED);
+@@ -1616,7 +1616,7 @@ sub ack
+             $self->{bad}->{$entry->[0]} = $!;
+             if (!$self->{econnrefused} &&
+                 (($! == ECONNREFUSED) ||
+-                 ($! == EAGAIN && $^O =~ /cygwin/i))) {
++                 ($! == EAGAIN && $^O =~ /cygwin|msys/i))) {
+               # "Connection refused" means reachable
+               # Good, continue
+             } else {
+diff --git a/dist/Net-Ping/t/001_new.t b/dist/Net-Ping/t/001_new.t
+index 46965b7..4703a14 100644
+--- a/dist/Net-Ping/t/001_new.t
++++ b/dist/Net-Ping/t/001_new.t
+@@ -60,7 +60,7 @@ SKIP: {
+     eval { $p = Net::Ping->new('icmp'); };
+     skip "icmp ping requires root privileges.", 3
+       if !Net::Ping::_isroot() or $^O eq 'MSWin32';
+-    if($> and $^O ne 'VMS' and $^O ne 'cygwin') {
++    if($> and $^O ne 'VMS' and $^O ne 'cygwin' and $^O ne 'msys') {
+         like($@, qr/icmp ping requires root privilege/, "Need root for icmp");
+         skip "icmp tests require root", 2;
+     } else {
 diff --git a/dist/Net-Ping/t/450_service.t b/dist/Net-Ping/t/450_service.t
 index 203d86b..9246a21 100644
 --- a/dist/Net-Ping/t/450_service.t
@@ -181,7 +1178,7 @@ index 203d86b..9246a21 100644
  
  {
 -    local $TODO = "Believed not to work on $^O" if $^O =~ /^(?:MSWin32|os390)$/;
-+    local $TODO = "Believed not to work on $^O" if $^O =~ /^(?:MSWin32|cygwin|os390)$/;
++    local $TODO = "Believed not to work on $^O" if $^O =~ /^(?:MSWin32|msys|os390)$/;
      is($p->ping("127.0.0.1"), 1, 'second port is reachable');
  }
  
@@ -190,22 +1187,301 @@ index 203d86b..9246a21 100644
    {
      local $TODO = "Believed not to work on $^O"
 -      if $^O =~ /^(?:MSWin32|os390)$/;
-+      if $^O =~ /^(?:MSWin32|cygwin|os390)$/;
++      if $^O =~ /^(?:MSWin32|msys|os390)$/;
      is($p->ack(), '127.0.0.1', 'IP should be reachable');
    }
  }
+diff --git a/dist/Net-Ping/t/510_ping_udp.t b/dist/Net-Ping/t/510_ping_udp.t
+index 9454736..1756060 100644
+--- a/dist/Net-Ping/t/510_ping_udp.t
++++ b/dist/Net-Ping/t/510_ping_udp.t
+@@ -4,7 +4,7 @@ use strict;
+ use Config;
+ 
+ sub isWindowsVista {
+-   return unless $^O eq 'MSWin32' or $^O eq "cygwin";
++   return unless $^O eq 'MSWin32' or $^O eq "cygwin" or $^O eq "msys";
+    return unless eval { require Win32 };
+    return unless defined &Win32::GetOSVersion();
+ 
+diff --git a/dist/PathTools/Cwd.pm b/dist/PathTools/Cwd.pm
+index 0683583..68b11b6 100644
+--- a/dist/PathTools/Cwd.pm
++++ b/dist/PathTools/Cwd.pm
+@@ -135,6 +135,15 @@ my %METHOD_MAP =
+     realpath		=> 'fast_abs_path',
+    },
+ 
++   msys =>
++   {
++    getcwd		=> 'cwd',
++    fastgetcwd		=> 'cwd',
++    fastcwd		=> 'cwd',
++    abs_path		=> 'fast_abs_path',
++    realpath		=> 'fast_abs_path',
++   },
++
+    amigaos =>
+    {
+     getcwd              => '_backtick_pwd',
+@@ -217,7 +226,7 @@ unless ($METHOD_MAP{$^O}{cwd} or defined &cwd) {
+     }
+ }
+ 
+-if ($^O eq 'cygwin') {
++if ($^O eq 'cygwin' || $^O eq 'msys') {
+   # We need to make sure cwd() is called with no args, because it's
+   # got an arg-less prototype and will die if args are present.
+   local $^W = 0;
+@@ -318,7 +327,7 @@ sub chdir_init {
+ 
+ sub chdir {
+     my $newdir = @_ ? shift : '';	# allow for no arg (chdir to HOME dir)
+-    if ($^O eq "cygwin") {
++    if ($^O eq "cygwin" || $^O eq "msys") {
+       $newdir =~ s|\A///+|//|;
+       $newdir =~ s|(?<=[^/])//+|/|g;
+     }
+diff --git a/dist/PathTools/lib/File/Spec.pm b/dist/PathTools/lib/File/Spec.pm
+index e0a49ed..df03121 100644
+--- a/dist/PathTools/lib/File/Spec.pm
++++ b/dist/PathTools/lib/File/Spec.pm
+@@ -13,6 +13,7 @@ my %module = (
+ 	      symbian => 'Win32', # Yes, File::Spec::Win32 works on symbian.
+ 	      dos     => 'OS2',   # Yes, File::Spec::OS2 works on DJGPP.
+ 	      cygwin  => 'Cygwin',
++	      msys    => 'Cygwin',
+ 	      amigaos => 'AmigaOS');
+ 
+ 
+diff --git a/dist/PathTools/lib/File/Spec/Cygwin.pm b/dist/PathTools/lib/File/Spec/Cygwin.pm
+index e21c0bb..427ce03 100644
+--- a/dist/PathTools/lib/File/Spec/Cygwin.pm
++++ b/dist/PathTools/lib/File/Spec/Cygwin.pm
+@@ -117,12 +117,12 @@ Default: 1
+ =cut
+ 
+ sub case_tolerant {
+-  return 1 unless $^O eq 'cygwin'
++  return 1 unless ($^O eq 'cygwin' || $^O eq 'msys')
+     and defined &Cygwin::mount_flags;
+ 
+   my $drive = shift;
+   if (! $drive) {
+-      my @flags = split(/,/, Cygwin::mount_flags('/cygwin'));
++      my @flags = split(/,/, Cygwin::mount_flags('/msys'));
+       my $prefix = pop(@flags);
+       if (! $prefix || $prefix eq 'cygdrive') {
+           $drive = '/cygdrive/c';
+diff --git a/dist/PathTools/lib/File/Spec/Unix.pm b/dist/PathTools/lib/File/Spec/Unix.pm
+index 52904b4..e771c5f 100644
+--- a/dist/PathTools/lib/File/Spec/Unix.pm
++++ b/dist/PathTools/lib/File/Spec/Unix.pm
+@@ -57,7 +57,7 @@ sub _pp_canonpath {
+       $node = $1;
+     }
+     # This used to be
+-    # $path =~ s|/+|/|g unless ($^O eq 'cygwin');
++    # $path =~ s|/+|/|g unless ($^O eq 'cygwin' || $^O eq 'msys');
+     # but that made tests 29, 30, 35, 46, and 213 (as of #13272) to fail
+     # (Mainly because trailing "" directories didn't get stripped).
+     # Why would cygwin avoid collapsing multiple slashes into one? --jhi
+diff --git a/dist/PathTools/t/crossplatform.t b/dist/PathTools/t/crossplatform.t
+index b7c76fc..6a42af3 100644
+--- a/dist/PathTools/t/crossplatform.t
++++ b/dist/PathTools/t/crossplatform.t
+@@ -6,7 +6,7 @@ use lib File::Spec->catfile('t', 'lib');
+ use Test::More;
+ local $|=1;
+ 
+-my @platforms = qw(Cygwin Epoc Mac OS2 Unix VMS Win32);
++my @platforms = qw(Cygwin Msys Epoc Mac OS2 Unix VMS Win32);
+ my $tests_per_platform = 10;
+ 
+ my $vms_unix_rpt = 0;
+diff --git a/dist/PathTools/t/cwd.t b/dist/PathTools/t/cwd.t
+index d155e33..ebdd7f2 100644
+--- a/dist/PathTools/t/cwd.t
++++ b/dist/PathTools/t/cwd.t
+@@ -41,7 +41,7 @@ if ($IsVMS) {
+ my $tests = 31;
+ # _perl_abs_path() currently only works when the directory separator
+ # is '/', so don't test it when it won't work.
+-my $EXTRA_ABSPATH_TESTS = ($Config{prefix} =~ m/\//) && $^O ne 'cygwin';
++my $EXTRA_ABSPATH_TESTS = ($Config{prefix} =~ m/\//) && $^O ne 'cygwin' && $^O ne 'msys';
+ $tests += 4 if $EXTRA_ABSPATH_TESTS;
+ plan tests => $tests;
+ 
+diff --git a/dist/PathTools/t/cwd_enoent.t b/dist/PathTools/t/cwd_enoent.t
+index 0fe3834..32c2b7d 100644
+--- a/dist/PathTools/t/cwd_enoent.t
++++ b/dist/PathTools/t/cwd_enoent.t
+@@ -6,7 +6,7 @@ use Errno qw();
+ use File::Temp qw(tempdir);
+ use Test::More;
+ 
+-if($^O eq "cygwin") {
++if($^O eq "cygwin" || $^O eq "msys") {
+     # This test skipping should be removed when the Cygwin bug is fixed.
+     plan skip_all => "getcwd() fails to fail on Cygwin [perl #132733]";
+ }
+@@ -24,7 +24,7 @@ foreach my $type (qw(regular perl)) {
+     SKIP: {
+ 	skip "_perl_abs_path() not expected to work", 4
+ 	    if $type eq "perl" &&
+-		!(($Config{prefix} =~ m/\//) && $^O ne "cygwin");
++		!(($Config{prefix} =~ m/\//) && $^O ne "cygwin" && $^O ne "msys");
+ 
+         # https://github.com/Perl/perl5/issues/16525
+         # https://bugs.dragonflybsd.org/issues/3250
+diff --git a/dist/Storable/stacksize b/dist/Storable/stacksize
+index 2896684..c9247bf 100644
+--- a/dist/Storable/stacksize
++++ b/dist/Storable/stacksize
+@@ -168,7 +168,7 @@ $max_depth = int(0.6 * $max_depth);
+ $max_depth_hash = int(0.6 * $max_depth_hash);
+ 
+ my $stack_reserve = $^O eq "MSWin32" ? 32 : 16;
+-if ($] ge "5.016" && !($^O eq "cygwin" && $ptrsize == 8)) {
++if ($] ge "5.016" && !(($^O eq "cygwin" || $^O eq "msys") && $ptrsize == 8)) {
+     $max_depth -= $stack_reserve;
+     $max_depth_hash -= $stack_reserve;
+ }
+diff --git a/dist/Term-ReadLine/t/ReadLine-STDERR.t b/dist/Term-ReadLine/t/ReadLine-STDERR.t
+index 2bdf799..3637dc0 100644
+--- a/dist/Term-ReadLine/t/ReadLine-STDERR.t
++++ b/dist/Term-ReadLine/t/ReadLine-STDERR.t
+@@ -30,7 +30,7 @@ SKIP:
+     is_deeply \@out, [ q{/dev/tty}, q{/dev/tty} ], "findConsole is using /dev/tty";
+ }
+ 
+-{
++SKIP: {
+     no warnings 'redefine';
+     my $donotexist = q[/this/should/not/exist/hopefully];
+ 
+@@ -40,6 +40,7 @@ SKIP:
+       *Term::ReadLine::Stub::devtty = sub { $donotexist };
+     is( Term::ReadLine->devtty(), $donotexist, "devtty mocked" );
+ 
++    skip('console is CONIN$/CONOUT$ in MSYS2, not /dev/tty', 3) if $^O eq 'msys';
+     my @out = Term::ReadLine::Stub::findConsole();
+     is_deeply \@out, [ q{&STDIN}, q{&STDERR} ], "findConsole isn't using /dev/tty" or diag explain \@out;
+ 
+diff --git a/dist/Time-HiRes/Makefile.PL b/dist/Time-HiRes/Makefile.PL
+index e5ba503..97b5903 100644
+--- a/dist/Time-HiRes/Makefile.PL
++++ b/dist/Time-HiRes/Makefile.PL
+@@ -23,7 +23,7 @@ our $self; # Used in 'sourcing' the hints.
+ 
+ # TBD: Can we just use $Config(exe_ext) here instead of this complex
+ #      expression?
+-my $ld_exeext = ($^O eq 'cygwin' ||
++my $ld_exeext = ($^O eq 'cygwin' || $^O eq 'msys' ||
+                  $^O eq 'os2' && $Config{ldflags} =~ /-Zexe\b/) ? '.exe' :
+                 (($^O eq 'vos') ? $Config{exe_ext} : '');
+ 
+@@ -829,7 +829,7 @@ EOM
+ 
+     my $has_w32api_windows_h;
+ 
+-    if ($^O eq 'cygwin') {
++    if ($^O eq 'cygwin' or $^O eq 'msys') {
+         print "Looking for <w32api/windows.h>... ";
+         if (has_include('w32api/windows.h')) {
+             $has_w32api_windows_h++;
+diff --git a/dist/Time-HiRes/t/stat.t b/dist/Time-HiRes/t/stat.t
+index 1f1fa96..4f33e37 100644
+--- a/dist/Time-HiRes/t/stat.t
++++ b/dist/Time-HiRes/t/stat.t
+@@ -6,7 +6,7 @@ BEGIN {
+         require Test::More;
+         Test::More::plan(skip_all => "no hi-res stat");
+     }
+-    if($^O =~ /\A(?:cygwin|MSWin)/) {
++    if($^O =~ /\A(?:cygwin|msys|MSWin)/) {
+         require Test::More;
+         Test::More::plan(skip_all =>
+                 "$^O file timestamps not reliable enough for stat test");
+diff --git a/dist/Time-HiRes/t/utime.t b/dist/Time-HiRes/t/utime.t
+index 8a4f071..117a6af 100644
+--- a/dist/Time-HiRes/t/utime.t
++++ b/dist/Time-HiRes/t/utime.t
+@@ -127,7 +127,7 @@ use Config;
+ my $atime = 1.111111111;
+ my $mtime = 2.222222222;
+ 
+-if ($^O eq 'cygwin') {
++if ($^O eq 'cygwin' || $^O eq 'msys') {
+     # Cygwin timestamps have less precision.
+     $atime = 1.1111111;
+     $mtime = 2.2222222;
+diff --git a/dist/XSLoader/XSLoader_pm.PL b/dist/XSLoader/XSLoader_pm.PL
+index af5586a..c31171e 100644
+--- a/dist/XSLoader/XSLoader_pm.PL
++++ b/dist/XSLoader/XSLoader_pm.PL
+@@ -80,7 +80,7 @@ my $to_print = <<'EOT';
+ EOT
+ 
+ $to_print =~ s~regexp~
+-    $^O eq 'MSWin32' || $^O eq 'os2' || $^O eq 'cygwin' || $^O eq 'amigaos'
++    $^O eq 'MSWin32' || $^O eq 'os2' || $^O eq 'cygwin' || $^O eq 'msys' || $^O eq 'amigaos'
+         ? '^(?:[A-Za-z]:)?[\\\/]' # Optional drive letter
+         : '^/'
+ ~e;
 diff --git a/ext/DynaLoader/DynaLoader_pm.PL b/ext/DynaLoader/DynaLoader_pm.PL
 index 93a858a..c881f91 100644
 --- a/ext/DynaLoader/DynaLoader_pm.PL
 +++ b/ext/DynaLoader/DynaLoader_pm.PL
-@@ -482,6 +482,7 @@
-             push(@names,"$_.$dl_dlext")    unless m/\.$dl_dlext$/o;
-             push(@names,"$_.$dl_so")     unless m/\.$dl_so$/o;
+@@ -484,6 +484,9 @@ sub dl_findfile {
  	    <<$^O-eq-cygwin>>
-+            push(@names,"msys-$_.$dl_so")  unless m:/:;
              push(@names,"cyg$_.$dl_so")  unless m:/:;
  	    <</$^O-eq-cygwin>>
++	    <<$^O-eq-msys>>
++            push(@names,"msys-$_.$dl_so")  unless m:/:;
++	    <</$^O-eq-msys>>
              push(@names,"lib$_.$dl_so")  unless m:/:;
+             push(@names, $_);
+         }
+diff --git a/ext/DynaLoader/t/DynaLoader.t b/ext/DynaLoader/t/DynaLoader.t
+index 11b37b5..6b6287f 100644
+--- a/ext/DynaLoader/t/DynaLoader.t
++++ b/ext/DynaLoader/t/DynaLoader.t
+@@ -119,7 +119,7 @@ SKIP: {
+     # (not at least by that name) that the dl_findfile()
+     # could find.
+     skip( "dl_findfile test not appropriate on $^O", 1 )
+-	if $^O =~ /(win32|vms|openbsd|bitrig|cygwin|vos|os390)/i;
++	if $^O =~ /(win32|vms|openbsd|bitrig|cygwin|msys|vos|os390)/i;
+     # Play safe and only try this test if this system
+     # looks pretty much Unix-like.
+     skip( "dl_findfile test not appropriate on $^O", 1 )
+diff --git a/ext/File-Find/t/find.t b/ext/File-Find/t/find.t
+index add20c2..1a50632 100644
+--- a/ext/File-Find/t/find.t
++++ b/ext/File-Find/t/find.t
+@@ -12,7 +12,7 @@ BEGIN {
+     }
+     $SIG{'__WARN__'} = sub { $warn_msg = $_[0]; warn "# $_[0]"; };
+ 
+-    if ($^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'VMS') {
++    if ($^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys' || $^O eq 'VMS') {
+         # This is a hack - at present File::Find does not produce native names
+         # on Win32 or VMS, so force File::Spec to use Unix names.
+         # must be set *before* importing File::Find
+diff --git a/ext/File-Glob/t/basic.t b/ext/File-Glob/t/basic.t
+index 412fe7e..3c59e42 100644
+--- a/ext/File-Glob/t/basic.t
++++ b/ext/File-Glob/t/basic.t
+@@ -141,7 +141,7 @@ SKIP: {
+ # should return an empty list, and set ERROR
+ SKIP: {
+     skip $^O, 2 if $^O eq 'MSWin32'
+-        or $^O eq 'os2' or $^O eq 'VMS' or $^O eq 'cygwin';
++        or $^O eq 'os2' or $^O eq 'VMS' or $^O eq 'cygwin' or $^O eq 'msys';
+     skip "AFS", 2 if Cwd::cwd() =~ m#^$Config{'afsroot'}#s;
+     skip "running as root", 2 if not $>;
+ 
 diff --git a/ext/NDBM_File/Makefile.PL b/ext/NDBM_File/Makefile.PL
 index fe2cb40..85e6f30 100644
 --- a/ext/NDBM_File/Makefile.PL
@@ -232,6 +1508,45 @@ index 0ae31f9..76f8f4f 100644
      XSPROTOARG => '-noprototypes', 		# XXX remove later?
      VERSION_FROM => 'ODBM_File.pm', 
  );
+diff --git a/ext/POSIX/Makefile.PL b/ext/POSIX/Makefile.PL
+index 462b8ed..1ec91f3 100644
+--- a/ext/POSIX/Makefile.PL
++++ b/ext/POSIX/Makefile.PL
+@@ -20,7 +20,7 @@ if ($^O eq 'solaris') {
+ if ($^O eq 'aix' && $Config{uselongdouble}) {
+     push @libs, qw(c128);
+ }
+-if ($^O eq 'cygwin' && $Config{usequadmath}) {
++if (($^O eq 'cygwin' || $^O eq 'msys') && $Config{usequadmath}) {
+     push @libs, qw(quadmath);
+ }
+ WriteMakefile(
+diff --git a/ext/POSIX/t/sysconf.t b/ext/POSIX/t/sysconf.t
+index 8644274..8f15be1 100644
+--- a/ext/POSIX/t/sysconf.t
++++ b/ext/POSIX/t/sysconf.t
+@@ -164,7 +164,7 @@ END {
+ }
+ 
+ SKIP: {
+-    if($^O eq 'cygwin') {
++    if($^O eq 'cygwin' or $^O eq 'msys') {
+         pop @sys_consts;
+         skip("No _SC_TZNAME_MAX on Cygwin", 1);
+     }
+diff --git a/ext/POSIX/t/time.t b/ext/POSIX/t/time.t
+index 6190e38..f85182a 100644
+--- a/ext/POSIX/t/time.t
++++ b/ext/POSIX/t/time.t
+@@ -22,7 +22,7 @@ SKIP: {
+     # actually do anything.  Cygwin works in some places, but not others.  The
+     # other Win32's below are guesses.
+     skip "No tzset()", 2
+-       if $^O eq "VMS" || $^O eq "cygwin" ||
++       if $^O eq "VMS" || $^O eq "cygwin" || $^O eq "msys" ||
+           $^O eq "MSWin32" || $^O eq "interix";
+     tzset();
+     my @tzname = tzname();
 diff --git a/ext/POSIX/t/wrappers.t b/ext/POSIX/t/wrappers.t
 index e41b319..b26b203 100644
 --- a/ext/POSIX/t/wrappers.t
@@ -240,22 +1555,364 @@ index e41b319..b26b203 100644
      my $func = do {no strict 'refs'; \&{"POSIX::$name"}};
  
   SKIP: {
-+        skip("chown() does not work with MSYS2", 2) if $name eq 'chown' and $^O eq 'cygwin';
++        skip("chown() does not work with MSYS2", 2) if $name eq 'chown' and $^O eq 'msys';
          skip("$name() is not available", 2) if $skip && !$Config{$skip};
 +
  	$! = 0;
  	is(&$func(@args), $expect, $name);
  	isnt($!, '', "$name reported an error");
+diff --git a/ext/Win32CORE/t/win32core.t b/ext/Win32CORE/t/win32core.t
+index 8ef8cd0..ad0d7f0 100644
+--- a/ext/Win32CORE/t/win32core.t
++++ b/ext/Win32CORE/t/win32core.t
+@@ -24,8 +24,8 @@ ok(eval { Win32::GetLastError(); 1 }, 'GetLastError() works on the first call');
+ my $errno = 0 + $!;
+ my $sys_errno = 0 + $^E;
+ SKIP: {
+-    $^O eq "cygwin"
+-        and skip q($^E isn't useful on cygwin), 1;
++    $^O eq "cygwin" || $^O eq 'msys'
++        and skip q($^E isn't useful on cygwin/msys), 1;
+     # [perl #42925] - Loading Win32::GetLastError() via the forwarder function
+     # should not affect the last error being retrieved
+     is($sys_errno, 42, '$^E is preserved across Win32 autoload');
+diff --git a/ext/XS-APItest/t/call_checker.t b/ext/XS-APItest/t/call_checker.t
+index d39a059..919cdc0 100644
+--- a/ext/XS-APItest/t/call_checker.t
++++ b/ext/XS-APItest/t/call_checker.t
+@@ -6,7 +6,7 @@ use XS::APItest;
+ 
+ {
+     local $TODO = "[perl #78502] function pointers don't match on cygwin"
+-        if $^O eq "cygwin";
++        if ($^O eq "cygwin" || $^O eq "msys");
+     ok( eval { XS::APItest::test_cv_getset_call_checker(); 1 },
+         "test_cv_getset_call_checker() works as expected")
+         or diag $@;
+diff --git a/haiku/Haiku/Makefile.PL b/haiku/Haiku/Makefile.PL
+index dacf230..fa335a0 100644
+--- a/haiku/Haiku/Makefile.PL
++++ b/haiku/Haiku/Makefile.PL
+@@ -6,7 +6,7 @@ unless ($^O eq "haiku") {
+ }
+ 
+ #my @libs;
+-#push @libs, '-L/lib/w32api -lole32 -lversion' if $^O eq "cygwin";
++#push @libs, '-L/lib/w32api -lole32 -lversion' if ($^O eq "cygwin" or $^O eq "msys");
+ 
+ WriteMakefile(
+     NAME          => 'Haiku',
+diff --git a/hints/msys.sh b/hints/msys.sh
+new file mode 100644
+index 0000000..4a757e0
+--- /dev/null
++++ b/hints/msys.sh
+@@ -0,0 +1,98 @@
++#! /bin/sh
++# msys.sh - hints for building perl using the MSYS environment for Win32
++#
++
++# not otherwise settable
++exe_ext='.exe'
++firstmakefile='GNUmakefile'
++case "$ldlibpthname" in
++'') ldlibpthname=PATH ;;
++esac
++archobjs='cygwin.o'
++
++# mandatory (overrides incorrect defaults)
++test -z "$cc" && cc='gcc'
++if test -z "$plibpth"
++then
++    plibpth=`gcc -print-file-name=libc.a`
++    plibpth=`dirname $plibpth`
++    plibpth=`cd $plibpth && pwd`
++fi
++so='dll'
++# - eliminate -lc, implied by gcc and a symlink to libmsys-2.0.a
++libswanted=`echo " $libswanted " | sed -e 's/ c / /g'`
++# - eliminate -lm, symlink to libmsys-2.0.a
++libswanted=`echo " $libswanted " | sed -e 's/ m / /g'`
++# - eliminate -lutil, symbols are all in libmsys-2.0.a
++libswanted=`echo " $libswanted " | sed -e 's/ util / /g'`
++ignore_versioned_solibs='y'
++usenm='no'
++libc='/usr/lib/libmsys-2.0.a'
++loclibpth=' '
++glibpth=' '
++plibpth=' '
++libpth=' '
++PATH='.:/usr/bin/'
++# - add libgdbm_compat $libswanted
++libswanted="$libswanted gdbm_compat"
++test -z "$optimize" && optimize='-O3'
++man3ext='3pm'
++test -z "$use64bitint" && use64bitint='define'
++test -z "$usethreads" && usethreads='define'
++test -z "$usemymalloc" && usemymalloc='undef'
++ccflags="$ccflags -DPERL_USE_SAFE_PUTENV -U__STRICT_ANSI__ -D_GNU_SOURCE"
++# - otherwise i686-msys
++archname='msys'
++
++# dynamic loading
++# - otherwise -fpic
++cccdlflags=' '
++lddlflags=' --shared'
++test -z "$ld" && ld='g++'
++
++case "$osvers" in
++    # Configure gets these wrong if the IPC server isn't yet running:
++    # only use for 1.5.7 and onwards
++    [2-9]*|1.[6-9]*|1.[1-5][0-9]*|1.5.[7-9]*|1.5.[1-6][0-9]*)
++        d_semctl_semid_ds='define'
++        d_semctl_semun='define'
++        ;;
++esac
++
++case "$osvers" in
++    [2-9]*|1.[6-9]*)
++        # IPv6 only since 1.7
++        d_inetntop='define'
++        d_inetpton='define'
++        ;;
++    *)
++        # IPv6 not implemented before cygwin-1.7
++        d_inetntop='undef'
++        d_inetpton='undef'
++esac
++
++case "$osvers" in
++    2.[0-4].*|1.*)
++        # newlib finitel is buggy before cygwin-2.5.0
++        d_finitel='undef'
++        ;;
++esac
++
++# compile Win32CORE "module" as static. try to avoid the space.
++if test -z "$static_ext"; then
++  static_ext="Win32CORE"
++else
++  static_ext="$static_ext Win32CORE"
++fi
++
++# Win9x problem with non-blocking read from a closed pipe
++d_eofnblk='define'
++
++# suppress auto-import warnings
++ldflags="$ldflags -Wl,--enable-auto-import -Wl,--export-all-symbols -Wl,--enable-auto-image-base"
++lddlflags="$lddlflags $ldflags"
++
++# strip exe's and dll's, better do it afterwards
++#ldflags="$ldflags -s"
++#ccdlflags="$ccdlflags -s"
++#lddlflags="$lddlflags -s"
+diff --git a/install_lib.pl b/install_lib.pl
+index 1c4d7de..b7319aa 100644
+--- a/install_lib.pl
++++ b/install_lib.pl
+@@ -46,7 +46,7 @@ if ($Config{d_umask}) {
+ $Is_VMS = $^O eq 'VMS';
+ $Is_W32 = $^O eq 'MSWin32';
+ $Is_OS2 = $^O eq 'os2';
+-$Is_Cygwin = $^O eq 'cygwin';
++$Is_Cygwin = ($^O eq 'cygwin' || $^O eq 'msys');
+ $Is_Darwin = $^O eq 'darwin';
+ $Is_AmigaOS = $^O eq 'amigaos';
+ 
+diff --git a/installman b/installman
+index 686862d..fcf467c 100755
+--- a/installman
++++ b/installman
+@@ -154,7 +154,7 @@ sub pod2man {
+ 	    next;
+ 	}
+ 
+-	if ($^O eq 'os2' || $^O eq 'amigaos' || $^O eq 'cygwin') {
++	if ($^O eq 'os2' || $^O eq 'amigaos' || $^O eq 'cygwin' || $^O eq 'msys') {
+             $manpage =~ s#::#.#g;
+ 	}
+         my $tmp = "${mandir}/${manpage}.tmp";
+diff --git a/lib/AnyDBM_File.t b/lib/AnyDBM_File.t
+index 22f262b..f4e2833 100644
+--- a/lib/AnyDBM_File.t
++++ b/lib/AnyDBM_File.t
+@@ -14,7 +14,8 @@ use Fcntl;
+ 
+ $Is_Dosish = ($^O eq 'amigaos' || $^O eq 'MSWin32' ||
+ 	      $^O eq 'os2' ||
+-	      $^O eq 'cygwin');
++	      $^O eq 'cygwin' ||
++	      $^O eq 'msys');
+ 
+ my $filename = "Any_dbmx$$";
+ unlink <"$filename*">;
+diff --git a/lib/ExtUtils/t/Embed.t b/lib/ExtUtils/t/Embed.t
+index 51c3ef2..70ebd0c 100644
+--- a/lib/ExtUtils/t/Embed.t
++++ b/lib/ExtUtils/t/Embed.t
+@@ -117,7 +117,7 @@ if ($^O eq 'VMS') {
+         s!-bE:(\S+)!-bE:$perl_exp!;
+     }
+    }
+-   elsif ($^O eq 'cygwin') { # Cygwin needs no special treatment like below
++   elsif ($^O eq 'cygwin' or $^O eq 'msys') { # Cygwin needs no special treatment like below
+        ;
+    }
+    elsif ($Config{'libperl'} !~ /\Alibperl\./) {
+@@ -160,7 +160,7 @@ unlink($exe,"embed_test.c",$obj);
+ unlink("$exe.manifest") if $cl and $Config{'ccversion'} =~ /^(\d+)/ and $1 >= 14;
+ unlink("$exe$Config{exe_ext}") if $skip_exe;
+ unlink("embed_test.map","embed_test.lis") if $^O eq 'VMS';
+-unlink(glob("./*.dll")) if $^O eq 'cygwin';
++unlink(glob("./*.dll")) if ($^O eq 'cygwin' or $^O eq 'msys');
+ unlink($testlib)	       if $libperl_copied;
+ 
+ # gcc -g -I.. -L../ -o perl_test perl_test.c -lperl `../perl -I../lib -MExtUtils::Embed -I../ -e ccflags -e ldopts`
+diff --git a/lib/File/Compare.t b/lib/File/Compare.t
+index 640b181..9bb2bb2 100644
+--- a/lib/File/Compare.t
++++ b/lib/File/Compare.t
+@@ -105,7 +105,7 @@ SKIP: {
+     TODO: {
+         my $why = "spaces after filename silently truncated";
+         my $how_many = 1;
+-        my $condition = ($^O eq "cygwin") or ($^O eq "vos");
++        my $condition = ($^O eq "cygwin") or ($^O eq "msys") or ($^O eq "vos");
+         todo_skip $why, $how_many if $condition;
+         is($donetests[2], 0, "file/fileCR [$donetests[2]]");
+     }
+diff --git a/lib/File/Copy.t b/lib/File/Copy.t
+index 57b86c1..d45e450 100644
+--- a/lib/File/Copy.t
++++ b/lib/File/Copy.t
+@@ -181,7 +181,7 @@ for my $cross_partition_test (0..1) {
+ 
+   SKIP: {
+     skip "Testing hard links", 3 
+-         if !$Config{d_link} or $^O eq 'MSWin32' or $^O eq 'cygwin';
++         if !$Config{d_link} or $^O eq 'MSWin32' or $^O eq 'cygwin' or $^O eq 'msys';
+ 
+     open(F, ">", "file-$$") or die $!;
+     print F "dummy content\n";
+diff --git a/lib/Net/hostent.t b/lib/Net/hostent.t
+index 3ee1980..4f0f44b 100644
+--- a/lib/Net/hostent.t
++++ b/lib/Net/hostent.t
+@@ -65,7 +65,7 @@ ok(defined $i, 'gethost on capture variable');
+ 
+ SKIP: {
+     skip "Windows will return the machine name instead of 'localhost'", 2
+-      if $^O eq 'MSWin32' or $^O eq 'cygwin';
++      if $^O eq 'MSWin32' or $^O eq 'cygwin' or $^O eq 'msys';
+ 
+     print "# name = " . $h->name . ", aliases = " . join (",", @{$h->aliases}) . "\n";
+ 
+diff --git a/lib/User/grent.t b/lib/User/grent.t
+index 8f34762..54f93c3 100644
+--- a/lib/User/grent.t
++++ b/lib/User/grent.t
+@@ -18,7 +18,7 @@ BEGIN {
+ }
+ 
+ BEGIN {
+-    our $gid = $^O ne 'cygwin' ? 0 : 18;
++    our $gid = ($^O ne 'cygwin' || $^O ne 'msys') ? 0 : 18;
+     our @grent = getgrgid $gid; # This is the function getgrgid.
+     unless (@grent) { plan skip_all => "no gid 0"; }
+ }
+diff --git a/lib/User/pwent.t b/lib/User/pwent.t
+index f93836f..369ce60 100644
+--- a/lib/User/pwent.t
++++ b/lib/User/pwent.t
+@@ -21,7 +21,7 @@ BEGIN {
+     # On VMS getpwuid(0) may return [$gid,0] UIC info (which may not exist).
+     # It is better to use the $< uid for testing on VMS instead.
+     if ( $^O eq 'VMS' ) { $uid = $< ; }
+-    if ( $^O eq 'cygwin' ) { $uid = 500 ; }
++    if ( $^O eq 'cygwin' or $^O eq 'msys' ) { $uid = 500 ; }
+     our @pwent = getpwuid $uid; # This is the function getpwuid.
+     unless (@pwent) { print "1..0 # Skip: no uid $uid\n"; exit 0 }
+ }
+@@ -35,7 +35,7 @@ print "ok 1\n";
+ my $pwent = getpwuid $uid; # This is the OO getpwuid.
+ 
+ my $uid_expect = $uid;
+-if ( $^O eq 'cygwin' ) {
++if ( $^O eq 'cygwin' or $^O eq 'msys' ) {
+     print "not " unless (   $pwent->uid == $uid_expect
+                          || $pwent->uid == 500         );  # go figure
+ }
+diff --git a/lib/locale.t b/lib/locale.t
+index 9aa8e1d..d88a81e 100644
+--- a/lib/locale.t
++++ b/lib/locale.t
+@@ -93,7 +93,7 @@ my %known_bad_locales = (
+ 
+ # cygwin isn't returning proper radix length in this locale, but supposedly to
+ # be fixed in later versions.
+-if ($os eq 'cygwin' && version->new(($Config{osvers} =~ /^(\d+(?:\.\d+)+)/)[0]) le v2.4.1) {
++if (($^O eq 'cygwin' or $^O eq 'msys') && version->new(($Config{osvers} =~ /^(\d+(?:\.\d+)+)/)[0]) le v2.4.1) {
+     $known_bad_locales{'cygwin'} = qr/ ^ ps_AF /ix;
+ }
+ 
+diff --git a/lib/perl5db.pl b/lib/perl5db.pl
+index 64f7fcb..cd6f6dd 100644
+--- a/lib/perl5db.pl
++++ b/lib/perl5db.pl
+@@ -1533,7 +1533,7 @@ We then determine what the console should be on various systems:
+ 
+ =cut
+ 
+-    if ( $^O eq 'cygwin' ) {
++    if ( $^O eq 'cygwin' or $^O eq 'msys' ) {
+ 
+         # /dev/tty is binary. use stdin for textmode
+         undef $console;
+diff --git a/regen/regen_lib.pl b/regen/regen_lib.pl
+index 0eb5654..77ff511 100644
+--- a/regen/regen_lib.pl
++++ b/regen/regen_lib.pl
+@@ -7,7 +7,7 @@ use Text::Wrap();
+ 
+ # Common functions needed by the regen scripts
+ 
+-our $Needs_Write = $^O eq 'cygwin' || $^O eq 'os2' || $^O eq 'MSWin32';
++our $Needs_Write = $^O eq 'cygwin' || $^O eq 'msys' || $^O eq 'os2' || $^O eq 'MSWin32';
+ 
+ our $Verbose = 0;
+ @ARGV = grep { not($_ eq '-q' and $Verbose = -1) }
+diff --git a/t/io/eintr.t b/t/io/eintr.t
+index 26a4636..fa6a943 100644
+--- a/t/io/eintr.t
++++ b/t/io/eintr.t
+@@ -50,7 +50,7 @@ if (exists $ENV{PERLIO} && $ENV{PERLIO} =~ /stdio/  ) {
+ # platforms
+ 
+ my ($osmajmin) = $Config{osvers} =~ /^(\d+\.\d+)/;
+-if ($^O eq 'VMS' || $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O =~ /freebsd/ || $^O eq 'midnightbsd' ||
++if ($^O eq 'VMS' || $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys' || $^O =~ /freebsd/ || $^O eq 'midnightbsd' ||
+      ($^O eq 'solaris' && $Config{osvers} eq '2.8') || $^O eq 'nto' ||
+      ($^O eq 'darwin' && $osmajmin < 9) ||
+     ((int($]*1000) & 1) == 0)
 diff --git a/t/io/fs.t b/t/io/fs.t
 index 9cda3e9..243cb38 100644
 --- a/t/io/fs.t
 +++ b/t/io/fs.t
+@@ -39,7 +39,7 @@ my $accurate_timestamps =
+     !($^O eq 'MSWin32' ||
+       $^O eq 'os2'     ||
+       $^O eq 'cygwin'  || $^O eq 'amigaos' ||
+-	  $wd =~ m#$Config{afsroot}/#
++      $^O eq 'msys'    || $wd =~ m#$Config{afsroot}/#
+      );
+ 
+ if (defined &Win32::IsWinNT && Win32::IsWinNT()) {
 @@ -59,7 +59,7 @@ my $needs_fh_reopen =
  $needs_fh_reopen = 1 if (defined &Win32::IsWin95 && Win32::IsWin95());
  
  my $skip_mode_checks =
 -    $^O eq 'cygwin' && $ENV{CYGWIN} !~ /ntsec/;
-+    $^O eq 'cygwin' && $ENV{MSYS} !~ /ntsec/;
++    $^O eq 'msys' && $ENV{MSYS} !~ /ntsec/;
  
  plan tests => 61;
  
@@ -289,14 +1946,45 @@ index 2affbac..630de14 100644
  
      SKIP: {
 -        skip('chown() not implemented on Win32', 2) if $^O eq 'MSWin32';
-+        skip('chown() not implemented on Win32', 2) if $^O eq 'MSWin32' or $^O eq 'cygwin';
++        skip('chown() not implemented on Win32', 2) if $^O eq 'MSWin32' or $^O eq 'msys';
          ok (!eval { chown 0, 0, $pvbm }, 'chown(PVBM) fails');
          ok (!eval { chown 0, 0, \$pvbm }, 'chown(PVBM ref) fails');
      }
+diff --git a/t/io/tell.t b/t/io/tell.t
+index 3e15663..ba38575 100644
+--- a/t/io/tell.t
++++ b/t/io/tell.t
+@@ -11,7 +11,7 @@ plan(36);
+ $TST = 'TST';
+ 
+ $Is_Dosish = ($^O eq 'MSWin32' or
+-              $^O eq 'os2' or $^O eq 'cygwin');
++              $^O eq 'os2' or $^O eq 'cygwin' or $^O eq 'msys');
+ 
+ open($TST, 'harness') || (die "Can't open harness");
+ binmode $TST if $Is_Dosish;
+@@ -159,7 +159,7 @@ if (tell ($tst) == 6) {
+   pass("check tell() after writing in mode '>>'");
+ }
+ else {
+-  if (($^O eq "cygwin") && (&PerlIO::get_layers($tst) eq 'stdio')) {
++  if (($^O eq "cygwin" || $^O eq "msys") && (&PerlIO::get_layers($tst) eq 'stdio')) {
+     fail "# TODO: file pointer not at eof";
+   }
+   elsif ($^O eq "vos") {
 diff --git a/t/lib/cygwin.t b/t/lib/cygwin.t
 index ba86170..0d316f3 100644
 --- a/t/lib/cygwin.t
 +++ b/t/lib/cygwin.t
+@@ -4,7 +4,7 @@ BEGIN {
+     chdir 't' if -d 't';
+     @INC = ('../lib');
+     require './test.pl';
+-    skip_all('cygwin specific test') unless $^O eq 'cygwin';
++    skip_all('cygwin specific test') unless ($^O eq 'cygwin' || $^O eq 'msys');
+ }
+ 
+ plan(tests => 16);
 @@ -41,7 +41,7 @@ chdir($pwd);
  is(Cygwin::win_to_posix_path($winpath, 1), "/", "win to absolute posix path");
  
@@ -306,31 +1994,125 @@ index ba86170..0d316f3 100644
  my $binmode = $1 =~ /binmode|binary/;
  is(Cygwin::is_binmount("/"),  $binmode ? 1 : '', "check / for binmount");
  
+diff --git a/t/lib/dbmt_common.pl b/t/lib/dbmt_common.pl
+index f8fbbb0..880a736 100644
+--- a/t/lib/dbmt_common.pl
++++ b/t/lib/dbmt_common.pl
+@@ -43,7 +43,7 @@ if (! -e $Dfile) {
+ }
+ SKIP: {
+     skip "different file permission semantics on $^O", 1
+-	if $^O eq 'amigaos' || $^O eq 'os2' || $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'vos';
++	if $^O eq 'amigaos' || $^O eq 'os2' || $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys' || $^O eq 'vos';
+     my ($dev,$ino,$mode,$nlink,$uid,$gid,$rdev,$size,$atime,$mtime,$ctime,
+ 	$blksize,$blocks) = stat($Dfile);
+     is($mode & 0777, 0640);
+diff --git a/t/op/groups.t b/t/op/groups.t
+index 65b5c05..8088885 100644
+--- a/t/op/groups.t
++++ b/t/op/groups.t
+@@ -310,7 +310,7 @@ sub darwin {
+ 
+ # Test if this is Cygwin
+ sub cygwin_nt {
+-    return $Config::Config{myuname} =~ /^cygwin_nt/i;
++    return $Config::Config{myuname} =~ /^msys_nt/i;
+ }
+ 
+ # Get perl's supplementary groups and the number of times each gid
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 2004a50..7d42494 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -52,7 +52,7 @@ use Config;
+ $Is_MSWin32  = $^O eq 'MSWin32';
+ $Is_VMS      = $^O eq 'VMS';
+ $Is_os2      = $^O eq 'os2';
+-$Is_Cygwin   = $^O eq 'cygwin';
++$Is_Cygwin   = ($^O eq 'cygwin' || $^O eq 'msys');
+ 
+ $PERL =
+    ($Is_VMS     ? $^X      :
 diff --git a/t/op/require_errors.t b/t/op/require_errors.t
 index 637457b..5aa250b 100644
 --- a/t/op/require_errors.t
 +++ b/t/op/require_errors.t
-@@ -173,6 +173,7 @@
+@@ -167,11 +167,12 @@ chmod 0333, $mod_file;
  
  SKIP: {
      skip_if_miniperl("these modules may not be available to miniperl", 2);
-+    skip "Can't test permissions meaningfully using MSYS2", 2 if $^O eq 'cygwin';
++    skip "Can't test permissions meaningfully using MSYS2", 2 if $^O eq 'msys';
  
      push @INC, '../lib';
      require Cwd;
+     require File::Spec::Functions;
+-    if ($^O eq 'cygwin') {
++    if ($^O eq 'cygwin' or $^O eq 'msys') {
+         require Win32;
+     }
+ 
+diff --git a/t/op/sigdispatch.t b/t/op/sigdispatch.t
+index 242fb8e..df6c933 100644
+--- a/t/op/sigdispatch.t
++++ b/t/op/sigdispatch.t
+@@ -44,7 +44,7 @@ SKIP: {
+     skip('We can\'t test blocking without sigprocmask', 17)
+ 	if is_miniperl() || !$Config{d_sigprocmask};
+     skip("This doesn\'t work on $^O threaded builds RT#88814", 17)
+-        if ($^O =~ /cygwin/ && $Config{useithreads});
++        if ($^O =~ /cygwin|msys/ && $Config{useithreads});
+     skip("This doesn\'t work on $^O version $Config{osvers} RT#88814", 17)
+         if ($^O eq "openbsd" && $Config{osvers} < 5.2);
+ 
+@@ -60,7 +60,7 @@ SKIP: {
+     kill 'SIGUSR1', $$;
+     is $gotit, 0, 'Haven\'t received third signal yet';
+ 
+-    diag "2nd sigpending crashes on cygwin" if $^O eq 'cygwin';
++    diag "2nd sigpending crashes on cygwin" if ($^O eq 'cygwin' or $^O eq 'msys');
+     is POSIX::sigpending($pending), '0 but true', 'sigpending';
+     is $pending->ismember(&POSIX::SIGUSR1), 1, 'SIGUSR1 is pending';
+     
+@@ -118,7 +118,7 @@ TODO:
+ 
+ SKIP: {
+     skip("alarm cannot interrupt blocking system calls on $^O", 2)
+-	if $^O =~ /MSWin32|cygwin|VMS/;
++	if $^O =~ /MSWin32|cygwin|msys|VMS/;
+     # RT #88774
+     # make sure the signal handler's called in an eval block *before*
+     # the eval is popped
 diff --git a/t/op/stat.t b/t/op/stat.t
 index b391dd0..03c5484 100644
 --- a/t/op/stat.t
 +++ b/t/op/stat.t
+@@ -37,7 +37,7 @@ $ENV{LC_ALL}   = 'C';		# Forge English error messages.
+ $ENV{LANGUAGE} = 'C';		# Ditto in GNU.
+ 
+ my $Is_Amiga   = $^O eq 'amigaos';
+-my $Is_Cygwin  = $^O eq 'cygwin';
++my $Is_Cygwin  = ($^O eq 'cygwin' || $^O eq 'msys');
+ my $Is_Darwin  = $^O eq 'darwin';
+ my $Is_MSWin32 = $^O eq 'MSWin32';
+ my $Is_OS2     = $^O eq 'os2';
 @@ -47,7 +47,7 @@ my $Is_MPRAS   = $^O =~ /svr4/ && -f '/etc/.relid';
  my $Is_Android = $^O =~ /android/;
  my $Is_Dfly    = $^O eq 'dragonfly';
  
 -my $Is_Dosish  = $Is_OS2 || $Is_MSWin32;
-+my $Is_Dosish  = $Is_OS2 || $Is_MSWin32 || $^O eq 'cygwin';
++my $Is_Dosish  = $Is_OS2 || $Is_MSWin32 || $^O eq 'msys';
  
  my $ufs_no_ctime = ($Is_Dfly || $Is_Darwin) && (() = `df -t ufs . 2>/dev/null`) == 2;
  
+@@ -127,7 +127,7 @@ SKIP: {
+     SKIP: {
+         skip "No link count", 1 if $Config{dont_use_nlink};
+         skip "Cygwin9X fakes hard links by copying", 1
+-          if $Config{myuname} =~ /^cygwin_(?:9\d|me)\b/i;
++          if $Config{myuname} =~ /^msys_(?:9\d|me)\b/i;
+ 
+         is($nlink, 2,     'Link count on hard linked file' );
+     }
 @@ -193,7 +193,7 @@ ok(-s $tmpfile,     '   and -s');
  ok( chmod(0000, $tmpfile),     'chmod 0000' );
  
@@ -346,10 +2128,36 @@ index b391dd0..03c5484 100644
  	skip "Readable by group/other means readable by me on $^O", 1 if $^O eq 'VMS'
 -          or ($^O =~ /^(cygwin|MSWin32|msys)$/ and Win32::IsAdminUser());
 +          or ($^O =~ /^(cygwin|MSWin32)$/ and Win32::IsAdminUser());
-+	skip "Unix permissions are meaningless with MSYS2", 1 if $^O eq 'cygwin';
++	skip "Unix permissions are meaningless with MSYS2", 1 if $^O eq 'msys';
  	lstat($tmpfile);
  	-T _;
  	ok(eval { lstat _ },
+diff --git a/t/op/taint.t b/t/op/taint.t
+index f4f06f7..7cba8ca 100644
+--- a/t/op/taint.t
++++ b/t/op/taint.t
+@@ -52,7 +52,7 @@ BEGIN {
+ 
+ my $Is_VMS      = $^O eq 'VMS';
+ my $Is_MSWin32  = $^O eq 'MSWin32';
+-my $Is_Cygwin   = $^O eq 'cygwin';
++my $Is_Cygwin   = ($^O eq 'cygwin' || $^O eq 'msys');
+ my $Is_OpenBSD  = $^O eq 'openbsd';
+ my $Is_MirBSD   = $^O eq 'mirbsd';
+ my $Invoke_Perl = $Is_VMS      ? 'MCR Sys$Disk:[]Perl.exe' :
+diff --git a/t/op/time.t b/t/op/time.t
+index 9fdc7b8..da593a1 100644
+--- a/t/op/time.t
++++ b/t/op/time.t
+@@ -50,7 +50,7 @@ ok(localtime() =~ /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat)[ ]
+ SKIP: {
+     # This conditional of "No tzset()" is stolen from ext/POSIX/t/time.t
+     skip "No tzset()", 1
+-        if $^O eq "VMS" || $^O eq "cygwin" ||
++        if $^O eq "VMS" || $^O eq "cygwin" || $^O eq "msys" ||
+            $^O eq "MSWin32" ||
+            $^O eq "interix";
+ 
 diff --git a/t/porting/exec-bit.t b/t/porting/exec-bit.t
 index 3e80f84..38174a4 100644
 --- a/t/porting/exec-bit.t
@@ -359,9 +2167,22 @@ index 3e80f84..38174a4 100644
  
  require './test.pl';
 -if ( $^O eq "MSWin32" ) {
-+if ( $^O eq "MSWin32" or $^O eq 'cygwin' ) {
++if ( $^O eq "MSWin32" or $^O eq 'msys' ) {
    skip_all( "-x on MSWin32 only indicates file has executable suffix. Try Cygwin?" );
  }
+ 
+diff --git a/t/porting/extrefs.t b/t/porting/extrefs.t
+index d898b49..3f7eeb4 100644
+--- a/t/porting/extrefs.t
++++ b/t/porting/extrefs.t
+@@ -48,7 +48,7 @@ CODE
+ sub try_compile_and_link {
+     my ($c, %args) = @_;
+ 
+-    my $ld_exeext = ($^O eq 'cygwin' || $^O eq 'MSWin32' ||
++    my $ld_exeext = ($^O eq 'cygwin' || $^O eq 'msys' || $^O eq 'MSWin32' ||
+                  $^O eq 'os2' && $Config{ldflags} =~ /-Zexe\b/) ? '.exe' :
+                 (($^O eq 'vos') ? $Config{exe_ext} : '');
  
 diff --git a/t/porting/globvar.t b/t/porting/globvar.t
 index 3e6d630..b4a9941 100644
@@ -376,6 +2197,32 @@ index 3e6d630..b4a9941 100644
       );
  
  $skip{PL_hash_rand_bits}= $skip{PL_hash_rand_bits_enabled}= 1; # we can be compiled without these, so skip testing them
+diff --git a/t/run/locale.t b/t/run/locale.t
+index 202f355..981b9e4 100644
+--- a/t/run/locale.t
++++ b/t/run/locale.t
+@@ -85,7 +85,7 @@ if ($non_C_locale) {
+ 
+     # Skip this locale on these cygwin versions as the returned radix character
+     # length is wrong
+-    if (   $^O eq 'cygwin'
++    if (($^O eq 'cygwin' || $^O eq 'msys')
+         && version->new(($Config{'osvers'} =~ /^(\d+(?:\.\d+)+)/)[0]) le v2.4.1)
+     {
+         @test_numeric_locales = grep { $_ !~ m/ps_AF/i } @test_numeric_locales;
+diff --git a/t/test.pl b/t/test.pl
+index d92f28f..d81c4bf 100644
+--- a/t/test.pl
++++ b/t/test.pl
+@@ -630,7 +630,7 @@ USE_OK
+ 
+ my $is_mswin    = $^O eq 'MSWin32';
+ my $is_vms      = $^O eq 'VMS';
+-my $is_cygwin   = $^O eq 'cygwin';
++my $is_cygwin   = ($^O eq 'cygwin' || $^O eq 'msys');
+ 
+ sub _quote_args {
+     my ($runperl, $args) = @_;
 diff --git a/utils/perlbug.PL b/utils/perlbug.PL
 index 4715e9d..5da0af0 100644
 --- a/utils/perlbug.PL
@@ -394,43 +2241,23 @@ index 4715e9d..5da0af0 100644
          qw(PATH LD_LIBRARY_PATH LANG PERL_BADLANG SHELL HOME LOGDIR LANGUAGE);
      push @env, $Config{ldlibpthname} if $Config{ldlibpthname} ne '';
 -    push @env, grep /^(?:PERL|LC_|LANG|CYGWIN)/, keys %ENV;
-+    push @env, grep /^(?:PERL|LC_|LANG|CYGWIN|MSYS)/, keys %ENV;
++    push @env, grep /^(?:PERL|LC_|LANG|MSYS)/, keys %ENV;
      my %env;
      @env{@env} = @env;
      for my $env (sort keys %env) {
---- perl-5.38.2/hints/cygwin.sh.orig	2025-02-02 21:15:37.363852600 +0100
-+++ perl-5.38.2/hints/cygwin.sh	2025-02-02 21:15:58.250835500 +0100
-@@ -27,7 +27,7 @@
- libswanted=`echo " $libswanted " | sed -e 's/ util / /g'`
- ignore_versioned_solibs='y'
- usenm='no'
--libc='/usr/lib/libcygwin.a'
-+libc='/usr/lib/libmsys-2.0.a'
- loclibpth=' '
- glibpth=' '
- plibpth=' '
-@@ -38,9 +38,9 @@
- test -z "$optimize" && optimize='-O3'
- man3ext='3pm'
- test -z "$use64bitint" && use64bitint='define'
--test -z "$useithreads" && useithreads='define'
-+test -z "$usethreads" && usethreads='define'
- test -z "$usemymalloc" && usemymalloc='undef'
--ccflags="$ccflags -U__STRICT_ANSI__ -D_GNU_SOURCE"
-+ccflags="$ccflags -DPERL_USE_SAFE_PUTENV -U__STRICT_ANSI__ -D_GNU_SOURCE"
- # - otherwise i686-cygwin
- archname='cygwin'
+diff --git a/win32/FindExt.pm b/win32/FindExt.pm
+index 4d46821..210047e 100644
+--- a/win32/FindExt.pm
++++ b/win32/FindExt.pm
+@@ -24,7 +24,7 @@ sub apply_config {
+       unless ($config->{i_dbm} || $config->{i_rpcsvcdbm}) && !$config->{d_cplusplus};
+     push @no, "Amiga.*" unless $^O eq "amigaos";
+     push @no, "VMS.*" unless $^O eq "VMS";
+-    push @no, "Win32.*" unless $^O eq "MSWin32" || $^O eq "cygwin";
++    push @no, "Win32.*" unless $^O eq "MSWin32" || $^O eq "cygwin" || $^O eq "msys";
  
-@@ -96,12 +96,3 @@
- #ldflags="$ldflags -s"
- #ccdlflags="$ccdlflags -s"
- #lddlflags="$lddlflags -s"
--
--# Seems that exporting _Thread_local doesn't work on cygwin. This 6 year old
--# gcc bug suggests that maybe the problem really is binutils, but either way
--# it still doesn't work, despite our probes looking good:
--# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64697
--d_thread_local=undef
--
--# Broken: https://sourceware.org/pipermail/cygwin/2022-August/252043.html */
--d_newlocale=undef
+     $no = join('|', @no);
+     $no = qr/^(?:$no)$/i;
+-- 
+2.37.1
+

--- a/perl/PKGBUILD
+++ b/perl/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=perl
 pkgname=('perl' 'perl-doc' 'perl-devel')
 pkgver=5.38.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A highly capable, feature-rich programming language"
 arch=(i686 x86_64)
 license=('GPL')
@@ -34,7 +34,7 @@ sha256sums=('f6777e856b22460e8091f9524593e93299f421cc23dbd408d3f5ed3328d357a7'
             'a074ce00dabd7876293cf0fa8c8be26029992f51873e33cd2213b6acf60cafbb'
             '1bf02b601f670cc1c8f65e63ec7a10578f92c8ecd8a5752fe331479bd6115311'
             'e05e20b29c950555edfa246d2b9177188a4b265d1887c262f5b272f382696474'
-            '4214c4f429958334837881c508b4d1c41cdd36f50f2e38458346dfa1fe05ae63'
+            '3ec217cb7f47c34a79addb9396d522596495584aaf6b24b17c6caf6a16d2cb62'
             '4c44801139321e77a3ade921ce93b114100346ad5b17d03a67b2a92b85ee8a27')
 
 prepare() {
@@ -64,7 +64,6 @@ _EOF
 build() {
   cd ${srcdir}/${pkgname}-${pkgver}
 
-  export MSYSTEM=CYGWIN
   ./Configure -des -Dusethreads \
     -Doptimize="${CFLAGS}" \
     -Dprefix=/usr \
@@ -80,8 +79,8 @@ build() {
     -Dvendorscript=/usr/bin/vendor_perl \
     -Dinc_version_list=none \
     -Dman1ext=1perl -Dman3ext=3perl \
-    -Darchname=${ARCH}-cygwin-threads \
-    -Dmyarchname=${ARCH}-cygwin \
+    -Darchname=${ARCH}-msys-threads \
+    -Dmyarchname=${ARCH}-msys \
     -Dlibperl=msys-perl"$(echo "${pkgver%.[0-9]*}" | tr . _)".dll \
     -Dcc=gcc -Dld=g++ \
     -Accflags="$CFLAGS -fwrapv"


### PR DESCRIPTION
To fix building mingw-w64-qt5-base (https://github.com/msys2/MINGW-packages/pull/23884) and mingw-w64-qt5-static (https://github.com/msys2/MINGW-packages/issues/23792).