### PR TITLE
cygutils: update to 1.4.17.4

### DIFF
--- a/cygutils/PKGBUILD
+++ b/cygutils/PKGBUILD
@@ -1,8 +1,11 @@
 # Maintainer: Jeremy Drake <github@jdrake.com>
 
 pkgname=cygutils
-pkgver=1.4.17
-pkgrel=2
+# it sucks, but upstream adds features in packaging patches, so treat
+# their -4 as a .4 so we can have our own pkgrel
+pkgver=1.4.17.4
+_realpkgver=${pkgver%.*}
+pkgrel=1
 pkgdesc="${pkgname} is a collection of simple utilities"
 arch=('i686' 'x86_64')
 url="https://cygwin.org/"
@@ -18,11 +21,18 @@ conflicts=('winln')
 replaces=('winln')
 provides=('winln')
 _commit='a804501b8c33c55a45a87b6e505b4e5db41e4f2f'
-source=("${pkgname}-${pkgver}::git+https://sourceware.org/git/cygwin-apps/${pkgname}.git#commit=${_commit}")
-sha256sums=('SKIP')
+source=("${pkgname}-${_realpkgver}::git+https://sourceware.org/git/cygwin-apps/${pkgname}.git#commit=${_commit}"
+        "cygutils-1.4.17-4.src.patch"
+        "lssparse-support-check.patch")
+sha256sums=('35ad70ebebd40cafc1bf7a87d308ad658e48f65462bf641241d75f95edd50abd'
+            '07d8184f5ed63c085450f9e27ca4a7d2e86d9ef7a6a23a2da20fe120f163668b'
+            '6170756c292a606fcf1876a2bd57ecb72262e4c1062132874be623d8de9233af')
 
 prepare(){
-  cd ${pkgname}-${pkgver}
+  cd ${pkgname}-${_realpkgver}
+
+  patch -Nbp1 -i "${srcdir}/cygutils-1.4.17-4.src.patch"
+  patch -Nbp1 -i "${srcdir}/lssparse-support-check.patch"
 
   autoreconf -fi
 }
@@ -35,7 +45,7 @@ build() {
 
   export MSYSTEM=CYGWIN
   local CYGWIN_CHOST="${CHOST/-msys/-cygwin}"
-  ../${pkgname}-${pkgver}/configure \
+  ../${pkgname}-${_realpkgver}/configure \
     --prefix=/usr \
     --build=${CYGWIN_CHOST} \
     --host=${CYGWIN_CHOST} \
@@ -48,5 +58,5 @@ package() {
   cd "${srcdir}/build-${CHOST}"
   make DESTDIR="${pkgdir}" install
 
-  install -Dm644 "${srcdir}/${pkgname}-${pkgver}/COPYING" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 "${srcdir}/${pkgname}-${_realpkgver}/COPYING" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/cygutils/cygutils-1.4.17-4.src.patch
+++ b/cygutils/cygutils-1.4.17-4.src.patch
@@ -1,0 +1,308 @@
+diff --git a/ChangeLog b/ChangeLog
+index 0a1709c..53dd562 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,21 @@
++2025-04-24  Mark Geisert  <mark@maxrnd.com>  (1.4.17-4)
++
++	* src/cygstart/cygstart.c: Fix len arg of mbstowcs. Thanks to user
++	  ggl329@gmail.com for the report and Christian Franke for the
++	  diagnosis and discussion.
++
++2025-04-05  Mark Geisert  <mark@maxrnd.com>  (1.4.17-3)
++
++	* src/lssparse/lssparse.c: Fix hole display glitch. Updated source
++	  provided by Roland Mainz.
++
++2025-04-01  Mark Geisert  <mark@maxrnd.com>  (1.4.17-2)
++
++	* src/lssparse/*: Add new tool contributed by Roland Mainz.
++	* src/configure.ac: Ditto.
++	* src/Makefile.am: Ditto.
++	* cygutils.cygport: Ditto. Also add CXXFLAGS+=" -std=gnu++03".
++
+ 2022-01-28  Mark Geisert  <mark@maxrnd.com>
+ 
+ 	Release 1.4.17
+diff --git a/Makefile.am b/Makefile.am
+index 79eb2b1..ef9b8a2 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -34,6 +34,7 @@ endif
+ 
+ bin_PROGRAMS = $(windows_progs) src/conv/conv \
+ 	src/dump/dump $(ipc_progs) \
++	src/lssparse/lssparse \
+ 	$(cygwin_specific_progs)
+ 
+ bin_SCRIPTS = $(ipc_scripts)
+diff --git a/NEWS b/NEWS
+index 3b42b62..c3326af 100644
+--- a/NEWS
++++ b/NEWS
+@@ -1,5 +1,6 @@
+ 1.4.17
+   * More bug fixes to getclip and putclip.
++  * New tool lssparse contributed by Roland Mainz.
+ 
+ 1.4.16
+   * Unicode support added to mkshortcut and readshortcut by Thomas Wolff.
+diff --git a/src/cygstart/cygstart.c b/src/cygstart/cygstart.c
+index 7e5bf3a..cfb2084 100644
+--- a/src/cygstart/cygstart.c
++++ b/src/cygstart/cygstart.c
+@@ -560,8 +560,7 @@ cygstart_mbs_to_wcs (const char *mbs_path, wchar_t **wcs_path)
+       goto err_cleanup;
+     }
+ 
+-  if (mbstowcs (*wcs_path, mbs_path, (len + 1) * sizeof (wchar_t)) ==
+-      (size_t) - 1)
++  if ((mbstowcs (*wcs_path, mbs_path, len)) == (size_t) - 1)
+     {
+       fprintf (stderr, "%s: error converting path `%s' to unicode: %s\n",
+                program_name, mbs_path, strerror (errno));
+diff --git a/src/lssparse/lssparse.c b/src/lssparse/lssparse.c
+new file mode 100644
+index 0000000..9c64d1b
+--- /dev/null
++++ b/src/lssparse/lssparse.c
+@@ -0,0 +1,239 @@
++/*
++ * MIT License
++ *
++ * Copyright (c) 2011-2025 Roland Mainz <roland.mainz@nrubsig.org>
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to deal
++ * in the Software without restriction, including without limitation the rights
++ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++ * copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++
++/*
++ * lssparse.c - print sparse file hole+data layout information
++ *
++ * Written by Roland Mainz <roland.mainz@nrubsig.org>
++ */
++
++#include <stdio.h>
++#include <stdlib.h>
++#include <stdbool.h>
++#include <string.h>
++#include <fcntl.h>
++#include <unistd.h>
++#include <errno.h>
++
++#define EXIT_USAGE (2)
++
++static
++void usage(const char *progname)
++{
++    (void)fprintf(stderr, "Usage: %s [-h] [-xdH] <sparse_file>\n"
++        "  -h: Display this help message\n"
++        "  -x: Print offsets in hexadecimal (base 16)\n"
++        "  -d: Print offsets in decimal (base 10)\n"
++        "  -H: Print hole information\n",
++        progname);
++}
++
++typedef enum _printbase {
++    pb_hex = 1,
++    pb_dec = 2
++} printbase;
++
++int main(int argc, char *argv[])
++{
++    /* Arguments */
++    const char *progname = argv[0];
++    printbase pb = pb_hex;
++    bool print_holes = false;
++    const char *filename;
++
++    int retval;
++    int opt;
++    int fd;
++
++    size_t i;
++    off_t offset = 0;
++    off_t data_start;
++    off_t hole_start;
++    off_t hole_end;
++    off_t file_size;
++    off_t data_len;
++    off_t hole_len;
++
++    while ((opt = getopt(argc, argv, "hxdH")) != -1) {
++        switch (opt) {
++            case '?':
++            case 'h':
++                usage(progname);
++                return EXIT_USAGE;
++            case 'x':
++                pb = pb_hex;
++                break;
++            case 'd':
++                pb = pb_dec;
++                break;
++            case 'H':
++                print_holes = true;
++                break;
++            default:
++                break;
++        }
++    }
++
++    if (optind >= argc) {
++        usage(progname);
++        return EXIT_USAGE;
++    }
++
++    filename = argv[optind];
++
++    fd = open(filename, O_RDONLY);
++    if (fd == -1) {
++        (void)fprintf(stderr, "%s: Open file failed with [%s]\n",
++            progname,
++            strerror(errno));
++        return EXIT_FAILURE;
++    }
++
++    /* Get file size */
++    file_size = lseek(fd, 0, SEEK_END);
++    if (file_size == -1) {
++        (void)fprintf(stderr, "%s: Cannot seek [%s]\n",
++            progname,
++            strerror(errno));
++        return EXIT_FAILURE;
++    }
++    (void)lseek(fd, 0, SEEK_SET);
++
++
++    /*
++     * Loop over hole&&data sections
++     *
++     * This loop must handle:
++     * - normal files with no holes
++     * - sparse files which start with data
++     * - sparse files which start with a hole
++     * - sparse files with multiple holes
++     * - sparse files which end with data
++     * - sparse files which end with a hole
++     *
++     * Note we start with index |1| for compatibility
++     * with SUN's original sparse file debuggung tools
++     * and Win32's
++     * $ /cygdrive/c/Windows/system32/fsutil sparse queryrange ... #
++     * output
++     */
++#define LSSPARSE_START_INDEX 1
++    for (i=LSSPARSE_START_INDEX ;;) {
++        data_start = lseek(fd, offset, SEEK_DATA);
++        if (data_start == -1)
++            break;
++        hole_start = lseek(fd, data_start, SEEK_HOLE);
++
++        if (hole_start == -1) {
++            if (errno == ENXIO) {
++                /* No more holes ? Use file site as pos of next hole */
++                hole_start = file_size;
++            } else {
++                (void)fprintf(stderr,
++                    "%s: lseek(..., SEEK_HOLE, ...) failed with [%s]\n",
++                    progname,
++                    strerror(errno));
++                    retval = EXIT_FAILURE;
++                goto done;
++            }
++        }
++
++        if (print_holes &&
++            (i == LSSPARSE_START_INDEX) && (data_start > 0)) {
++            (void)printf((pb == pb_hex)?
++                "Hole range[%ld]: offset=0x%llx,\tlength=0x%llx\n":
++                "Hole range[%ld]: offset=%lld,\tlength=%lld\n",
++                (long)i,
++                (long long)0,
++                (long long)data_start);
++            i++;
++        }
++
++        data_len = hole_start - data_start;
++
++        (void)printf((pb == pb_hex)?
++            "Data range[%ld]: offset=0x%llx,\tlength=0x%llx\n":
++            "Data range[%ld]: offset=%lld,\tlength=%lld\n",
++            (long)i,
++            (long long)data_start,
++            (long long)data_len);
++        i++;
++
++        hole_end = lseek(fd, hole_start, SEEK_DATA);
++
++        if (hole_end == -1) {
++            if (errno == ENXIO) {
++                /* No more holes ? */
++                hole_end = file_size;
++            } else {
++                (void)fprintf(stderr,
++                    "%s: lseek(..., SEEK_DATA, ...) failed with [%s]\n",
++                    progname,
++                    strerror(errno));
++                retval = EXIT_FAILURE;
++                goto done;
++            }
++        }
++
++        hole_len = hole_end - hole_start;
++
++        if (print_holes && (hole_len > 0LL)) {
++            (void)printf((pb == pb_hex)?
++                "Hole range[%ld]: offset=0x%llx,\tlength=0x%llx\n":
++                "Hole range[%ld]: offset=%lld,\tlength=%lld\n",
++                (long)i,
++                (long long)hole_start,
++                (long long)hole_len);
++            i++;
++        }
++
++        offset = hole_end;
++    }
++
++    if ((data_start == -1) && (errno == ENXIO) && (offset == 0)) {
++        if (print_holes) {
++            (void)printf((pb == pb_hex)?
++                "Hole range[%ld]: offset=0x%llx,\tlength=0x%llx\n":
++                "Hole range[%ld]: offset=%lld,\tlength=%lld\n",
++                (long)LSSPARSE_START_INDEX,
++                (long long)0LL,
++                (long long)file_size);
++        }
++
++        retval = EXIT_SUCCESS;
++    } else if ((data_start == -1) && (errno != ENXIO)) {
++        (void)fprintf(stderr,
++            "%s: lseek(..., SEEK_DATA, ...) failed with [%s]\n",
++            progname,
++            strerror(errno));
++            retval = EXIT_FAILURE;
++    }
++    else {
++        retval = EXIT_SUCCESS;
++    }
++
++done:
++    (void)close(fd);
++    return retval;
++}

--- a/cygutils/lssparse-support-check.patch
+++ b/cygutils/lssparse-support-check.patch
@@ -1,0 +1,35 @@
+--- a/Makefile.am	2025-04-24 13:03:35.750405000 -0700
++++ b/Makefile.am	2025-04-24 13:24:52.995906000 -0700
+@@ -32,9 +32,13 @@
+ cygwin_specific_progs = src/cygdrop/cygdrop
+ endif
+ 
++if WITH_LSSPARSE
++lssparse_progs = src/lssparse/lssparse
++endif
++
+ bin_PROGRAMS = $(windows_progs) src/conv/conv \
+ 	src/dump/dump $(ipc_progs) \
+-	src/lssparse/lssparse \
++	$(lssparse_progs) \
+ 	$(cygwin_specific_progs)
+ 
+ bin_SCRIPTS = $(ipc_scripts)
+--- a/configure.ac
++++ b/configure.ac
+@@ -82,6 +82,7 @@ case "$host" in
+ *cygwin* ) AC_MSG_ERROR([At least cygwin-1.7 is required]) ;;
+ esac],dnl
+   [[#include <sys/cygwin.h>]])
++AC_CHECK_DECL([SEEK_HOLE],[],[],[[#include <unistd.h>]])
+ 
+ dnl Set Conditionals for Makefile.am
+ AM_CONDITIONAL(WITH_WINDOWS_PROGRAMS, test "$ac_cv_func_OpenClipboard" = yes)
+@@ -91,6 +92,7 @@ case "$host" in
+ *cygwin* ) host_is_cygwin=yes ;;
+ esac
+ AM_CONDITIONAL(WITH_CYGWIN_SPECIFIC_PROGRAMS, test "$host_is_cygwin" = yes)
++AM_CONDITIONAL(WITH_LSSPARSE, test "$ac_cv_have_decl_SEEK_HOLE" = yes)
+ 
+ AC_CONFIG_FILES([Makefile po/Makefile.in src/cygicons/cygicons.rc])
+ 


### PR DESCRIPTION
Corresponds to Cygwin's 1.4.17-4.

Additional patch to not build lssparse if SEEK_HOLE is not defined in unistd.h, as it is not on runtime versions < 3.6.

Fixes #5311