### PR TITLE
cross-gcc: Update to 15.1.0

### DIFF
--- a/mingw-w64-cross-gcc/0101-Cygwin-enable-libgccjit-not-just-for-MingW.patch
+++ b/mingw-w64-cross-gcc/0101-Cygwin-enable-libgccjit-not-just-for-MingW.patch
@@ -102,19 +102,6 @@ index 7e8e628b325..a688d4ae24a 100644
            ;;
          esac
  
-diff --git a/gcc/cp/Make-lang.in b/gcc/cp/Make-lang.in
-index 155be74efdb..b750114185c 100644
---- a/gcc/cp/Make-lang.in
-+++ b/gcc/cp/Make-lang.in
-@@ -286,7 +286,7 @@ c++.install-plugin: installdirs
- # Install import library.
- ifeq ($(plugin_implib),yes)
- 	$(mkinstalldirs) $(DESTDIR)$(plugin_resourcesdir)
--	$(INSTALL_DATA) cc1plus$(exeext).a $(DESTDIR)/$(plugin_resourcesdir)/cc1plus$(exeext).a
-+	$(INSTALL_DATA) cc1plus$(exeext).a $(DESTDIR)$(plugin_resourcesdir)/cc1plus$(exeext).a
- endif
- 
- c++.uninstall:
 diff --git a/gcc/jit/Make-lang.in b/gcc/jit/Make-lang.in
 index 2a774d7feb1..6bd882c5ddf 100644
 --- a/gcc/jit/Make-lang.in
@@ -162,22 +149,6 @@ index 2a774d7feb1..6bd882c5ddf 100644
  jit.install-common: installdirs jit.install-headers
  # Install import library
  	$(INSTALL_PROGRAM) $(LIBGCCJIT_IMPORT_LIB) \
-diff --git a/gcc/system.h b/gcc/system.h
-index b13e9429577..42ccb48e671 100644
---- a/gcc/system.h
-+++ b/gcc/system.h
-@@ -693,8 +693,9 @@ extern int vsnprintf (char *, size_t, const char *, va_list);
- # endif
- #endif
- 
--#if defined (ENABLE_PLUGIN) && defined (HAVE_DLFCN_H)
--/* If plugin support is enabled, we could use libdl.  */
-+#if defined (HAVE_DLFCN_H) && (defined (ENABLE_PLUGIN) || defined (__CYGWIN__))
-+/* If plugin support is enabled, we could use libdl.
-+   On Cygwin libdl is needed for libgccjit but no plugin support is available.  */
- #include <dlfcn.h>
- #endif
- 
 -- 
 2.39.0
 

--- a/mingw-w64-cross-gcc/0200-add-m-no-align-vector-insn-option-for-i386.patch
+++ b/mingw-w64-cross-gcc/0200-add-m-no-align-vector-insn-option-for-i386.patch
@@ -6,7 +6,7 @@ Subject: [PATCH 15/16] add -m(no-)align-vector-insn option for i386
 ---
  gcc/config/i386/i386-options.cc |  9 +++++--
  gcc/config/i386/i386.opt        |  8 ++++++
- gcc/config/i386/mingw32.h       |  2 +-
+ gcc/config/mingw/mingw32.h      |  2 +-
  gcc/config/i386/predicates.md   |  2 +-
  gcc/config/i386/sse.md          | 43 +++++++++++++++++++++++++++++----
  5 files changed, 55 insertions(+), 9 deletions(-)
@@ -64,19 +64,6 @@ index 0dbaacb57ed..3b1a644e2b6 100644
  mpreferred-stack-boundary=
  Target RejectNegative Joined UInteger Var(ix86_preferred_stack_boundary_arg)
  Attempt to keep stack aligned to this power of 2.
-diff --git a/gcc/config/i386/mingw32.h b/gcc/config/i386/mingw32.h
-index baf80400862..2ff2a99e31b 100644
---- a/gcc/config/i386/mingw32.h
-+++ b/gcc/config/i386/mingw32.h
-@@ -30,7 +30,7 @@ along with GCC; see the file COPYING3.  If not see
- #define TARGET_SUBTARGET_DEFAULT \
- 	(MASK_80387 | MASK_IEEE_FP | MASK_FLOAT_RETURNS \
- 	 | MASK_STACK_PROBE | MASK_ALIGN_DOUBLE \
--	 | MASK_MS_BITFIELD_LAYOUT)
-+	 | MASK_MS_BITFIELD_LAYOUT | MASK_NO_ALIGN_VECTOR_INSN)
- 
- #ifndef TARGET_USING_MCFGTHREAD
- #define TARGET_USING_MCFGTHREAD  0
 diff --git a/gcc/config/i386/predicates.md b/gcc/config/i386/predicates.md
 index c4141a96735..0ee5a9054ee 100644
 --- a/gcc/config/i386/predicates.md
@@ -186,6 +173,17 @@ index 076064f97e6..b224b578676 100644
  (define_expand "sse2_loadhpd_exp"
    [(set (match_operand:V2DF 0 "nonimmediate_operand")
  	(vec_concat:V2DF
--- 
-2.38.1
+diff --git a/gcc/config/mingw/mingw32.h b/gcc/config/mingw/mingw32.h
+index baf80400862..2ff2a99e31b 100644
+--- a/gcc/config/mingw/mingw32.h
++++ b/gcc/config/mingw/mingw32.h
+@@ -30,7 +30,7 @@ along with GCC; see the file COPYING3.  If not see
+ #define TARGET_SUBTARGET_DEFAULT \
+ 	(MASK_80387 | MASK_IEEE_FP | MASK_FLOAT_RETURNS \
+ 	 | MASK_STACK_PROBE | MASK_ALIGN_DOUBLE \
+-	 | MASK_MS_BITFIELD_LAYOUT)
++	 | MASK_MS_BITFIELD_LAYOUT | MASK_NO_ALIGN_VECTOR_INSN)
+ 
+ #ifndef TARGET_USING_MCFGTHREAD
+ #define TARGET_USING_MCFGTHREAD  0
 

--- a/mingw-w64-cross-gcc/PKGBUILD
+++ b/mingw-w64-cross-gcc/PKGBUILD
@@ -5,8 +5,8 @@ _mingw_suff=mingw-w64-cross
 pkgbase="${_mingw_suff}-${_realname}"
 _targetpkgs=("${_mingw_suff}-ucrt64-${_realname}" "${_mingw_suff}-mingw32-${_realname}" "${_mingw_suff}-mingw64-${_realname}")
 pkgname=("${_mingw_suff}-${_realname}" "${_targetpkgs[@]}")
-pkgver=14.2.0
-pkgrel=3
+pkgver=15.1.0
+pkgrel=1
 pkgdesc="Cross GCC for the MinGW-w64"
 arch=('i686' 'x86_64')
 url="https://gcc.gnu.org"
@@ -40,7 +40,7 @@ source=(https://ftp.gnu.org/gnu/gcc/gcc-${pkgver}/gcc-${pkgver}.tar.gz
         0014-gcc-9-branch-clone_function_name_1-Retain-any-stdcall-suffix.patch
         0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
         0200-add-m-no-align-vector-insn-option-for-i386.patch)
-sha256sums=('7d376d445f93126dc545e2c0086d0f647c3094aae081cdb78f42ce2bc25e7293'
+sha256sums=('51b9919ea69c980d7a381db95d4be27edf73b21254eb13d752a08003b4d013b1'
             'bc788aa466a83184d285cc2f6c1ffc40c6ed416dd08c6999015262a53f1ab1b5'
             '704acfaeb11d24d3fe5aab34bc883c184ca93aff03d752016c9a50fdd82c5655'
             'c5676fd62d5f7f69be26062b95d42ef47f28151af83b83efa3998ecd8e939e19'
@@ -52,15 +52,14 @@ sha256sums=('7d376d445f93126dc545e2c0086d0f647c3094aae081cdb78f42ce2bc25e7293'
             'a40e7025507130a2a5d2eb2eea8ba4b053398c307cd55b3c9421a8507bd315ed'
             '2658eb376f7829179963978b69a048ed105a41508adc55d0fc0d607c14181926'
             '83b6aea4a462ae80121fd68d42c6234d02e20865132197a10575bbf95fd33b7e'
-            'c5aeab9609f90a8430c43bb50172b63c3155eb10082369f81fac58a395d2e2ee'
+            'c6763a1558a8f273868a664133806cfe155ae3312eb1b6df74a883fcde711d8c'
             '3707b0aab99b203cbd9e513be46c7d4600de06e6c8344160b7fb1779061d08da'
             'e98805ead7d78ee2a92f237894c4b2b7ddc1688e1b517d8c04f28d440202e40f'
             'fd9bdecb2bbc4796bbc9f00b708dac42ef9e3464a06d6d27e5475cee117de5be'
             'ad1f7b5e7afaaec008b7cbd14feea13a10989fa91bda7003af72d457619bb199'
-            'c34f9e71b5a092be1987ad4c65891742c74c9eb8ef6560100e751cd31375f579')
+            '1484911163634f30324827619c873a6267b377abba0df8bbedfd128163c53ea4')
 
 _threads="win32"
-_targets="x86_64-w64-mingw32ucrt i686-w64-mingw32 x86_64-w64-mingw32"
 
 apply_patch_with_msg() {
   for _fname in "$@"
@@ -135,6 +134,7 @@ _build() {
     --enable-threads=${_threads} \
     --enable-graphite \
     --enable-fully-dynamic-string \
+    --enable-libstdcxx-backtrace=yes \
     --enable-libstdcxx-filesystem-ts \
     --enable-libstdcxx-time \
     --disable-libstdcxx-pch \


### PR DESCRIPTION
Refreshes due to these upstream commits:

* https://github.com/gcc-mirror/gcc/commit/bd9c550acc42c5b04a61be3c8d981359b2093357
* https://github.com/gcc-mirror/gcc/commit/e22962538f64bb6e5ac87977ec8a5d86f4ef21cb
* https://github.com/gcc-mirror/gcc/commit/1f05dfc131c7996a85dd82b3300f7b5f93d4b1bd

enable libstdcxx-backtrace to match our mingw build

remove unused _targets var