### PR TITLE
cross-mingwarm64-gcc: Update

### DIFF
--- a/mingw-w64-cross-mingwarm64-gcc/PKGBUILD
+++ b/mingw-w64-cross-mingwarm64-gcc/PKGBUILD
@@ -5,9 +5,9 @@ _mingw_suff=mingw-w64-cross
 pkgbase="${_mingw_suff}-mingwarm64-${_realname}"
 _targetpkgs=("${_mingw_suff}-mingwarm64-${_realname}")
 pkgname=("${_targetpkgs[@]}")
-_realver=15.0.0
-pkgver=15.0.0dev
-pkgrel=3
+_realver=15.0.1
+pkgver=15.0.1dev
+pkgrel=1
 pkgdesc="Cross GCC for the MinGW-w64"
 arch=('aarch64' 'i686' 'x86_64')
 url="https://gcc.gnu.org"
@@ -23,7 +23,7 @@ makedepends=("gcc" 'lndir' "gmp-devel" "mpc-devel" "zlib-devel" "isl-devel" 'aut
              "${_mingw_suff}-mingwarm64-windows-default-manifest" "${_mingw_suff}-mingwarm64-binutils" "git")
 #checkdepends=('dejagnu')
 options=('!strip' 'staticlibs' '!emptydirs' '!buildflags')
-_commit='e5c582536a57cbe031770db1515c41e7aa3a11cd'
+_commit='f565ee034dab4c5cfd130accbe401b2b2a9afffd'
 source=("${_realname}"::"git+https://github.com/Windows-on-ARM-Experiments/gcc-woarm64.git#commit=${_commit}"
         0001-Cygwin-use-SysV-ABI-on-x86_64.patch
         0002-Cygwin-add-dummy-pthread-tsaware-and-large-address-a.patch
@@ -42,7 +42,7 @@ source=("${_realname}"::"git+https://github.com/Windows-on-ARM-Experiments/gcc-w
         0014-gcc-9-branch-clone_function_name_1-Retain-any-stdcall-suffix.patch
         0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
         0200-add-m-no-align-vector-insn-option-for-i386.patch)
-sha256sums=('0d8263deaa4290b910f3ecb3205189b24dade280b171bf9a4d9eda1e9eee7004'
+sha256sums=('64c9448493263914b8bb126157900e718f00010c803521f3821653b866890d87'
             'bc788aa466a83184d285cc2f6c1ffc40c6ed416dd08c6999015262a53f1ab1b5'
             '704acfaeb11d24d3fe5aab34bc883c184ca93aff03d752016c9a50fdd82c5655'
             'c5676fd62d5f7f69be26062b95d42ef47f28151af83b83efa3998ecd8e939e19'
@@ -86,21 +86,23 @@ prepare() {
   del_file_exists \
     libgomp/config/cygwin/plugin-suffix.h
 
+  # Part of the commits in gcc-woarm64 now, so we don't need to apply them
+  # as long as we build from there:
   # Cygwin patches
-  apply_patch_with_msg \
-    0001-Cygwin-use-SysV-ABI-on-x86_64.patch \
-    0002-Cygwin-add-dummy-pthread-tsaware-and-large-address-a.patch \
-    0003-Cygwin-handle-dllimport-properly-in-medium-model-V2.patch \
-    0004-Cygwin-MinGW-skip-test.patch \
-    0005-Cygwin-define-RTS_CONTROL_ENABLE-and-DTR_CONTROL_ENA.patch \
-    0006-Cygwin-fix-some-implicit-declaration-warnings-and-re.patch \
-    0007-Cygwin-__cxa-atexit.patch \
-    0008-Cygwin-libgomp-soname.patch \
-    0009-Cygwin-g-time.patch \
-    0010-Cygwin-newlib-ftm.patch \
-    0011-Cygwin-define-STD_UNIX.patch \
-    0101-Cygwin-enable-libgccjit-not-just-for-MingW.patch \
-    0102-Cygwin-testsuite-fixes-for-libgccjit.patch
+  #apply_patch_with_msg \
+  #  0001-Cygwin-use-SysV-ABI-on-x86_64.patch \
+  #  0002-Cygwin-add-dummy-pthread-tsaware-and-large-address-a.patch \
+  #  0003-Cygwin-handle-dllimport-properly-in-medium-model-V2.patch \
+  #  0004-Cygwin-MinGW-skip-test.patch \
+  #  0005-Cygwin-define-RTS_CONTROL_ENABLE-and-DTR_CONTROL_ENA.patch \
+  #  0006-Cygwin-fix-some-implicit-declaration-warnings-and-re.patch \
+  #  0007-Cygwin-__cxa-atexit.patch \
+  #  0008-Cygwin-libgomp-soname.patch \
+  #  0009-Cygwin-g-time.patch \
+  #  0010-Cygwin-newlib-ftm.patch \
+  #  0011-Cygwin-define-STD_UNIX.patch \
+  #  0101-Cygwin-enable-libgccjit-not-just-for-MingW.patch \
+  #  0102-Cygwin-testsuite-fixes-for-libgccjit.patch
 
   # MinGW Patches
   apply_patch_with_msg \
@@ -143,6 +145,7 @@ _build() {
     --enable-threads=${_threads} \
     --enable-graphite \
     --enable-fully-dynamic-string \
+    --enable-libstdcxx-backtrace=yes \
     --enable-libstdcxx-filesystem-ts \
     --enable-libstdcxx-time \
     --disable-libstdcxx-pch \


### PR DESCRIPTION
the upstream fork now contains the cygwin patches, so uncomment them for now.

enable libstdcxx-backtrace to match the other gcc cross compilers