### PR TITLE
emacs: explicitly disable native compilation

### DIFF
--- a/emacs/PKGBUILD
+++ b/emacs/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=emacs
 pkgver=30.1
-pkgrel=1
+pkgrel=2
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (msys2)"
 url="https://www.gnu.org/software/${pkgname}/"
 msys2_references=(
@@ -38,13 +38,16 @@ build() {
   CPPFLAGS="-DNDEBUG"
   CFLAGS="-pipe -O3 -fomit-frame-pointer -funroll-loops"
   LDFLAGS="-s -Wl,-s"
+  # native compilation is not enabled due to not finding libgccjit.h, and is
+  # unsupported on 32-bit (and fails configure there due to this)
   ./configure \
     --prefix=/usr \
     --build="${CYGWIN_CHOST}" \
     --with-x-toolkit=no \
     --with-sound=yes \
     --with-modules \
-    --without-compress-install
+    --without-compress-install \
+    --without-native-compilation
 
   make
 }


### PR DESCRIPTION
It is implicitly disabled due to configure not finding libgccjit.h, and is not supported (and causes configure to fail) on 32-bit, so just disable it.