### PR TITLE
pacman: make msystems pluggable

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.1.0
-pkgrel=11
+pkgrel=12
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -45,6 +45,11 @@ source=(pacman::git+https://gitlab.archlinux.org/pacman/pacman.git#commit=${_com
         "pacman.conf"
         "makepkg.conf"
         "makepkg_mingw.conf"
+        "makepkg_mingw.conf.d.clang64.conf"
+        "makepkg_mingw.conf.d.clangarm64.conf"
+        "makepkg_mingw.conf.d.mingw32.conf"
+        "makepkg_mingw.conf.d.mingw64.conf"
+        "makepkg_mingw.conf.d.ucrt64.conf"
         "makepkg-mingw"
         0001-makepkg-clean-up-more-things.patch
         0002-makepkg-build-env-export.patch
@@ -83,8 +88,13 @@ validpgpkeys=('6645B0A8C7005E78DB1D7864F99FFE0FEAE999BD'  # Allan McRae <allan@a
 sha256sums=('803cba087e713a59866797747c3c63abbc0e4354c45cc2c0467d11e78364d66f'
             '0f25288c70ade80c7fac57d3149209b64a7ba23f00232b7e42103f6330b0c1c0'
             '98bc3b83665ce0a102cd74b2a8e69c17eb6b55e0f89f17e57dc37d0f4577093a'
-            'a587b4bdad33d51d3e9505ca65faba12beaa818b496051c032f4916587aef107'
-            'df8c94263cc372938851ebbccaca8f73097e6e9a569ef2dbaf10217ad2d8a5ad'
+            '420b27a5f71489799d4ae05e365ac1d4ffb2de2885e20b1f63671aa267441956'
+            '8ad405b84d92869961effce9d0658032e6a533a80c7d2f41c3349e8b7009c684'
+            '30460144a75eaebb497c152e7619be732a15934a9c8b5a7cc860a8cbffd1de8c'
+            'b8cab28667f6bbe6e16d579e3dbba6abf048d5ca5762710ca51a0daefb2f5910'
+            'c3d5e802117f9adc7dc5a5f397c2f01ea98741cf7f6c94612e637d521853dc25'
+            '56e55083caf3d46ab0d36dee4b9a3b28e7b184886176dcfe93ab1ff277b5e5a4'
+            'be3377c7a77ca3369ddf713ff6a595d1843d681c40d6d1e02d8d9be393edc8c0'
             '167e9ffe59e55fb07d47e0c9a4bddd9d967c50ec2c8711a0a0bbe4b184fc8b0f'
             '1021dc5950ff9f9efac795688c4b53a1d3cda42b0f270ee755a038bbcf9eccab'
             'af0c734c6efa167bdd9505f0cf8d5d85a8d535a5062a69b6e38473bb43b37aff'
@@ -220,6 +230,10 @@ package() {
 
   install -m644 ${srcdir}/makepkg.conf ${pkgdir}/etc/
   install -m644 ${srcdir}/makepkg_mingw.conf ${pkgdir}/etc/
+  install -dm755 ${pkgdir}/etc/makepkg_mingw.conf.d
+  for f in "${srcdir}/"makepkg_mingw.conf.d.*.conf; do
+    install -m644 "${f}" "${pkgdir}/etc/makepkg_mingw.conf.d/${f#${srcdir}/makepkg_mingw.conf.d.}"
+  done
   install -m755 ${srcdir}/makepkg-mingw ${pkgdir}/usr/bin/
 
   # set things correctly in the default conf file

--- a/pacman/makepkg-mingw
+++ b/pacman/makepkg-mingw
@@ -84,7 +84,11 @@ if [[ -z "${MINGW_ARCH}" ]] && [[ -n "${MINGW_INSTALLS}" ]]; then
 fi
 
 # Validate or set MINGW_ARCH
-MINGW_ARCH_ALLOWED=('mingw32' 'mingw64' 'clang64' 'clangarm64' 'ucrt64')
+declare -a MINGW_ARCH_ALLOWED
+for _conf in /etc/makepkg_mingw.conf.d/*.conf; do
+  MINGW_ARCH_ALLOWED+=("$(basename "$_conf" .conf)")
+done
+
 MINGW_ARCH="${MINGW_ARCH,,}"
 if [[ -z "$MINGW_ARCH" ]]; then
   # In case MINGW_ARCH isn't set we default to MSYSTEM, or error out

--- a/pacman/makepkg_mingw.conf
+++ b/pacman/makepkg_mingw.conf
@@ -33,71 +33,8 @@ VCSCLIENTS=('bzr::breezy'
 #########################################################################
 #
 
-if [[ "$MSYSTEM" == "MINGW64" ]]; then
-  CARCH="x86_64"
-  CHOST="x86_64-w64-mingw32"
-  MINGW_CHOST="x86_64-w64-mingw32"
-  MINGW_PREFIX="/mingw64"
-  MINGW_PACKAGE_PREFIX="mingw-w64-x86_64"
-  CC="gcc"
-  CXX="g++"
-  CPPFLAGS=
-  CFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1"
-  CXXFLAGS="$CFLAGS"
-  LDFLAGS=""
-  RUSTFLAGS="-Cforce-frame-pointers=yes"
-elif [[ "$MSYSTEM" == "MINGW32" ]]; then
-  CARCH="i686"
-  CHOST="i686-w64-mingw32"
-  MINGW_CHOST="i686-w64-mingw32"
-  MINGW_PREFIX="/mingw32"
-  MINGW_PACKAGE_PREFIX="mingw-w64-i686"
-  CC="gcc"
-  CXX="g++"
-  CPPFLAGS=
-  CFLAGS="-march=pentium4 -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1"
-  CXXFLAGS="$CFLAGS"
-  LDFLAGS="-Wl,--no-seh -Wl,--large-address-aware"
-  RUSTFLAGS="-Cforce-frame-pointers=yes"
-elif [[ "$MSYSTEM" == "CLANG64" ]]; then
-  CARCH="x86_64"
-  CHOST="x86_64-w64-mingw32"
-  MINGW_CHOST="x86_64-w64-mingw32"
-  MINGW_PREFIX="/clang64"
-  MINGW_PACKAGE_PREFIX="mingw-w64-clang-x86_64"
-  CC="clang"
-  CXX="clang++"
-  CPPFLAGS=
-  CFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1"
-  CXXFLAGS="$CFLAGS"
-  LDFLAGS=""
-  RUSTFLAGS="-Cforce-frame-pointers=yes"
-elif [[ "$MSYSTEM" == "CLANGARM64" ]]; then
-  CARCH="aarch64"
-  CHOST="aarch64-w64-mingw32"
-  MINGW_CHOST="aarch64-w64-mingw32"
-  MINGW_PREFIX="/clangarm64"
-  MINGW_PACKAGE_PREFIX="mingw-w64-clang-aarch64"
-  CC="clang"
-  CXX="clang++"
-  CPPFLAGS=
-  CFLAGS="-O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1"
-  CXXFLAGS="$CFLAGS"
-  LDFLAGS=""
-  RUSTFLAGS="-Cforce-frame-pointers=yes"
-elif [[ "$MSYSTEM" == "UCRT64" ]]; then
-  CARCH="x86_64"
-  CHOST="x86_64-w64-mingw32"
-  MINGW_CHOST="x86_64-w64-mingw32"
-  MINGW_PREFIX="/ucrt64"
-  MINGW_PACKAGE_PREFIX="mingw-w64-ucrt-x86_64"
-  CC="gcc"
-  CXX="g++"
-  CPPFLAGS=
-  CFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1"
-  CXXFLAGS="$CFLAGS"
-  LDFLAGS=""
-  RUSTFLAGS="-Cforce-frame-pointers=yes"
+if [ -e "/etc/makepkg_mingw.conf.d/${MSYSTEM,,}.conf" ]; then
+  source "/etc/makepkg_mingw.conf.d/${MSYSTEM,,}.conf"
 else
   echo "Unsupported MSYSTEM: $MSYSTEM"
   exit 1

--- a/pacman/makepkg_mingw.conf.d.clang64.conf
+++ b/pacman/makepkg_mingw.conf.d.clang64.conf
@@ -1,0 +1,12 @@
+CARCH="x86_64"
+CHOST="x86_64-w64-mingw32"
+MINGW_CHOST="x86_64-w64-mingw32"
+MINGW_PREFIX="/clang64"
+MINGW_PACKAGE_PREFIX="mingw-w64-clang-x86_64"
+CC="clang"
+CXX="clang++"
+CPPFLAGS=
+CFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1"
+CXXFLAGS="$CFLAGS"
+LDFLAGS=""
+RUSTFLAGS="-Cforce-frame-pointers=yes"

--- a/pacman/makepkg_mingw.conf.d.clangarm64.conf
+++ b/pacman/makepkg_mingw.conf.d.clangarm64.conf
@@ -1,0 +1,12 @@
+CARCH="aarch64"
+CHOST="aarch64-w64-mingw32"
+MINGW_CHOST="aarch64-w64-mingw32"
+MINGW_PREFIX="/clangarm64"
+MINGW_PACKAGE_PREFIX="mingw-w64-clang-aarch64"
+CC="clang"
+CXX="clang++"
+CPPFLAGS=
+CFLAGS="-O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1"
+CXXFLAGS="$CFLAGS"
+LDFLAGS=""
+RUSTFLAGS="-Cforce-frame-pointers=yes"

--- a/pacman/makepkg_mingw.conf.d.mingw32.conf
+++ b/pacman/makepkg_mingw.conf.d.mingw32.conf
@@ -1,0 +1,12 @@
+CARCH="i686"
+CHOST="i686-w64-mingw32"
+MINGW_CHOST="i686-w64-mingw32"
+MINGW_PREFIX="/mingw32"
+MINGW_PACKAGE_PREFIX="mingw-w64-i686"
+CC="gcc"
+CXX="g++"
+CPPFLAGS=
+CFLAGS="-march=pentium4 -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1"
+CXXFLAGS="$CFLAGS"
+LDFLAGS="-Wl,--no-seh -Wl,--large-address-aware"
+RUSTFLAGS="-Cforce-frame-pointers=yes"

--- a/pacman/makepkg_mingw.conf.d.mingw64.conf
+++ b/pacman/makepkg_mingw.conf.d.mingw64.conf
@@ -1,0 +1,12 @@
+CARCH="x86_64"
+CHOST="x86_64-w64-mingw32"
+MINGW_CHOST="x86_64-w64-mingw32"
+MINGW_PREFIX="/mingw64"
+MINGW_PACKAGE_PREFIX="mingw-w64-x86_64"
+CC="gcc"
+CXX="g++"
+CPPFLAGS=
+CFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1"
+CXXFLAGS="$CFLAGS"
+LDFLAGS=""
+RUSTFLAGS="-Cforce-frame-pointers=yes"

--- a/pacman/makepkg_mingw.conf.d.ucrt64.conf
+++ b/pacman/makepkg_mingw.conf.d.ucrt64.conf
@@ -1,0 +1,12 @@
+CARCH="x86_64"
+CHOST="x86_64-w64-mingw32"
+MINGW_CHOST="x86_64-w64-mingw32"
+MINGW_PREFIX="/ucrt64"
+MINGW_PACKAGE_PREFIX="mingw-w64-ucrt-x86_64"
+CC="gcc"
+CXX="g++"
+CPPFLAGS=
+CFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1"
+CXXFLAGS="$CFLAGS"
+LDFLAGS=""
+RUSTFLAGS="-Cforce-frame-pointers=yes"


### PR DESCRIPTION
makepkg-mingw.conf will include /etc/makepkg_mingw.conf.d/${MSYSTEM,,}.conf, and makepkg-mingw will list these confs to populate MINGW_ARCH_ALLOWED

Addresses #5285 along with #5381