### PR TITLE
`autorebase.bat`: Add quotes to prevent space issues

### DIFF
--- a/rebase/PKGBUILD
+++ b/rebase/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=rebase
 pkgver=4.5.0
-pkgrel=4
+pkgrel=5
 pkgdesc="The Cygwin rebase distribution contains four utilities, rebase, rebaseall, peflags, and peflagsall"
 arch=('i686' 'x86_64')
 license=('custom')
@@ -27,7 +27,7 @@ sha256sums=('f8ebc4dec0aeceecad2ed96662c83c7da5dfc3c88fddd1579ac4055756a418f9'
             '4b789d2f6ae7de9afd778cce5823600ee0f53590b3e70e133dcafbb583d6cbbb'
             '35484af07e1df8b00821428b774744537106f99592d849ad7db26b41f570fa8c'
             'ee06d92470a8685b29595c974aaa819da91a9d6f361f81ad3001f5e83a1ea6f5'
-            '8e4099a29107a1d03031b198c3d142bbc31a40ff19298d6e099d9bcffd31b1b0'
+            '37fbcf495c90c41c98afcd0ce06aabbc727a65468e92960efd9d88c0e3f83330'
             'a50a8bfdb28c47c1742f400287a8a7ba65f9893dee74c109aad517d46afed2a1')
 
 prepare() {

--- a/rebase/autorebase.bat
+++ b/rebase/autorebase.bat
@@ -1,4 +1,4 @@
 @echo off
 
-set PATH=%~dp0\usr\bin;%PATH%
-%~dp0\usr\bin\dash /usr/bin/rebaseall -p
+set "PATH=%~dp0\usr\bin;%PATH%"
+"%~dp0\usr\bin\dash" /usr/bin/rebaseall -p


### PR DESCRIPTION
### Description
Technically, the installation path or the `%PATH%` environment variable could contain a space.

Since this is a simple wrapper script to launch dash with the actual rebase script, it must follow Windows convention and quote the arguments to avoid an issue if the batch directory (`%~dp0`) is a path that contains space.

### Screenshot
<img width="414" alt="space-issue" src="https://github.com/user-attachments/assets/a0255858-74b2-4a23-8486-6629ed23e543" />
