### PR TITLE
gnupg: update to v2.4.8

### DIFF
--- a/gnupg/PKGBUILD
+++ b/gnupg/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=gnupg
-pkgver=2.4.7
-pkgrel=2
+pkgver=2.4.8
+pkgrel=1
 pkgdesc='Complete and free implementation of the OpenPGP standard'
 provides=('dirmngr' "gnupg2=${pkgver}")
 url='https://gnupg.org/'
@@ -61,7 +61,7 @@ source=("https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2"{,
         'gnupg-2.4-avoid_beta_warning.patch'
         'gnupg-2.4-drop_import_clean.patch'
         'gnupg-2.4-revert_default_rfc4880bis.patch')
-sha256sums=('7b24706e4da7e0e3b06ca068231027401f238102c41c909631349dcc3b85eb46'
+sha256sums=('b58c80d79b04d3243ff49c1c3fc6b5f83138eb3784689563bcdd060595318616'
             'SKIP'
             '902563c91c72ed9222343de3482f4ca7b141775235625af5ad790f3d86419370'
             '243c3a79295519b3931f9d846cf2af5caa064a78de812ee336dc786c1567b4d0'


### PR DESCRIPTION
This version [was tagged yesterday](https://github.com/gpg/gnupg/releases/tag/gnupg-2.4.8). There are [no news](https://gnupg.org/) about it as of time of writing, [not even in `gnupg-announce`](https://lists.gnupg.org/pipermail/gnupg-announce/2025q2/thread.html), but [the `NEWS` file](https://github.com/gpg/gnupg/blob/gnupg-2.4.8/NEWS#L1-L30) suggests that it is official.