### PR TITLE
less: upgrade to version 678

### DIFF
--- a/less/PKGBUILD
+++ b/less/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=less
-pkgver=668
+pkgver=678
 pkgrel=1
 pkgdesc="A terminal based program for viewing text files"
 license=('GPL3')
@@ -14,7 +14,7 @@ msys2_references=(
 depends=('ncurses' 'libpcre2_8')
 makedepends=('ncurses-devel' 'pcre2-devel' 'autotools' 'gcc' 'groff')
 source=("https://github.com/gwsw/${pkgname}/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('69d6c5587c361e4f2ae051b6c483ca979a0381e2b8145d3d2af37cea29577b6f')
+sha256sums=('c671da3ce45f697d6c11f5695b760c829861bbed3bd4f9c8785ab058a4a96f85')
 validpgpkeys=('AE27252BD6846E7D6EAE1DD6F153A7C833235259') # Mark Nudelman
 
 prepare() {


### PR DESCRIPTION
Release notes (https://www.greenwoodsoftware.com/less/news.678.html):

Version 678 was released for beta testing on 2 May 2025, and was released for general use on 17 May 2025.

These are the differences between [version 668](https://www.greenwoodsoftware.com/less/news.668.html) and version 678:

-   Treat -r in LESS environment variable as -R.
-   Add ESC-j and ESC-k commands ([github #560](https://github.com/gwsw/less/issues/560)).
-   Add --no-paste option ([github #523](https://github.com/gwsw/less/issues/523)).
-   Add --no-edit-warn option ([github #513](https://github.com/gwsw/less/issues/513)).
-   Add --form-feed option ([github #496](https://github.com/gwsw/less/issues/496)).
-   Add ESC-b command ([github #615](https://github.com/gwsw/less/issues/615)).
-   Make TAB complete option name in -- command ([github #531](https://github.com/gwsw/less/issues/531)).
-   Update the file size on an attempt to go past end of file.
-   Make -R able to pass through any OSC escape sequences, not just OSC 8 ([github #504](https://github.com/gwsw/less/issues/504)).
-   Setting LESS_IS_MORE=0 now disables "more" compatibility even if invoked via a file link named "more" ([github #500](https://github.com/gwsw/less/issues/500)).
-   Pass through escape sequences in prompts even if -R is not set.
-   Add LESS_SHELL_LINES to support shell prompts which use more than one line ([github #514](https://github.com/gwsw/less/issues/514)).
-   Add LESSANSIOSCALLOW to define OSC types which may be passed through.
-   Add LESSANSIOSCCHARS to define non-standard OSC intro chars.
-   Add LESS_SIGUSR1 to define user signal handler ([github #582](https://github.com/gwsw/less/issues/582)).
-   Add mouse and mouse6 commands to lesskey ([github #569](https://github.com/gwsw/less/issues/569)).
-   Improve behavior of ^O^N and ^O^P commands.
-   Leave stty tabs setting unchanged ([github #620](https://github.com/gwsw/less/issues/620)).
-   Fix unexpected behavior when entering a partial command followed by a valid command ([github #543](https://github.com/gwsw/less/issues/543)).
-   Fix bug when coloring prompt string with SGR sequences ([github #516](https://github.com/gwsw/less/issues/516)).
-   Fix bug when searching for text near an invalid UTF-8 sequence ([github #542](https://github.com/gwsw/less/issues/542)).
-   Fix display bug when file contains ESC followed by NUL ([github #550](https://github.com/gwsw/less/issues/550)).
-   Fix bug when using +:n +:p +:x or +:d on the command line ([github #552](https://github.com/gwsw/less/issues/552)).
-   Fix bug with --no-number-headers when header is not at start of file ([github #566](https://github.com/gwsw/less/issues/566)).
-   Fix bug where lesstest fails if window is resized ([github #570](https://github.com/gwsw/less/issues/570)).
-   Fix bug using "configure --with-secure=no" ([github #584](https://github.com/gwsw/less/issues/584)).
-   Fix bug using multibyte command chars ([github #595](https://github.com/gwsw/less/issues/595)).
-   Fix auto_wrap setting on Windows ([github #497](https://github.com/gwsw/less/issues/497)).
-   Fix two bugs using ^S search modifier ([github #605](https://github.com/gwsw/less/issues/605)).
-   Fix bug searching for UTF-8 strings with the PCRE2 library ([github #610](https://github.com/gwsw/less/issues/610)).
-   Fix bug highlighting OSC 8 links when opening a new file.
-   Fix bug when & filtering is active ([github #618](https://github.com/gwsw/less/issues/618)).