### PR TITLE
mingw-w64-cross-clang-{crt,headers}: update to 2ca6f1348c

### DIFF
--- a/mingw-w64-cross-clang-crt/PKGBUILD
+++ b/mingw-w64-cross-clang-crt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=crt
 _mingw_suff=mingw-w64-cross-clang
 pkgname=("${_mingw_suff}-${_realname}")
 conflicts=("${_mingw_suff%-*}-${_realname}")
-pkgver=12.0.0.r657.g1e8b1ccdd
+pkgver=12.0.0.r731.g2ca6f1348
 pkgrel=1
 pkgdesc='MinGW-w64 CRT for cross-compiler'
 arch=('i686' 'x86_64')
@@ -15,9 +15,9 @@ groups=("${_mingw_suff}-toolchain")
 depends=("${_mingw_suff}-headers")
 makedepends=("git" "clang" "lld" 'autotools')
 options=('!strip' 'staticlibs' '!emptydirs' '!buildflags')
-_commit='1e8b1ccdd415de4c67be53e803521279a4d8abc1'
+_commit='2ca6f1348cab58b5b994fd5916ff57445ade22f8'
 source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit")
-sha256sums=('8bbb1846c7004ab501815e6f9178ffdc9ad26044e5cc56a63abc4f5344f0785c')
+sha256sums=('7151f7b1d04445fa4ec40a3edabdafa4b12867aaf64f3ad8329e9fcc3e05b7c3')
 msys2_references=(
   'archlinux: mingw-w64-crt'
   'cpe: cpe:/a:mingw-w64:mingw-w64'

--- a/mingw-w64-cross-clang-headers/PKGBUILD
+++ b/mingw-w64-cross-clang-headers/PKGBUILD
@@ -5,7 +5,7 @@ _mingw_suff=mingw-w64-cross-clang
 pkgname=("${_mingw_suff}-${_realname}")
 conflicts=("${_mingw_suff%-*}-${_realname}")
 pkgdesc="MinGW-w64 headers for cross-compiler"
-pkgver=12.0.0.r657.g1e8b1ccdd
+pkgver=12.0.0.r731.g2ca6f1348
 pkgrel=1
 arch=('i686' 'x86_64')
 url="https://mingw-w64.sourceforge.io/"
@@ -14,9 +14,9 @@ license=('spdx:ZPL-2.1 AND LGPL-2.1-or-later')
 groups=("${_mingw_suff}-toolchain")
 makedepends=('git' 'autotools' 'gcc')
 options=('!strip' '!libtool' '!emptydirs' '!buildflags')
-_commit='1e8b1ccdd415de4c67be53e803521279a4d8abc1'
+_commit='2ca6f1348cab58b5b994fd5916ff57445ade22f8'
 source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit")
-sha256sums=('8bbb1846c7004ab501815e6f9178ffdc9ad26044e5cc56a63abc4f5344f0785c')
+sha256sums=('7151f7b1d04445fa4ec40a3edabdafa4b12867aaf64f3ad8329e9fcc3e05b7c3')
 msys2_references=(
   'archlinux: mingw-w64-headers'
   'cpe: cpe:/a:mingw-w64:mingw-w64'


### PR DESCRIPTION
to match mingw-w64-cross-{crt,headers}