### PR TITLE
makepkg confs: apply +crt-static in RUSTFLAGS for CLANG*

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=6.1.0
-pkgrel=13
+pkgrel=14
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -89,8 +89,8 @@ sha256sums=('803cba087e713a59866797747c3c63abbc0e4354c45cc2c0467d11e78364d66f'
             '0f25288c70ade80c7fac57d3149209b64a7ba23f00232b7e42103f6330b0c1c0'
             '98bc3b83665ce0a102cd74b2a8e69c17eb6b55e0f89f17e57dc37d0f4577093a'
             '2c1e5fadc8f4f87afdd58f94996caa066faae26f9c2dcac7794ce2c06105a3a2'
-            '8ad405b84d92869961effce9d0658032e6a533a80c7d2f41c3349e8b7009c684'
-            '30460144a75eaebb497c152e7619be732a15934a9c8b5a7cc860a8cbffd1de8c'
+            'e1a2b77526f279532cb46a6a76046adaeff4693c9ad4da41a5ff76616a187bcc'
+            '659b558831632a4d6efb9daa5a38ae8a5d3bad5fa81485fc692a04c929ef7e8b'
             'b8cab28667f6bbe6e16d579e3dbba6abf048d5ca5762710ca51a0daefb2f5910'
             'c3d5e802117f9adc7dc5a5f397c2f01ea98741cf7f6c94612e637d521853dc25'
             '56e55083caf3d46ab0d36dee4b9a3b28e7b184886176dcfe93ab1ff277b5e5a4'

--- a/pacman/makepkg_mingw.d.clang64.conf
+++ b/pacman/makepkg_mingw.d.clang64.conf
@@ -9,4 +9,4 @@ CPPFLAGS=
 CFLAGS="-march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1"
 CXXFLAGS="$CFLAGS"
 LDFLAGS=""
-RUSTFLAGS="-Cforce-frame-pointers=yes"
+RUSTFLAGS="-Cforce-frame-pointers=yes -Ctarget-feature=+crt-static"

--- a/pacman/makepkg_mingw.d.clangarm64.conf
+++ b/pacman/makepkg_mingw.d.clangarm64.conf
@@ -9,4 +9,4 @@ CPPFLAGS=
 CFLAGS="-O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1"
 CXXFLAGS="$CFLAGS"
 LDFLAGS=""
-RUSTFLAGS="-Cforce-frame-pointers=yes"
+RUSTFLAGS="-Cforce-frame-pointers=yes -Ctarget-feature=+crt-static"


### PR DESCRIPTION
currently there is an issue with `crt-static` option being uncontrollable for windows-gnu targets: https://github.com/rust-lang/rust/issues/137389. this behavour is bad because libunwind.dll is linked by default for windows-gnullvm, but no gcc dynamic libs are linked in case of windows-gnu. I tried to use bootstrap.toml option, but it doesn't do what is expected. this leads to confusion because there is a need to pull libunwind package separately for all rust-based packages...

this change should be temp before the issue is fixed. this flag can be changed in case of package which has cc-libs as their dependency anyway. didn't add the flag for GCC envs because nothing changes with it

I'll block some rust updates/additions before this is merged