### PR TITLE
pacman-mirrors: Update to 20250607

### DIFF
--- a/pacman-mirrors/PKGBUILD
+++ b/pacman-mirrors/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Ray Donnelly <mingwandroid@gmail.com>
 
 pkgname=pacman-mirrors
-pkgver=20250220
+pkgver=20250607
 pkgrel=1
 pkgdesc="MSYS2 mirror list for use by pacman"
 arch=('any')
@@ -9,8 +9,8 @@ url="https://www.msys2.org/dev/mirrors/"
 license=('GPL')
 source=(mirrorlist.msys
         mirrorlist.mingw)
-sha256sums=('f226d79ea571c62498b38cf8fab76f5f8c9cf689e54201d36d4b0efcc962f0cf'
-            '57f384c821bcb7e9e8c51cf80164816f7c921cede924c4b1f0dff7b43bd9664c')
+sha256sums=('c1f2f8ccd59e6c41d7c2f504af47e26ecfd6d18adf089c625ad09b926c1fe72f'
+            'e96ce5a2c8d6a1d56418cd16b0650b88e77517cdb16e768e02dd095cc3566df2')
 backup=(
   'etc/pacman.d/mirrorlist.msys'
   'etc/pacman.d/mirrorlist.mingw'

--- a/pacman-mirrors/mirrorlist.mingw
+++ b/pacman-mirrors/mirrorlist.mingw
@@ -5,12 +5,10 @@ Server = https://mirror.msys2.org/mingw/$repo/
 Server = https://repo.msys2.org/mingw/$repo/
 
 ## Tier 1
-Server = https://mirror.umd.edu/msys2/mingw/$repo/
+Server = https://ftp2.osuosl.org/pub/msys2/mingw/$repo/
 Server = https://mirror.yandex.ru/mirrors/msys2/mingw/$repo/
-Server = https://download.nus.edu.sg/mirror/msys2/mingw/$repo/
 Server = https://mirror.accum.se/mirror/msys2.org/mingw/$repo/
 Server = https://ftp.nluug.nl/pub/os/windows/msys2/builds/mingw/$repo/
-Server = https://ftp.osuosl.org/pub/msys2/mingw/$repo/
 Server = https://mirror.internet.asn.au/pub/msys2/mingw/$repo/
 Server = https://mirror.selfnet.de/msys2/mingw/$repo/
 Server = https://mirrors.dotsrc.org/msys2/mingw/$repo/
@@ -18,11 +16,11 @@ Server = https://mirrors.bfsu.edu.cn/msys2/mingw/$repo/
 Server = https://mirrors.tuna.tsinghua.edu.cn/msys2/mingw/$repo/
 Server = https://mirrors.ustc.edu.cn/msys2/mingw/$repo/
 Server = https://mirror.nju.edu.cn/msys2/mingw/$repo/
-Server = https://repo.extreme-ix.org/msys2/mingw/$repo/
 Server = https://mirror.clarkson.edu/msys2/mingw/$repo/
 Server = https://quantum-mirror.hu/mirrors/pub/msys2/mingw/$repo/
 Server = https://mirror.archlinux.tw/MSYS2/mingw/$repo/
 Server = https://distrohub.kyiv.ua/msys2/mingw/$repo/
+Server = https://mirror.umd.edu/msys2/mingw/$repo/
 
 ## Tier 2
 Server = https://ftp.cc.uoc.gr/mirrors/msys2/mingw/$repo/
@@ -34,3 +32,5 @@ Server = https://mirrors.bit.edu.cn/msys2/mingw/$repo/
 Server = https://mirrors.aliyun.com/msys2/mingw/$repo/
 Server = https://mirror.iscas.ac.cn/msys2/mingw/$repo/
 Server = https://mirrors.cloud.tencent.com/msys2/mingw/$repo/
+Server = https://download.nus.edu.sg/mirror/msys2/mingw/$repo/
+Server = https://repo.extreme-ix.org/msys2/mingw/$repo/

--- a/pacman-mirrors/mirrorlist.msys
+++ b/pacman-mirrors/mirrorlist.msys
@@ -5,12 +5,10 @@ Server = https://mirror.msys2.org/msys/$arch/
 Server = https://repo.msys2.org/msys/$arch/
 
 ## Tier 1
-Server = https://mirror.umd.edu/msys2/msys/$arch/
+Server = https://ftp2.osuosl.org/pub/msys2/msys/$arch/
 Server = https://mirror.yandex.ru/mirrors/msys2/msys/$arch/
-Server = https://download.nus.edu.sg/mirror/msys2/msys/$arch/
 Server = https://mirror.accum.se/mirror/msys2.org/msys/$arch/
 Server = https://ftp.nluug.nl/pub/os/windows/msys2/builds/msys/$arch/
-Server = https://ftp.osuosl.org/pub/msys2/msys/$arch/
 Server = https://mirror.internet.asn.au/pub/msys2/msys/$arch/
 Server = https://mirror.selfnet.de/msys2/msys/$arch/
 Server = https://mirrors.dotsrc.org/msys2/msys/$arch/
@@ -18,11 +16,11 @@ Server = https://mirrors.bfsu.edu.cn/msys2/msys/$arch/
 Server = https://mirrors.tuna.tsinghua.edu.cn/msys2/msys/$arch/
 Server = https://mirrors.ustc.edu.cn/msys2/msys/$arch/
 Server = https://mirror.nju.edu.cn/msys2/msys/$arch/
-Server = https://repo.extreme-ix.org/msys2/msys/$arch/
 Server = https://mirror.clarkson.edu/msys2/msys/$arch/
 Server = https://quantum-mirror.hu/mirrors/pub/msys2/msys/$arch/
 Server = https://mirror.archlinux.tw/MSYS2/msys/$arch/
 Server = https://distrohub.kyiv.ua/msys2/msys/$arch/
+Server = https://mirror.umd.edu/msys2/msys/$arch/
 
 ## Tier 2
 Server = https://ftp.cc.uoc.gr/mirrors/msys2/msys/$arch/
@@ -34,3 +32,5 @@ Server = https://mirrors.bit.edu.cn/msys2/msys/$arch/
 Server = https://mirrors.aliyun.com/msys2/msys/$arch/
 Server = https://mirror.iscas.ac.cn/msys2/msys/$arch/
 Server = https://mirrors.cloud.tencent.com/msys2/msys/$arch/
+Server = https://download.nus.edu.sg/mirror/msys2/msys/$arch/
+Server = https://repo.extreme-ix.org/msys2/msys/$arch/


### PR DESCRIPTION
* move mirror.umd.edu down, as it is still flaky
* rename ftp.osuosl.org to the new ftp2.osuosl.org
* move ftp2.osuosl.org up as it is our best mirror
* move download.nus.edu.sg to tier 2 (we lost rsync some time ago)
* move repo.extreme-ix.org to tier 2 (too slow for tier 1)