### PR TITLE
gcc: Update to 13.4.0

### DIFF
--- a/gcc/0101-Cygwin-enable-libgccjit-not-just-for-MingW.patch
+++ b/gcc/0101-Cygwin-enable-libgccjit-not-just-for-MingW.patch
@@ -162,22 +162,6 @@ index 2a774d7feb1..6bd882c5ddf 100644
  jit.install-common: installdirs jit.install-headers
  # Install import library
  	$(INSTALL_PROGRAM) $(LIBGCCJIT_IMPORT_LIB) \
-diff --git a/gcc/system.h b/gcc/system.h
-index b13e9429577..42ccb48e671 100644
---- a/gcc/system.h
-+++ b/gcc/system.h
-@@ -693,8 +693,9 @@ extern int vsnprintf (char *, size_t, const char *, va_list);
- # endif
- #endif
- 
--#if defined (ENABLE_PLUGIN) && defined (HAVE_DLFCN_H)
--/* If plugin support is enabled, we could use libdl.  */
-+#if defined (HAVE_DLFCN_H) && (defined (ENABLE_PLUGIN) || defined (__CYGWIN__))
-+/* If plugin support is enabled, we could use libdl.
-+   On Cygwin libdl is needed for libgccjit but no plugin support is available.  */
- #include <dlfcn.h>
- #endif
- 
 -- 
 2.39.0
 

--- a/gcc/PKGBUILD
+++ b/gcc/PKGBUILD
@@ -9,12 +9,13 @@ pkgname=('gcc' 'gcc-libs')
 # NOTE: gdb must be rebuilt with each new gcc version.
 # NOTE: libtool must be rebuilt with each new gcc version.
 # FIXME: run compileall on /usr/share/gcc-${pkgver}/python/libstdcxx on the next version update
-pkgver=13.3.0
+pkgver=13.4.0
 pkgrel=1
 pkgdesc="The GNU Compiler Collection"
 arch=('i686' 'x86_64')
 license=('spdx:GPL-3.0-or-later AND GPL-2.0-or-later AND LGPL-2.1-or-later AND LGPL-3.0-or-later AND GCC-exception-3.1 AND GFDL-1.3-or-later')
 url="https://gcc.gnu.org/"
+msys2_repository_url="https://gcc.gnu.org/git/?p=gcc.git"
 msys2_references=(
   "cpe: cpe:/a:gnu:gcc"
 )
@@ -39,7 +40,7 @@ source=(https://ftp.gnu.org/gnu/gcc/gcc-${pkgver}/gcc-${pkgver}.tar.xz
         0950-11.2.0-configure-msys2.patch
         0951-11.2.0-msys2-spec.patch
         0953-11.2.0-testsuite-msys2.patch)
-sha256sums=('0845e9621c9543a13f484e94584a49ffc0129970e9914624235fc1d061a0c083'
+sha256sums=('9c4ce6dbb040568fdc545588ac03c5cbc95a8dbf0c7aa490170843afb59ca8f5'
             'bc788aa466a83184d285cc2f6c1ffc40c6ed416dd08c6999015262a53f1ab1b5'
             '704acfaeb11d24d3fe5aab34bc883c184ca93aff03d752016c9a50fdd82c5655'
             'c5676fd62d5f7f69be26062b95d42ef47f28151af83b83efa3998ecd8e939e19'
@@ -51,7 +52,7 @@ sha256sums=('0845e9621c9543a13f484e94584a49ffc0129970e9914624235fc1d061a0c083'
             'a40e7025507130a2a5d2eb2eea8ba4b053398c307cd55b3c9421a8507bd315ed'
             '2658eb376f7829179963978b69a048ed105a41508adc55d0fc0d607c14181926'
             '83b6aea4a462ae80121fd68d42c6234d02e20865132197a10575bbf95fd33b7e'
-            'c5aeab9609f90a8430c43bb50172b63c3155eb10082369f81fac58a395d2e2ee'
+            '929b2d0e26259bfc79a9d67a7cf28bbd8d26289ef0933094672b1e09a43d75cc'
             '3707b0aab99b203cbd9e513be46c7d4600de06e6c8344160b7fb1779061d08da'
             '8a29a40ee426ee786da97656c35d2e9c17838b12c1b750cecf857760da273381'
             'eeb167fe5f12d122038cbc5d7f79f093ab40ace1f0973dd109aad2e1168cb8a8'


### PR DESCRIPTION
the removed change was fixed upstream via
https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=1283b9f946eea07573be5ba0e0785c9e9279b3be