### PR TITLE
less: upgrade to 679

### DIFF
--- a/less/PKGBUILD
+++ b/less/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=less
-pkgver=678
+pkgver=679
 pkgrel=1
 pkgdesc="A terminal based program for viewing text files"
 license=('GPL3')
@@ -14,7 +14,7 @@ msys2_references=(
 depends=('ncurses' 'libpcre2_8')
 makedepends=('ncurses-devel' 'pcre2-devel' 'autotools' 'gcc' 'groff')
 source=("https://github.com/gwsw/${pkgname}/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('c671da3ce45f697d6c11f5695b760c829861bbed3bd4f9c8785ab058a4a96f85')
+sha256sums=('39d3f4f716d2889a7118f23e5ab561b50c8122ef51042dd114a40eda235716e1')
 validpgpkeys=('AE27252BD6846E7D6EAE1DD6F153A7C833235259') # Mark Nudelman
 
 prepare() {


### PR DESCRIPTION
Release notes (from https://www.greenwoodsoftware.com/less/news.679.html):

Version 679 was released for beta testing on 29 May 2025, and was released for general use on 19 Jun 2025.

These are the differences between version 678 and version 679:

* Fix bad parsing of lesskey file an env var is a prefix of another env var (github gwsw/less#626).
* Fix unexpected exit using -K if a key press is received while ng the input file (github gwsw/less#628).