### PR TITLE
emacs: fix the build with newer gcc

### DIFF
--- a/emacs/PKGBUILD
+++ b/emacs/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=emacs
 pkgver=30.1
-pkgrel=2
+pkgrel=3
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (msys2)"
 url="https://www.gnu.org/software/${pkgname}/"
 msys2_references=(
@@ -33,6 +33,8 @@ prepare() {
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
 
+  # gl_cv_clean_version_stddef:
+  # https://github.com/msys2/MSYS2-packages/pull/5503#issuecomment-3054117962
 
   CPPFLAGS="-DNDEBUG"
   CFLAGS="-pipe -O3 -fomit-frame-pointer -funroll-loops"
@@ -46,7 +48,8 @@ build() {
     --with-sound=yes \
     --with-modules \
     --without-compress-install \
-    --without-native-compilation
+    --without-native-compilation \
+    gl_cv_clean_version_stddef=yes
 
   make
 }


### PR DESCRIPTION
workaround a gnulib issue