### PR TITLE
fish: use rustc completions from v4.0

### DIFF
--- a/fish/PKGBUILD
+++ b/fish/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=fish
 pkgver=3.7.1
-pkgrel=5
+pkgrel=6
 epoch=
 pkgdesc='Smart and user friendly shell intended mostly for interactive use'
 arch=('i686' 'x86_64')
@@ -18,6 +18,7 @@ optdepends=('python: for manual page completion parser and web configuration too
 install=fish.install
 backup=('etc/fish/config.fish' 'etc/fish/msys2.fish' 'etc/fish/perlbin.fish')
 source=("https://github.com/fish-shell/fish-shell/releases/download/${pkgver}/${pkgname}-${pkgver}.tar.xz"{,.asc}
+        "https://raw.githubusercontent.com/fish-shell/fish-shell/4868166f86e2f6c7c54082c36c9c7a5d67dc1092/share/completions/rustc.fish"
         config.fish
         msys2.fish
         msystem.fish
@@ -25,6 +26,7 @@ source=("https://github.com/fish-shell/fish-shell/releases/download/${pkgver}/${
         0001-cmake-4-backport.patch)
 sha256sums=('614c9f5643cd0799df391395fa6bbc3649427bb839722ce3b114d3bbc1a3b250'
             'SKIP'
+            '97a6fc8746dbb7117de79446c4b85f412624f8f797bb10f12e07361c4995bc23'
             '983c3273e0249957ed6c40785e005739da30f31d4f029383f257f9990d38811a'
             '8bb0d28df47b66e6785f7db00a2c4316bc15960e67bdec0daca7f811f5bf3895'
             '71c6990b39caf5d50c10f10074283adfc6a36aafff30fd54f7eb451d4e007496'
@@ -62,4 +64,6 @@ package() {
   install -D -m644 "${srcdir}/msys2.fish" "${pkgdir}/etc/fish/msys2.fish"
   install -D -m644 "${srcdir}/msystem.fish" "${pkgdir}/etc/fish/msystem.fish"
   install -D -m644 "${srcdir}/perlbin.fish" "${pkgdir}/etc/fish/perlbin.fish"
+  # install more fresh rustc completions because it was buggy
+  install -D -m644 "${srcdir}/rustc.fish" "${pkgdir}/usr/share/fish/completions/rustc.fish"
 }


### PR DESCRIPTION
they were broken in v3.x, and it was fixed only in 4.0 release

```shell
$ rustc +string split: - hashes of green query instances: unknown option

/usr/share/fish/completions/rustc.fish (line 1):
string split -m 1 ' ' $line
^
in command substitution
        called on line 43 of file /usr/share/fish/completions/rustc.fish
from sourcing file /usr/share/fish/completions/rustc.fish

(Type 'help string' for related documentation)
string split: - hash collisions of query keys: unknown option

/usr/share/fish/completions/rustc.fish (line 1):
string split -m 1 ' ' $line
^
in command substitution
        called on line 43 of file /usr/share/fish/completions/rustc.fish
from sourcing file /usr/share/fish/completions/rustc.fish

(Type 'help string' for related documentation)
string split: - hash collisions when creating dep-nodes: unknown option

/usr/share/fish/completions/rustc.fish (line 1):
string split -m 1 ' ' $line
^
in command substitution
        called on line 43 of file /usr/share/fish/completions/rustc.fish
from sourcing file /usr/share/fish/completions/rustc.fish

(Type 'help string' for related documentation)
```
(if you press Tab after typing '+')