### PR TITLE
ansible: update to 9.13.0 + ansible-core: update to 2.16.14

### DIFF
--- a/ansible-core/PKGBUILD
+++ b/ansible-core/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Alexandre Ferreira <contact@alexjorgef.com>
 
 pkgname=ansible-core
-pkgver=2.16.2
-pkgrel=3
+pkgver=2.16.14
+pkgrel=1
 pkgdesc='Radically simple IT automation platform'
 arch=('any')
 url='https://pypi.org/project/ansible-core'
@@ -21,11 +21,11 @@ optdepends=(
 makedepends=('tar' 'python-build' 'python-installer' 'python-setuptools')
 replaces=('ansible-base')
 backup=('etc/ansible/ansible.cfg')
-source=("https://pypi.python.org/packages/source/a/ansible-core/ansible-core-${pkgver}.tar.gz"
+source=("https://pypi.python.org/packages/source/a/ansible-core/ansible_core-${pkgver}.tar.gz"
         "0001-ctypes-cdll-loadlibrary-msys2.patch")
-sha512sums=('6e2389fc6b34645c0f1566eca960da36616619a5ed5e35b46f3d659979fe519db20d89b4f598344a389f4b6ac33bb660ea91a1a6509002bbf4ac791ea3cb4cbd'
+sha512sums=('246875815234112b9c4f7aa31d971f0c0017c9bc4195116741fb5db2e70c6d8feacc29b9882c9b6c4a3186be1d6bea0571be10541d0d8593fb7da3d46f30e2e8'
             'f129850ecf75b48dd89b2f43e7f09a2585d63959be807299f5c1ddcdb12ecafafa4a230dc0d8a9c284d5d6fec21eae22eb4c0c8c5fde37a09d7bdac7b8503b98')
-noextract=("${pkgname}-${pkgver}.tar.gz")
+noextract=("${pkgname/-/_}-${pkgver}.tar.gz")
 
 apply_patch_with_msg() {
   for _fname in "$@"
@@ -36,9 +36,9 @@ apply_patch_with_msg() {
 }
 
 prepare() {
-  tar zxf "${srcdir}/${pkgname}-${pkgver}.tar.gz" || tar zxf "${srcdir}/${pkgname}-${pkgver}.tar.gz"
+  tar zxf "${srcdir}/${pkgname/-/_}-${pkgver}.tar.gz" || tar zxf "${srcdir}/${pkgname/-/_}-${pkgver}.tar.gz"
 
-  cd "${srcdir}/${pkgname}-${pkgver}"
+  cd "${srcdir}/${pkgname/-/_}-${pkgver}"
 
   # Patches
   apply_patch_with_msg \
@@ -46,12 +46,12 @@ prepare() {
 }
 
 build() {
-  cd "${srcdir}/${pkgname}-${pkgver}"
+  cd "${srcdir}/${pkgname/-/_}-${pkgver}"
   python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 package() {
-  cd ${pkgname}-${pkgver}
+  cd ${pkgname/-/_}-${pkgver}
   python -m installer --destdir="${pkgdir}" dist/*.whl
   install -Dm644 COPYING "${pkgdir}"/usr/share/doc/${pkgname}/COPYING
 }

--- a/ansible/PKGBUILD
+++ b/ansible/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Alexandre Ferreira <contact@alexjorgef.com>
 
 pkgname=ansible
-pkgver=9.1.0
-pkgrel=3
+pkgver=9.13.0
+pkgrel=1
 pkgdesc='Official assortment of Ansible collections'
 arch=('any')
 url='https://pypi.org/project/ansible/'
@@ -24,7 +24,7 @@ makedepends=(
   'python-setuptools'
 )
 source=("https://pypi.python.org/packages/source/a/ansible/ansible-${pkgver}.tar.gz")
-sha512sums=('ec6d86b3d05e66053001720b6b7d7bd1dba8bd50917c913e1f08a63b0c94f76a5d69732c78e793d038622a0b8c652860290a89cee1dfb22491a81763923ef843')
+sha512sums=('7f2236da982463764e1a05d17115dbf85d9eff1117c1c19f4244d6bad134cababedba548d9c78e39c4835e0b104dcb05bc4fec47182ada58890320972b2b0164')
 
 build() {
   cd ansible-${pkgver}


### PR DESCRIPTION
Upstream changed the name of the downloadable artifact from ansible-core-version.tar.gz to ansible_core-version.tar.gz, so a bit of character juggling is added to compensate for that.


Ansible 9.13.0 is the final release of the Ansible 9.x series, see https://forum.ansible.com/t/release-announcement-ansible-community-package-9-13-0/38866.