### PR TITLE
llvm: update to 21.1.1

### DIFF
--- a/llvm/0201-LLD-COFF-Prevent-to-emit-relocations-for-discarded-w.patch
+++ b/llvm/0201-LLD-COFF-Prevent-to-emit-relocations-for-discarded-w.patch
@@ -1,0 +1,200 @@
+From adbbd5bb996725d5ec328747f03aa9c958c736b4 Mon Sep 17 00:00:00 2001
+From: Tomohiro Kashiwada <kikairoya@gmail.com>
+Date: Tue, 9 Sep 2025 19:10:28 +0900
+Subject: [PATCH] [LLD][COFF] Prevent to emit relocations for discarded weak
+ wrapped symbols (#156214)
+
+When a symbol is imported from a DLL, a base relocation record is
+normally emitted.
+However, if the import is pulled in via a wrapped symbol (using
+`--wrap`) and later dropped because it is only referenced weakly, a
+dangling base relocation remains in the output.
+At runtime, this relocation changes the symbol value from null to a
+garbage pointer.
+
+This patch adds checks to avoid emitting relocation records for
+non-`Defined` symbols, and to prevent creating an auto-import entry if
+an import entry for the wrapped symbol already exists.
+
+Fixes https://github.com/llvm/llvm-project/issues/150739
+
+(cherry picked from commit e976622e2d7464b09fcf0141291003bf5fe9fd6f)
+---
+ lld/COFF/Chunks.cpp                  |  2 +-
+ lld/COFF/MinGW.cpp                   | 13 ++++---
+ lld/test/COFF/reloc-undefined-weak.s | 52 ++++++++++++++++++++++++++++
+ lld/test/COFF/wrap-dllimport.s       | 34 +++++++++++++-----
+ 4 files changed, 88 insertions(+), 13 deletions(-)
+ create mode 100644 lld/test/COFF/reloc-undefined-weak.s
+
+diff --git a/lld/COFF/Chunks.cpp b/lld/COFF/Chunks.cpp
+index 01752cdc6a..532f4d640f 100644
+--- a/lld/COFF/Chunks.cpp
++++ b/lld/COFF/Chunks.cpp
+@@ -570,7 +570,7 @@ void SectionChunk::getBaserels(std::vector<Baserel> *res) {
+     if (ty == IMAGE_REL_BASED_ABSOLUTE)
+       continue;
+     Symbol *target = file->getSymbol(rel.SymbolTableIndex);
+-    if (!target || isa<DefinedAbsolute>(target))
++    if (!isa_and_nonnull<Defined>(target) || isa<DefinedAbsolute>(target))
+       continue;
+     res->emplace_back(rva + rel.VirtualAddress, ty);
+   }
+diff --git a/lld/COFF/MinGW.cpp b/lld/COFF/MinGW.cpp
+index e7117cbea2..597c508115 100644
+--- a/lld/COFF/MinGW.cpp
++++ b/lld/COFF/MinGW.cpp
+@@ -269,10 +269,15 @@ void lld::coff::wrapSymbols(SymbolTable &symtab) {
+       // (We can't easily distinguish whether any object file actually
+       // referenced it or not, though.)
+       if (imp) {
+-        DefinedLocalImport *wrapimp = make<DefinedLocalImport>(
+-            symtab.ctx, saver().save("__imp_" + w.wrap->getName()), d);
+-        symtab.localImportChunks.push_back(wrapimp->getChunk());
+-        map[imp] = wrapimp;
++        if (Symbol *wrapimp =
++                symtab.find(("__imp_" + w.wrap->getName()).str())) {
++          map[imp] = wrapimp;
++        } else {
++          DefinedLocalImport *localwrapimp = make<DefinedLocalImport>(
++              symtab.ctx, saver().save("__imp_" + w.wrap->getName()), d);
++          symtab.localImportChunks.push_back(localwrapimp->getChunk());
++          map[imp] = localwrapimp;
++        }
+       }
+     }
+   }
+diff --git a/lld/test/COFF/reloc-undefined-weak.s b/lld/test/COFF/reloc-undefined-weak.s
+new file mode 100644
+index 0000000000..dc0a230c37
+--- /dev/null
++++ b/lld/test/COFF/reloc-undefined-weak.s
+@@ -0,0 +1,52 @@
++// REQUIRES: x86
++
++// Check that base-relocations for unresolved weak symbols will be omitted.
++
++// RUN: rm -rf %t.dir && split-file %s %t.dir && cd %t.dir
++// RUN: llvm-mc -filetype=obj -triple=x86_64-mingw main.s -o main.obj
++// RUN: llvm-mc -filetype=obj -triple=x86_64-mingw other.s -o other.obj
++
++// RUN: lld-link -lldmingw -machine:x64 -dll -out:other.dll other.obj -noentry -export:foo -implib:other.lib
++// RUN: lld-link -lldmingw -machine:x64 -out:main.exe main.obj other.lib -entry:entry -wrap:foo -debug:symtab
++// RUN: llvm-readobj --sections --symbols --coff-imports --coff-basereloc main.exe | FileCheck %s --implicit-check-not=other.dll
++
++// CHECK:      Number: 3
++// CHECK-NEXT: Name: .data
++// CHECK-NEXT: VirtualSize:
++// CHECK-NEXT: VirtualAddress: 0x[[#%x,SECTOP:0x3000]]
++// CHECK:      Name: ref_foo
++// CHECK-NEXT: Value: [[#%d,SYMVAL:]]
++// CHECK:      BaseReloc [
++// CHECK-NOT:    Address: 0x[[#%x,SECTOP+SYMVAL]]
++
++#--- main.s
++.global entry
++entry:
++  movq ref_foo(%rip), %rax
++  call *%rax
++
++.global __wrap_foo
++__wrap_foo:
++  ret
++
++.data
++.global ref_foo
++.p2align 3
++ref_foo:
++  .quad __real_foo
++
++.globl _pei386_runtime_relocator
++_pei386_runtime_relocator:
++  movl __RUNTIME_PSEUDO_RELOC_LIST__(%rip), %eax
++  movl __RUNTIME_PSEUDO_RELOC_LIST_END__(%rip), %eax
++
++.weak __real_foo
++.addrsig
++.addrsig_sym __real_foo
++.addrsig_sym ref_foo
++
++#--- other.s
++.global foo
++
++foo:
++  ret
+diff --git a/lld/test/COFF/wrap-dllimport.s b/lld/test/COFF/wrap-dllimport.s
+index d7662b29fd..a26e43b698 100644
+--- a/lld/test/COFF/wrap-dllimport.s
++++ b/lld/test/COFF/wrap-dllimport.s
+@@ -1,42 +1,60 @@
+ // REQUIRES: x86
+ 
+ // Check that we can wrap a dllimported symbol, so that references to
+-// __imp_<symbol> gets redirected to a defined local import instead.
++// __imp_<symbol> gets redirected to a symbol that already exists or a defined
++// local import instead.
+ 
+ // RUN: split-file %s %t.dir
+ // RUN: llvm-mc -filetype=obj -triple=i686-win32-gnu %t.dir/main.s -o %t.main.obj
+ // RUN: llvm-mc -filetype=obj -triple=i686-win32-gnu %t.dir/other.s -o %t.other.obj
+ 
+-// RUN: lld-link -dll -out:%t.dll %t.other.obj -noentry -safeseh:no -export:foo -implib:%t.lib
+-// RUN: lld-link -out:%t.exe %t.main.obj %t.lib -entry:entry -subsystem:console -debug:symtab -safeseh:no -wrap:foo -lldmap:%t.map
++// RUN: lld-link -dll -out:%t.dll %t.other.obj -noentry -safeseh:no -export:foo -export:bar -implib:%t.lib
++// RUN: lld-link -out:%t.exe %t.main.obj %t.lib -entry:entry -subsystem:console -debug:symtab -safeseh:no -wrap:foo -wrap:bar -lldmap:%t.map
+ // RUN: llvm-objdump -s -d --print-imm-hex %t.exe | FileCheck %s
+ 
+ // CHECK:      Contents of section .rdata:
+-// CHECK-NEXT:  402000 06104000
++// CHECK-NEXT:  402000 0c104000
+ 
+ // CHECK:      Disassembly of section .text:
+ // CHECK-EMPTY:
+ // CHECK:      00401000 <_entry>:
+ // CHECK-NEXT:   401000: ff 25 00 20 40 00             jmpl    *0x402000
++// CHECK-NEXT:   401006: ff 25 00 00 00 00             jmpl    *0x0
+ // CHECK-EMPTY:
+-// CHECK-NEXT: 00401006 <___wrap_foo>:
+-// CHECK-NEXT:   401006: c3                            retl
++// CHECK-NEXT: 0040100c <___wrap_foo>:
++// CHECK-NEXT:   40100c: c3                            retl
++// CHECK-EMPTY:
++// CHECK-NEXT: 0040100d <___wrap_bar>:
++// CHECK-NEXT:   40100d: c3                            retl
+ 
+-// The jmpl instruction in _entry points at an address in 0x402000,
++// The first jmpl instruction in _entry points at an address in 0x402000,
+ // which is the first 4 bytes of the .rdata section (above), which is a
+ // pointer that points at ___wrap_foo.
+ 
++// The second jmpl instruction in _entry points to null because the referenced
++// symbol `__imp____wrap_bar` is declared as a weak reference to prevent pull a
++// reference from an external DLL.
++
+ #--- main.s
+ .global _entry
+ _entry:
+   jmpl *__imp__foo
++  jmpl *__imp__bar
+ 
+ .global ___wrap_foo
+ ___wrap_foo:
+   ret
+ 
++.weak __imp____wrap_bar
++.global ___wrap_bar
++___wrap_bar:
++  ret
++
+ #--- other.s
+ .global _foo
+-
+ _foo:
+   ret
++
++.global _bar
++_bar:
++  ret
+-- 
+2.51.0.windows.1
+

--- a/llvm/PKGBUILD
+++ b/llvm/PKGBUILD
@@ -9,11 +9,11 @@ pkgname=("llvm"
          "clang-analyzer"
          "compiler-rt"
          "lld")
-_version=21.1.0
+_version=21.1.1
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=2
+pkgrel=1
 pkgdesc="C language family frontend for LLVM"
 arch=('i686' 'x86_64')
 url="https://llvm.org/"
@@ -52,22 +52,23 @@ source=("${_url}/llvm-${pkgver}.src.tar.xz"{,.sig}
         "0104-Clang-Cygwin-call-linker-directly.patch"
         "0105-Tests-Add-system-cygwin-feature-and-use-it.-152611.patch"
         "0199-msysize.patch"
+        "0201-LLD-COFF-Prevent-to-emit-relocations-for-discarded-w.patch"
         )
-sha256sums=('0582ee18cb6e93f4e370cb4aa1e79465ba1100408053e1ff8294cef7fb230bd8'
+sha256sums=('23336f9f2290f2317121a5995e298a4616041ba06cbb07cfd1220a21b48775fe'
             'SKIP'
-            '4c8d148d4c5931c65116d1a5fdebd9d9579c3d135f36551b1cad53e220986cb2'
+            '65a19a75440c6d0f92138d82432e7a201677fad5cecf39d3200eaa2f458c29e3'
             'SKIP'
-            'b065a2686674d931f2696517965260b1c92ffd18a492efb847fafb54457d690f'
+            'f5e46d1734be28bc8ea83d0a5621a43388d349def91e37e6907609e5b67d1f8e'
             'SKIP'
-            '0394c634edb6fa421b3690b042cfd5a42d7f7ab141aebedecb0b1d23ff882422'
+            '5e83536d8197ba38f40b8c4fbdeef7315a7dc15ed894a7b837a9a3482b9f80ef'
             'SKIP'
-            '528347c84c3571d9d387b825ef8b07c7ad93e9437243c32173838439c3b6028f'
+            '9c0b9064b7d0f2a3004f1d034aadf84d2af4e5dca2135ebf697b0a1eb85ef769'
             'SKIP'
-            'bbee5d791ed693d57ff0668e7f150e43cb9616501fd20a48f96768b16cab2ca2'
+            '1a8847f4c256d2eac5852b8f821205862f925eadf013cd3a660bd8a28a2849ec'
             'SKIP'
-            'd92a197171b3ebef6e35eeb9724c9c7fcfbd369ffba6b052c79711b8adbda69a'
+            'e28a57f3895f0d652aaaf9389b3db691d4200241815333d9e5edd25c2cdc4c2e'
             'SKIP'
-            '60b3d8c2d1d8d43a705f467299144d232b8061a10541eaa3b0d6eaa2049a462f'
+            'e9b7299b0b32aa827231ed35101a3b5ea37dd5a45719225cb2c08ac571791233'
             'SKIP'
             '7cb70e14a5c6e87ef28427356ad3d366d58c367b2039d2a3bf92fa7dee33d79d'
             '275eb63a8d99bf9c3f6168665641fea1010448a9296b3d6b41d1ba1e78d1201e'
@@ -81,7 +82,8 @@ sha256sums=('0582ee18cb6e93f4e370cb4aa1e79465ba1100408053e1ff8294cef7fb230bd8'
             '9b6b248f63e04f810b4d1d919f0b2eb584b08888f0dad11d41e56769e0a01d10'
             '9f741cdf2454526427d5941219583c2c0420d144368edd69954092086861a35b'
             '18320250d0e175d6dabdfa44e6dc6fee6c6ca30ca91e9e1ed1f7c27417b7a671'
-            '9fd31dbc1f4066c2e2ab606369db27ade8336085c7487f4ac5f6f42dfefd74bf')
+            '9fd31dbc1f4066c2e2ab606369db27ade8336085c7487f4ac5f6f42dfefd74bf'
+            'fc4b425f9e88200a0baef63d0dbc23c70dce66f3e08fafa85717078c80ae8e2f')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Google.
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard
               'D574BD5D1D0E98895E3BF90044F2485E45D59042') # Tobias Hieta
@@ -150,6 +152,8 @@ prepare() {
 
   # Patch lld
   cd "${srcdir}"/lld
+  apply_git_patch_with_msg \
+    0201-LLD-COFF-Prevent-to-emit-relocations-for-discarded-w.patch
 }
 
 build() {

--- a/llvm/README-patches.md
+++ b/llvm/README-patches.md
@@ -23,3 +23,4 @@ Legend:
 - `"0104-Clang-Cygwin-call-linker-directly.patch"` :arrow_down_small: https://github.com/llvm/llvm-project/pull/147960
 - `"0105-Tests-Add-system-cygwin-feature-and-use-it.-152611.patch"` :arrow_up_small: https://github.com/llvm/llvm-project/commit/ff616b4806ed6c9b9698290a9c807626aa3844f7
 - `"0199-msysize.patch"` :grey_exclamation:
+- `"0201-LLD-COFF-Prevent-to-emit-relocations-for-discarded-w.patch"` :arrow_down_small: https://github.com/llvm/llvm-project/commit/e976622e2d7464b09fcf0141291003bf5fe9fd6f


### PR DESCRIPTION
backport LLD patch for wrapped dllimported weak symbols (used by Cygwin for C++ operator new/delete)