### PR TITLE
ansible-core: Update to 2.19.2

### DIFF
--- a/ansible-core/PKGBUILD
+++ b/ansible-core/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexandre Ferreira <contact@alexjorgef.com>
 
 pkgname=ansible-core
-pkgver=2.16.14
+pkgver=2.19.2
 pkgrel=1
 pkgdesc='Radically simple IT automation platform'
 arch=('any')
@@ -23,7 +23,7 @@ replaces=('ansible-base')
 backup=('etc/ansible/ansible.cfg')
 source=("https://pypi.python.org/packages/source/a/ansible-core/ansible_core-${pkgver}.tar.gz"
         "0001-ctypes-cdll-loadlibrary-msys2.patch")
-sha512sums=('246875815234112b9c4f7aa31d971f0c0017c9bc4195116741fb5db2e70c6d8feacc29b9882c9b6c4a3186be1d6bea0571be10541d0d8593fb7da3d46f30e2e8'
+sha512sums=('f349e2ae8c226b82d1a92069cab681f356db6b985bf5d034c92c687fb611f52dacc54106b68bbdcb6bd5b155396eeea410b80a7e136b3962bbeb223af6486977'
             'f129850ecf75b48dd89b2f43e7f09a2585d63959be807299f5c1ddcdb12ecafafa4a230dc0d8a9c284d5d6fec21eae22eb4c0c8c5fde37a09d7bdac7b8503b98')
 noextract=("${pkgname/-/_}-${pkgver}.tar.gz")
 


### PR DESCRIPTION
## Build Environment

* OS: Windows 11 24H2
* MSYS2 Version: 20250830.0.0

Installation (`pacman -U --noconfirm ...`):

```text
    ...
    default: ==> Finished making: ansible-core 2.19.2-1 (Fri, Sep 12, 2025  9:50:10 AM)
    default: Installing package...
    default: loading packages...
    default: resolving dependencies...
    default: looking for conflicting packages...
    default: 
    default: Packages (1) ansible-core-2.19.2-1
    default: 
    default: Total Installed Size:  21.97 MiB
    default: 
    default: :: Proceed with installation? [Y/n]
    default: checking keyring...
    default: checking package integrity...
    default: loading package files...
    default: checking for file conflicts...
    default: checking available disk space...
    default: :: Processing package changes...
    default: installing ansible-core...
    default: Optional dependencies for ansible-core
    default:     sshpass: for ssh connections with password
```

Check Ansible version (`ansible --version`):

```text
    default: ansible [core 2.19.2]
    default:   config file = None
    default:   configured module search path = ['/home/vagrant/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
    default:   ansible python module location = /usr/lib/python3.12/site-packages/ansible
    default:   ansible collection location = /home/vagrant/.ansible/collections:/usr/share/ansible/collections
    default:   executable location = /usr/bin/ansible
    default:   python version = 3.12.11 (main, Jun  9 2025, 11:30:55) [GCC 13.3.0] (/usr/bin/python.exe)
    default:   jinja version = 3.1.6
    default:   pyyaml version = 6.0.2 (with libyaml v0.2.5)
```