### PR TITLE
ansible: add version constraint on ansible-core

### DIFF
--- a/ansible/PKGBUILD
+++ b/ansible/PKGBUILD
@@ -1,8 +1,10 @@
 # Maintainer: Alexandre Ferreira <contact@alexjorgef.com>
 
 pkgname=ansible
+# Note: When packaging a new version of ansible, bump version of ansible-core in
+# depends, if required.
 pkgver=12.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Official assortment of Ansible collections'
 arch=('any')
 url='https://pypi.org/project/ansible/'
@@ -15,7 +17,11 @@ msys2_references=(
 license=('spdx:GPL-3.0-or-later')
 depends=(
   'python'
-  'ansible-core'
+  # Bump the version of ansible-core at least whenever a new major version of
+  # ansible is packaged / released. Check the ansible release notes to get the
+  # corresponding version of ansible-core. It usually has a statement like
+  # "Ansible x.y.z depends on ansible-core a.b.c" in it.
+  'ansible-core>=2.19.1'
 )
 makedepends=(
   'python-setuptools'


### PR DESCRIPTION
ansible implicitly depends on a certain version of ansible-core, so let's formalize this by adding the version to PKGBUILD.