### PR TITLE
libtool: Add new LLVM Flang runtime library name to exceptions

### DIFF
--- a/libtool/0004-Allow-statically-linking-Flang-support-libraries-whe.patch
+++ b/libtool/0004-Allow-statically-linking-Flang-support-libraries-whe.patch
@@ -17,7 +17,7 @@ index 5f9af8c2..97810d08 100644
 +		      # libraries is allowed, but linking other static libraries is
 +		      # non-portable.
 +		      case $potlib in
-+		        */libFortran*.$libext)
++		        */libFortran*.$libext | */libflang_rt*.$libext)
 +		          func_append newdeplibs " $potlib"
 +		          a_deplib=
 +		          ;;

--- a/libtool/PKGBUILD
+++ b/libtool/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=libtool
 pkgname=('libtool' 'libltdl')
 pkgver=2.5.4
-pkgrel=3
+pkgrel=4
 pkgdesc="A generic library support script"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/libtool"
@@ -34,7 +34,7 @@ sha256sums=('f81f5860666b0bc7d84baddefa60d1cb9fa6fceb2398cc3baca6afaa60266675'
             '67e4f2429dfe67499b1829d0a8312d9a043057db354307f8db41d9f967944346'
             'd873306936060e6c72cf0f3c174131cc85debc2ea6dc924eabdf6e3a813c768e'
             '00f0b0429431a884b481eb92f4b138c50bc17eb09f0985d7ebfd4a0a50407eb6'
-            '30b361a43266dbd80c94fe58196113ad3ae78e134da62d9dfad65ac67e337db8'
+            '96538c6cb843f8673f4db8199402b4b02d9477d71c86df5f5e94e3e4d1347b54'
             '0dd70a4f955ed4cd94a0d13b784b7db7dddbd4d1d6ee5b092202f8b9496fd3eb'
             '2cb1b61247a4632698ac7e26c496c3ad8c1b4fde080d301994dbddc0794a4bf4'
             'fca5986c0010b202ee65c69939815269bd46b3ce948d9222916985652da7e2af'


### PR DESCRIPTION
The Flang runtime library was renamed in LLVM 21. Add the new name of the Flang runtime library to the list of static libraries that are allowed exceptionally to be linked into shared libraries.

Without this change, attempting to link shared libraries with objects that have been compiled with LLVM Flang 21 fails with messages like the following:
```
libtool: warning: Linker path does not have real file for library -lflang_rt.runtime.
libtool: warning: I have the capability to make that library automatically link in when
libtool: warning: you link to this library.  But I can only do this if you have a
libtool: warning: shared version of the library, which you do not appear to have
libtool: warning: because I did check the linker path looking for a file starting
libtool: warning: with libflang_rt.runtime and none of the candidates passed a file format test
libtool: warning: using a file magic. Last file checked: C:/msys64/clang64/lib/libflang_rt.runtime.a
```

(Still untested)

See also https://github.com/msys2/MINGW-packages/pull/25641