### PR TITLE
git: fix aspell support for git-gui

### DIFF
--- a/git/0001-aspell.patch
+++ b/git/0001-aspell.patch
@@ -1,0 +1,40 @@
+--- git-2.51.0/git-gui/git-gui.sh.orig	2025-08-18 02:18:23.000000000 +0200
++++ git-2.51.0/git-gui/git-gui.sh	2025-09-25 09:14:55.155971300 +0200
+@@ -3919,7 +3936,7 @@
+ 	#
+ 	set spell_cmd [list |]
+ 	set spell_dict [get_config gui.spellingdictionary]
+-	lappend spell_cmd aspell
++	lappend spell_cmd [exec cygpath --windows --absolute {/usr/bin/aspell}]
+ 	if {$spell_dict ne {}} {
+ 		lappend spell_cmd --master=$spell_dict
+ 	}
+--- git-2.51.0/git-gui/lib/spellcheck.tcl.orig	2025-08-18 02:18:23.000000000 +0200
++++ git-2.51.0/git-gui/lib/spellcheck.tcl	2025-09-25 09:14:06.155400800 +0200
+@@ -43,7 +43,7 @@
+ 			if {$s_prog eq {aspell}
+ 				&& [regexp -nocase {^Usage: } $err]
+ 				&& ![catch {
+-						set pipe_fd [open [list | $s_prog -v] r]
++						set pipe_fd [open [list | [exec cygpath --windows --absolute {/usr/bin/aspell}] -v] r]
+ 						gets $pipe_fd s_version
+ 						close $pipe_fd
+ 				}]
+@@ -124,7 +124,7 @@
+ method lang {{n {}}} {
+ 	if {$n ne {} && $s_lang ne $n && !$s_failed} {
+ 		set spell_cmd [list |]
+-		lappend spell_cmd aspell
++		lappend spell_cmd [exec cygpath --windows --absolute {/usr/bin/aspell}]
+ 		lappend spell_cmd --master=$n
+ 		lappend spell_cmd --mode=none
+ 		lappend spell_cmd --encoding=UTF-8
+@@ -401,7 +401,7 @@
+ proc available_langs {} {
+ 	set langs [list]
+ 	catch {
+-		set fd [open [list | aspell dump dicts] r]
++		set fd [open [list | [exec cygpath --windows --absolute {/usr/bin/aspell}] dump dicts] r]
+ 		while {[gets $fd line] >= 0} {
+ 			if {$line eq {}} continue
+ 			lappend langs $line

--- a/git/PKGBUILD
+++ b/git/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=git
 pkgver=2.51.0
-pkgrel=1
+pkgrel=2
 pkgdesc="The fast distributed version control system"
 arch=('i686' 'x86_64')
 url="https://git-scm.com/"
@@ -49,6 +49,7 @@ makedepends=('asciidoc'
 optdepends=(#'tk: gitk and git gui'
             'python: various helper scripts'
             'subversion: git svn'
+            'aspell: spell checking in git gui'
             #'cvsps: git cvsimport'
             )
 replaces=('git-core')
@@ -60,14 +61,16 @@ source=("${pkgname}-${pkgver}.tar.gz"::https://github.com/git/git/archive/v${pkg
         git-2.3.5-mingw-pwd.patch
         git-2.8.2-Cygwin-Allow-DOS-paths.patch
         git-tcsh-completion-fixes.patch
-        git-2.43.0-git-gui.patch)
+        git-2.43.0-git-gui.patch
+        0001-aspell.patch)
 sha256sums=('3524fc5fd81f16f80e1696a8281bd8ad831048b67848015d7b7382bf365ae685'
             '32baa705d76789d82316a1325e61c9a261114eaa9814dca9c05683bf63069dea'
             '9bc4da5022c5004c4c5b45417b25c6636ddf0ac338574a624c2c775d4394546d'
             '336159815092f503e0254ebbbea2b637ffc09a36217c4c644167b86852568272'
             '148a2c45de2c8bb2dfffc96bd40523f860a4b13f4e661609636158b7b3bc930b'
             '6f25aae9e92469d5e284dcf372e15ee0e57ff91531e691e7391f9bfb78f73626'
-            '830b72ed3c9f7443c9553cf553ed18c0bc70a07ff0ba32a3606e446f46460be6')
+            '830b72ed3c9f7443c9553cf553ed18c0bc70a07ff0ba32a3606e446f46460be6'
+            '28ae4263169ef2b32ab2d6190752e5605d1ae3931a8f92cc5f3b38e3012d31dd')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -92,6 +95,10 @@ prepare() {
   # We have a mix where git is cygwin but tcl/tk is native, so we need to adjust
   # a few things, so git-gui works in the mingw environments at least.
   apply_patch_with_msg git-2.43.0-git-gui.patch
+
+  # mingw aspell might work, but "--mode" is broken there,
+  # so force cygwin variant for now
+  apply_patch_with_msg 0001-aspell.patch
 
   make configure
 }


### PR DESCRIPTION
mingw aspell has a broken --mode, and "dump dicts" is also broken (maybe relocation missing?) so force the cygwin variant.

Fixes #5668