### PR TITLE
[u-boot-tools] add fdt_add_pubkey fix (fixes msys2#5673)

### DIFF
--- a/u-boot-tools/PKGBUILD
+++ b/u-boot-tools/PKGBUILD
@@ -40,4 +40,5 @@ package() {
   cp -f tools/fit_check_sign.exe ${pkgdir}/usr/bin/
   cp -f tools/mkimage.exe ${pkgdir}/usr/bin/
   cp -f tools/mkenvimage.exe ${pkgdir}/usr/bin/
+  cp -f tools/fdt_add_pubkey.exe ${pkgdir}/usr/bin/
 }

--- a/u-boot-tools/PKGBUILD
+++ b/u-boot-tools/PKGBUILD
@@ -2,12 +2,12 @@
 
 pkgname=u-boot-tools
 pkgver=2025.07
-pkgrel=1
+pkgrel=2
 pkgdesc="U-Boot Tools"
 arch=('i686' 'x86_64')
 url="https://github.com/u-boot/u-boot"
 msys2_references=(
-  "anitya: 5022"s
+  "anitya: 5022"
   "cpe: cpe:/a:denx:u-boot"
   "archlinux: uboot-tools"
 )


### PR DESCRIPTION
noticed fdt_add_pubkey missing, added to PKGBUILD