### PR TITLE
u-boot-tools: add ifwitool.exe, mkeficapsule.exe, proftool.exe

### DIFF
--- a/u-boot-tools/PKGBUILD
+++ b/u-boot-tools/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=u-boot-tools
 pkgver=2025.07
-pkgrel=2
+pkgrel=3
 pkgdesc="U-Boot Tools"
 arch=('i686' 'x86_64')
 url="https://github.com/u-boot/u-boot"
@@ -35,10 +35,13 @@ package() {
   mkdir -p ${pkgdir}/usr/bin
   cd ${srcdir}/u-boot-${pkgver}
   cp -f tools/dumpimage.exe ${pkgdir}/usr/bin/
+  cp -f tools/fdt_add_pubkey.exe ${pkgdir}/usr/bin/
   cp -f tools/fdtgrep.exe ${pkgdir}/usr/bin/
   cp -f tools/fit_info.exe ${pkgdir}/usr/bin/
   cp -f tools/fit_check_sign.exe ${pkgdir}/usr/bin/
+  cp -f tools/ifwitool.exe ${pkgdir}/usr/bin/
+  cp -f tools/mkeficapsule.exe ${pkgdir}/usr/bin/
   cp -f tools/mkimage.exe ${pkgdir}/usr/bin/
   cp -f tools/mkenvimage.exe ${pkgdir}/usr/bin/
-  cp -f tools/fdt_add_pubkey.exe ${pkgdir}/usr/bin/
+  cp -f tools/proftool.exe ${pkgdir}/usr/bin/
 }


### PR DESCRIPTION
To get ahead of possible future issues like <https://github.com/msys2/MSYS2-packages/issues/5673>, let's just add those binaries, too. After all they are built during the package creation anyway, so why not use them?