### PR TITLE
tar: backport windows specific fix

### DIFF
--- a/tar/PKGBUILD
+++ b/tar/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=tar
 pkgver=1.35
-pkgrel=2
+pkgrel=3
 pkgdesc="Utility used to store, backup, and transport files"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/tar/tar.html"
@@ -15,15 +15,17 @@ groups=('compression')
 depends=('libiconv' 'libintl' 'sh')
 makedepends=('libiconv-devel' 'gettext-devel' 'autotools' 'gcc')
 options=('!emptydirs')
-source=(https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz{,.sig}
+source=(https://ftpmirror.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz{,.sig}
         tar-1.33-textmount.patch
         tar-LDADD.patch::https://git.savannah.gnu.org/cgit/tar.git/patch/?id=8632df398b2f548465ebe68b8f494c0d6f8d913d
-        tar-LDADD-tests.patch::https://git.savannah.gnu.org/cgit/tar.git/patch/?id=71530f72d21d9af00b5688948111666f62f5ec4b)
+        tar-LDADD-tests.patch::https://git.savannah.gnu.org/cgit/tar.git/patch/?id=71530f72d21d9af00b5688948111666f62f5ec4b
+        paxutils-Prevent-file-name-escape.patch)
 sha256sums=('4d62ff37342ec7aed748535323930c7cf94acf71c3591882b26a7ea50f3edc16'
             'SKIP'
             'eb43f400cdf1317aac2937cce8eb4f47c7da3b41a6d5b10369cf9cbf9f33e244'
-            'c0efaccada3126f95f6137579400ee2244cf22ab9b859b31825cc801ed0b2708'
-            '04212f61aee6216f3b6aa60809420eb8afe1d09bd98ff5babee859819bd45a90')
+            '95a8cec49a3a2909cabf4ef6f5daaebb45befa4a4ccb4367028a257bc5c6506a'
+            '994ba0c59db44e993081ac3e35741025814b25b3b3b92c2a32d931780f4b605d'
+            '1078b211e1dc12fa253beb6368c9a7dffe97c7e3a05755c8c8e67607a50fc511')
 validpgpkeys=('325F650C4C2B6AD58807327A3602B07F55D0C732') # Sergey Poznyakoff
 
 prepare() {
@@ -32,6 +34,10 @@ prepare() {
   patch -p2 -i ${srcdir}/tar-1.33-textmount.patch
   patch -p1 -i ${srcdir}/tar-LDADD.patch
   patch -p1 -i ${srcdir}/tar-LDADD-tests.patch
+
+  # Backport from paxutils which is vendored:
+  # https://cgit.git.savannah.gnu.org/cgit/paxutils.git/commit/?id=063408cc6f32fff79b4f436a62236b84ca442d2e
+  patch -bp1 -i ${srcdir}/paxutils-Prevent-file-name-escape.patch
 
   autoreconf -fi
 }

--- a/tar/paxutils-Prevent-file-name-escape.patch
+++ b/tar/paxutils-Prevent-file-name-escape.patch
@@ -1,0 +1,75 @@
+--- tar-1.35/lib/paxnames.c.orig	2023-05-18 07:34:00.000000000 +0200
++++ tar-1.35/lib/paxnames.c	2025-10-10 12:49:36.700734800 +0200
+@@ -90,50 +81,45 @@
+          || (prefix_table[1] && hash_get_n_entries (prefix_table[1]) != 0);
+ }
+ 
+-/* Return a safer suffix of FILE_NAME, or "." if it has no safer
+-   suffix.  Check for fully specified file names and other atrocities.
+-   Warn the user if we do not return NAME.  If LINK_TARGET is 1,
++/* Return a safer suffix of FILE_NAME, or "." if it has no safer suffix.
++   Skip any sequence of prefixes each of which would cause
++   the file name to escape the working directory on this platform.
++   Warn the user if we do not return NAME.  If LINK_TARGET,
+    FILE_NAME is the target of a hard link, not a member name.
+-   If ABSOLUTE_NAMES is 0, strip filesystem prefix from the file name. */
++   However, if ABSOLUTE_NAMES, do not skip prefixes, but instead
++   return FILE_NAME if nonempty, "." otherwise.  */
+ 
+ char *
+ safer_name_suffix (char const *file_name, bool link_target,
+ 		   bool absolute_names)
+ {
+-  char const *p;
++  char const *p = file_name;
+ 
+-  if (absolute_names)
+-    p = file_name;
+-  else
++  if (!absolute_names)
+     {
+-      /* Skip file system prefixes, leading file name components that contain
+-	 "..", and leading slashes.  */
+-
+-      size_t prefix_len = FILE_SYSTEM_PREFIX_LEN (file_name);
+-
+-      for (p = file_name + prefix_len; *p; )
++      /* Skip any sequences of prefixes each of which would cause the
++	 resulting file name to escape the working directory on this platform.
++         The resulting file name is relative, not absolute.  */
++      for (;;)
+ 	{
+-          if (p[0] == '.' && p[1] == '.' && (ISSLASH (p[2]) || !p[2]))
+-	    prefix_len = p + 2 - file_name;
+-
+-	  do
++	  if (ISSLASH (*p))
++	    p++;
++	  else if (p[0] == '.' && p[1] == '.' && (ISSLASH (p[2]) || !p[2]))
++	    p += 2;
++	  else
+ 	    {
+-	      char c = *p++;
+-	      if (ISSLASH (c))
++	      int prefix_len = FILE_SYSTEM_PREFIX_LEN (p);
++	      if (prefix_len == 0)
+ 		break;
++	      p += prefix_len;
+ 	    }
+-	  while (*p);
+ 	}
+ 
+-      for (p = file_name + prefix_len; ISSLASH (*p); p++)
+-	continue;
+-      prefix_len = p - file_name;
+-
+-      if (prefix_len)
++      if (p != file_name)
+ 	{
+ 	  const char *prefix;
+ 	  if (hash_string_insert_prefix (&prefix_table[link_target], file_name,
+-					 prefix_len, &prefix))
++					 p - file_name, &prefix))
+ 	    {
+ 	      static char const *const diagnostic[] =
+ 	      {


### PR DESCRIPTION
* checksums of old patches are updated since they include the cgit version
* the backports had various context conflicts, so adjust the patch
* switch to ftpmirror, ftp.gnu is not usable right now

Note that paxlib/names.c from paxutils is vendored as lib/paxnames.c in tar.