### PR TITLE
maturin: update to 1.10.1

### DIFF
--- a/maturin/0004-ring-support-cygwin.patch
+++ b/maturin/0004-ring-support-cygwin.patch
@@ -1,0 +1,118 @@
+--- a/crypto/crypto.c
++++ b/crypto/crypto.c
+@@ -19,7 +19,7 @@
+ // undesirable, so all assembly-referenced symbols should be hidden. CPU
+ // capabilities are the only such symbols defined in C. Explicitly hide them,
+ // rather than rely on being built with -fvisibility=hidden.
+-#if defined(OPENSSL_WINDOWS)
++#if defined(OPENSSL_WINDOWS) || defined(__CYGWIN__)
+ #define HIDDEN
+ #else
+ #define HIDDEN __attribute__((visibility("hidden")))
+--- a/src/rand.rs
++++ b/src/rand.rs
+@@ -128,6 +128,7 @@ impl SystemRandom {
+     all(feature = "less-safe-getrandom-espidf", target_os = "espidf"),
+     target_os = "aix",
+     target_os = "android",
++    target_os = "cygwin",
+     target_os = "dragonfly",
+     target_os = "freebsd",
+     target_os = "fuchsia",
+--- a/build.rs
++++ b/build.rs
+@@ -246,7 +247,7 @@ const ASM_TARGETS: &[AsmTarget] = &[
+         perlasm_format: WIN32N,
+     },
+     AsmTarget {
+-        oss: &[WINDOWS],
++        oss: &[WINDOWS, CYGWIN],
+         arch: X86_64,
+         perlasm_format: NASM,
+     },
+@@ -297,6 +298,7 @@ const NASM: &str = "nasm";
+ const APPLE_ABI: &[&str] = &["ios", "macos", "tvos", "visionos", "watchos"];
+ 
+ const WINDOWS: &str = "windows";
++const CYGWIN: &str = "cygwin";
+ 
+ fn main() {
+     // Avoid assuming the working directory is the same is the $CARGO_MANIFEST_DIR so that toolchains
+@@ -651,7 +653,11 @@ fn nasm(file: &Path, arch: &str, include_dir: &Path, out_dir: &Path, c_root_dir:
+     let mut include_dir = include_dir.as_os_str().to_os_string();
+     include_dir.push(OsString::from(String::from(std::path::MAIN_SEPARATOR)));
+ 
+-    let mut c = Command::new("./target/tools/windows/nasm/nasm");
++    let mut c = Command::new(if env::var("HOST").unwrap().contains("cygwin") {
++        "nasm"
++    } else {
++        "./target/tools/windows/nasm/nasm"
++    });
+     let _ = c
+         .arg("-o")
+         .arg(out_file.to_str().expect("Invalid path"))
+@@ -763,7 +769,19 @@ fn perlasm(
+ }
+ 
+ fn join_components_with_forward_slashes(path: &Path) -> OsString {
+-    let parts = path.components().map(|c| c.as_os_str()).collect::<Vec<_>>();
++    let mut parts = path.components().map(|c| c.as_os_str()).collect::<Vec<_>>();
++    if env::var("HOST").unwrap().contains("cygwin") {
++        // Most platforms treat `//foo` the same as `/foo`, but POSIX allows `//`
++        // specifically to have an implementation-defined behavior. Most platforms
++        // treat them equal, but Cygwin is not one of them.
++        //
++        // - POSIX.1-2024: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap04.html#tag_04_16
++        // - gnulib notes: https://cgit.git.savannah.gnu.org/cgit/gnulib.git/plain/m4/double-slash-root.m4?id=f4038dcb346fccb58d910e2f0a62c0f45022d2a8
++
++        if parts[0] == OsStr::new("/") {
++            parts[0] = OsStr::new("");
++        }
++    }
+     parts.join(OsStr::new("/"))
+ }
+ 
+--- a/third_party/fiat/asm/fiat_curve25519_adx_mul.S
++++ b/third_party/fiat/asm/fiat_curve25519_adx_mul.S
+@@ -1,7 +1,7 @@
+ #include <ring-core/asm_base.h>
+ 
+ #if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_X86_64) && \
+-    (defined(__APPLE__) || defined(__ELF__))
++    (defined(__APPLE__) || defined(__ELF__) || defined(__CYGWIN__))
+ 
+ .intel_syntax noprefix
+ .text
+@@ -10,8 +10,10 @@
+ .global _fiat_curve25519_adx_mul
+ _fiat_curve25519_adx_mul:
+ #else
++#if defined(__ELF__)
+ .type fiat_curve25519_adx_mul, @function
+ .hidden fiat_curve25519_adx_mul
++#endif
+ .global fiat_curve25519_adx_mul
+ fiat_curve25519_adx_mul:
+ #endif
+--- a/third_party/fiat/asm/fiat_curve25519_adx_square.S
++++ b/third_party/fiat/asm/fiat_curve25519_adx_square.S
+@@ -1,7 +1,7 @@
+ #include <ring-core/asm_base.h>
+ 
+ #if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_X86_64) && \
+-    (defined(__APPLE__) || defined(__ELF__))
++    (defined(__APPLE__) || defined(__ELF__) || defined(__CYGWIN__))
+ 
+ .intel_syntax noprefix
+ .text
+@@ -10,8 +10,10 @@
+ .global _fiat_curve25519_adx_square
+ _fiat_curve25519_adx_square:
+ #else
++#if defined (__ELF__)
+ .type fiat_curve25519_adx_square, @function
+ .hidden fiat_curve25519_adx_square
++#endif
+ .global fiat_curve25519_adx_square
+ fiat_curve25519_adx_square:
+ #endif

--- a/maturin/PKGBUILD
+++ b/maturin/PKGBUILD
@@ -21,22 +21,33 @@ makedepends=(
   "pkgconf")
 options=('!strip')
 source=("https://pypi.org/packages/source/${pkgbase::1}/${pkgbase}/${pkgbase}-${pkgver}.tar.gz"
-        "0003-allow-msys-too.patch")
+        "ring-0.17.14.tar.gz::https://crates.io/api/v1/crates/ring/0.17.14/download"
+        "0003-allow-msys-too.patch"
+        "0004-ring-support-cygwin.patch")
 sha256sums=('69543e8bad4221c3c7ae7d7f31f275757bff8a66936368e013fa0256f8d6b512'
-            '023b52d6eb2985608f1a7206d1950bf7e428bd4c00a7f2b69a8b3cf18c1b4c0c')
+            'a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7'
+            '023b52d6eb2985608f1a7206d1950bf7e428bd4c00a7f2b69a8b3cf18c1b4c0c'
+            '258dc64aab2bb464878b9cc203e59db87d7b769b6b58fb2d9c69bf53bb418683')
 
 prepare() {
   cp -r "${pkgbase}-${pkgver}" "python-build" && cd "python-build"
 
   patch -Np1 -i ../0003-allow-msys-too.patch
+  patch -p1 -d ../ring-0.17.14 -i ../0004-ring-support-cygwin.patch
+  cat >> Cargo.toml <<END
 
+[patch.crates-io]
+ring.path = "../ring-0.17.14"
+END
+
+  cargo update -p ring
   cargo fetch --locked --target 'x86_64-pc-cygwin'
 }
 
 build() {
   cd "python-build"
 
-  export MATURIN_SETUP_ARGS="--no-default-features --features cli-completion,scaffolding"
+  export MATURIN_SETUP_ARGS="--no-default-features --features full,rustls"
   export OPENSSL_NO_VENDOR=1
   python -m build --wheel --skip-dependency-check --no-isolation
 }


### PR DESCRIPTION
remove backport; packages are updated upstream

*0003-allow-msys-too.patch is a great name: it can be both "too" and "2"*