### PR TITLE
ansible: depend on msys2-runtime-devel

### DIFF
--- a/ansible-core/PKGBUILD
+++ b/ansible-core/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=ansible-core
 pkgver=2.20.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Radically simple IT automation platform'
 arch=('any')
 url='https://pypi.org/project/ansible-core'
@@ -13,7 +13,9 @@ msys2_references=(
   "purl: pkg:pypi/ansible-core"
 )
 license=('spdx:GPL-3.0-or-later')
-depends=('python' 'python-yaml' 'python-jinja' 'python-packaging' 'python-cryptography' 'python-resolvelib')
+depends=('python' 'python-yaml' 'python-jinja' 'python-packaging' 'python-cryptography' 'python-resolvelib'
+         # msys2-runtime-devel is needed for ctypes.util.find_library("c") as it provides libc.a
+         'msys2-runtime-devel')
 provides=('python-ansible' 'ansible-base')
 optdepends=(
 	'sshpass: for ssh connections with password'


### PR DESCRIPTION
so that ctypes.util.find_library("c") finds libc.a and can $ dlltool -I /usr/lib/libc.a
msys-2.0.dll

Fixes #5785