### PR TITLE
binutils: Update to 2.45.1

### DIFF
--- a/binutils/PKGBUILD
+++ b/binutils/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=binutils
-pkgver=2.45
+pkgver=2.45.1
 pkgrel=1
 pkgdesc="A set of programs to assemble and manipulate binary and object files"
 arch=('i686' 'x86_64')
@@ -18,13 +18,14 @@ source=(https://ftp.gnu.org/gnu/binutils/binutils-${pkgver}.tar.xz{,.sig}
         0050-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
         0100-binutils-2.37-msys2.patch
         2002-Allow-spaces-in-the-name-of-the-external-preprocesso.patch)
-sha256sums=('c50c0e7f9cb188980e2cc97e4537626b1672441815587f1eab69d2a1bfbef5d2'
+sha256sums=('5fe101e6fe9d18fdec95962d81ed670fdee5f37e3f48f0bef87bddf862513aa5'
             'SKIP'
             '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18'
             '4a457d6ec33c5040a4d6a897c32e0a1743aa5052f24a989c86609de508d53bdf'
             '699be1b01abec4bbb5a6fc649bee4da33048899c58e28d53ee9c97ba6b741114')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
-              '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
+              '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F'
+              '5EF3A41171BB77E6110ED2D01F3D03348DB1A3E2')
 
 prepare() {
   cd "${srcdir}"/binutils-${pkgver}


### PR DESCRIPTION
signing key advertised here:
https://sourceware.org/pipermail/binutils/2025-November/145592.html