### PR TITLE
python: dep on binutils

### DIFF
--- a/python/PKGBUILD
+++ b/python/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=python
 pkgname=('python' 'python-devel')
 pkgver=3.12.12
-pkgrel=2
+pkgrel=3
 _pybasever=${pkgver%.*}
 pkgdesc="Next generation of the python high-level scripting language"
 arch=('i686' 'x86_64')
@@ -129,7 +129,9 @@ check() {
 }
 
 package_python() {
-  depends=('libbz2' 'libexpat' 'libffi' 'liblzma' 'ncurses' 'libopenssl' 'libreadline' 'mpdecimal' 'libsqlite' 'zlib' 'libxcrypt')
+  depends=('libbz2' 'libexpat' 'libffi' 'liblzma' 'ncurses' 'libopenssl' 'libreadline' 'mpdecimal' 'libsqlite' 'zlib' 'libxcrypt'
+           # ctypes.util.find_library() depends on 'dlltool' from binutils
+           'binutils')
   provides=('python3')
   replaces=('python3')
 


### PR DESCRIPTION
ctypes.util.find_library() requires dlltool which is part of binutils

See #5785