### PR TITLE
cargo-c: depend on rust

### DIFF
--- a/cargo-c/PKGBUILD
+++ b/cargo-c/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=cargo-c
 pkgver=0.10.18
-pkgrel=1
+pkgrel=2
 pkgdesc='A cargo subcommand to build and install C-ABI compatibile dynamic and static libraries'
 arch=('i686' 'x86_64')
 url='https://github.com/lu-zero/cargo-c/'
@@ -13,6 +13,7 @@ msys2_references=(
 )
 license=('spdx:MIT')
 depends=(
+  "rust"
   "libsqlite"
   "libssh2"
   "libgit2"
@@ -20,7 +21,6 @@ depends=(
   "openssl-devel"
 )
 makedepends=(
-  "rust"
   "pkgconf"
   "libopenssl"
   "libgit2-devel"


### PR DESCRIPTION
same as msys2/MINGW-packages#26541