### PR TITLE
libxslt: Update to 1.1.44

### DIFF
--- a/libxslt/PKGBUILD
+++ b/libxslt/PKGBUILD
@@ -2,8 +2,8 @@
 
 pkgbase=libxslt
 pkgname=('libxslt' 'libxslt-devel')
-pkgver=1.1.43
-pkgrel=2
+pkgver=1.1.44
+pkgrel=1
 pkgdesc="XML stylesheet transformation library"
 arch=('i686' 'x86_64')
 url="https://gitlab.gnome.org/GNOME/libxslt/-/wikis/"
@@ -13,17 +13,17 @@ msys2_references=(
 license=('custom')
 makedepends=('gcc' 'libxml2-devel' 'libgcrypt-devel' 'autotools')
 checkdepends=('docbook-xml')
-source=("https://download.gnome.org/sources/libxslt/${pkgver%.*}/${pkgbase}-${pkgver}.tar.xz")
-sha256sums=('5a3d6b383ca5afc235b171118e90f5ff6aa27e9fea3303065231a6d403f0183a')
+source=("https://gitlab.gnome.org/GNOME/libxslt/-/archive/v${pkgver}/libxslt-v${pkgver}.tar.gz")
+sha256sums=('f306393d1913ca42946429e22baaa36dd6639de9b23b19765023961bea01dd6e')
 
 prepare() {
-  cd "${srcdir}/${pkgbase}-${pkgver}"
+  cd "${srcdir}/${pkgbase}-v${pkgver}"
 
   autoreconf -fi
 }
 
 build() {
-  cd "${srcdir}/${pkgbase}-${pkgver}"
+  cd "${srcdir}/${pkgbase}-v${pkgver}"
 
   export lt_cv_deplibs_check_method='pass_all'
   ./configure \
@@ -44,7 +44,7 @@ build() {
 }
 
 check() {
-  cd "${srcdir}/${pkgbase}-${pkgver}"
+  cd "${srcdir}/${pkgbase}-v${pkgver}"
   make check
 }
 
@@ -56,7 +56,7 @@ package_libxslt() {
   cp -rf ${srcdir}/dest/usr/bin ${pkgdir}/usr/
   rm -f ${pkgdir}/usr/bin/*-config
   cp -rf ${srcdir}/dest/usr/share/man ${pkgdir}/usr/share/
-  install -Dm644 ${srcdir}/${pkgbase}-${pkgver}/Copyright "${pkgdir}/usr/share/licenses/${pkgbase}/Copyright"
+  install -Dm644 ${srcdir}/${pkgbase}-v${pkgver}/Copyright "${pkgdir}/usr/share/licenses/${pkgbase}/Copyright"
 }
 
 package_libxslt-devel() {


### PR DESCRIPTION
there is no tarball (new maintainer, so might take some time), so just use gitlab instead.