### PR TITLE
coreutils: Backport fix for md5sum --text

### DIFF
--- a/coreutils/PKGBUILD
+++ b/coreutils/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=coreutils
 pkgver=8.32
-pkgrel=5
+pkgrel=6
 pkgdesc="The basic file, shell and text manipulation utilities of the GNU operating system"
 arch=('i686' 'x86_64')
 license=('GPL3')
@@ -13,12 +13,14 @@ msys2_references=(
 depends=('gmp' 'libiconv' 'libintl')
 makedepends=('groff' 'gmp-devel' 'libiconv-devel' 'gettext-devel' 'help2man' 'autotools' 'gcc')
 source=(https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz{,.sig}
+        https://github.com/user-attachments/files/24189303/md5sum--text.patch
         001-coreutils-8.30.patch
         002-coreutils-8.32-enable-stdbuf.patch
         003-coreutils-8.32-fix-test-cases.patch
         004-msystem-osname-cygwin.patch)
 sha256sums=('4458d8de7849df44ccab15e16b1548b285224dbba5f08fac070c1c0e0bcc4cfa'
             'SKIP'
+            'aa6cde17c2b434530985fb74c32dd5b58a5062e301c5f8d037a45c8fe4e173e2'
             '467bde24da0ccea48260f58d3c94a84de4e027ab598a926003642f791da47ca2'
             'e3be62b9aceb3231f09f05bc3bd8b18f6aaa495f5063781cdd261d560a7e80d0'
             'ad9e0582373500c0668e38483401169f48d6a2f8ad8d28ef8e7b06e4a3e08a74'
@@ -27,7 +29,7 @@ validpgpkeys=('6C37DC12121A5006BC1DB804DF6FD971306037D9')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
-
+  patch -p1 -i ${srcdir}/md5sum--text.patch
   patch -p1 -i ${srcdir}/001-coreutils-8.30.patch
   patch -p1 -i ${srcdir}/002-coreutils-8.32-enable-stdbuf.patch
   patch -p1 -i ${srcdir}/003-coreutils-8.32-fix-test-cases.patch

--- a/coreutils/md5sum--text.patch
+++ b/coreutils/md5sum--text.patch
@@ -1,0 +1,35 @@
+From 6f265b515e5b93cef9bef0c4994622574c55a1ba Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?P=C3=A1draig=20Brady?= <P@draigBrady.com>
+Date: Fri, 7 Nov 2025 13:55:39 +0000
+Subject: [PATCH] md5sum: fix --text with the MSYS2 runtime
+
+Note the use of "rt" is non-standard, but we're restricting
+its use here to systems that define O_BINARY, which should
+invariably support "rt" mode.
+
+* src/digest.c (): Where significant, explicitly use "rt" mode
+with --text, as MSYS2 defaults to binary mode for fopen'd files
+(though not for standard streams).
+* NEWS: Mention the bug fix.
+Fixes https://github.com/coreutils/coreutils/issues/123
+---
+ NEWS         | 6 ++++++
+ src/digest.c | 2 +-
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/md5sum.c b/src/md5sum.c
+index 58b9c9ec1..f330bc1e9 100644
+--- a/src/md5sum.c
++++ b/src/md5sum.c
+@@ -611,7 +611,7 @@ digest_file (char const *filename, int *binary, unsigned char *bin_result,
+     }
+   else
+     {
+-      fp = fopen (filename, (O_BINARY && *binary ? "rb" : "r"));
++      fp = fopen (filename, O_BINARY ? (*binary ? "rb" : "rt") : "r");
+       if (fp == NULL)
+         {
+           if (ignore_missing && errno == ENOENT)
+-- 
+2.52.0
+


### PR DESCRIPTION
Closes #5792 . I failed to build mingw version of `cksum`.