### PR TITLE
pacman-mirrors: remove env specific mirror lists

### DIFF
--- a/pacman-mirrors/PKGBUILD
+++ b/pacman-mirrors/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=pacman-mirrors
 pkgver=20251220
-pkgrel=1
+pkgrel=2
 pkgdesc="MSYS2 mirror list for use by pacman"
 arch=('any')
 url="https://www.msys2.org/dev/mirrors/"
@@ -14,10 +14,6 @@ sha256sums=('c1f2f8ccd59e6c41d7c2f504af47e26ecfd6d18adf089c625ad09b926c1fe72f'
 backup=(
   'etc/pacman.d/mirrorlist.msys'
   'etc/pacman.d/mirrorlist.mingw'
-  'etc/pacman.d/mirrorlist.mingw32'
-  'etc/pacman.d/mirrorlist.mingw64'
-  'etc/pacman.d/mirrorlist.ucrt64'
-  'etc/pacman.d/mirrorlist.clang64'
 )
 msys2_references=(
   'internal'
@@ -27,14 +23,4 @@ package() {
   mkdir -p ${pkgdir}/etc/pacman.d
   install -m644 ${srcdir}/mirrorlist.msys ${pkgdir}/etc/pacman.d/
   install -m644 ${srcdir}/mirrorlist.mingw ${pkgdir}/etc/pacman.d/
-
-  # For backwards compatibility
-  install -m644 ${srcdir}/mirrorlist.mingw ${pkgdir}/etc/pacman.d/mirrorlist.mingw32
-  sed -s 's|$repo|i686|g' -i ${pkgdir}/etc/pacman.d/mirrorlist.mingw32
-  install -m644 ${srcdir}/mirrorlist.mingw ${pkgdir}/etc/pacman.d/mirrorlist.mingw64
-  sed -s 's|$repo|x86_64|g' -i ${pkgdir}/etc/pacman.d/mirrorlist.mingw64
-  install -m644 ${srcdir}/mirrorlist.mingw ${pkgdir}/etc/pacman.d/mirrorlist.ucrt64
-  sed -s 's|$repo|ucrt64|g' -i ${pkgdir}/etc/pacman.d/mirrorlist.ucrt64
-  install -m644 ${srcdir}/mirrorlist.mingw ${pkgdir}/etc/pacman.d/mirrorlist.clang64
-  sed -s 's|$repo|clang64|g' -i ${pkgdir}/etc/pacman.d/mirrorlist.clang64
 }


### PR DESCRIPTION
These were added in https://github.com/msys2/MSYS2-packages/pull/2569 since we switched to a unified list by default in
https://github.com/msys2/MSYS2-packages/pull/2572

They were kept in case someone had modified their pacman config and not keep it in sync.

It's been 4.5 years now, so remove those files. While they don't hurt, they can be confusing to users as they are in the same dir but just not used, and changes to them are thus ignored.