### PR TITLE
uutils-coreutils: don't build stdbuf, bring back uu-

### DIFF
--- a/uutils-coreutils/PKGBUILD
+++ b/uutils-coreutils/PKGBUILD
@@ -55,7 +55,7 @@ package() {
     DESTDIR="${pkgdir}" \
     PREFIX="/usr" \
     PROFILE=release-fast \
-    SKIP_UTILS="more kill uptime stdbuf" \
+    SKIP_UTILS="stdbuf" \
     PROG_PREFIX="uu-" \
     MULTICALL=y
 


### PR DESCRIPTION
stdbuf pulls rust-ctor, which somehow fails to build specifically in autobuild due to base image issue

partially reverts 768fe06184c56ddc83d0123b20c46ec1f1504554, making uutils-coreutils non-replacing package (because stdbuf must be available)