### PR TITLE
fish: update to 4.3.1

### DIFF
--- a/fish/PKGBUILD
+++ b/fish/PKGBUILD
@@ -1,7 +1,7 @@
 # Contributor: 王宇逸 <Strawberry_Str@hotmail.com>
 
 pkgname=fish
-pkgver=4.3.0
+pkgver=4.3.1
 pkgrel=1
 pkgdesc='Smart and user friendly shell intended mostly for interactive use'
 arch=('x86_64')
@@ -16,7 +16,7 @@ msys2_references=(
 )
 license=('spdx:GPL-2.0-only')
 depends=('gcc-libs' 'libpcre2_32' 'libpcre2_8' 'man-db')
-makedepends=('gcc' 'gettext' 'pcre2-devel' 'cmake' 'pkgconf' 'rust' 'ninja')
+makedepends=('gcc' 'gettext' 'pcre2-devel' 'cmake' 'pkgconf' 'rust' 'ninja' 'python-sphinx')
 optdepends=('python: for manual page completion parser and web configuration tool')
 install=fish.install
 backup=('etc/fish/config.fish' 'etc/fish/msys2.fish' 'etc/fish/perlbin.fish')
@@ -25,7 +25,7 @@ source=("https://github.com/fish-shell/fish-shell/releases/download/${pkgver}/${
         msys2.fish
         msystem.fish
         perlbin.fish)
-sha256sums=('42fdcfacf0e595db256f31abee33bff35fbf5e7a226cf931355002cbd1824aa9'
+sha256sums=('78f8881b971ab95ace5f2a9a25efef66f6c180396b2085b9852f21f8e4a30408'
             '983c3273e0249957ed6c40785e005739da30f31d4f029383f257f9990d38811a'
             '8bb0d28df47b66e6785f7db00a2c4316bc15960e67bdec0daca7f811f5bf3895'
             '71c6990b39caf5d50c10f10074283adfc6a36aafff30fd54f7eb451d4e007496'


### PR DESCRIPTION
Release tarballs no longer contain the documentation. Thererefore, they are not in the package anymore either. Building documentation requires Sphinx now.

See the paragraph "For distributors and developers" (<https://fishshell.com/docs/current/relnotes.html#for-distributors-and-developers>) in the release notes for Fish 4.3.0.

cc @Berrysoft @ognevny 