### PR TITLE
ncurses: update to 6.6

### DIFF
--- a/ncurses/PKGBUILD
+++ b/ncurses/PKGBUILD
@@ -2,10 +2,8 @@
 
 pkgbase=ncurses
 pkgname=('ncurses' 'ncurses-devel')
-_base_ver=6.5
-_date_rev=20240831
-pkgver=${_base_ver}.${_date_rev}
-pkgrel=2
+pkgver=6.6
+pkgrel=1
 pkgdesc="System V Release 4.0 curses emulation library"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/ncurses/"
@@ -16,17 +14,17 @@ msys2_references=(
 )
 license=('spdx:MIT')
 makedepends=('autotools' 'gcc')
-source=(https://invisible-island.net/archives/ncurses/current/${pkgbase}-${_base_ver}-${_date_rev}.tgz{,.asc}
+source=(https://invisible-island.net/archives/ncurses/${pkgbase}-${pkgver}.tar.gz{,.asc}
         "ncurses-6.3-pkgconfig.patch"
         "ncurses-6.3-cflags-private.patch")
-sha256sums=('685161fec9c20c0896f6d7569f8d1cba9124a1884d3d8be527253a773b787577'
+sha256sums=('355b4cbbed880b0381a04c46617b7656e362585d52e9cf84a67e2009b749ff11'
             'SKIP'
             'b8544a607dfbeffaba2b087f03b57ed1fa81286afca25df65f61b04b5f3b3738'
             '3107029dfb807e338d34641d78329cd6725c58e6b873352621f4b9611a8380bf')
 validpgpkeys=('19882D92DDA4C400C22C0D56CC2AF4472167BE03')  # "Thomas E. Dickey (self-signed w/o SHA1) <dickey@invisible-island.net>"
 
 prepare() {
-  cd ${srcdir}/${pkgbase}-${_base_ver}-${_date_rev}
+  cd ${srcdir}/${pkgbase}-${pkgver}
 
   # do not leak build-time LDFLAGS into the pkgconfig files:
   # https://bugs.archlinux.org/task/68523
@@ -36,10 +34,10 @@ prepare() {
 }
 
 build() {
-  cd ${srcdir}/${pkgbase}-${_base_ver}-${_date_rev}
+  cd ${srcdir}/${pkgbase}-${pkgver}
 
   ./configure \
-    --build=${CHOST} \
+    --build=${CARCH}-pc-msys \
     --with-install-prefix=/usr \
     --without-ada \
     --with-shared \
@@ -86,10 +84,8 @@ package_ncurses() {
   cp -rf $srcdir/dest/usr/lib/terminfo ${pkgdir}/usr/lib/
   cp -rf $srcdir/dest/usr/share ${pkgdir}/usr/
 
-  # install license, rip it from the readme
-  cd ${srcdir}/${pkgname}-${_base_ver}-${_date_rev}
-  install -dm755 ${pkgdir}/usr/share/licenses/${pkgname}
-  grep -B 100 '$Id' README > ${pkgdir}/usr/share/licenses/${pkgname}/license.txt
+  install -Dm644 "${srcdir}"/${pkgname}-${pkgver}/COPYING \
+    "${pkgdir}"/usr/share/licenses/${pkgname}/LICENSE
 }
 
 package_ncurses-devel() {


### PR DESCRIPTION
using cygwin triplet breaks the entire environment.

@lazka could you do something about it?