### PR TITLE
ctags: don't install a etags binary

### DIFF
--- a/ctags/PKGBUILD
+++ b/ctags/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname="ctags"
 pkgver="6.2.1"
-pkgrel=1
+pkgrel=2
 pkgdesc="Generate tag files for source code"
 arch=("i686" "x86_64")
 url="https://ctags.io/"
@@ -19,7 +19,6 @@ build () {
   cd "${pkgname}"
   ./autogen.sh
   ./configure --prefix=/usr \
-              --enable-etags \
               --enable-macro-patterns \
               --with-readlib
   make


### PR DESCRIPTION
It conflicts with emacs, and from what I understand one can use "ctags -e" to get what etags provides.

Also Arch does the same.

Fixes #5920