### PR TITLE
cross-binutils: Update to 2.45.1

### DIFF
--- a/mingw-w64-cross-binutils/PKGBUILD
+++ b/mingw-w64-cross-binutils/PKGBUILD
@@ -5,7 +5,7 @@ _realname=binutils
 _mingw_suff=mingw-w64-cross
 _targetpkgs=("${_mingw_suff}-ucrt64-${_realname}" "${_mingw_suff}-mingw32-${_realname}" "${_mingw_suff}-mingw64-${_realname}")
 pkgname=("${_mingw_suff}-${_realname}" "${_mingw_suff}-common-${_realname}" "${_targetpkgs[@]}")
-pkgver=2.45
+pkgver=2.45.1
 pkgrel=1
 pkgdesc="A set of programs to assemble and manipulate binary and object files"
 arch=('i686' 'x86_64')
@@ -23,12 +23,13 @@ options=('staticlibs' '!distcc' '!ccache' '!buildflags')
 source=(https://ftp.gnu.org/gnu/binutils/binutils-${pkgver}.tar.xz{,.sig}
         0002-check-for-unusual-file-harder.patch
         0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch)
-sha256sums=('c50c0e7f9cb188980e2cc97e4537626b1672441815587f1eab69d2a1bfbef5d2'
+sha256sums=('5fe101e6fe9d18fdec95962d81ed670fdee5f37e3f48f0bef87bddf862513aa5'
             'SKIP'
             '2c99345fc575c3a060d6677537f636c6c4154fac0fde508070f3b6296c1060d4'
             '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
-              '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
+              '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F'
+              '5EF3A41171BB77E6110ED2D01F3D03348DB1A3E2')
 
 apply_patch_with_msg() {
   for _patch in "$@"


### PR DESCRIPTION
signing key advertised here:
https://sourceware.org/pipermail/binutils/2025-November/145592.html