### PR TITLE
libblake3: update to 1.8.3

### DIFF
--- a/libblake3/PKGBUILD
+++ b/libblake3/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=BLAKE3
 pkgname=libblake3
-pkgver=1.8.2
+pkgver=1.8.3
 pkgrel=1
 pkgdesc='The official C implementation of BLAKE3'
 arch=(x86_64 i686)
@@ -20,13 +20,9 @@ makedepends=(
   ninja
 )
 source=("https://github.com/BLAKE3-team/BLAKE3/archive/${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('6b51aefe515969785da02e87befafc7fdc7a065cd3458cf1141f29267749e81f')
+sha256sums=('5a11e3f834719b6c1cae7aced1e848a37013f6f10f97272e7849aa0da769f295')
 
 build() {
-
-  # FIXME: fails to link otherwise
-  CFLAGS+=" -DBLAKE3_NO_AVX512"
-
   cmake \
     -GNinja \
     -DCMAKE_INSTALL_PREFIX=/usr \


### PR DESCRIPTION
remove workaround, source should be fixed to not use AVX512