### PR TITLE
global: Fixes building with gcc 15.x, bump global to version 6.6.14

### DIFF
--- a/global/0001-Fixes-detecting-of-HAVE_SIGSETJMP-in-cygwin.patch
+++ b/global/0001-Fixes-detecting-of-HAVE_SIGSETJMP-in-cygwin.patch
@@ -1,0 +1,25 @@
+From 3fbfc30d0be48ae120c11ce67fedbda8e1d60a27 Mon Sep 17 00:00:00 2001
+From: Yonggang Luo <luoyonggang@gmail.com>
+Date: Sun, 18 Jan 2026 10:43:26 +0800
+Subject: [PATCH] Fixes detecting of HAVE_SIGSETJMP in cygwin
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 740ded3..f67e7c6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -172,7 +172,7 @@ AC_CHECK_TYPE(sighandler_t,[],[],[
+ #endif])
+ dnl This test was ripped from gnuplot's configure.in:
+ AC_MSG_CHECKING(for sigsetjmp)
+-AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <setjmp.h>]], [[jmp_buf env; sigsetjmp(env, 1);]])],[AC_MSG_RESULT(yes)
++AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <setjmp.h>]], [[sigjmp_buf env; sigsetjmp(env, 1);]])],[AC_MSG_RESULT(yes)
+    AC_DEFINE(HAVE_SIGSETJMP,1,
+              [ Define if we have sigsetjmp(). ])],[AC_MSG_RESULT(no)])
+ 
+-- 
+2.52.0.windows.1
+

--- a/global/PKGBUILD
+++ b/global/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: João Guerra <joca.bt@gmail.com>
 
 pkgname=global
-pkgver=6.6.12
+pkgver=6.6.14
 pkgrel="1"
 pkgdesc="A source code tagging system"
 arch=("i686" "x86_64")
@@ -17,18 +17,25 @@ depends=("libltdl")
 optdepends=("ctags" "python3-pygments")
 makedepends=("ncurses-devel" 'autotools' 'gperf' 'gcc')
 options=(libtool !emptydirs)
-source=("https://ftp.gnu.org/gnu/global/${pkgname}-${pkgver}.tar.gz"{,.sig})
-sha256sums=('542a5b06840e14eca548b4bb60b44c0adcf01024e68eb362f8bf716007885901'
-            'SKIP')
+source=(
+  "https://ftp.gnu.org/gnu/global/${pkgname}-${pkgver}.tar.gz"{,.sig}
+  0001-Fixes-detecting-of-HAVE_SIGSETJMP-in-cygwin.patch
+)
+sha256sums=('f6e7fd0b68aed292e85bb686616baf6551d5c9424adcddca11d808ba318cb320'
+            'SKIP'
+            '46de890ef48c98f66f00b7fbed83ee08fa54d36b38ae007145a584dc3a8064c9')
 validpgpkeys=("26F631B43D624A927E6F1C33969C3BE389DDA6EB") # Shigio YAMAGUCHI <shigio@gnu.org>
 
 prepare() {
   cd "${pkgname}-${pkgver}"
+  patch -p1 -i "${srcdir}/0001-Fixes-detecting-of-HAVE_SIGSETJMP-in-cygwin.patch"
   autoreconf -fiv
 }
 
 build () {
   cd "${pkgname}-${pkgver}"
+
+  CFLAGS="$CFLAGS -std=gnu17" \
   ./configure --prefix=/usr \
               --build=${CHOST} \
               --host=${CHOST} \


### PR DESCRIPTION
Also bump global to version 6.6.14

Closes: https://github.com/msys2/MSYS2-packages/pull/5633