### PR TITLE
colordiff faild to downloading a URL

### DIFF
--- a/colordiff/PKGBUILD
+++ b/colordiff/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=colordiff
 pkgver=1.0.21
-pkgrel=1
+pkgrel=2
 pkgdesc='Diff wrapper with pretty syntax highlighting'
 url='https://www.colordiff.org/'
 msys2_repository_url="https://github.com/daveewart/colordiff"


### PR DESCRIPTION
"/usr/bin/xmllint" --noout --nonet --xinclude --postvalid --noent  "/e/work/xemu/MSYS2-packages/colordiff/src/colordiff-1.0.21/colordiff.xml" xmlto: /e/work/xemu/MSYS2-packages/colordiff/src/colordiff-1.0.21/colordiff.xml does not validate (status 3) xmlto: Fix document syntax or use --skip-validation option /e/work/xemu/MSYS2-packages/colordiff/src/colordiff-1.0.21/colordiff.xml:6: I/O warning : failed to load "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd": No such file or directory ]>
  ^
I/O warning : failed to load "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd": No such file or directory Document /e/work/xemu/MSYS2-packages/colordiff/src/colordiff-1.0.21/colordiff.xml does not validate


seems the cause is libxml2, but don't know what's happened.