### PR TITLE
libxml2: apply patch Resolve URI after xmlCatalogResolve

### DIFF
--- a/libxml2/3b08ff965513378f2a79d285233667dba3717055.patch
+++ b/libxml2/3b08ff965513378f2a79d285233667dba3717055.patch
@@ -1,0 +1,42 @@
+From 3b08ff965513378f2a79d285233667dba3717055 Mon Sep 17 00:00:00 2001
+From: Daniel Garcia Moreno <daniel.garcia@suse.com>
+Date: Thu, 22 Jan 2026 13:21:23 +0100
+Subject: [PATCH] Resolve URI after xmlCatalogResolve
+
+xmlCatalogResolve returns the plain "uri" value when looking for a
+publicID that exists in the catalog.
+
+This patch calls to xmlCatalogResolveURI after the resource resultion to
+make sure that all rewrite rules are correctly applied in the new
+resource uri.
+
+Fix https://gitlab.gnome.org/GNOME/libxml2/-/issues/1046
+---
+ parserInternals.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/parserInternals.c b/parserInternals.c
+index c3eec132d..a274fc2ee 100644
+--- a/parserInternals.c
++++ b/parserInternals.c
+@@ -2329,6 +2329,17 @@ xmlResolveFromCatalog(const char *url, const char *publicId,
+                                               BAD_CAST url);
+     }
+ 
++    /*
++     * Resolve the URI, to make sure that rewrite rules are applied
++     */
++    if ((resource != NULL) && !xmlStrEqual(BAD_CAST resource, BAD_CAST url)) {
++        xmlChar *res = xmlCatalogResolveURI(BAD_CAST resource);
++        if (res != NULL) {
++            xmlFree(resource);
++            resource = (char *) res;
++        }
++    }
++
+     /*
+      * Try to resolve url using URI rules.
+      *
+-- 
+GitLab
+

--- a/libxml2/PKGBUILD
+++ b/libxml2/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=libxml2
 pkgname=('libxml2' 'libxml2-devel')
 pkgver=2.15.1
-pkgrel=1
+pkgrel=2
 pkgdesc="XML parsing library, version 2"
 arch=(i686 x86_64)
 license=('spdx:MIT')
@@ -14,9 +14,11 @@ msys2_references=(
   "cpe: cpe:/a:xmlsoft:libxml2"
 )
 source=("https://download.gnome.org/sources/libxml2/${pkgver%.*}/${pkgbase}-${pkgver}.tar.xz"
-        https://www.w3.org/XML/Test/xmlts20130923.tar.gz)
+        https://www.w3.org/XML/Test/xmlts20130923.tar.gz
+        3b08ff965513378f2a79d285233667dba3717055.patch)
 sha256sums=('c008bac08fd5c7b4a87f7b8a71f283fa581d80d80ff8d2efd3b26224c39bc54c'
-            '9b61db9f5dbffa545f4b8d78422167083a8568c59bd1129f94138f936cf6fc1f')
+            '9b61db9f5dbffa545f4b8d78422167083a8568c59bd1129f94138f936cf6fc1f'
+            'ff0d6703c7697b21f6b4dd4b4b15cd99626a66e12531437c3643d5c396d5b18d')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -44,6 +46,9 @@ prepare() {
   mv xmlconf -t ${pkgbase}-${pkgver}
 
   cd ${pkgbase}-${pkgver}
+
+  apply_patch_with_msg \
+    3b08ff965513378f2a79d285233667dba3717055.patch
 
   autoreconf -vfi
 }


### PR DESCRIPTION
Apply MR https://gitlab.gnome.org/GNOME/libxml2/-/merge_requests/378

Should be able Closes: https://github.com/msys2/MSYS2-packages/pull/5969
