### PR TITLE
docbook-xml: Use file:/// instead of http:// in file etc/xml/docbook-xml

### DIFF
--- a/docbook-xml/PKGBUILD
+++ b/docbook-xml/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=docbook-xml
 pkgver=4.5
-pkgrel=5
+pkgrel=6
 pkgdesc="A widely used XML scheme for writing documentation and help"
 arch=('any')
 url="https://www.oasis-open.org/docbook/"
@@ -67,39 +67,39 @@ package() {
   # V4.1.2
   xmlcatalog --noout --add "public" \
     "-//OASIS//DTD DocBook XML V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.1.2/docbookx.dtd" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//DTD DocBook XML CALS Table Model V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/calstblx.dtd" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.1.2/calstblx.dtd" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//DTD DocBook XML CALS Table Model V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/calstblx.dtd" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.1.2/calstblx.dtd" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//DTD XML Exchange Table Model 19990315//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/soextblx.dtd" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.1.2/soextblx.dtd" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ELEMENTS DocBook XML Information Pool V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/dbpoolx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.1.2/dbpoolx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ELEMENTS DocBook XML Document Hierarchy V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/dbhierx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.1.2/dbhierx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ENTITIES DocBook XML Additional General Entities V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/dbgenent.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.1.2/dbgenent.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ENTITIES DocBook XML Notations V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/dbnotnx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.1.2/dbnotnx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ENTITIES DocBook XML Character Entities V4.1.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.1.2/dbcentx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.1.2/dbcentx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "rewriteSystem" \
     "http://www.oasis-open.org/docbook/xml/4.1.2" \
@@ -113,35 +113,35 @@ package() {
   # V4.2
   xmlcatalog --noout --add "public" \
     "-//OASIS//DTD DocBook XML V4.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.2/docbookx.dtd" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//DTD DocBook CALS Table Model V4.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/calstblx.dtd" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.2/calstblx.dtd" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//DTD XML Exchange Table Model 19990315//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/soextblx.dtd" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.2/soextblx.dtd" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ELEMENTS DocBook Information Pool V4.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/dbpoolx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.2/dbpoolx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ELEMENTS DocBook Document Hierarchy V4.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/dbhierx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.2/dbhierx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ENTITIES DocBook Additional General Entities V4.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/dbgenent.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.2/dbgenent.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ENTITIES DocBook Notations V4.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/dbnotnx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.2/dbnotnx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ENTITIES DocBook Character Entities V4.2//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.2/dbcentx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.2/dbcentx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "rewriteSystem" \
     "http://www.oasis-open.org/docbook/xml/4.2" \
@@ -155,35 +155,35 @@ package() {
   # V4.3
   xmlcatalog --noout --add "public" \
     "-//OASIS//DTD DocBook XML V4.3//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.3/docbookx.dtd" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//DTD DocBook CALS Table Model V4.3//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/calstblx.dtd" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.3/calstblx.dtd" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//DTD XML Exchange Table Model 19990315//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/soextblx.dtd" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.3/soextblx.dtd" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ELEMENTS DocBook Information Pool V4.3//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/dbpoolx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.3/dbpoolx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ELEMENTS DocBook Document Hierarchy V4.3//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/dbhierx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.3/dbhierx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ENTITIES DocBook Additional General Entities V4.3//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/dbgenent.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.3/dbgenent.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ENTITIES DocBook Notations V4.3//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/dbnotnx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.3/dbnotnx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ENTITIES DocBook Character Entities V4.3//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.3/dbcentx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.3/dbcentx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "rewriteSystem" \
     "http://www.oasis-open.org/docbook/xml/4.3" \
@@ -197,39 +197,39 @@ package() {
   # V4.4
   xmlcatalog --noout --add "public" \
     "-//OASIS//DTD DocBook XML V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.4/docbookx.dtd" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//DTD DocBook CALS Table Model V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/calstblx.dtd" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.4/calstblx.dtd" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ELEMENTS DocBook XML HTML Tables V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/htmltblx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.4/htmltblx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//DTD XML Exchange Table Model 19990315//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/soextblx.dtd" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.4/soextblx.dtd" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ELEMENTS DocBook Information Pool V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/dbpoolx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.4/dbpoolx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ELEMENTS DocBook Document Hierarchy V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/dbhierx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.4/dbhierx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ENTITIES DocBook Additional General Entities V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/dbgenent.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.4/dbgenent.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ENTITIES DocBook Notations V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/dbnotnx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.4/dbnotnx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//ENTITIES DocBook Character Entities V4.4//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.4/dbcentx.mod" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.4/dbcentx.mod" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "rewriteSystem" \
     "http://www.oasis-open.org/docbook/xml/4.4" \
@@ -243,7 +243,7 @@ package() {
   # V4.5
   xmlcatalog --noout --add "public" \
     "-//OASIS//DTD DocBook XML V4.5//EN" \
-    "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" \
+    "file:///usr/share/xml/docbook/xml-dtd-4.5/docbookx.dtd" \
     "${pkgdir}/etc/xml/docbook-xml"
   xmlcatalog --noout --add "public" \
     "-//OASIS//DTD DocBook XML CALS Table Model V4.5//EN" \


### PR DESCRIPTION
The rewriteSystem and rewriteURI would not take effect according to

https://gitlab.gnome.org/GNOME/libxml2/-/issues/1046#note_2658627

Closes: https://github.com/msys2/MSYS2-packages/pull/5974

Closes: https://github.com/msys2/MSYS2-packages/pull/5969
