### PR TITLE
atool: Update url for downloading

### DIFF
--- a/atool/PKGBUILD
+++ b/atool/PKGBUILD
@@ -6,7 +6,7 @@
 
 pkgname=atool
 pkgver=0.39.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A script for managing file archives of various types"
 arch=('any')
 url="https://www.nongnu.org/atool/"
@@ -24,7 +24,7 @@ optdepends=('bzip2: for using atool with bzip2 compressed archives'
             'unace: for using atool with ace archives'
             'zip: for using atool for creating zip archives'
             'unzip: for using atool for unpacking archives')
-source=(https://savannah.nongnu.org/download/${pkgname}/${pkgname}-${pkgver}.tar.gz)
+source=(https://download.savannah.gnu.org/releases/${pkgname}/${pkgname}-${pkgver}.tar.gz)
 sha256sums=('aaf60095884abb872e25f8e919a8a63d0dabaeca46faeba87d12812d6efc703b')
 
 build() {


### PR DESCRIPTION
https://savannah.nongnu.org/download is redirected to https://download.savannah.gnu.org/releases/
and downloading failed locally