### PR TITLE
libbobcat: Fixes building with MSYS=winsymlinks:native

### DIFF
--- a/libbobcat/0002-Fixes-copy-of-cygbobcat.dll.patch
+++ b/libbobcat/0002-Fixes-copy-of-cygbobcat.dll.patch
@@ -1,0 +1,26 @@
+From 11a7816cad28d43de3aea9788ec62b60141b0a56 Mon Sep 17 00:00:00 2001
+From: Yonggang Luo <luoyonggang@gmail.com>
+Date: Mon, 26 Jan 2026 14:17:29 +0800
+Subject: [PATCH] Fixes copy of cygbobcat.dll
+
+cp: 'tmp/libso/cygbobcat.dll' and 'tmp/install//usr/lib/cygbobcat.dll' are the same file
+---
+ bobcat/icmake/loginstall | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bobcat/icmake/loginstall b/bobcat/icmake/loginstall
+index aab6d5fc..477f81af 100644
+--- a/bobcat/icmake/loginstall
++++ b/bobcat/icmake/loginstall
+@@ -25,7 +25,7 @@ void logInstall(string src, string pattern, string dest)
+     entries = findAll("f", src, pattern);
+ 
+     for (idx = listlen(entries); idx--; )
+-        run("cp " + src + entries[idx] + " " + dest);
++        run("rm -f " + dest + entries[idx] + "; cp " + src + entries[idx] + " " + dest);
+ 
+     chdir(g_cwd);
+     entries = findAll("l", src, pattern);
+-- 
+2.52.0.windows.1
+

--- a/libbobcat/PKGBUILD
+++ b/libbobcat/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=libbobcat
 pkgname=('libbobcat' 'libbobcat-devel')
 pkgver=5.07.03
-pkgrel=1
+pkgrel=2
 pkgdesc="Bobcat (Brokken's Own Base Classes And Templates) library"
 arch=('i686' 'x86_64')
 url="https://fbb-git.gitlab.io/bobcat/"
@@ -16,12 +16,14 @@ source=("${pkgname}::git+https://gitlab.com/fbb-git/bobcat.git#tag=${pkgver}"
         "fix-g_errno.patch"
         "fix-build.patch"
         "fix-light-build.patch"
-        "0001-missing-header.patch")
+        "0001-missing-header.patch"
+        "0002-Fixes-copy-of-cygbobcat.dll.patch")
 sha256sums=('da1fa4d2c4649ab754dd9e94f753bd059f03eb92d3cbb7d5f4c2c7ada57e4ea9'
             '875f0176b256897eb9e62656877255a909321c7268a6e0eedafc900ca04c0d55'
             'd710f99c90e351d9b8a9927f0a41686489355404fcaf19c745e38323396d93b6'
             'b2f2773d4486d4b2b3c3f6c20042a7eb3b01e7e2a75d5bd3b28761283b891d9d'
-            '5b043a14f152707df698a1aa4d5a4752613000f962f8002242f8620fba7aadb4')
+            '5b043a14f152707df698a1aa4d5a4752613000f962f8002242f8620fba7aadb4'
+            '1f8aa0c02d88ca6ca479e6ace80d08c4087a9ed1b7ac231b53190e1833307b4f')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -38,7 +40,8 @@ prepare() {
     fix-g_errno.patch \
     fix-build.patch \
     fix-light-build.patch \
-    0001-missing-header.patch
+    0001-missing-header.patch \
+    0002-Fixes-copy-of-cygbobcat.dll.patch
 }
 build() {
   cd "${srcdir}/${pkgbase}/bobcat"


### PR DESCRIPTION
The building error:
cp: 'tmp/libso/libbobcat.dll.a' and 'tmp/install//usr/lib/libbobcat.dll.a' are the same file Fatal: system - failure of system call (status 256)