### PR TITLE
binutils: Update to 2.46

### DIFF
--- a/binutils/PKGBUILD
+++ b/binutils/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=binutils
-pkgver=2.45.1
+pkgver=2.46
 pkgrel=1
 pkgdesc="A set of programs to assemble and manipulate binary and object files"
 arch=('i686' 'x86_64')
@@ -14,11 +14,11 @@ depends=('libiconv' 'libintl' 'zlib')
 checkdepends=('dejagnu' 'bc')
 makedepends=('libiconv-devel' 'gettext-devel' 'zlib-devel' 'autotools' 'gcc')
 options=('staticlibs' '!distcc' '!ccache')
-source=(https://ftp.gnu.org/gnu/binutils/binutils-${pkgver}.tar.xz{,.sig}
+source=(https://ftp.gnu.org/gnu/binutils/binutils-with-gold-${pkgver}.tar.xz{,.sig}
         0050-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
         0100-binutils-2.37-msys2.patch
         2002-Allow-spaces-in-the-name-of-the-external-preprocesso.patch)
-sha256sums=('5fe101e6fe9d18fdec95962d81ed670fdee5f37e3f48f0bef87bddf862513aa5'
+sha256sums=('a389850c2d3919f2cc96fb8b5e7711eacfc819259aaffb11615c9fb9756eaeae'
             'SKIP'
             '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18'
             '4a457d6ec33c5040a4d6a897c32e0a1743aa5052f24a989c86609de508d53bdf'
@@ -28,6 +28,8 @@ validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '5EF3A41171BB77E6110ED2D01F3D03348DB1A3E2')
 
 prepare() {
+  mv binutils-with-gold-${pkgver} binutils-${pkgver}
+
   cd "${srcdir}"/binutils-${pkgver}
   patch -p1 -i "${srcdir}"/0050-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
   patch -p1 -i "${srcdir}"/0100-binutils-2.37-msys2.patch


### PR DESCRIPTION
use the gold tarball since the other one is missing