### PR TITLE
util-linux: Add package 'file' as its dependencies

### DIFF
--- a/util-linux/PKGBUILD
+++ b/util-linux/PKGBUILD
@@ -17,6 +17,7 @@ msys2_references=(
   "cpe: cpe:/a:util-linux_project:util-linux"
 )
 makedepends=('autotools'
+             'file'
              'gcc'
              'gettext-devel'
              'gtk-doc'
@@ -175,7 +176,7 @@ check() {
 
 package_util-linux() {
   pkgdesc="Collection of basic system utilities"
-  depends=("coreutils" "libutil-linux" "libiconv" "libreadline" "libsqlite")
+  depends=("coreutils" "file" "libutil-linux" "libiconv" "libreadline" "libsqlite")
   provides=('getopt')
   conflicts=('getopt')
   replaces=('getopt')


### PR DESCRIPTION
`/usr/bin/more.exe` from `ports/util-linux/PKGBUILD` depends on msys-magic-1.dll of `ports/file/PKGBUILD`


Without this MR it's working because the base package depends on both
(util-linux,file); according to https://github.com/msys2/MSYS2-packages/blob/259a693c60432814a0e9b40da40165ef7bbe4205/base/PKGBUILD#L10-L45 , but we should not depends on that.
