### PR TITLE
grml-zsh-config: Bump version to 0.19.25, as version 0.19.13 do not exist anymore

### DIFF
--- a/grml-zsh-config/PKGBUILD
+++ b/grml-zsh-config/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Norbert Pfeiler <norbert.pfeiler+aur ät gmail.com>
 
 pkgname=grml-zsh-config
-pkgver=0.19.13
+pkgver=0.19.25
 pkgrel=1
 pkgdesc="grml's zsh setup"
 arch=('any')
@@ -9,11 +9,12 @@ url='https://grml.org/zsh/'
 license=('GPL2')
 provides=('grmlzshrc')
 depends=('zsh' 'coreutils' 'grep' 'sed' 'procps-ng')
-makedepends=('txt2tags')
-source=("http://deb.grml.org/pool/main/g/grml-etc-core/grml-etc-core_${pkgver}.tar.xz")
-sha256sums=('51cc87bb2f9dae2ebe063fb357947de51629cecc9e213dd55ac03cc1c9079e60')
+makedepends=('txt2tags' 'ruby')
+source=("https://deb.grml.org/pool/main/g/grml-etc-core/grml-etc-core_${pkgver}.tar.xz")
+sha256sums=('5a3bf42a21ebbe87b1d96b4b3b487a040d75de12de9a46cbfa9f74c61ebb6356')
 
 build() {
+  gem install --no-user-install asciidoctor
   cd ${srcdir}/grml-etc-core-${pkgver}/doc
   make
 }


### PR DESCRIPTION
Dot not use 0.19.28 because it's may be removed in future, so a more stable version 0.19.25 is used
