### PR TITLE
[do not merge] screen: init recipe

### DIFF
--- a/screen/PKGBUILD
+++ b/screen/PKGBUILD
@@ -1,0 +1,81 @@
+# Maintainer: Tiara Rodney <tiara@byteb4rb1e.me>
+# Ported from the Cygwin package by Andrew Schulman.
+# Upstream Cygwin recipe: https://cygwin.com/cgit/cygwin-packages/screen/
+
+pkgname=screen
+pkgver=5.0.1
+pkgrel=1
+pkgdesc='Terminal window manager that multiplexes a physical terminal between several processes'
+arch=('x86_64' 'i686')
+url='https://www.gnu.org/software/screen/'
+msys2_repository_url='https://git.savannah.gnu.org/cgit/screen.git'
+msys2_references=(
+  'anitya: 4772'
+  'cpe: cpe:/a:gnu:screen'
+)
+license=('spdx:GPL-3.0-only')
+depends=('libxcrypt' 'ncurses')
+makedepends=('libxcrypt-devel' 'ncurses-devel' 'gcc' 'texinfo')
+backup=('etc/screenrc')
+source=("https://ftp.gnu.org/gnu/screen/${pkgname}-${pkgver}.tar.gz"
+        'colortest.sh'
+        'cygwin-auth.patch'
+        'etcscreenrc.patch'
+        'install-exe.patch'
+        'peercred.patch'
+        'texinfo.patch'
+        'TIOCCONS.patch')
+sha256sums=('2dae36f4db379ffcd14b691596ba6ec18ac3a9e22bc47ac239789ab58409869d'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP')
+
+# The 5.0.1 tarball contains a symlink screen-5.0.1/FAQ -> doc/FAQ. Without
+# admin / Developer Mode on Windows, bsdtar fails while creating that symlink
+# and makepkg aborts extraction.
+noextract=("${pkgname}-${pkgver}.tar.gz")
+
+prepare() {
+  cd "${srcdir}"
+  MSYS=winsymlinks:lnk tar -xzf "${pkgname}-${pkgver}.tar.gz"
+  cd "${pkgname}-${pkgver}"
+  # Cygwin patches were generated against cygport tree where source
+  # lives under src/screen-5.0.0/... twostill carry prefix need, hence need
+  # -p2; the rest were regenerated with -p1-style headers upstream.
+  patch -p2 -i "${srcdir}/cygwin-auth.patch"
+  patch -p2 -i "${srcdir}/TIOCCONS.patch"
+  patch -p1 -i "${srcdir}/peercred.patch"
+  patch -p1 -i "${srcdir}/install-exe.patch"
+  patch -p1 -i "${srcdir}/etcscreenrc.patch"
+  patch -p1 -i "${srcdir}/texinfo.patch"
+}
+
+build() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  ./configure \
+    --build=${CHOST} \
+    --prefix=/usr \
+    --sysconfdir=/etc \
+    --localstatedir=/var \
+    --mandir=/usr/share/man \
+    --infodir=/usr/share/info \
+    --disable-pam \
+    --enable-utmp
+  make
+  make info
+}
+
+package() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  make DESTDIR="${pkgdir}" install
+
+  install -Dm644 etc/etcscreenrc "${pkgdir}/etc/screenrc"
+
+  install -Dm755 "${srcdir}/colortest.sh" "${pkgdir}/usr/share/screen/colortest.sh"
+
+  install -Dm644 COPYING "${pkgdir}/usr/share/licenses/${pkgname}/COPYING"
+}

--- a/screen/TIOCCONS.patch
+++ b/screen/TIOCCONS.patch
@@ -1,0 +1,18 @@
+--- origsrc/screen-5.0.0/tty.c	2024-08-29 04:55:03.000000000 +0900
++++ src/screen-5.0.0/tty.c	2025-04-06 00:57:11.489640800 +0900
+@@ -802,6 +802,7 @@ static void consredir_readev_fn(Event *
+ 
+ int TtyGrabConsole(int fd, bool on, char *rc_name)
+ {
++#ifndef __CYGWIN__
+ 	Display *d;
+ #ifdef SRIOCSREDIR
+ 	int cfd;
+@@ -880,6 +881,7 @@ int TtyGrabConsole(int fd, bool on, char
+ 	consredir_ev.type = EV_READ;
+ 	consredir_ev.handler = consredir_readev_fn;
+ 	evenq(&consredir_ev);
++#endif
+ 	return 0;
+ }
+ 

--- a/screen/colortest.sh
+++ b/screen/colortest.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Print colored text, with guidance about the terminal's color capabilities
+# Adapted from:
+# - 256color2.pl by Todd Larason <jtl@molehill.org>
+# - https://github.com/termstandard/colors
+# By Andrew Schulman <andrex.e.schulman@gmail.com>
+
+# System colors (range 0-15)
+
+echo System colors:
+for ((color = 0; color < 8; ++color)) ; do
+	printf "\033[48;5;${color}m  "
+done
+printf "\033[0m\n"
+for ((color = 8; $color < 16; ++color)) ; do
+	printf "\033[48;5;${color}m  "
+done
+printf "\033[0m\n\n"
+
+# Color cube (range 16-231)
+
+echo Color cube, 6x6x6:
+for ((g = 0; g < 6; ++g)) ; do
+	for ((r = 0; r < 6; ++r)) ; do
+		for ((b = 0; b < 6; ++b)) ; do
+			color=$(( 16 + 36*r + 6*g + b ))
+			printf "\033[48;5;${color}m  "
+		done
+		printf "\033[0m "
+	done
+	echo
+done
+echo
+
+# Grayscale ramp (range 232-255)
+
+echo Grayscale ramp:
+for ((color = 232; color < 256; ++color)) ; do
+	printf "\033[48;5;${color}m  "
+done
+printf "\033[0m\n\n"
+
+# Truecolor ramp
+
+for n in $(tput cols) $COLUMNS 80 ; do
+	ncols=$n
+	break
+done
+
+echo Truecolor ramp:
+for ((col = 0; col < ncols; ++col)) ; do
+	r=$(( 255 - ( 255 * col / ncols ) ))
+	g=$(( 510 * col / ncols )) ; if (( g > 255 )) ; then g=$(( 510 - g )) ; fi
+	b=$(( 255 * col / ncols ))
+	printf "\033[48;2;%d;%d;%dm" $r $g $b
+	printf "\033[38;2;%d;%d;%dm" $(( 255 - r )) $(( 255 - g )) $(( 255 - b ))
+	printf -- "-\033[0m"
+done
+echo
+
+# Interpretation
+
+ncols=$(printf "%3d" $ncols)
+cat <<END
+
+If your terminal supports
+this many colors:                  8     16     256  24-bit
+
+Then you'll see about this many
+distinct shades of color above:
+
+System colors ..................   8     16    8-16      16
+Color cube (each square) .......   3     10      36      36
+Greyscale ramp (incl. black) ...   1      4      25      25
+Truecolor ramp .................   1      1    1-64     ${ncols}
+
+See /usr/share/doc/screen/README.msys2 for information about terminal color
+support on MSYS2.
+END

--- a/screen/cygwin-auth.patch
+++ b/screen/cygwin-auth.patch
@@ -1,0 +1,45 @@
+--- origsrc/screen-5.0.0/socket.c	2025-04-08 00:24:31.851467200 +0900
++++ src/screen-5.0.0/socket.c	2025-04-08 16:31:46.927444900 +0900
+@@ -82,6 +82,17 @@
+ #include "tty.h"
+ #include "utmp.h"
+ 
++#ifdef __CYGWIN__
++typedef void *HANDLE;
++typedef void *HMODULE;
++typedef uint32_t DWORD;
++typedef uintptr_t DWORD_PTR;
++#define INVALID_HANDLE_VALUE ((HANDLE)-1)
++#define WINVER 0x0502
++#define MAX_PATH 260
++#include <sys/cygwin.h>
++#endif
++
+ static int CheckPid(pid_t);
+ static void ExecCreate(Message *);
+ static void DoCommandMsg(Message *);
+@@ -1214,6 +1225,7 @@ static bool CheckPassword(const char *pa
+ #else /* ENABLE_PAM */
+ 
+ static bool CheckPassword(const char *password) {
++#ifndef __CYGWIN__
+ 	bool ret = false;
+ 	char *passwd = 0;
+ 
+@@ -1256,6 +1264,16 @@ static bool CheckPassword(const char *pa
+ 	ret = (strcmp(passwd, p->sp_pwdp) == 0);
+ #endif
+ 	return ret;
++#else
++	struct passwd *p;
++	p = getpwnam(ppp->pw_name);
++	if (p == NULL)
++		return false;
++
++	HANDLE hToken = (HANDLE) cygwin_logon_user (p, password);
++	cygwin_set_impersonation_token (hToken);
++	return hToken != INVALID_HANDLE_VALUE;
++#endif
+ }
+ #endif /* ENABLE_PAM */
+ 

--- a/screen/etcscreenrc.patch
+++ b/screen/etcscreenrc.patch
@@ -1,0 +1,65 @@
+diff --unified '--color=auto' -urN screen-5.0.1.orig/etc/etcscreenrc screen-5.0.1/etc/etcscreenrc
+--- screen-5.0.1.orig/etc/etcscreenrc	2025-05-15 11:31:27.000000000 -0400
++++ screen-5.0.1/etc/etcscreenrc	2025-09-25 07:53:06.039806300 -0400
+@@ -1,20 +1,14 @@
+-#
+-# This is an example for the global screenrc file.
+-# You may want to install this file as /usr/local/etc/screenrc.
+-# Check config.h for the exact location.
+-#
+-# Flaws of termcap and standard settings are done here.
+-#
+ 
+ #startup_message off
+ 
+ #defflow on # will force screen to process ^S/^Q
++defflow off # leave it off, so we can use ^S to save in *emacs
+ 
+-deflogin on
++#deflogin on
+ #autodetach off
+ 
+-vbell on
+-vbell_msg "   Wuff  ----  Wuff!!  "
++#vbell on
++#vbell_msg "   Wuff  ----  Wuff!!  "
+ 
+ # all termcap entries are now duplicated as terminfo entries.
+ # only difference should be the slightly modified syntax, and check for
+@@ -65,6 +59,9 @@
+ termcap xterm 'is=\E[r\E[m\E[2J\E[H\E[?7h\E[?1;4;6l'
+ terminfo xterm 'is=\E[r\E[m\E[2J\E[H\E[?7h\E[?1;4;6l'
+ 
++# Set the hardstatus prop on gui terms to set the titlebar/icon title
++termcapinfo xterm*|rxvt*|kterm*|Eterm*|cygwin hs:ts=\E]0;:fs=\007:ds=\E]0;\007
++
+ #
+ # Do not use xterms alternate window buffer. 
+ # This one would not add lines to the scrollback buffer.
+@@ -81,14 +78,19 @@
+ termcap wy75-42 nx:xo:Z0=\E[?3h\E[31h:Z1=\E[?3l\E[31h
+ terminfo wy75-42 nx:xo:Z0=\E[?3h\E[31h:Z1=\E[?3l\E[31h
+ 
+-#remove some stupid / dangerous key bindings
++# Enable true (24-bit) color
++truecolor on
++
++# Remove some unwanted key bindings
+ bind ^k
+ #bind L
+ bind ^\
+-#make them better
+-bind \\ quit
+-bind K kill
+-bind I login on
+-bind O login off
+-bind } history
++
++# Adjust key bindings
++bind \\ quit --confirm
++bind k  kill --confirm
++bind K  kill
++bind I  login on
++bind O  login off
++bind }  history
+ 

--- a/screen/install-exe.patch
+++ b/screen/install-exe.patch
@@ -1,0 +1,27 @@
+diff '--color=auto' -urN screen-5.0.0.orig/Makefile.in screen-5.0.0/Makefile.in
+--- screen-5.0.0.orig/Makefile.in	2024-08-28 15:55:03.000000000 -0400
++++ screen-5.0.0/Makefile.in	2024-09-18 10:51:07.853494400 -0400
+@@ -20,7 +20,7 @@
+ bindir  = $(exec_prefix)/bin
+ 
+ VERSION = @PACKAGE_VERSION@
+-SCREEN = screen-$(VERSION)
++SCREEN = screen
+ 
+ DATE_FMT = %Y-%m-%d %H:%m:%S
+ ifdef SOURCE_DATE_EPOCH
+@@ -77,14 +77,7 @@
+ 	$(CC) $(CPPFLAGS) $(CFLAGS) $< -o $@ $*.o tests/mallocmock.o
+ 
+ install_bin: screen installdirs
+-	-if [ -f $(DESTDIR)$(bindir)/$(SCREEN) ] && [ ! -f $(DESTDIR)$(bindir)/$(SCREEN).old ]; \
+-		then mv $(DESTDIR)$(bindir)/$(SCREEN) $(DESTDIR)$(bindir)/$(SCREEN).old; fi
+ 	$(INSTALL_PROGRAM) screen $(DESTDIR)$(bindir)/$(SCREEN)
+-	-chown root $(DESTDIR)$(bindir)/$(SCREEN) && chmod 4755 $(DESTDIR)$(bindir)/$(SCREEN)
+-# This doesn't work if $(bindir)/screen is a symlink
+-	-if [ -f $(DESTDIR)$(bindir)/screen ] && [ ! -f $(DESTDIR)$(bindir)/screen.old ]; then mv $(DESTDIR)$(bindir)/screen $(DESTDIR)$(bindir)/screen.old; fi
+-	rm -f $(DESTDIR)$(bindir)/screen
+-	(cd $(DESTDIR)$(bindir) && ln -f -s $(SCREEN) screen)
+ 	cp $(srcdir)/utf8encodings/?? $(DESTDIR)$(SCREENENCODINGS)
+ 
+ ###############################################################################

--- a/screen/peercred.patch
+++ b/screen/peercred.patch
@@ -1,0 +1,33 @@
+diff '--color=auto' -urN screen-5.0.0.m1/socket.c screen-5.0.0/socket.c
+--- screen-5.0.0.m1/socket.c	2024-08-28 15:55:03.000000000 -0400
++++ screen-5.0.0/socket.c	2024-09-18 11:01:23.921380700 -0400
+@@ -361,6 +361,9 @@
+ 	a.sun_path[ARRAY_SIZE(a.sun_path) - 1] = 0;
+ 	xseteuid(real_uid);
+ 	xsetegid(real_gid);
++    #ifdef __CYGWIN__
++        setsockopt(s, SOL_SOCKET, SO_PEERCRED, NULL, 0);
++    #endif
+ 	if (connect(s, (struct sockaddr *)&a, strlen(SocketPath) + 2) != -1) {
+ 		if (quietflag) {
+ 			Kill(D_userpid, SIG_BYE);
+@@ -390,6 +393,9 @@
+ 	chmod(SocketPath, SOCKMODE);
+ 	if (chown(SocketPath, real_uid, real_gid))
+ 		Panic(errno, "chown");
++    #ifdef __CYGWIN__
++        setsockopt(s, SOL_SOCKET, SO_PEERCRED, NULL, 0);
++    #endif
+ 	if (listen(s, 5) == -1)
+ 		Panic(errno, "listen");
+ #ifdef F_SETOWN
+@@ -412,6 +418,9 @@
+ 	a.sun_path[ARRAY_SIZE(a.sun_path) - 1] = 0;
+ 	xseteuid(real_uid);
+ 	xsetegid(real_gid);
++    #ifdef __CYGWIN__
++        setsockopt(s, SOL_SOCKET, SO_PEERCRED, NULL, 0);
++    #endif
+ 	if (connect(s, (struct sockaddr *)&a, strlen(SocketPath) + 2) == -1) {
+ 		if (err)
+ 			Msg(errno, "%s: connect", SocketPath);

--- a/screen/texinfo.patch
+++ b/screen/texinfo.patch
@@ -1,0 +1,12 @@
+diff --unified '--color=auto' -urN screen-5.0.1.orig/doc/screen.texinfo screen-5.0.1/doc/screen.texinfo
+--- screen-5.0.1.orig/doc/screen.texinfo	2025-05-15 11:39:40.000000000 -0400
++++ screen-5.0.1/doc/screen.texinfo	2025-09-25 07:28:15.906312000 -0400
+@@ -5940,7 +5940,7 @@
+ hardware and operating system, the compiler used to compile, a
+ description of the bug behavior, and the conditions that triggered the
+ bug. In case of security issue please send an mail to
+-@w{@samp{alexander_naumov@opensuse.org}}.
++@w{@samp{alexander_naumov@@opensuse.org}}.
+ 
+ @node Availability,  , Reporting Bugs, Bugs
+ @section Availability


### PR DESCRIPTION
Hi. I'm proposing a GNU screen package.

A working recipe already exists for cygwin, so just slight adaptations were needed. I've built and tested it with 20260322.

There are a few caveats though, and I'm not sure what would be the right way to expose notices about these to users? No other non-essential recipe is using README.md?

- socket directory permissions and manually setting SCREENDIR
    - needs an ACL-enabled mount, so /etc/fstab modifications needed and FAT-backed fs not supported
- provided terminal color support tests

Also, I'm not sure where to properly place credits to the original cygwin port?

Kind regards