### PR TITLE
libcbor: Disable building of cjson2cbor examples

### DIFF
--- a/libcbor/PKGBUILD
+++ b/libcbor/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=libcbor
 pkgname=("${pkgbase}" "${pkgbase}-devel")
 pkgver=0.14.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A C library for parsing and generating CBOR, a general-purpose schema-less binary data format"
 arch=('i686' 'x86_64')
 url="https://github.com/PJK/libcbor"
@@ -21,6 +21,7 @@ build() {
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCBOR_CUSTOM_ALLOC=ON \
+    -DWITH_EXAMPLES=OFF \
     -DBUILD_SHARED_LIBS=ON \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   cmake --build build


### PR DESCRIPTION
The cjson2cbor example can only linkage to static library version of libcbor

: && /usr/bin/gcc.exe -march=nocona -msahf -mtune=generic -O2 -pipe -pedantic -O3 -DNDEBUG -O3 -Wall -Wextra -DNDEBUG -flto=auto -fno-fat-lto-objects -Wl,--enable-auto-import examples/CMakeFiles/cjson2cbor.dir/cjson2cbor.c.o -o examples/cjson2cbor.exe -Wl,--out-implib,examples/libcjson2cbor.dll.a -Wl,--major-image-version,0,--minor-image-version,0  src/libcbor.dll.a  /usr/lib/libcjson.dll.a && : /usr/lib/gcc/x86_64-pc-cygwin/15.2.0/../../../../x86_64-pc-cygwin/bin/ld: /tmp/ccTBTMjP.ltrans0.ltrans.o:<artificial>:(.data+0x18): undefined reference to `cbor_builder_uint64_callback' /usr/lib/gcc/x86_64-pc-cygwin/15.2.0/../../../../x86_64-pc-cygwin/bin/ld: /tmp/ccTBTMjP.ltrans0.ltrans.o:<artificial>:(.data+0x20): undefined reference to `cbor_builder_negint64_callback' /usr/lib/gcc/x86_64-pc-cygwin/15.2.0/../../../../x86_64-pc-cygwin/bin/ld: /tmp/ccTBTMjP.ltrans0.ltrans.o:<artificial>:(.data+0x50): undefined reference to `cbor_builder_string_callback' /usr/lib/gcc/x86_64-pc-cygwin/15.2.0/../../../../x86_64-pc-cygwin/bin/ld: /tmp/ccTBTMjP.ltrans0.ltrans.o:<artificial>:(.data+0x68): undefined reference to `cbor_builder_array_start_callback' /usr/lib/gcc/x86_64-pc-cygwin/15.2.0/../../../../x86_64-pc-cygwin/bin/ld: /tmp/ccTBTMjP.ltrans0.ltrans.o:<artificial>:(.data+0x78): undefined reference to `cbor_builder_map_start_callback' /usr/lib/gcc/x86_64-pc-cygwin/15.2.0/../../../../x86_64-pc-cygwin/bin/ld: /tmp/ccTBTMjP.ltrans0.ltrans.o:<artificial>:(.data+0x90): undefined reference to `cbor_builder_float4_callback' /usr/lib/gcc/x86_64-pc-cygwin/15.2.0/../../../../x86_64-pc-cygwin/bin/ld: /tmp/ccTBTMjP.ltrans0.ltrans.o:<artificial>:(.data+0xa8): undefined reference to `cbor_builder_null_callback' /usr/lib/gcc/x86_64-pc-cygwin/15.2.0/../../../../x86_64-pc-cygwin/bin/ld: /tmp/ccTBTMjP.ltrans0.ltrans.o:<artificial>:(.data+0xb0): undefined reference to `cbor_builder_boolean_callback' /usr/lib/gcc/x86_64-pc-cygwin/15.2.0/../../../../x86_64-pc-cygwin/bin/ld: /tmp/ccTBTMjP.ltrans0.ltrans.o:<artificial>:(.text.startup+0x96): undefined reference to `_cbor_stack_init'