### PR TITLE
gnutls: Update to 3.8.13

### DIFF
--- a/gnutls/PKGBUILD
+++ b/gnutls/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=gnutls
 pkgname=('gnutls' 'libgnutls' 'libgnutls-devel')
-pkgver=3.8.12
+pkgver=3.8.13
 pkgrel=1
 pkgdesc="A library which provides a secure layer over a reliable transport layer"
 arch=('x86_64' 'i686')
@@ -26,12 +26,13 @@ makedepends=('gtk-doc'
              'zlib-devel')
 source=(https://gnupg.org/ftp/gcrypt/gnutls/v${pkgver%.*}/${pkgname}-${pkgver}.tar.xz{,.sig}
         0001-doc-fix-implicit-rule-build-failure.patch)
-sha256sums=('a7b341421bfd459acf7a374ca4af3b9e06608dcd7bd792b2bf470bea012b8e51'
+sha256sums=('ffed8ec1bf09c2426d4f14aae377de4753b53e537d685e604e99a8b16ca9c97e'
             'SKIP'
             'e5b3459dd15408d899073f4001b757284e1e743b19060c11b2d9be8d43b7c30b')
 validpgpkeys=('0424D4EE81A0E3D119C6F835EDA21E94B565716F' # "Simon Josefsson <simon@josefsson.org>"
               '1F42418905D8206AA754CCDC29EE58B996865171' # "Nikos Mavrogiannopoulos <nmav@gnutls.org>
               '462225C3B46F34879FC8496CD605848ED7E69871' # "Daiki Ueno <ueno@unixuser.org>"
+              'E987AB7F7E89667776D05B3BB0E9DD20B29F1432' # Alexander Sosedkin <monk at unboiled.info>
               '5D46CB0F763405A7053556F47A75A648B3F9220C') # Zoltan Fridrich <zfridric at redhat.com>
 
 prepare() {


### PR DESCRIPTION
For the new signing key see:
https://lists.gnutls.org/pipermail/gnutls-help/2026-April/004922.html