### PR TITLE
vim: update to 9.2.0437

### DIFF
--- a/vim/PKGBUILD
+++ b/vim/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=vim
 _topver=9.2
-_patchlevel=0390
+_patchlevel=0437
 _versiondir="${pkgname}${_topver//./}"
 pkgver=${_topver}.${_patchlevel}
 pkgrel=1
@@ -32,7 +32,7 @@ source=(${pkgname}-${pkgver}.tar.gz::https://github.com/vim/vim/archive/v${pkgve
         'pretend-cygwin-msys.patch'
         'accept-crlf.patch'
         'vim-completion')
-sha256sums=('18f5abda9cae11359cc9625370fc142bdfbefbbc4c07aad55d21dca5d5bdbdf2'
+sha256sums=('8fcb3380d112e001149e47c7b7e2e6d42a4bdc435be7888de82c593daa1982f6'
             'edd18e0756406ee7b659e4552e444c50c3a0c1e9fb4fce2ddd770c933ea6c7f5'
             'bca6e030d50c0d2468ab5c78aa0b359eb18a88a197de8406c593458ffedde922'
             '44d7738a8f801195898eeef766ff77506c717dd5d19145ade3c1c2349d4bc4fd'


### PR DESCRIPTION
Fixes <https://github.com/vim/vim/security/advisories/GHSA-hwg5-3cxw-wvvg>.