### PR TITLE
gradle: Package missing files

### DIFF
--- a/gradle/PKGBUILD
+++ b/gradle/PKGBUILD
@@ -9,7 +9,7 @@
 
 pkgname=('gradle' 'gradle-doc')
 pkgver=9.5.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 url='https://www.gradle.org/'
 msys2_repository_url='https://github.com/gradle/gradle'
@@ -35,10 +35,10 @@ package_gradle(){
   mkdir -p "${pkgdir}/usr/share/java/${pkgname}/lib/plugins"
   mkdir -p "${pkgdir}/usr/bin"
 
-  # copy across jar files
-  install -Dm644 lib/*.jar "${pkgdir}/usr/share/java/${pkgname}/lib" || return 1
-  install -Dm644 lib/agents/*.jar "${pkgdir}/usr/share/java/${pkgname}/lib/agents" || return 1
-  install -Dm644 lib/plugins/*.jar "${pkgdir}/usr/share/java/${pkgname}/lib/plugins" || return 1
+  # copy across jar and properties files
+  install -Dm644 lib/*.jar lib/*.properties "${pkgdir}/usr/share/java/${pkgname}/lib" || return 1
+  install -Dm644 lib/agents/*.jar lib/agents/*.properties "${pkgdir}/usr/share/java/${pkgname}/lib/agents" || return 1
+  install -Dm644 lib/plugins/*.jar lib/plugins/*.properties "${pkgdir}/usr/share/java/${pkgname}/lib/plugins" || return 1
 
   # copy across supporting text documentation and scripts
   install -m644 LICENSE "${pkgdir}/usr/share/java/${pkgname}" || return 1            # license


### PR DESCRIPTION
Fixes:

    org.gradle.api.internal.classpath.UnknownModuleException: Cannot find module 'ant' in distribution directory 'C:\msys64\usr\share\java\gradle'.