### PR TITLE
ci: don't include archive size in meta diffs

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -105,7 +105,7 @@ for package in "${packages[@]}"; do
 
         echo "::group::[meta-diff] ${pkgname}"
         message "Package info diff for ${pkgname}"
-        diff -Nur <(pacman -Si ${MSYSTEM,,}/"${pkgname}") <(pacman -Qip "${pkg}") || true
+        diff -Nur <(pacman -Si ${MSYSTEM,,}/"${pkgname}" | sed '/Download Size/d') <(pacman -Qip "${pkg}" | sed '/Compressed Size/d') || true
         echo "::endgroup::"
 
         echo "::group::[file-diff] ${pkgname}"


### PR DESCRIPTION
same as in MINGW repo