### PR TITLE
vim: update to 9.2.0452

### DIFF
--- a/vim/PKGBUILD
+++ b/vim/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=vim
 _topver=9.2
-_patchlevel=0437
+_patchlevel=0452
 _versiondir="${pkgname}${_topver//./}"
 pkgver=${_topver}.${_patchlevel}
 pkgrel=1
@@ -32,7 +32,7 @@ source=(${pkgname}-${pkgver}.tar.gz::https://github.com/vim/vim/archive/v${pkgve
         'pretend-cygwin-msys.patch'
         'accept-crlf.patch'
         'vim-completion')
-sha256sums=('8fcb3380d112e001149e47c7b7e2e6d42a4bdc435be7888de82c593daa1982f6'
+sha256sums=('e0d67dcd88569b37deb6d58a49ac64f7b0489433d455472198bcf585137405b5'
             'edd18e0756406ee7b659e4552e444c50c3a0c1e9fb4fce2ddd770c933ea6c7f5'
             'bca6e030d50c0d2468ab5c78aa0b359eb18a88a197de8406c593458ffedde922'
             '44d7738a8f801195898eeef766ff77506c717dd5d19145ade3c1c2349d4bc4fd'


### PR DESCRIPTION
Contains fix for <https://github.com/vim/vim/security/advisories/GHSA-q4jv-r9gj-6cwv>.