### PR TITLE
mingw-w64-cross-gcc: enable native tls

### DIFF
--- a/mingw-w64-cross-gcc/PKGBUILD
+++ b/mingw-w64-cross-gcc/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase="${_mingw_suff}-${_realname}"
 _targetpkgs=("${_mingw_suff}-ucrt64-${_realname}" "${_mingw_suff}-mingw32-${_realname}" "${_mingw_suff}-mingw64-${_realname}")
 pkgname=("${_mingw_suff}-${_realname}" "${_targetpkgs[@]}")
 pkgver=16.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Cross GCC for the MinGW-w64"
 arch=('i686' 'x86_64')
 url="https://gcc.gnu.org"
@@ -143,6 +143,7 @@ _build() {
     --disable-isl-version-check \
     --enable-lto \
     --enable-libgomp \
+    --enable-tls \
     --disable-libssp \
     --disable-multilib \
     --enable-checking=release \


### PR DESCRIPTION
See https://github.com/msys2/MINGW-packages/issues/29272