### PR TITLE
pax fixes building with gcc 15.2

### DIFF
--- a/pax/0001-Fixes-error-implicit-declaration-of-function-vasprin.patch
+++ b/pax/0001-Fixes-error-implicit-declaration-of-function-vasprin.patch
@@ -1,0 +1,28 @@
+From a18d966f6663c8dd23cd7766b7ff2f98f42fa16c Mon Sep 17 00:00:00 2001
+From: Yonggang Luo <luoyonggang@gmail.com>
+Date: Sun, 11 Jan 2026 07:10:13 +0800
+Subject: [PATCH] Fixes error: implicit declaration of function 'vasprintf'
+
+The error:
+../tty_subs.c:98:23: error: implicit declaration of function 'vasprintf'; did you mean 'vasnprintf'? [-Wimplicit-function-declaration]
+   98 |                 len = vasprintf(&cp, fmt, ap);
+---
+ tty_subs.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/tty_subs.c b/tty_subs.c
+index e87f232..95bdcdc 100644
+--- a/tty_subs.c
++++ b/tty_subs.c
+@@ -36,6 +36,8 @@
+  * SUCH DAMAGE.
+  */
+ 
++#define _GNU_SOURCE
++
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <errno.h>
+-- 
+2.52.0.windows.1
+

--- a/pax/PKGBUILD
+++ b/pax/PKGBUILD
@@ -16,14 +16,26 @@ provides=("${pkgname}-git")
 conflicts=("${pkgname}-git")
 replaces=("${pkgname}-git")
 makedepends=('gcc')
-source=("http://www.mirbsd.org/MirOS/dist/mir/cpio/paxmirabilis-${pkgver}.cpio.gz")
+_patches=(
+  0001-Fixes-error-implicit-declaration-of-function-vasprin.patch
+)
+source=("https://mbsd.evolvis.org/MirOS/dist/mir/cpio/paxmirabilis-${pkgver}.cpio.gz"
+        ${_patches[@]})
 noextract=("paxmirabilis-${pkgver}.cpio.gz")
-sha256sums=('fe3f99c28ba7a46c4bce0b329da3742908b87fe8fbe17f0db1f99a1bd053d46b')
+sha256sums=('fe3f99c28ba7a46c4bce0b329da3742908b87fe8fbe17f0db1f99a1bd053d46b'
+            'a1ff89b87ac050600446e0d0fe85c7721e9b40ded3f62115ec59a8ca3cccfecf')
 
 prepare() {
   mkdir -p "${pkgname}-${pkgver}/build"
 
   bsdtar -x -f "paxmirabilis-${pkgver}.cpio.gz" -C "$pkgname-${pkgver}" --strip-components='1'
+
+  cd "${srcdir}/$pkgname-${pkgver}"
+
+  for patch in "${_patches[@]}"; do
+    msg2 "Patching with ${patch}"
+    patch -Nbp1 -i "${srcdir}/${patch}"
+  done
 }
 
 build() {


### PR DESCRIPTION
pax fixes building with gcc 15.2
URL use https version for downloading fine
The URL comes from http://www.mirbsd.org/pax.htm