### PR TITLE
less: update to 702

### DIFF
--- a/less/PKGBUILD
+++ b/less/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=less
-pkgver=692
+pkgver=702
 pkgrel=1
 pkgdesc="A terminal based program for viewing text files"
 license=('GPL3')
@@ -14,7 +14,7 @@ msys2_references=(
 depends=('ncurses' 'libpcre2_8')
 makedepends=('ncurses-devel' 'pcre2-devel' 'autotools' 'gcc' 'groff')
 source=("https://github.com/gwsw/${pkgname}/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('5e2ba1936f9d19d903d8b224c3af39c8693bf3add8de42fef3a18b2cde964b35')
+sha256sums=('ed6ef844c5f23ae2d360be7bcdb7efeb4a823630331e97ab0e0a3a15981381d1')
 validpgpkeys=('AE27252BD6846E7D6EAE1DD6F153A7C833235259') # Mark Nudelman
 
 prepare() {


### PR DESCRIPTION
This updates less from 692 to 702, released on 22 May 2026.

Full changelog: https://www.greenwoodsoftware.com/less/news.702.html