### PR TITLE
.patch files should be binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,4 @@
 *.lib binary
 *.a binary
 *.ico binary
+*.patch binary


### PR DESCRIPTION
Because in patch files, there may line ending changes. Keep it in binary format to support for all kinds of patches.