### PR TITLE
cscope: Fixes detecting of HAVE_SIGSETJMP in cygwin

### DIFF
--- a/cscope/0001-cscope-Fixes-detecting-of-HAVE_SIGSETJMP-in-cygwin.patch
+++ b/cscope/0001-cscope-Fixes-detecting-of-HAVE_SIGSETJMP-in-cygwin.patch
@@ -1,0 +1,26 @@
+From 5f859ca81f00d649dffb2b6831f8683f0da1703b Mon Sep 17 00:00:00 2001
+From: Yonggang Luo <luoyonggang@gmail.com>
+Date: Mon, 12 Jan 2026 01:36:53 +0800
+Subject: [PATCH] cscope: Fixes detecting of HAVE_SIGSETJMP in cygwin
+
+Signed-off-by: Yonggang Luo <luoyonggang@gmail.com>
+---
+ configure.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.in b/configure.in
+index 323f119..076f96a 100644
+--- a/configure.in
++++ b/configure.in
+@@ -393,7 +393,7 @@ AC_CHECK_TYPE(sighandler_t,[],[],[
+ #endif])
+ dnl This test was ripped from gnuplot's configure.in:
+ AC_MSG_CHECKING(for sigsetjmp)
+-AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <setjmp.h>]], [[jmp_buf env; sigsetjmp(env, 1);]])],[AC_MSG_RESULT(yes)
++AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <setjmp.h>]], [[sigjmp_buf env; sigsetjmp(env, 1);]])],[AC_MSG_RESULT(yes)
+    AC_DEFINE(HAVE_SIGSETJMP,1,
+              [ Define if we have sigsetjmp(). ])],[AC_MSG_RESULT(no)])
+ 
+-- 
+2.52.0.windows.1
+

--- a/cscope/PKGBUILD
+++ b/cscope/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=cscope
 pkgver=15.9
-pkgrel=2
+pkgrel=3
 pkgdesc="A tool for browsing source code"
 arch=("i686" "x86_64")
 url="https://cscope.sourceforge.io/"
@@ -12,11 +12,24 @@ msys2_references=(
 license=('BSD')
 depends=('ncurses')
 makedepends=("ncurses-devel" 'autotools' 'gcc')
-source=("https://sourceforge.net/projects/cscope/files/${pkgname}/v${pkgver}/${pkgname}-${pkgver}.tar.gz")
-sha256sums=('c5505ae075a871a9cd8d9801859b0ff1c09782075df281c72c23e72115d9f159')
+
+_patches=(
+  0001-cscope-Fixes-detecting-of-HAVE_SIGSETJMP-in-cygwin.patch
+)
+
+source=("https://sourceforge.net/projects/cscope/files/${pkgname}/v${pkgver}/${pkgname}-${pkgver}.tar.gz"
+        ${_patches[@]})
+sha256sums=('c5505ae075a871a9cd8d9801859b0ff1c09782075df281c72c23e72115d9f159'
+            '6b6cbda9cb77c7c486559b60b2ce57489edba75caae7f7dacc8e588d6dd29988')
 
 prepare () {
   cd "${pkgname}-${pkgver}"
+
+  for patch in "${_patches[@]}"; do
+    msg2 "Patching with ${patch}"
+    patch -Nbp1 -i "${srcdir}/${patch}"
+  done
+
   sed -i 's|/usr/local/lib/cs|/usr/lib/cs|' contrib/ocs
 }
 


### PR DESCRIPTION
display.c:62:17: error: conflicting types for 'sigjmp_buf'; have 'jmp_buf' {aka 'long int[32]'}
   62 | typedef jmp_buf sigjmp_buf;