### PR TITLE
less: update to v704

### DIFF
--- a/less/PKGBUILD
+++ b/less/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=less
-pkgver=702
+pkgver=704
 pkgrel=1
 pkgdesc="A terminal based program for viewing text files"
 license=('GPL3')
@@ -14,7 +14,7 @@ msys2_references=(
 depends=('ncurses' 'libpcre2_8')
 makedepends=('ncurses-devel' 'pcre2-devel' 'autotools' 'gcc' 'groff')
 source=("https://github.com/gwsw/${pkgname}/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('ed6ef844c5f23ae2d360be7bcdb7efeb4a823630331e97ab0e0a3a15981381d1')
+sha256sums=('0a801a147af1e41c1d9daa273316ce6d560053534659b5487ed5de6fc5032de4')
 validpgpkeys=('AE27252BD6846E7D6EAE1DD6F153A7C833235259') # Mark Nudelman
 
 prepare() {


### PR DESCRIPTION
This is obviously a little bit of a more urgent update, seeing as the beta testing window was uncharacteristically short this time: It was released for beta testing on May 31th, and for general use on June 6th.

For full details, see https://www.greenwoodsoftware.com/less/news.704.html