### PR TITLE
mintty: Update to 3.8.3

### DIFF
--- a/mintty/PKGBUILD
+++ b/mintty/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=mintty
-pkgver=3.8.2
+pkgver=3.8.3
 pkgrel=1
 epoch=1
 pkgdesc="Terminal emulator with native Windows look and feel"
@@ -17,7 +17,7 @@ msys2_references=(
 backup=('etc/minttyrc')
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/mintty/mintty/archive/${pkgver}.tar.gz
         "minttyrc")
-sha256sums=('273a90b271e7c876ee0c737a495c2c95fdbe208518a455153420a1f66e70cb90'
+sha256sums=('01e31d569dc11c428bc663447ee4cd3dd7bd39406f7f1cdba3d66f1039b3b38a'
             'ce43a9b0c8eb01a695d0543ceb56c9281708a02aaf92021b72d0f0b69a7feeb9')
 
 build() {


### PR DESCRIPTION
From https://github.com/mintty/mintty/releases/tag/3.8.3:

Terminal features
  * Font glyph coverage enquiry also works beyond the Unicode BMP (~https://github.com/mintty/mintty/issues/1352).
  * Suppress ReGIS delay command on graphics refresh.
  * Ensure refresh of blinking graphics (broken since 3.7.9).
  * Fix emoji sequence rendering in context of font or changing attributes.
  * Fix glitch of incomplete emoji joiner at end of line.
  * DECRQM requests for UTF-8, ambiguous-wide and emoji width modes (xterm 407).

Character rendering
  * Font substitution mechanism checks glyph coverage and selects suitable alternative font (https://github.com/mintty/mintty/issues/1352).
  * Narrow single-cell-rendered emoji graphics.
  * Narrow certain single-cell-rendered emoji text presentations from Miscellaneous ranges.
  * In emoji width mode, apply VS15 modifier to narrow character.
  * Do not display VS15/VS16 modifiers, or Fitzpatrick in emoji width mode.
  * Emoji width mode can be preconfigured as default.

Keyboard handling
  * After IME option switch, reset Control state to avoid input misinterpretation (https://github.com/mintty/mintty/issues/1353).
  * User-defined key assignments (setting KeyFunctions) stay in effect in shortcut override mode (~https://github.com/mintty/mintty/issues/1351).
  * Restrict VT220 application keypad sequences to VT220 mode by default (https://github.com/mintty/mintty/issues/1357).
  * Support previous special VT220-style keypad sequences if Escape key mode enabled (~https://github.com/mintty/mintty/issues/1357).

Window handling
  * Drag-and-drop onto terminal or Options sets window focus (https://github.com/mintty/mintty/issues/1354).
  * Keep window maximised after changing monitor dimensions (git-for-windows/githttps://github.com/mintty/mintty/issues/6085).
  * Default width of line-style cursors can now be configured (https://github.com/mintty/mintty/issues/1360).

Other
  * Restore Windows XP compatibility.
  * Fix WSL home dir conversion (option -~).
  * Make reading from clipboard more reliable (https://cygwin.com/pipermail/cygwin/2026-February/259438.html).
  * Manual: note on how to override overridden shortcuts (https://github.com/mintty/mintty/issues/1364) with user-defined functions.

Configuration
  * New option DropFocus (https://github.com/mintty/mintty/issues/1354).
  * New option FontSubst (https://github.com/mintty/mintty/issues/1352).
  * New option CursorSize (https://github.com/mintty/mintty/issues/1360).
  * New option OldAppKeypad (https://github.com/mintty/mintty/issues/1357).
  * New option EmojiWidth.
  * Enable drag-and-drop from updated 4bit Color Scheme Designer (https://github.com/mintty/mintty/issues/1363).