### PR TITLE
tig: update to v2.6.1

### DIFF
--- a/tig/PKGBUILD
+++ b/tig/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <Alexpux@gmail.com>
 
 pkgname=tig
-pkgver=2.6.0
+pkgver=2.6.1
 pkgrel=1
 pkgdesc='Text-mode interface for Git'
 depends=('git' 'libreadline' 'ncurses')
@@ -17,7 +17,7 @@ license=('spdx:GPL-2.0-or-later')
 arch=('i686' 'x86_64')
 backup=('etc/tigrc')
 source=("https://github.com/jonas/${pkgname}/releases/download/${pkgname}-${pkgver}/${pkgname}-${pkgver}.tar.gz")
-sha256sums=('99d4a0fdd3d93547ebacfe511195cb92e4f75b91644c06293c067f401addeb3e')
+sha256sums=('5adeabdcd93aa0423d618da8b878b53482bef6e0e9e1fe224acc0f18031fe91e')
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"


### PR DESCRIPTION
From https://github.com/jonas/tig/releases/tag/tig-2.6.1:

Security fixes:

*   Fix editor command injection vulnerability (only affects version 2.6.0).

Bug fixes:

*   Fix notes handling in the main view.
*   Honor init_size in string_map_put_to().
*   Reset view->parent both when switching and closing view.
*   Fix grep with revision argument.
*   Minor tweaks to the blame view.
*   Fix repo info in bare repository with no HEAD.
*   Document `%(status)`.
*   Update Cygwin build.
*   Fix "DU" conflicts showing as 'Staged changes' in the main view.
*   Ensure consistent blame view access from the blob view.
*   Fix compiler warning with glibc-2.43.
*   contrib: chocolate-theme: Fix cursor color in backgrounded view.
*   Fix date for 'Not Committed Yet' changes.
*   Fix slow tig status when given a subdirectory path.
*   Handle pure file rename in the diff view.

Improvements:

*   Handle the NO_COLOR environment variable.
*   Run tests against system's tig when SYSTEM_TIG=1.
*   Support option append.
*   Add an option to make the tree view recursive.
*   Enable direct blob edits in clean HEAD state.