### PR TITLE
vim: update to 9.2.0677

### DIFF
--- a/vim/PKGBUILD
+++ b/vim/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=vim
 _topver=9.2
-_patchlevel=0663
+_patchlevel=0677
 _versiondir="${pkgname}${_topver//./}"
 pkgver=${_topver}.${_patchlevel}
 pkgrel=1
@@ -32,7 +32,7 @@ source=(${pkgname}-${pkgver}.tar.gz::https://github.com/vim/vim/archive/v${pkgve
         'pretend-cygwin-msys.patch'
         'accept-crlf.patch'
         'vim-completion')
-sha256sums=('7eb2a5ed3423d1f56b1eeb8731f24346e461736f709043338cec8ddd06f0a404'
+sha256sums=('cd2bb9c964d8227e00d23c26141e15a40358dc0dda99453b5cb5ceda71b2ab49'
             'edd18e0756406ee7b659e4552e444c50c3a0c1e9fb4fce2ddd770c933ea6c7f5'
             'bca6e030d50c0d2468ab5c78aa0b359eb18a88a197de8406c593458ffedde922'
             '44d7738a8f801195898eeef766ff77506c717dd5d19145ade3c1c2349d4bc4fd'


### PR DESCRIPTION
Contains fixes for <https://github.com/vim/vim/security/advisories/GHSA-f36c-2qcp-7gpw> and <https://github.com/vim/vim/security/advisories/GHSA-c4j9-wr9j-4486>.