### PR TITLE
vim: revert faulty non-dynamic binding to the Ruby DLL

### DIFF
--- a/vim/PKGBUILD
+++ b/vim/PKGBUILD
@@ -6,7 +6,7 @@ _topver=9.2
 _patchlevel=0677
 _versiondir="${pkgname}${_topver//./}"
 pkgver=${_topver}.${_patchlevel}
-pkgrel=1
+pkgrel=2
 pkgdesc='Vi Improved, a highly configurable, improved version of the vi text editor'
 arch=('i686' 'x86_64')
 license=('custom:vim')
@@ -25,6 +25,7 @@ groups=('editors')
 makedepends=('gawk' 'perl-devel' 'python-devel' 'ruby' 'ncurses-devel' 'autotools' 'gcc'
              'libiconv-devel' 'gettext-devel' 'libxcrypt-devel') # To satisfy python3/dyn feature #3052
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/vim/vim/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz
+        https://github.com/vim/vim/commit/cb1dc1fcadcae0f7fb14d410bc57e69bb02478c0.patch
         'dot.vimrc'
         '7.3-cygwin-mouse.patch'
         '7.3-virc.patch'
@@ -33,6 +34,7 @@ source=(${pkgname}-${pkgver}.tar.gz::https://github.com/vim/vim/archive/v${pkgve
         'accept-crlf.patch'
         'vim-completion')
 sha256sums=('cd2bb9c964d8227e00d23c26141e15a40358dc0dda99453b5cb5ceda71b2ab49'
+            '4c17a6d93dd6ed33f4e3cbfa9164598d7ef488ea70fb4bf4603615c1f6f8737c'
             'edd18e0756406ee7b659e4552e444c50c3a0c1e9fb4fce2ddd770c933ea6c7f5'
             'bca6e030d50c0d2468ab5c78aa0b359eb18a88a197de8406c593458ffedde922'
             '44d7738a8f801195898eeef766ff77506c717dd5d19145ade3c1c2349d4bc4fd'
@@ -46,6 +48,10 @@ prepare() {
 
   iconv -f ISO-8859-1 -t UTF-8 runtime/doc/eval.txt \
     > runtime/doc/eval.tmp && mv -f runtime/doc/eval.{tmp,txt}
+
+  # This reverts the faulty https://github.com/vim/vim/pull/20558 which made
+  # msys-ruby340.dll a hard, required dependency, even with --enable-rubyinterp=dynamic
+  patch -p1 -R -i ${srcdir}/cb1dc1fcadcae0f7fb14d410bc57e69bb02478c0.patch
 
   patch -p2 -i ${srcdir}/7.3-cygwin-mouse.patch
   patch -p2 -i ${srcdir}/7.3-virc.patch


### PR DESCRIPTION
As of the update to v9.2.0677-1, `vim.exe` will no longer start unless libruby _happens_ to be installed (it is marked as an optional dependency, not a required one). The reason is that an upstream vim change recently broke the dynamic binding to the Ruby DLL.

Let's revert that faulty patch.

Fixes: https://github.com/vim/vim/pull/20558