### PR TITLE
sqlite: add README.md.in to source array

### DIFF
--- a/sqlite/PKGBUILD
+++ b/sqlite/PKGBUILD
@@ -10,7 +10,7 @@ _sqlite_year=2026
 _srcver=3530200
 _docver=${_srcver}
 pkgver=3.53.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A C library that implements an SQL database engine"
 arch=('i686' 'x86_64')
 license=('spdx:LicenseRef-Sqlite')
@@ -27,14 +27,16 @@ source=(https://www.sqlite.org/${_sqlite_year}/sqlite-src-${_srcver}.zip
         0001-sqlite-pcachetrace-include-sqlite3.patch
         0002-sqlite3.32.3-Makefile.in-fix-rule-compiling-rbu.exe.patch
         0031-use-packaged-lempar.c.patch
-        Makefile.ext.in)
+        Makefile.ext.in
+        README.md.in)
 sha256sums=('cafff764c03f6d720968f746e2f47a986bbf12bf4c18904f1eb131c0b0b592d3'
             '30c5488926e72a0b958d64377c91c975a35a8f16d285cbb83cfad31f4af71c6d'
             '0b76663a90e034f3d7f2af5bfada4cedec5ebc275361899eccc5c18e6f01ff1f'
             '6518119034ceb2820d058afcb099d11f636271f55a41ffae22855af66a369166'
             '2a3be75d6a0e8f7ea1a53f0434a9e1823fcb5965069f482083694388c7564f1c'
             '9d51e267719f48454627860cf0529928b6711c053e3b930344d897e95a0810fa'
-            '8c169857b1c449fb7f4e31aaedccdb15435b2f8a83f0f4e744569894a86d8bbd')
+            '8c169857b1c449fb7f4e31aaedccdb15435b2f8a83f0f4e744569894a86d8bbd'
+            'ef3a1faa02a88e05539d160d51679f164dfa23cc5a637ff36bc504bf04d6d7a6')
 
 _sqlite_tools="sqlite3.exe sqlite3_analyzer.exe sqldiff.exe dbhash.exe rbu.exe"
 


### PR DESCRIPTION
- Declare README.md.in in PKGBUILD source() so it is extracted into $srcdir during the build.

- Add the matching sha256sum for README.md.in.

- Fixes package_sqlite-extensions() failing with 'cat: README.md.in: No such file or directory' when generating /usr/share/sqlite/extensions/README.md from the template.