### PR TITLE
jsoncpp: Update to 1.9.8

### DIFF
--- a/cmake/PKGBUILD
+++ b/cmake/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=cmake
 pkgname=("${_realname}" "${_realname}-emacs" "${_realname}-vim")
 pkgver=4.3.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform open-source make system"
 arch=('i686' 'x86_64')
 url="https://www.cmake.org/"

--- a/jsoncpp/PKGBUILD
+++ b/jsoncpp/PKGBUILD
@@ -2,8 +2,8 @@
 
 pkgbase="jsoncpp"
 pkgname=("${pkgbase}" "${pkgbase}-devel")
-pkgver=1.9.6
-pkgrel=3
+pkgver=1.9.8
+pkgrel=1
 pkgdesc="A C++ library for interacting with JSON"
 arch=('i686' 'x86_64')
 url="https://github.com/open-source-parsers/jsoncpp"
@@ -19,7 +19,7 @@ makedepends=("gcc"
              "pkgconf"
              "ninja")
 source=(${pkgname}-${pkgver}.tar.gz::"https://github.com/open-source-parsers/jsoncpp/archive/${pkgver}.tar.gz")
-sha256sums=('f93b6dd7ce796b13d02c108bc9f79812245a82e577581c4c9aabe57075c90ea2')
+sha256sums=('51828cf3574281d2b79ec2a1c56a9e4c20cc1103711321ea96384cffb8d2d904')
 
 build() {
   [[ -d "${srcdir}/build-${CARCH}-static" ]] && rm -rf "${srcdir}/build-${CARCH}-static"


### PR DESCRIPTION
- Bump pkgver from 1.9.6 to 1.9.8 and reset pkgrel to 1.
- Update source tarball sha256sum for the new release.
This is for fixes building with gcc 15.x