### PR TITLE
enscript: Fixes building with gcc 15.x

### DIFF
--- a/enscript/.gitattributes
+++ b/enscript/.gitattributes
@@ -1,0 +1,1 @@
+*.patch binary

--- a/enscript/0001-enscript-newencodings.patch
+++ b/enscript/0001-enscript-newencodings.patch
@@ -1,0 +1,2059 @@
+diff -up enscript-1.6.6/885913.txt.newencodings enscript-1.6.6/885913.txt
+--- enscript-1.6.6/885913.txt.newencodings	2019-01-29 12:33:53.497612931 +0100
++++ enscript-1.6.6/885913.txt	2019-01-29 12:33:53.496612939 +0100
+@@ -0,0 +1,291 @@
++		ISO-8859-13 (ISO Latin7) character set
++
++octal	hex	PostScript	HTML entity	character
++----------------------------------------------------------------------
++000	0x00	non-printable
++001	0x01	non-printable
++002	0x02	non-printable
++003	0x03	non-printable
++004	0x04	non-printable
++005	0x05	non-printable
++006	0x06	non-printable
++007	0x07	non-printable
++
++010	0x08	non-printable
++011	0x09	non-printable
++012	0x0a	non-printable
++013	0x0b	non-printable
++014	0x0c	non-printable
++015	0x0d	non-printable
++016	0x0e	non-printable
++017	0x0f	non-printable
++
++020	0x10	non-printable
++021	0x11	non-printable
++022	0x12	non-printable
++023	0x13	non-printable
++024	0x14	non-printable
++025	0x15	non-printable
++026	0x16	non-printable
++027	0x17	non-printable
++
++030	0x18	non-printable
++031	0x19	non-printable
++032	0x1a	non-printable
++033	0x1b	non-printable
++034	0x1c	non-printable
++035	0x1d	non-printable
++036	0x1e	non-printable
++037	0x1f	non-printable
++
++040	0x20	/space
++041	0x21	/exclam
++042	0x22	/quotedbl
++043	0x23	/numbersign
++044	0x24	/dollar
++045	0x25	/percent
++046	0x26	/ampersand
++047	0x27	/quoteright
++
++050	0x28	/parenleft
++051	0x29	/parenright
++052	0x2a	/asterisk
++053	0x2b	/plus
++054	0x2c	/comma
++055	0x2d	/minus
++056	0x2e	/period
++057	0x2f	/slash
++
++060	0x30	/zero
++061	0x31	/one
++062	0x32	/two
++063	0x33	/three
++064	0x34	/four
++065	0x35	/five
++066	0x36	/six
++067	0x37	/seven
++
++070	0x38	/eight
++071	0x39	/nine
++072	0x3a	/colon
++073	0x3b	/semicolon
++074	0x3c	/less
++075	0x3d	/equal
++076	0x3e	/greater
++077	0x3f	/question
++
++0100	0x40	/at
++0101	0x41	/A
++0102	0x42	/B
++0103	0x43	/C
++0104	0x44	/D
++0105	0x45	/E
++0106	0x46	/F
++0107	0x47	/G
++
++0110	0x48	/H
++0111	0x49	/I
++0112	0x4a	/J
++0113	0x4b	/K
++0114	0x4c	/L
++0115	0x4d	/M
++0116	0x4e	/N
++0117	0x4f	/O
++
++0120	0x50	/P
++0121	0x51	/Q
++0122	0x52	/R
++0123	0x53	/S
++0124	0x54	/T
++0125	0x55	/U
++0126	0x56	/V
++0127	0x57	/W
++
++0130	0x58	/X
++0131	0x59	/Y
++0132	0x5a	/Z
++0133	0x5b	/bracketleft
++0134	0x5c	/backslash
++0135	0x5d	/bracketright
++0136	0x5e	/asciicircum
++0137	0x5f	/underscore
++
++0140	0x60	/quoteleft
++0141	0x61	/a
++0142	0x62	/b
++0143	0x63	/c
++0144	0x64	/d
++0145	0x65	/e
++0146	0x66	/f
++0147	0x67	/g
++
++0150	0x68	/h
++0151	0x69	/i
++0152	0x6a	/j
++0153	0x6b	/k
++0154	0x6c	/l
++0155	0x6d	/m
++0156	0x6e	/n
++0157	0x6f	/o
++
++0160	0x70	/p
++0161	0x71	/q
++0162	0x72	/r
++0163	0x73	/s
++0164	0x74	/t
++0165	0x75	/u
++0166	0x76	/v
++0167	0x77	/w
++
++0170	0x78	/x
++0171	0x79	/y
++0172	0x7a	/z
++0173	0x7b	/braceleft
++0174	0x7c	/bar
++0175	0x7d	/braceright
++0176	0x7e	/asciitilde
++0177	0x7f	non-printable
++
++0200	0x80	non-printable
++0201	0x81	non-printable
++0202	0x82	non-printable
++0203	0x83	non-printable
++0204	0x84	non-printable
++0205	0x85	non-printable
++0206	0x86	non-printable
++0207	0x87	non-printable
++
++0210	0x88	non-printable
++0211	0x89	non-printable
++0212	0x8a	non-printable
++0213	0x8b	non-printable
++0214	0x8c	non-printable
++0215	0x8d	non-printable
++0216	0x8e	non-printable
++0217	0x8f	non-printable
++
++0220	0x90	non-printable
++0221	0x91	non-printable
++0222	0x92	non-printable
++0223	0x93	non-printable
++0224	0x94	non-printable
++0225	0x95	non-printable
++0226	0x96	non-printable
++0227	0x97	non-printable
++
++0230	0x98	non-printable
++0231	0x99	non-printable
++0232	0x9a	non-printable
++0233	0x9b	non-printable
++0234	0x9c	non-printable
++0235	0x9d	non-printable
++0236	0x9e	non-printable
++0237	0x9f	non-printable
++
++0240	0xa0	/space
++0241	0xa1	/quotedblright
++0242	0xa2	/cent
++0243	0xa3	/sterling
++0244	0xa4	/currency
++0245	0xa5	/quotedblbase
++0246	0xa6	/brokenbar
++0247	0xa7	/section
++
++0250	0xa8	/Oslash
++0251	0xa9	/copyright
++0252	0xaa	/Rcedilla
++0253	0xab	/guillemotleft
++0254	0xac	/logicalnot
++0255	0xad	/hyphen
++0256	0xae	/registered
++0257	0xaf	/AE
++
++0260	0xb0	/degree
++0261	0xb1	/plusminus
++0262	0xb2	/twosuperior
++0263	0xb3	/threesuperior
++0264	0xb4	/quotedblleft
++0265	0xb5	/mu
++0266	0xb6	/paragraph
++0267	0xb7	/bullet
++
++0270	0xb8	/oslash
++0271	0xb9	/onesuperior
++0272	0xba	/rcedilla
++0273	0xbb	/guillemotright
++0274	0xbc	/onequarter
++0275	0xbd	/onehalf
++0276	0xbe	/threequarters
++0277	0xbf	/ae
++
++0300	0xc0	/Aogonek
++0301	0xc1	/Iogonek
++0302	0xc2	/Amacron
++0303	0xc3	/Cacute
++0304	0xc4	/Adieresis
++0305	0xc5	/Aring
++0306	0xc6	/Eogonek
++0307	0xc7	/Emacron
++
++0310	0xc8	/Ccaron
++0311	0xc9	/Eacute
++0312	0xca	/Zacute
++0313	0xcb	/Edotaccent
++0314	0xcc	/Gcedilla
++0315	0xcd	/Kcedilla
++0316	0xce	/Imacron
++0317	0xcf	/Lcedilla
++
++0320	0xd0	/Scaron
++0321	0xd1	/Nacute
++0322	0xd2	/Ncedilla
++0323	0xd3	/Oacute
++0324	0xd4	/Omacron
++0325	0xd5	/Otilde
++0326	0xd6	/Odieresis
++0327	0xd7	/multiply
++
++0330	0xd8	/Uogonek
++0331	0xd9	/Lslash
++0332	0xda	/Sacute
++0333	0xdb	/Umacron
++0334	0xdc	/Udieresis
++0335	0xdd	/Zdotaccent
++0336	0xde	/Zcaron
++0337	0xdf	/germandbls
++
++0340	0xe0	/aogonek
++0341	0xe1	/iogonek
++0342	0xe2	/amacron
++0343	0xe3	/cacute
++0344	0xe4	/adieresis
++0345	0xe5	/aring
++0346	0xe6	/eogonek
++0347	0xe7	/emacron
++
++0350	0xe8	/ccaron
++0351	0xe9	/eacute
++0352	0xea	/zacute
++0353	0xeb	/edotaccent
++0354	0xec	/gcedilla
++0355	0xed	/kcedilla
++0356	0xee	/imacron
++0357	0xef	/lcedilla
++
++0360	0xf0	/scaron
++0361	0xf1	/nacute
++0362	0xf2	/ncedilla
++0363	0xf3	/oacute
++0364	0xf4	/omacron
++0365	0xf5	/otilde
++0366	0xf6	/odieresis
++0367	0xf7	/divide
++
++0370	0xf8	/uogonek
++0371	0xf9	/lslash
++0372	0xfa	/sacute
++0373	0xfb	/umacron
++0374	0xfc	/udieresis
++0375	0xfd	/zdotaccent
++0376	0xfe	/zcaron
++0377	0xff	/quoteright
+diff -up enscript-1.6.6/885915.txt.newencodings enscript-1.6.6/885915.txt
+--- enscript-1.6.6/885915.txt.newencodings	2019-01-29 12:33:53.498612923 +0100
++++ enscript-1.6.6/885915.txt	2019-01-29 12:33:53.498612923 +0100
+@@ -0,0 +1,291 @@
++		ISO-8859-15 (ISO Latin9) character set
++
++octal	hex	PostScript	HTML entity	character
++----------------------------------------------------------------------
++000	0x00	non-printable
++001	0x01	non-printable
++002	0x02	non-printable
++003	0x03	non-printable
++004	0x04	non-printable
++005	0x05	non-printable
++006	0x06	non-printable
++007	0x07	non-printable
++
++010	0x08	non-printable
++011	0x09	non-printable
++012	0x0a	non-printable
++013	0x0b	non-printable
++014	0x0c	non-printable
++015	0x0d	non-printable
++016	0x0e	non-printable
++017	0x0f	non-printable
++
++020	0x10	non-printable
++021	0x11	non-printable
++022	0x12	non-printable
++023	0x13	non-printable
++024	0x14	non-printable
++025	0x15	non-printable
++026	0x16	non-printable
++027	0x17	non-printable
++
++030	0x18	non-printable
++031	0x19	non-printable
++032	0x1a	non-printable
++033	0x1b	non-printable
++034	0x1c	non-printable
++035	0x1d	non-printable
++036	0x1e	non-printable
++037	0x1f	non-printable
++
++040	0x20	/space
++041	0x21	/exclam
++042	0x22	/quotedbl
++043	0x23	/numbersign
++044	0x24	/dollar
++045	0x25	/percent
++046	0x26	/ampersand
++047	0x27	/quoteright
++
++050	0x28	/parenleft
++051	0x29	/parenright
++052	0x2a	/asterisk
++053	0x2b	/plus
++054	0x2c	/comma
++055	0x2d	/minus
++056	0x2e	/period
++057	0x2f	/slash
++
++060	0x30	/zero
++061	0x31	/one
++062	0x32	/two
++063	0x33	/three
++064	0x34	/four
++065	0x35	/five
++066	0x36	/six
++067	0x37	/seven
++
++070	0x38	/eight
++071	0x39	/nine
++072	0x3a	/colon
++073	0x3b	/semicolon
++074	0x3c	/less
++075	0x3d	/equal
++076	0x3e	/greater
++077	0x3f	/question
++
++0100	0x40	/at
++0101	0x41	/A
++0102	0x42	/B
++0103	0x43	/C
++0104	0x44	/D
++0105	0x45	/E
++0106	0x46	/F
++0107	0x47	/G
++
++0110	0x48	/H
++0111	0x49	/I
++0112	0x4a	/J
++0113	0x4b	/K
++0114	0x4c	/L
++0115	0x4d	/M
++0116	0x4e	/N
++0117	0x4f	/O
++
++0120	0x50	/P
++0121	0x51	/Q
++0122	0x52	/R
++0123	0x53	/S
++0124	0x54	/T
++0125	0x55	/U
++0126	0x56	/V
++0127	0x57	/W
++
++0130	0x58	/X
++0131	0x59	/Y
++0132	0x5a	/Z
++0133	0x5b	/bracketleft
++0134	0x5c	/backslash
++0135	0x5d	/bracketright
++0136	0x5e	/asciicircum
++0137	0x5f	/underscore
++
++0140	0x60	/quoteleft
++0141	0x61	/a
++0142	0x62	/b
++0143	0x63	/c
++0144	0x64	/d
++0145	0x65	/e
++0146	0x66	/f
++0147	0x67	/g
++
++0150	0x68	/h
++0151	0x69	/i
++0152	0x6a	/j
++0153	0x6b	/k
++0154	0x6c	/l
++0155	0x6d	/m
++0156	0x6e	/n
++0157	0x6f	/o
++
++0160	0x70	/p
++0161	0x71	/q
++0162	0x72	/r
++0163	0x73	/s
++0164	0x74	/t
++0165	0x75	/u
++0166	0x76	/v
++0167	0x77	/w
++
++0170	0x78	/x
++0171	0x79	/y
++0172	0x7a	/z
++0173	0x7b	/braceleft
++0174	0x7c	/bar
++0175	0x7d	/braceright
++0176	0x7e	/asciitilde
++0177	0x7f	non-printable
++
++0200	0x80	non-printable
++0201	0x81	non-printable
++0202	0x82	non-printable
++0203	0x83	non-printable
++0204	0x84	non-printable
++0205	0x85	non-printable
++0206	0x86	non-printable
++0207	0x87	non-printable
++
++0210	0x88	non-printable
++0211	0x89	non-printable
++0212	0x8a	non-printable
++0213	0x8b	non-printable
++0214	0x8c	non-printable
++0215	0x8d	non-printable
++0216	0x8e	non-printable
++0217	0x8f	non-printable
++
++0220	0x90	non-printable
++0221	0x91	non-printable
++0222	0x92	non-printable
++0223	0x93	non-printable
++0224	0x94	non-printable
++0225	0x95	non-printable
++0226	0x96	non-printable
++0227	0x97	non-printable
++
++0230	0x98	non-printable
++0231	0x99	non-printable
++0232	0x9a	non-printable
++0233	0x9b	non-printable
++0234	0x9c	non-printable
++0235	0x9d	non-printable
++0236	0x9e	non-printable
++0237	0x9f	non-printable
++
++0240	0xa0	/space
++0241	0xa1	/exclamdown
++0242	0xa2	/cent
++0243	0xa3	/sterling
++0244	0xa4	/Euro
++0245	0xa5	/yen
++0246	0xa6	/Scaron
++0247	0xa7	/section
++
++0250	0xa8	/scaron
++0251	0xa9	/copyright
++0252	0xaa	/ordfeminine
++0253	0xab	/guillemotleft
++0254	0xac	/logicalnot
++0255	0xad	/hyphen
++0256	0xae	/registered
++0257	0xaf	/macron
++
++0260	0xb0	/degree
++0261	0xb1	/plusminus
++0262	0xb2	/twosuperior
++0263	0xb3	/threesuperior
++0264	0xb4	/Zcaron
++0265	0xb5	/mu
++0266	0xb6	/paragraph
++0267	0xb7	/bullet
++
++0270	0xb8	/zcaron
++0271	0xb9	/onesuperior
++0272	0xba	/ordmasculine
++0273	0xbb	/guillemotright
++0274	0xbc	/OE
++0275	0xbd	/oe
++0276	0xbe	/Ydieresis
++0277	0xbf	/questiondown
++
++0300	0xc0	/Agrave
++0301	0xc1	/Aacute
++0302	0xc2	/Acircumflex
++0303	0xc3	/Atilde
++0304	0xc4	/Adieresis
++0305	0xc5	/Aring
++0306	0xc6	/AE
++0307	0xc7	/Ccedilla
++
++0310	0xc8	/Egrave
++0311	0xc9	/Eacute
++0312	0xca	/Ecircumflex
++0313	0xcb	/Edieresis
++0314	0xcc	/Igrave
++0315	0xcd	/Iacute
++0316	0xce	/Icircumflex
++0317	0xcf	/Idieresis
++
++0320	0xd0	/Eth
++0321	0xd1	/Ntilde
++0322	0xd2	/Ograve
++0323	0xd3	/Oacute
++0324	0xd4	/Ocircumflex
++0325	0xd5	/Otilde
++0326	0xd6	/Odieresis
++0327	0xd7	/multiply
++
++0330	0xd8	/Oslash
++0331	0xd9	/Ugrave
++0332	0xda	/Uacute
++0333	0xdb	/Ucircumflex
++0334	0xdc	/Udieresis
++0335	0xdd	/Yacute
++0336	0xde	/Thorn
++0337	0xdf	/germandbls
++
++0340	0xe0	/agrave
++0341	0xe1	/aacute
++0342	0xe2	/acircumflex
++0343	0xe3	/atilde
++0344	0xe4	/adieresis
++0345	0xe5	/aring
++0346	0xe6	/ae
++0347	0xe7	/ccedilla
++
++0350	0xe8	/egrave
++0351	0xe9	/eacute
++0352	0xea	/ecircumflex
++0353	0xeb	/edieresis
++0354	0xec	/igrave
++0355	0xed	/iacute
++0356	0xee	/icircumflex
++0357	0xef	/idieresis
++
++0360	0xf0	/eth
++0361	0xf1	/ntilde
++0362	0xf2	/ograve
++0363	0xf3	/oacute
++0364	0xf4	/ocircumflex
++0365	0xf5	/otilde
++0366	0xf6	/odieresis
++0367	0xf7	/divide
++
++0370	0xf8	/oslash
++0371	0xf9	/ugrave
++0372	0xfa	/uacute
++0373	0xfb	/ucircumflex
++0374	0xfc	/udieresis
++0375	0xfd	/yacute
++0376	0xfe	/thorn
++0377	0xff	/ydieresis
+diff -up enscript-1.6.6/afm/cob.afm.newencodings enscript-1.6.6/afm/cob.afm
+--- enscript-1.6.6/afm/cob.afm.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afm/cob.afm	2019-01-29 12:33:53.500612907 +0100
+@@ -19,7 +19,7 @@ CapHeight 562
+ XHeight 439
+ Ascender 626
+ Descender -142
+-StartCharMetrics 260
++StartCharMetrics 261
+ C 32 ; WX 600 ; N space ; B 0 0 0 0 ;
+ C 33 ; WX 600 ; N exclam ; B 202 -15 398 572 ;
+ C 34 ; WX 600 ; N quotedbl ; B 135 277 465 562 ;
+@@ -238,6 +238,7 @@ C -1 ; WX 600 ; N Igrave ; B 77 0 523 784 ;
+ C -1 ; WX 600 ; N brokenbar ; B 255 -175 345 675 ;
+ C -1 ; WX 600 ; N Oacute ; B 22 -18 578 784 ;
+ C -1 ; WX 600 ; N otilde ; B 30 -15 570 636 ;
++C -1 ; WX 600 ; N Euro ; B -2 0 602 562 ;
+ C -1 ; WX 600 ; N Yacute ; B 12 0 589 784 ;
+ C -1 ; WX 600 ; N lira ; B 72 -28 558 611 ;
+ C -1 ; WX 600 ; N Icircumflex ; B 77 0 523 780 ;
+@@ -281,7 +282,7 @@ C -1 ; WX 600 ; N aring ; B 35 -15 570 678 ;
+ C -1 ; WX 600 ; N yacute ; B -4 -142 601 661 ;
+ C -1 ; WX 600 ; N icircumflex ; B 63 0 523 657 ;
+ EndCharMetrics
+-StartComposites 58
++StartComposites 59
+ CC Aacute 2 ; PCC A 0 0 ; PCC acute 30 123 ;
+ CC Acircumflex 2 ; PCC A 0 0 ; PCC circumflex -30 123 ;
+ CC Adieresis 2 ; PCC A 0 0 ; PCC dieresis -20 123 ;
+@@ -332,6 +333,7 @@ CC ocircumflex 2 ; PCC o 0 0 ; PCC circumflex 0 0 ;
+ CC odieresis 2 ; PCC o 0 0 ; PCC dieresis 0 0 ;
+ CC ograve 2 ; PCC o 0 0 ; PCC grave 0 0 ;
+ CC otilde 2 ; PCC o 0 0 ; PCC tilde 0 0 ;
++CC Euro 2 ; PCC C 0 0 ; PCC equal 0 0 ;
+ CC scaron 2 ; PCC s 0 0 ; PCC caron 0 0 ;
+ CC uacute 2 ; PCC u 0 0 ; PCC acute 0 0 ;
+ CC ucircumflex 2 ; PCC u 0 0 ; PCC circumflex -20 0 ;
+diff -up enscript-1.6.6/afm/cobo.afm.newencodings enscript-1.6.6/afm/cobo.afm
+--- enscript-1.6.6/afm/cobo.afm.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afm/cobo.afm	2019-01-29 12:33:53.501612899 +0100
+@@ -19,7 +19,7 @@ CapHeight 562
+ XHeight 439
+ Ascender 626
+ Descender -142
+-StartCharMetrics 260
++StartCharMetrics 261
+ C 32 ; WX 600 ; N space ; B 0 0 0 0 ;
+ C 33 ; WX 600 ; N exclam ; B 216 -15 495 572 ;
+ C 34 ; WX 600 ; N quotedbl ; B 212 277 584 562 ;
+@@ -238,6 +238,7 @@ C -1 ; WX 600 ; N Igrave ; B 77 0 642 784 ;
+ C -1 ; WX 600 ; N brokenbar ; B 218 -175 488 675 ;
+ C -1 ; WX 600 ; N Oacute ; B 74 -18 645 784 ;
+ C -1 ; WX 600 ; N otilde ; B 71 -15 642 636 ;
++C -1 ; WX 600 ; N Euro ; B -2 0 721 562 ;
+ C -1 ; WX 600 ; N Yacute ; B 109 0 708 784 ;
+ C -1 ; WX 600 ; N lira ; B 107 -28 650 611 ;
+ C -1 ; WX 600 ; N Icircumflex ; B 77 0 642 780 ;
+@@ -281,7 +282,7 @@ C -1 ; WX 600 ; N aring ; B 62 -15 592 678 ;
+ C -1 ; WX 600 ; N yacute ; B -20 -142 694 661 ;
+ C -1 ; WX 600 ; N icircumflex ; B 77 0 566 657 ;
+ EndCharMetrics
+-StartComposites 58
++StartComposites 59
+ CC Aacute 2 ; PCC A 0 0 ; PCC acute 56 123 ;
+ CC Acircumflex 2 ; PCC A 0 0 ; PCC circumflex -4 123 ;
+ CC Adieresis 2 ; PCC A 0 0 ; PCC dieresis 6 123 ;
+@@ -332,6 +333,7 @@ CC ocircumflex 2 ; PCC o 0 0 ; PCC circumflex 0 0 ;
+ CC odieresis 2 ; PCC o 0 0 ; PCC dieresis 0 0 ;
+ CC ograve 2 ; PCC o 0 0 ; PCC grave 0 0 ;
+ CC otilde 2 ; PCC o 0 0 ; PCC tilde 0 0 ;
++CC Euro 2 ; PCC C 0 0 ; PCC equal 0 0 ;
+ CC scaron 2 ; PCC s 0 0 ; PCC caron 0 0 ;
+ CC uacute 2 ; PCC u 0 0 ; PCC acute 0 0 ;
+ CC ucircumflex 2 ; PCC u 0 0 ; PCC circumflex -20 0 ;
+diff -up enscript-1.6.6/afm/com.afm.newencodings enscript-1.6.6/afm/com.afm
+--- enscript-1.6.6/afm/com.afm.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afm/com.afm	2019-01-29 12:33:53.503612883 +0100
+@@ -19,7 +19,7 @@ CapHeight 562
+ XHeight 426
+ Ascender 629
+ Descender -157
+-StartCharMetrics 260
++StartCharMetrics 261
+ C 32 ; WX 600 ; N space ; B 0 0 0 0 ;
+ C 33 ; WX 600 ; N exclam ; B 236 -15 364 572 ;
+ C 34 ; WX 600 ; N quotedbl ; B 187 328 413 562 ;
+@@ -238,6 +238,7 @@ C -1 ; WX 600 ; N Igrave ; B 96 0 504 793 ;
+ C -1 ; WX 600 ; N brokenbar ; B 275 -175 326 675 ;
+ C -1 ; WX 600 ; N Oacute ; B 43 -18 557 793 ;
+ C -1 ; WX 600 ; N otilde ; B 62 -15 538 606 ;
++C -1 ; WX 600 ; N Euro ; B 4 0 596 562 ;
+ C -1 ; WX 600 ; N Yacute ; B 24 0 576 793 ;
+ C -1 ; WX 600 ; N lira ; B 73 -21 521 611 ;
+ C -1 ; WX 600 ; N Icircumflex ; B 96 0 504 775 ;
+@@ -281,7 +282,7 @@ C -1 ; WX 600 ; N aring ; B 53 -15 559 627 ;
+ C -1 ; WX 600 ; N yacute ; B 7 -157 592 672 ;
+ C -1 ; WX 600 ; N icircumflex ; B 94 0 505 654 ;
+ EndCharMetrics
+-StartComposites 58
++StartComposites 59
+ CC Aacute 2 ; PCC A 0 0 ; PCC acute 20 121 ;
+ CC Acircumflex 2 ; PCC A 0 0 ; PCC circumflex -30 121 ;
+ CC Adieresis 2 ; PCC A 0 0 ; PCC dieresis -30 136 ;
+@@ -332,6 +333,7 @@ CC ocircumflex 2 ; PCC o 0 0 ; PCC circumflex 0 0 ;
+ CC odieresis 2 ; PCC o 0 0 ; PCC dieresis 0 0 ;
+ CC ograve 2 ; PCC o 0 0 ; PCC grave 0 0 ;
+ CC otilde 2 ; PCC o 0 0 ; PCC tilde 0 0 ;
++CC Euro 2 ; PCC C 0 0 ; PCC equal 0 0 ;
+ CC scaron 2 ; PCC s 0 0 ; PCC caron 0 0 ;
+ CC uacute 2 ; PCC u 0 0 ; PCC acute -10 0 ;
+ CC ucircumflex 2 ; PCC u 0 0 ; PCC circumflex -10 0 ;
+diff -up enscript-1.6.6/afm/coo.afm.newencodings enscript-1.6.6/afm/coo.afm
+--- enscript-1.6.6/afm/coo.afm.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afm/coo.afm	2019-01-29 12:33:53.505612866 +0100
+@@ -19,7 +19,7 @@ CapHeight 562
+ XHeight 426
+ Ascender 629
+ Descender -157
+-StartCharMetrics 260
++StartCharMetrics 261
+ C 32 ; WX 600 ; N space ; B 0 0 0 0 ;
+ C 33 ; WX 600 ; N exclam ; B 243 -15 464 572 ;
+ C 34 ; WX 600 ; N quotedbl ; B 273 328 532 562 ;
+@@ -238,6 +238,7 @@ C -1 ; WX 600 ; N Igrave ; B 96 0 623 793 ;
+ C -1 ; WX 600 ; N brokenbar ; B 238 -175 469 675 ;
+ C -1 ; WX 600 ; N Oacute ; B 94 -18 638 793 ;
+ C -1 ; WX 600 ; N otilde ; B 102 -15 629 606 ;
++C -1 ; WX 600 ; N Euro ; B 4 0 715 562 ;
+ C -1 ; WX 600 ; N Yacute ; B 133 0 695 793 ;
+ C -1 ; WX 600 ; N lira ; B 118 -21 621 611 ;
+ C -1 ; WX 600 ; N Icircumflex ; B 96 0 623 775 ;
+@@ -281,7 +282,7 @@ C -1 ; WX 600 ; N aring ; B 76 -15 569 627 ;
+ C -1 ; WX 600 ; N yacute ; B -4 -157 683 672 ;
+ C -1 ; WX 600 ; N icircumflex ; B 95 0 551 654 ;
+ EndCharMetrics
+-StartComposites 58
++StartComposites 59
+ CC Aacute 2 ; PCC A 0 0 ; PCC acute 46 121 ;
+ CC Acircumflex 2 ; PCC A 0 0 ; PCC circumflex -4 121 ;
+ CC Adieresis 2 ; PCC A 0 0 ; PCC dieresis -1 136 ;
+@@ -332,6 +333,7 @@ CC ocircumflex 2 ; PCC o 0 0 ; PCC circumflex 0 0 ;
+ CC odieresis 2 ; PCC o 0 0 ; PCC dieresis 0 0 ;
+ CC ograve 2 ; PCC o 0 0 ; PCC grave 0 0 ;
+ CC otilde 2 ; PCC o 0 0 ; PCC tilde 0 0 ;
++CC Euro 2 ; PCC C 0 0 ; PCC equal 0 0 ;
+ CC scaron 2 ; PCC s 0 0 ; PCC caron 0 0 ;
+ CC uacute 2 ; PCC u 0 0 ; PCC acute -10 0 ;
+ CC ucircumflex 2 ; PCC u 0 0 ; PCC circumflex -10 0 ;
+diff -up enscript-1.6.6/afm/hv.afm.newencodings enscript-1.6.6/afm/hv.afm
+--- enscript-1.6.6/afm/hv.afm.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afm/hv.afm	2019-01-29 12:33:53.505612866 +0100
+@@ -19,7 +19,7 @@ CapHeight 718
+ XHeight 523
+ Ascender 718
+ Descender -207
+-StartCharMetrics 228
++StartCharMetrics 229
+ C 32 ; WX 278 ; N space ; B 0 0 0 0 ;
+ C 33 ; WX 278 ; N exclam ; B 90 0 187 718 ;
+ C 34 ; WX 355 ; N quotedbl ; B 70 463 285 718 ;
+@@ -181,6 +181,7 @@ C -1 ; WX 556 ; N egrave ; B 40 -15 516 734 ;
+ C -1 ; WX 333 ; N twosuperior ; B 4 281 323 703 ;
+ C -1 ; WX 556 ; N eacute ; B 40 -15 516 734 ;
+ C -1 ; WX 556 ; N otilde ; B 35 -14 521 722 ;
++C -1 ; WX 833 ; N Euro ; B 73 0 761 718 ;
+ C -1 ; WX 667 ; N Aacute ; B 14 0 654 929 ;
+ C -1 ; WX 556 ; N ocircumflex ; B 35 -14 521 734 ;
+ C -1 ; WX 500 ; N yacute ; B 11 -214 489 734 ;
+@@ -549,7 +550,7 @@ KPX z o -15
+ KPX z e -15
+ EndKernPairs
+ EndKernData
+-StartComposites 58
++StartComposites 59
+ CC Aacute 2 ; PCC A 0 0 ; PCC acute 167 195 ;
+ CC Acircumflex 2 ; PCC A 0 0 ; PCC circumflex 167 195 ;
+ CC Adieresis 2 ; PCC A 0 0 ; PCC dieresis 167 195 ;
+@@ -600,6 +601,7 @@ CC ocircumflex 2 ; PCC o 0 0 ; PCC circumflex 112 0 ;
+ CC odieresis 2 ; PCC o 0 0 ; PCC dieresis 112 0 ;
+ CC ograve 2 ; PCC o 0 0 ; PCC grave 112 0 ;
+ CC otilde 2 ; PCC o 0 0 ; PCC tilde 112 0 ;
++CC Euro 2 ; PCC C 0 0 ; PCC equal 0 0 ;
+ CC scaron 2 ; PCC s 0 0 ; PCC caron 84 0 ;
+ CC uacute 2 ; PCC u 0 0 ; PCC acute 112 0 ;
+ CC ucircumflex 2 ; PCC u 0 0 ; PCC circumflex 112 0 ;
+diff -up enscript-1.6.6/afm/hvb.afm.newencodings enscript-1.6.6/afm/hvb.afm
+--- enscript-1.6.6/afm/hvb.afm.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afm/hvb.afm	2019-01-29 12:33:53.505612866 +0100
+@@ -19,7 +19,7 @@ CapHeight 718
+ XHeight 532
+ Ascender 718
+ Descender -207
+-StartCharMetrics 228
++StartCharMetrics 229
+ C 32 ; WX 278 ; N space ; B 0 0 0 0 ;
+ C 33 ; WX 333 ; N exclam ; B 90 0 244 718 ;
+ C 34 ; WX 474 ; N quotedbl ; B 98 447 376 718 ;
+@@ -181,6 +181,7 @@ C -1 ; WX 556 ; N egrave ; B 23 -14 528 750 ;
+ C -1 ; WX 333 ; N twosuperior ; B 9 283 324 710 ;
+ C -1 ; WX 556 ; N eacute ; B 23 -14 528 750 ;
+ C -1 ; WX 611 ; N otilde ; B 34 -14 578 737 ;
++C -1 ; WX 833 ; N Euro ; B 69 0 765 718 ;
+ C -1 ; WX 722 ; N Aacute ; B 20 0 702 936 ;
+ C -1 ; WX 611 ; N ocircumflex ; B 34 -14 578 750 ;
+ C -1 ; WX 556 ; N yacute ; B 10 -214 539 750 ;
+@@ -507,7 +508,7 @@ KPX y a -30
+ KPX z e 10
+ EndKernPairs
+ EndKernData
+-StartComposites 58
++StartComposites 59
+ CC Aacute 2 ; PCC A 0 0 ; PCC acute 195 186 ;
+ CC Acircumflex 2 ; PCC A 0 0 ; PCC circumflex 195 186 ;
+ CC Adieresis 2 ; PCC A 0 0 ; PCC dieresis 195 186 ;
+@@ -558,6 +559,7 @@ CC ocircumflex 2 ; PCC o 0 0 ; PCC circumflex 139 0 ;
+ CC odieresis 2 ; PCC o 0 0 ; PCC dieresis 139 0 ;
+ CC ograve 2 ; PCC o 0 0 ; PCC grave 139 0 ;
+ CC otilde 2 ; PCC o 0 0 ; PCC tilde 139 0 ;
++CC Euro 2 ; PCC C 0 0 ; PCC equal 0 0 ;
+ CC scaron 2 ; PCC s 0 0 ; PCC caron 112 0 ;
+ CC uacute 2 ; PCC u 0 0 ; PCC acute 139 0 ;
+ CC ucircumflex 2 ; PCC u 0 0 ; PCC circumflex 139 0 ;
+diff -up enscript-1.6.6/afm/hvbo.afm.newencodings enscript-1.6.6/afm/hvbo.afm
+--- enscript-1.6.6/afm/hvbo.afm.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afm/hvbo.afm	2019-01-29 12:33:53.505612866 +0100
+@@ -19,7 +19,7 @@ CapHeight 718
+ XHeight 532
+ Ascender 718
+ Descender -207
+-StartCharMetrics 228
++StartCharMetrics 229
+ C 32 ; WX 278 ; N space ; B 0 0 0 0 ;
+ C 33 ; WX 333 ; N exclam ; B 94 0 397 718 ;
+ C 34 ; WX 474 ; N quotedbl ; B 193 447 529 718 ;
+@@ -181,6 +181,7 @@ C -1 ; WX 556 ; N egrave ; B 70 -14 593 750 ;
+ C -1 ; WX 333 ; N twosuperior ; B 69 283 449 710 ;
+ C -1 ; WX 556 ; N eacute ; B 70 -14 627 750 ;
+ C -1 ; WX 611 ; N otilde ; B 82 -14 646 737 ;
++C -1 ; WX 833 ; N Euro ; B 69 0 918 718 ;
+ C -1 ; WX 722 ; N Aacute ; B 20 0 750 936 ;
+ C -1 ; WX 611 ; N ocircumflex ; B 82 -14 643 750 ;
+ C -1 ; WX 556 ; N yacute ; B 42 -214 652 750 ;
+@@ -507,7 +508,7 @@ KPX y a -30
+ KPX z e 10
+ EndKernPairs
+ EndKernData
+-StartComposites 58
++StartComposites 59
+ CC Aacute 2 ; PCC A 0 0 ; PCC acute 235 186 ;
+ CC Acircumflex 2 ; PCC A 0 0 ; PCC circumflex 235 186 ;
+ CC Adieresis 2 ; PCC A 0 0 ; PCC dieresis 235 186 ;
+@@ -558,6 +559,7 @@ CC ocircumflex 2 ; PCC o 0 0 ; PCC circumflex 139 0 ;
+ CC odieresis 2 ; PCC o 0 0 ; PCC dieresis 139 0 ;
+ CC ograve 2 ; PCC o 0 0 ; PCC grave 139 0 ;
+ CC otilde 2 ; PCC o 0 0 ; PCC tilde 139 0 ;
++CC Euro 2 ; PCC C 0 0 ; PCC equal 0 0 ;
+ CC scaron 2 ; PCC s 0 0 ; PCC caron 112 0 ;
+ CC uacute 2 ; PCC u 0 0 ; PCC acute 139 0 ;
+ CC ucircumflex 2 ; PCC u 0 0 ; PCC circumflex 139 0 ;
+diff -up enscript-1.6.6/afm/hvo.afm.newencodings enscript-1.6.6/afm/hvo.afm
+--- enscript-1.6.6/afm/hvo.afm.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afm/hvo.afm	2019-01-29 12:33:53.507612850 +0100
+@@ -19,7 +19,7 @@ CapHeight 718
+ XHeight 523
+ Ascender 718
+ Descender -207
+-StartCharMetrics 228
++StartCharMetrics 229
+ C 32 ; WX 278 ; N space ; B 0 0 0 0 ;
+ C 33 ; WX 278 ; N exclam ; B 90 0 340 718 ;
+ C 34 ; WX 355 ; N quotedbl ; B 168 463 438 718 ;
+@@ -181,6 +181,7 @@ C -1 ; WX 556 ; N egrave ; B 84 -15 578 734 ;
+ C -1 ; WX 333 ; N twosuperior ; B 64 281 449 703 ;
+ C -1 ; WX 556 ; N eacute ; B 84 -15 587 734 ;
+ C -1 ; WX 556 ; N otilde ; B 83 -14 602 722 ;
++C -1 ; WX 833 ; N Euro ; B 73 0 914 718 ;
+ C -1 ; WX 667 ; N Aacute ; B 14 0 683 929 ;
+ C -1 ; WX 556 ; N ocircumflex ; B 83 -14 585 734 ;
+ C -1 ; WX 500 ; N yacute ; B 15 -214 600 734 ;
+@@ -549,7 +550,7 @@ KPX z o -15
+ KPX z e -15
+ EndKernPairs
+ EndKernData
+-StartComposites 58
++StartComposites 59
+ CC Aacute 2 ; PCC A 0 0 ; PCC acute 208 195 ;
+ CC Acircumflex 2 ; PCC A 0 0 ; PCC circumflex 208 195 ;
+ CC Adieresis 2 ; PCC A 0 0 ; PCC dieresis 208 195 ;
+@@ -600,6 +601,7 @@ CC ocircumflex 2 ; PCC o 0 0 ; PCC circumflex 112 0 ;
+ CC odieresis 2 ; PCC o 0 0 ; PCC dieresis 112 0 ;
+ CC ograve 2 ; PCC o 0 0 ; PCC grave 112 0 ;
+ CC otilde 2 ; PCC o 0 0 ; PCC tilde 112 0 ;
++CC Euro 2 ; PCC C 0 0 ; PCC equal 0 0 ;
+ CC scaron 2 ; PCC s 0 0 ; PCC caron 84 0 ;
+ CC uacute 2 ; PCC u 0 0 ; PCC acute 112 0 ;
+ CC ucircumflex 2 ; PCC u 0 0 ; PCC circumflex 112 0 ;
+diff -up enscript-1.6.6/afmlib/afm.c.newencodings enscript-1.6.6/afmlib/afm.c
+--- enscript-1.6.6/afmlib/afm.c.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afmlib/afm.c	2019-01-29 12:33:53.509612834 +0100
+@@ -647,6 +647,14 @@ afm_font_encoding (AFMFont font, AFMEnco
+       apply_encoding (font, afm_885910_encoding, flags);
+       break;
+ 
++    case AFM_ENCODING_ISO_8859_13:
++      apply_encoding (font, afm_885913_encoding, flags);
++      break;
++
++    case AFM_ENCODING_ISO_8859_15:
++      apply_encoding (font, afm_885915_encoding, flags);
++      break;
++
+     case AFM_ENCODING_IBMPC:
+       apply_encoding (font, afm_ibmpc_encoding, flags);
+       break;
+diff -up enscript-1.6.6/afmlib/afm.h.newencodings enscript-1.6.6/afmlib/afm.h
+--- enscript-1.6.6/afmlib/afm.h.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afmlib/afm.h	2019-01-29 12:33:53.510612826 +0100
+@@ -281,6 +281,8 @@ typedef enum
+   AFM_ENCODING_ISO_8859_7,	/* ISO-8859-7 */
+   AFM_ENCODING_ISO_8859_9,	/* ISO-8859-9 */
+   AFM_ENCODING_ISO_8859_10,	/* ISO-8859-10 */
++  AFM_ENCODING_ISO_8859_13,	/* ISO-8859-13 */
++  AFM_ENCODING_ISO_8859_15,	/* ISO-8859-15 */
+   AFM_ENCODING_IBMPC,		/* IBM PC */
+   AFM_ENCODING_ASCII,		/* 7 bit ASCII */
+   AFM_ENCODING_MAC,		/* Mac */
+diff -up enscript-1.6.6/afmlib/afmint.h.newencodings enscript-1.6.6/afmlib/afmint.h
+--- enscript-1.6.6/afmlib/afmint.h.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afmlib/afmint.h	2019-01-29 12:33:53.510612826 +0100
+@@ -256,6 +256,8 @@ extern AFMEncodingTable afm_88595_encodi
+ extern AFMEncodingTable afm_88597_encoding[];
+ extern AFMEncodingTable afm_88599_encoding[];
+ extern AFMEncodingTable afm_885910_encoding[];
++extern AFMEncodingTable afm_885913_encoding[];
++extern AFMEncodingTable afm_885915_encoding[];
+ extern AFMEncodingTable afm_ibmpc_encoding[];
+ extern AFMEncodingTable afm_mac_encoding[];
+ extern AFMEncodingTable afm_vms_encoding[];
+diff -up enscript-1.6.6/afmlib/e_885913.c.newencodings enscript-1.6.6/afmlib/e_885913.c
+--- enscript-1.6.6/afmlib/e_885913.c.newencodings	2019-01-29 12:54:02.420921665 +0100
++++ enscript-1.6.6/afmlib/e_885913.c	2019-01-29 12:56:40.424716774 +0100
+@@ -0,0 +1,284 @@
++/*
++ * AFM 885913 encoding.
++ *
++ * This file is automatically generated from file `885913.txt'.  If you
++ * have any corrections to this file, please, edit file `885913.txt' instead.
++ */
++
++/*
++ * Enscript is free software: you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation, either version 3 of the License, or
++ * (at your option) any later version.
++ *
++ * Enscript is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with Enscript.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include "afmint.h"
++
++AFMEncodingTable afm_885913_encoding[] =
++{
++  {0x00, AFM_ENC_NONE},
++  {0x01, AFM_ENC_NONE},
++  {0x02, AFM_ENC_NONE},
++  {0x03, AFM_ENC_NONE},
++  {0x04, AFM_ENC_NONE},
++  {0x05, AFM_ENC_NONE},
++  {0x06, AFM_ENC_NONE},
++  {0x07, AFM_ENC_NONE},
++  {0x08, AFM_ENC_NONE},
++  {0x09, AFM_ENC_NONE},
++  {0x0a, AFM_ENC_NONE},
++  {0x0b, AFM_ENC_NONE},
++  {0x0c, AFM_ENC_NONE},
++  {0x0d, AFM_ENC_NONE},
++  {0x0e, AFM_ENC_NONE},
++  {0x0f, AFM_ENC_NONE},
++  {0x10, AFM_ENC_NONE},
++  {0x11, AFM_ENC_NONE},
++  {0x12, AFM_ENC_NONE},
++  {0x13, AFM_ENC_NONE},
++  {0x14, AFM_ENC_NONE},
++  {0x15, AFM_ENC_NONE},
++  {0x16, AFM_ENC_NONE},
++  {0x17, AFM_ENC_NONE},
++  {0x18, AFM_ENC_NONE},
++  {0x19, AFM_ENC_NONE},
++  {0x1a, AFM_ENC_NONE},
++  {0x1b, AFM_ENC_NONE},
++  {0x1c, AFM_ENC_NONE},
++  {0x1d, AFM_ENC_NONE},
++  {0x1e, AFM_ENC_NONE},
++  {0x1f, AFM_ENC_NONE},
++  {0x20, "space"},
++  {0x21, "exclam"},
++  {0x22, "quotedbl"},
++  {0x23, "numbersign"},
++  {0x24, "dollar"},
++  {0x25, "percent"},
++  {0x26, "ampersand"},
++  {0x27, "quoteright"},
++  {0x28, "parenleft"},
++  {0x29, "parenright"},
++  {0x2a, "asterisk"},
++  {0x2b, "plus"},
++  {0x2c, "comma"},
++  {0x2d, "minus"},
++  {0x2e, "period"},
++  {0x2f, "slash"},
++  {0x30, "zero"},
++  {0x31, "one"},
++  {0x32, "two"},
++  {0x33, "three"},
++  {0x34, "four"},
++  {0x35, "five"},
++  {0x36, "six"},
++  {0x37, "seven"},
++  {0x38, "eight"},
++  {0x39, "nine"},
++  {0x3a, "colon"},
++  {0x3b, "semicolon"},
++  {0x3c, "less"},
++  {0x3d, "equal"},
++  {0x3e, "greater"},
++  {0x3f, "question"},
++  {0x40, "at"},
++  {0x41, "A"},
++  {0x42, "B"},
++  {0x43, "C"},
++  {0x44, "D"},
++  {0x45, "E"},
++  {0x46, "F"},
++  {0x47, "G"},
++  {0x48, "H"},
++  {0x49, "I"},
++  {0x4a, "J"},
++  {0x4b, "K"},
++  {0x4c, "L"},
++  {0x4d, "M"},
++  {0x4e, "N"},
++  {0x4f, "O"},
++  {0x50, "P"},
++  {0x51, "Q"},
++  {0x52, "R"},
++  {0x53, "S"},
++  {0x54, "T"},
++  {0x55, "U"},
++  {0x56, "V"},
++  {0x57, "W"},
++  {0x58, "X"},
++  {0x59, "Y"},
++  {0x5a, "Z"},
++  {0x5b, "bracketleft"},
++  {0x5c, "backslash"},
++  {0x5d, "bracketright"},
++  {0x5e, "asciicircum"},
++  {0x5f, "underscore"},
++  {0x60, "quoteleft"},
++  {0x61, "a"},
++  {0x62, "b"},
++  {0x63, "c"},
++  {0x64, "d"},
++  {0x65, "e"},
++  {0x66, "f"},
++  {0x67, "g"},
++  {0x68, "h"},
++  {0x69, "i"},
++  {0x6a, "j"},
++  {0x6b, "k"},
++  {0x6c, "l"},
++  {0x6d, "m"},
++  {0x6e, "n"},
++  {0x6f, "o"},
++  {0x70, "p"},
++  {0x71, "q"},
++  {0x72, "r"},
++  {0x73, "s"},
++  {0x74, "t"},
++  {0x75, "u"},
++  {0x76, "v"},
++  {0x77, "w"},
++  {0x78, "x"},
++  {0x79, "y"},
++  {0x7a, "z"},
++  {0x7b, "braceleft"},
++  {0x7c, "bar"},
++  {0x7d, "braceright"},
++  {0x7e, "asciitilde"},
++  {0x7f, AFM_ENC_NONE},
++  {0x80, AFM_ENC_NONE},
++  {0x81, AFM_ENC_NONE},
++  {0x82, AFM_ENC_NONE},
++  {0x83, AFM_ENC_NONE},
++  {0x84, AFM_ENC_NONE},
++  {0x85, AFM_ENC_NONE},
++  {0x86, AFM_ENC_NONE},
++  {0x87, AFM_ENC_NONE},
++  {0x88, AFM_ENC_NONE},
++  {0x89, AFM_ENC_NONE},
++  {0x8a, AFM_ENC_NONE},
++  {0x8b, AFM_ENC_NONE},
++  {0x8c, AFM_ENC_NONE},
++  {0x8d, AFM_ENC_NONE},
++  {0x8e, AFM_ENC_NONE},
++  {0x8f, AFM_ENC_NONE},
++  {0x90, AFM_ENC_NONE},
++  {0x91, AFM_ENC_NONE},
++  {0x92, AFM_ENC_NONE},
++  {0x93, AFM_ENC_NONE},
++  {0x94, AFM_ENC_NONE},
++  {0x95, AFM_ENC_NONE},
++  {0x96, AFM_ENC_NONE},
++  {0x97, AFM_ENC_NONE},
++  {0x98, AFM_ENC_NONE},
++  {0x99, AFM_ENC_NONE},
++  {0x9a, AFM_ENC_NONE},
++  {0x9b, AFM_ENC_NONE},
++  {0x9c, AFM_ENC_NONE},
++  {0x9d, AFM_ENC_NONE},
++  {0x9e, AFM_ENC_NONE},
++  {0x9f, AFM_ENC_NONE},
++  {0xa0, "space"},
++  {0xa1, "quotedblright"},
++  {0xa2, "cent"},
++  {0xa3, "sterling"},
++  {0xa4, "currency"},
++  {0xa5, "quotedblbase"},
++  {0xa6, "brokenbar"},
++  {0xa7, "section"},
++  {0xa8, "Oslash"},
++  {0xa9, "copyright"},
++  {0xaa, "Rcedilla"},
++  {0xab, "guillemotleft"},
++  {0xac, "logicalnot"},
++  {0xad, "hyphen"},
++  {0xae, "registered"},
++  {0xaf, "AE"},
++  {0xb0, "degree"},
++  {0xb1, "plusminus"},
++  {0xb2, "twosuperior"},
++  {0xb3, "threesuperior"},
++  {0xb4, "quotedblleft"},
++  {0xb5, "mu"},
++  {0xb6, "paragraph"},
++  {0xb7, "bullet"},
++  {0xb8, "oslash"},
++  {0xb9, "onesuperior"},
++  {0xba, "rcedilla"},
++  {0xbb, "guillemotright"},
++  {0xbc, "onequarter"},
++  {0xbd, "onehalf"},
++  {0xbe, "threequarters"},
++  {0xbf, "ae"},
++  {0xc0, "Aogonek"},
++  {0xc1, "Iogonek"},
++  {0xc2, "Amacron"},
++  {0xc3, "Cacute"},
++  {0xc4, "Adieresis"},
++  {0xc5, "Aring"},
++  {0xc6, "Eogonek"},
++  {0xc7, "Emacron"},
++  {0xc8, "Ccaron"},
++  {0xc9, "Eacute"},
++  {0xca, "Zacute"},
++  {0xcb, "Edotaccent"},
++  {0xcc, "Gcedilla"},
++  {0xcd, "Kcedilla"},
++  {0xce, "Imacron"},
++  {0xcf, "Lcedilla"},
++  {0xd0, "Scaron"},
++  {0xd1, "Nacute"},
++  {0xd2, "Ncedilla"},
++  {0xd3, "Oacute"},
++  {0xd4, "Omacron"},
++  {0xd5, "Otilde"},
++  {0xd6, "Odieresis"},
++  {0xd7, "multiply"},
++  {0xd8, "Uogonek"},
++  {0xd9, "Lslash"},
++  {0xda, "Sacute"},
++  {0xdb, "Umacron"},
++  {0xdc, "Udieresis"},
++  {0xdd, "Zdotaccent"},
++  {0xde, "Zcaron"},
++  {0xdf, "germandbls"},
++  {0xe0, "aogonek"},
++  {0xe1, "iogonek"},
++  {0xe2, "amacron"},
++  {0xe3, "cacute"},
++  {0xe4, "adieresis"},
++  {0xe5, "aring"},
++  {0xe6, "eogonek"},
++  {0xe7, "emacron"},
++  {0xe8, "ccaron"},
++  {0xe9, "eacute"},
++  {0xea, "zacute"},
++  {0xeb, "edotaccent"},
++  {0xec, "gcedilla"},
++  {0xed, "kcedilla"},
++  {0xee, "imacron"},
++  {0xef, "lcedilla"},
++  {0xf0, "scaron"},
++  {0xf1, "nacute"},
++  {0xf2, "ncedilla"},
++  {0xf3, "oacute"},
++  {0xf4, "omacron"},
++  {0xf5, "otilde"},
++  {0xf6, "odieresis"},
++  {0xf7, "divide"},
++  {0xf8, "uogonek"},
++  {0xf9, "lslash"},
++  {0xfa, "sacute"},
++  {0xfb, "umacron"},
++  {0xfc, "udieresis"},
++  {0xfd, "zdotaccent"},
++  {0xfe, "zcaron"},
++  {0xff, "quoteright"},
++  {-1,   NULL},
++};
+diff -up enscript-1.6.6/afmlib/e_885915.c.newencodings enscript-1.6.6/afmlib/e_885915.c
+--- enscript-1.6.6/afmlib/e_885915.c.newencodings	2019-01-29 12:54:08.939871954 +0100
++++ enscript-1.6.6/afmlib/e_885915.c	2019-01-29 12:56:47.536662540 +0100
+@@ -0,0 +1,284 @@
++/*
++ * AFM 885915 encoding.
++ *
++ * This file is automatically generated from file `885915.txt'.  If you
++ * have any corrections to this file, please, edit file `885915.txt' instead.
++ */
++
++/*
++ * Enscript is free software: you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation, either version 3 of the License, or
++ * (at your option) any later version.
++ *
++ * Enscript is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with Enscript.  If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include "afmint.h"
++
++AFMEncodingTable afm_885915_encoding[] =
++{
++  {0x00, AFM_ENC_NONE},
++  {0x01, AFM_ENC_NONE},
++  {0x02, AFM_ENC_NONE},
++  {0x03, AFM_ENC_NONE},
++  {0x04, AFM_ENC_NONE},
++  {0x05, AFM_ENC_NONE},
++  {0x06, AFM_ENC_NONE},
++  {0x07, AFM_ENC_NONE},
++  {0x08, AFM_ENC_NONE},
++  {0x09, AFM_ENC_NONE},
++  {0x0a, AFM_ENC_NONE},
++  {0x0b, AFM_ENC_NONE},
++  {0x0c, AFM_ENC_NONE},
++  {0x0d, AFM_ENC_NONE},
++  {0x0e, AFM_ENC_NONE},
++  {0x0f, AFM_ENC_NONE},
++  {0x10, AFM_ENC_NONE},
++  {0x11, AFM_ENC_NONE},
++  {0x12, AFM_ENC_NONE},
++  {0x13, AFM_ENC_NONE},
++  {0x14, AFM_ENC_NONE},
++  {0x15, AFM_ENC_NONE},
++  {0x16, AFM_ENC_NONE},
++  {0x17, AFM_ENC_NONE},
++  {0x18, AFM_ENC_NONE},
++  {0x19, AFM_ENC_NONE},
++  {0x1a, AFM_ENC_NONE},
++  {0x1b, AFM_ENC_NONE},
++  {0x1c, AFM_ENC_NONE},
++  {0x1d, AFM_ENC_NONE},
++  {0x1e, AFM_ENC_NONE},
++  {0x1f, AFM_ENC_NONE},
++  {0x20, "space"},
++  {0x21, "exclam"},
++  {0x22, "quotedbl"},
++  {0x23, "numbersign"},
++  {0x24, "dollar"},
++  {0x25, "percent"},
++  {0x26, "ampersand"},
++  {0x27, "quoteright"},
++  {0x28, "parenleft"},
++  {0x29, "parenright"},
++  {0x2a, "asterisk"},
++  {0x2b, "plus"},
++  {0x2c, "comma"},
++  {0x2d, "minus"},
++  {0x2e, "period"},
++  {0x2f, "slash"},
++  {0x30, "zero"},
++  {0x31, "one"},
++  {0x32, "two"},
++  {0x33, "three"},
++  {0x34, "four"},
++  {0x35, "five"},
++  {0x36, "six"},
++  {0x37, "seven"},
++  {0x38, "eight"},
++  {0x39, "nine"},
++  {0x3a, "colon"},
++  {0x3b, "semicolon"},
++  {0x3c, "less"},
++  {0x3d, "equal"},
++  {0x3e, "greater"},
++  {0x3f, "question"},
++  {0x40, "at"},
++  {0x41, "A"},
++  {0x42, "B"},
++  {0x43, "C"},
++  {0x44, "D"},
++  {0x45, "E"},
++  {0x46, "F"},
++  {0x47, "G"},
++  {0x48, "H"},
++  {0x49, "I"},
++  {0x4a, "J"},
++  {0x4b, "K"},
++  {0x4c, "L"},
++  {0x4d, "M"},
++  {0x4e, "N"},
++  {0x4f, "O"},
++  {0x50, "P"},
++  {0x51, "Q"},
++  {0x52, "R"},
++  {0x53, "S"},
++  {0x54, "T"},
++  {0x55, "U"},
++  {0x56, "V"},
++  {0x57, "W"},
++  {0x58, "X"},
++  {0x59, "Y"},
++  {0x5a, "Z"},
++  {0x5b, "bracketleft"},
++  {0x5c, "backslash"},
++  {0x5d, "bracketright"},
++  {0x5e, "asciicircum"},
++  {0x5f, "underscore"},
++  {0x60, "quoteleft"},
++  {0x61, "a"},
++  {0x62, "b"},
++  {0x63, "c"},
++  {0x64, "d"},
++  {0x65, "e"},
++  {0x66, "f"},
++  {0x67, "g"},
++  {0x68, "h"},
++  {0x69, "i"},
++  {0x6a, "j"},
++  {0x6b, "k"},
++  {0x6c, "l"},
++  {0x6d, "m"},
++  {0x6e, "n"},
++  {0x6f, "o"},
++  {0x70, "p"},
++  {0x71, "q"},
++  {0x72, "r"},
++  {0x73, "s"},
++  {0x74, "t"},
++  {0x75, "u"},
++  {0x76, "v"},
++  {0x77, "w"},
++  {0x78, "x"},
++  {0x79, "y"},
++  {0x7a, "z"},
++  {0x7b, "braceleft"},
++  {0x7c, "bar"},
++  {0x7d, "braceright"},
++  {0x7e, "asciitilde"},
++  {0x7f, AFM_ENC_NONE},
++  {0x80, AFM_ENC_NONE},
++  {0x81, AFM_ENC_NONE},
++  {0x82, AFM_ENC_NONE},
++  {0x83, AFM_ENC_NONE},
++  {0x84, AFM_ENC_NONE},
++  {0x85, AFM_ENC_NONE},
++  {0x86, AFM_ENC_NONE},
++  {0x87, AFM_ENC_NONE},
++  {0x88, AFM_ENC_NONE},
++  {0x89, AFM_ENC_NONE},
++  {0x8a, AFM_ENC_NONE},
++  {0x8b, AFM_ENC_NONE},
++  {0x8c, AFM_ENC_NONE},
++  {0x8d, AFM_ENC_NONE},
++  {0x8e, AFM_ENC_NONE},
++  {0x8f, AFM_ENC_NONE},
++  {0x90, AFM_ENC_NONE},
++  {0x91, AFM_ENC_NONE},
++  {0x92, AFM_ENC_NONE},
++  {0x93, AFM_ENC_NONE},
++  {0x94, AFM_ENC_NONE},
++  {0x95, AFM_ENC_NONE},
++  {0x96, AFM_ENC_NONE},
++  {0x97, AFM_ENC_NONE},
++  {0x98, AFM_ENC_NONE},
++  {0x99, AFM_ENC_NONE},
++  {0x9a, AFM_ENC_NONE},
++  {0x9b, AFM_ENC_NONE},
++  {0x9c, AFM_ENC_NONE},
++  {0x9d, AFM_ENC_NONE},
++  {0x9e, AFM_ENC_NONE},
++  {0x9f, AFM_ENC_NONE},
++  {0xa0, "space"},
++  {0xa1, "exclamdown"},
++  {0xa2, "cent"},
++  {0xa3, "sterling"},
++  {0xa4, "Euro"},
++  {0xa5, "yen"},
++  {0xa6, "Scaron"},
++  {0xa7, "section"},
++  {0xa8, "scaron"},
++  {0xa9, "copyright"},
++  {0xaa, "ordfeminine"},
++  {0xab, "guillemotleft"},
++  {0xac, "logicalnot"},
++  {0xad, "hyphen"},
++  {0xae, "registered"},
++  {0xaf, "macron"},
++  {0xb0, "degree"},
++  {0xb1, "plusminus"},
++  {0xb2, "twosuperior"},
++  {0xb3, "threesuperior"},
++  {0xb4, "Zcaron"},
++  {0xb5, "mu"},
++  {0xb6, "paragraph"},
++  {0xb7, "bullet"},
++  {0xb8, "zcaron"},
++  {0xb9, "onesuperior"},
++  {0xba, "ordmasculine"},
++  {0xbb, "guillemotright"},
++  {0xbc, "OE"},
++  {0xbd, "oe"},
++  {0xbe, "Ydieresis"},
++  {0xbf, "questiondown"},
++  {0xc0, "Agrave"},
++  {0xc1, "Aacute"},
++  {0xc2, "Acircumflex"},
++  {0xc3, "Atilde"},
++  {0xc4, "Adieresis"},
++  {0xc5, "Aring"},
++  {0xc6, "AE"},
++  {0xc7, "Ccedilla"},
++  {0xc8, "Egrave"},
++  {0xc9, "Eacute"},
++  {0xca, "Ecircumflex"},
++  {0xcb, "Edieresis"},
++  {0xcc, "Igrave"},
++  {0xcd, "Iacute"},
++  {0xce, "Icircumflex"},
++  {0xcf, "Idieresis"},
++  {0xd0, "Eth"},
++  {0xd1, "Ntilde"},
++  {0xd2, "Ograve"},
++  {0xd3, "Oacute"},
++  {0xd4, "Ocircumflex"},
++  {0xd5, "Otilde"},
++  {0xd6, "Odieresis"},
++  {0xd7, "multiply"},
++  {0xd8, "Oslash"},
++  {0xd9, "Ugrave"},
++  {0xda, "Uacute"},
++  {0xdb, "Ucircumflex"},
++  {0xdc, "Udieresis"},
++  {0xdd, "Yacute"},
++  {0xde, "Thorn"},
++  {0xdf, "germandbls"},
++  {0xe0, "agrave"},
++  {0xe1, "aacute"},
++  {0xe2, "acircumflex"},
++  {0xe3, "atilde"},
++  {0xe4, "adieresis"},
++  {0xe5, "aring"},
++  {0xe6, "ae"},
++  {0xe7, "ccedilla"},
++  {0xe8, "egrave"},
++  {0xe9, "eacute"},
++  {0xea, "ecircumflex"},
++  {0xeb, "edieresis"},
++  {0xec, "igrave"},
++  {0xed, "iacute"},
++  {0xee, "icircumflex"},
++  {0xef, "idieresis"},
++  {0xf0, "eth"},
++  {0xf1, "ntilde"},
++  {0xf2, "ograve"},
++  {0xf3, "oacute"},
++  {0xf4, "ocircumflex"},
++  {0xf5, "otilde"},
++  {0xf6, "odieresis"},
++  {0xf7, "divide"},
++  {0xf8, "oslash"},
++  {0xf9, "ugrave"},
++  {0xfa, "uacute"},
++  {0xfb, "ucircumflex"},
++  {0xfc, "udieresis"},
++  {0xfd, "yacute"},
++  {0xfe, "thorn"},
++  {0xff, "ydieresis"},
++  {-1,   NULL},
++};
+diff -up enscript-1.6.6/afmlib/make-encoding.pl.newencodings enscript-1.6.6/afmlib/make-encoding.pl
+--- enscript-1.6.6/afmlib/make-encoding.pl.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afmlib/make-encoding.pl	2019-01-29 12:33:53.510612826 +0100
+@@ -1,4 +1,4 @@
+-#!/usr/local/bin/perl
++#!/usr/bin/perl
+ #
+ # Create encoding files from the `*.txt' encoding files.
+ # Copyright (c) 1995-1998 Markku Rossi.
+diff -up enscript-1.6.6/afmlib/Makefile.am.newencodings enscript-1.6.6/afmlib/Makefile.am
+--- enscript-1.6.6/afmlib/Makefile.am.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afmlib/Makefile.am	2019-01-29 12:33:53.509612834 +0100
+@@ -24,7 +24,7 @@
+ noinst_LIBRARIES = libafm.a
+ libafm_a_SOURCES = afm.c afmparse.c strhash.c e_88591.c e_88592.c	\
+ e_88593.c e_88594.c e_88595.c e_88597.c e_88599.c e_885910.c e_pc.c	\
+-e_mac.c e_vms.c e_hp8.c e_koi8.c deffont.c
++e_mac.c e_vms.c e_hp8.c e_koi8.c deffont.c e_885913.c e_885915.c
+ 
+ noinst_HEADERS = afm.h afmint.h strhash.h
+ 
+diff -up enscript-1.6.6/afmlib/Makefile-encodings.newencodings enscript-1.6.6/afmlib/Makefile-encodings
+--- enscript-1.6.6/afmlib/Makefile-encodings.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afmlib/Makefile-encodings	2019-01-29 12:33:53.509612834 +0100
+@@ -22,7 +22,7 @@
+ #
+ 
+ ENCODINGS = e_88591.c e_88592.c e_88593.c e_88594.c e_88595.c \
+-e_88597.c e_88599.c e_885910.c e_pc.c e_mac.c e_vms.c e_hp8.c e_koi8.c
++e_88597.c e_88599.c e_885910.c e_885913.c e_885915.c e_pc.c e_mac.c e_vms.c e_hp8.c e_koi8.c
+ 
+ all: $(ENCODINGS)
+ 
+@@ -53,6 +53,12 @@ e_88599.c: make-encoding.pl ../88599.txt
+ e_885910.c: make-encoding.pl ../885910.txt
+ 	./make-encoding.pl ../885910.txt >e_885910.c
+ 
++e_885913.c: make-encoding.pl ../885913.txt
++	./make-encoding.pl ../885913.txt >e_885913.c
++
++e_885915.c: make-encoding.pl ../885915.txt
++	./make-encoding.pl ../885915.txt >e_885915.c
++
+ e_pc.c: make-encoding.pl ../ibmpc.txt
+ 	./make-encoding.pl ../ibmpc.txt >e_pc.c
+ 
+diff -up enscript-1.6.6/afm/tib.afm.newencodings enscript-1.6.6/afm/tib.afm
+--- enscript-1.6.6/afm/tib.afm.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afm/tib.afm	2019-01-29 12:33:53.507612850 +0100
+@@ -19,7 +19,7 @@ CapHeight 676
+ XHeight 461
+ Ascender 676
+ Descender -205
+-StartCharMetrics 228
++StartCharMetrics 229
+ C 32 ; WX 250 ; N space ; B 0 0 0 0 ;
+ C 33 ; WX 333 ; N exclam ; B 81 -13 251 691 ;
+ C 34 ; WX 555 ; N quotedbl ; B 83 404 472 691 ;
+@@ -181,6 +181,7 @@ C -1 ; WX 444 ; N egrave ; B 25 -14 426
+ C -1 ; WX 300 ; N twosuperior ; B 0 275 300 688 ;
+ C -1 ; WX 444 ; N eacute ; B 25 -14 426 713 ;
+ C -1 ; WX 500 ; N otilde ; B 25 -14 476 674 ;
++C -1 ; WX 944 ; N Euro ; B 14 0 921 676 ;
+ C -1 ; WX 722 ; N Aacute ; B 9 0 689 923 ;
+ C -1 ; WX 500 ; N ocircumflex ; B 25 -14 476 704 ;
+ C -1 ; WX 500 ; N yacute ; B 16 -205 480 713 ;
+@@ -585,7 +586,7 @@ KPX z o 0
+ KPX z e 0
+ EndKernPairs
+ EndKernData
+-StartComposites 58
++StartComposites 59
+ CC Aacute 2 ; PCC A 0 0 ; PCC acute 188 210 ;
+ CC Acircumflex 2 ; PCC A 0 0 ; PCC circumflex 188 210 ;
+ CC Adieresis 2 ; PCC A 0 0 ; PCC dieresis 188 210 ;
+@@ -636,6 +637,7 @@ CC ocircumflex 2 ; PCC o 0 0 ; PCC circu
+ CC odieresis 2 ; PCC o 0 0 ; PCC dieresis 84 0 ;
+ CC ograve 2 ; PCC o 0 0 ; PCC grave 84 0 ;
+ CC otilde 2 ; PCC o 0 0 ; PCC tilde 84 0 ;
++CC Euro 2 ; PCC C 0 0 ; PCC equal 0 0 ;
+ CC scaron 2 ; PCC s 0 0 ; PCC caron 28 0 ;
+ CC uacute 2 ; PCC u 0 0 ; PCC acute 105 0 ;
+ CC ucircumflex 2 ; PCC u 0 0 ; PCC circumflex 105 0 ;
+@@ -646,4 +648,3 @@ CC ydieresis 2 ; PCC y 0 0 ; PCC dieresi
+ CC zcaron 2 ; PCC z 0 0 ; PCC caron 56 0 ;
+ EndComposites
+ EndFontMetrics
+-
+\ No newline at end of file
+diff -up enscript-1.6.6/afm/tibi.afm.newencodings enscript-1.6.6/afm/tibi.afm
+--- enscript-1.6.6/afm/tibi.afm.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afm/tibi.afm	2019-01-29 12:33:53.508612842 +0100
+@@ -19,7 +19,7 @@ CapHeight 669
+ XHeight 462
+ Ascender 699
+ Descender -205
+-StartCharMetrics 228
++StartCharMetrics 229
+ C 32 ; WX 250 ; N space ; B 0 0 0 0 ;
+ C 33 ; WX 389 ; N exclam ; B 67 -13 370 684 ;
+ C 34 ; WX 555 ; N quotedbl ; B 136 398 536 685 ;
+@@ -181,6 +181,7 @@ C -1 ; WX 444 ; N egrave ; B 5 -13 398 6
+ C -1 ; WX 300 ; N twosuperior ; B 2 274 313 683 ;
+ C -1 ; WX 444 ; N eacute ; B 5 -13 435 697 ;
+ C -1 ; WX 500 ; N otilde ; B -3 -13 491 655 ;
++C -1 ; WX 889 ; N Euro ; B -29 -12 917 669 ;
+ C -1 ; WX 667 ; N Aacute ; B -67 0 593 904 ;
+ C -1 ; WX 500 ; N ocircumflex ; B -3 -13 451 690 ;
+ C -1 ; WX 444 ; N yacute ; B -94 -205 435 697 ;
+@@ -585,7 +586,7 @@ KPX z o 0
+ KPX z e 0
+ EndKernPairs
+ EndKernData
+-StartComposites 58
++StartComposites 59
+ CC Aacute 2 ; PCC A 0 0 ; PCC acute 172 207 ;
+ CC Acircumflex 2 ; PCC A 0 0 ; PCC circumflex 187 207 ;
+ CC Adieresis 2 ; PCC A 0 0 ; PCC dieresis 167 207 ;
+@@ -636,6 +637,7 @@ CC ocircumflex 2 ; PCC o 0 0 ; PCC circu
+ CC odieresis 2 ; PCC o 0 0 ; PCC dieresis 69 0 ;
+ CC ograve 2 ; PCC o 0 0 ; PCC grave 74 0 ;
+ CC otilde 2 ; PCC o 0 0 ; PCC tilde 84 0 ;
++CC Euro 2 ; PCC C 0 0 ; PCC equal 0 0 ;
+ CC scaron 2 ; PCC s 0 0 ; PCC caron 28 0 ;
+ CC uacute 2 ; PCC u 0 0 ; PCC acute 112 0 ;
+ CC ucircumflex 2 ; PCC u 0 0 ; PCC circumflex 112 0 ;
+@@ -646,4 +648,3 @@ CC ydieresis 2 ; PCC y 0 0 ; PCC dieresi
+ CC zcaron 2 ; PCC z 0 0 ; PCC caron 13 0 ;
+ EndComposites
+ EndFontMetrics
+-
+\ No newline at end of file
+diff -up enscript-1.6.6/afm/tii.afm.newencodings enscript-1.6.6/afm/tii.afm
+--- enscript-1.6.6/afm/tii.afm.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afm/tii.afm	2019-01-29 12:33:53.508612842 +0100
+@@ -19,7 +19,7 @@ CapHeight 653
+ XHeight 441
+ Ascender 683
+ Descender -205
+-StartCharMetrics 228
++StartCharMetrics 229
+ C 32 ; WX 250 ; N space ; B 0 0 0 0 ;
+ C 33 ; WX 333 ; N exclam ; B 39 -11 302 667 ;
+ C 34 ; WX 420 ; N quotedbl ; B 144 421 432 666 ;
+@@ -181,6 +181,7 @@ C -1 ; WX 444 ; N egrave ; B 31 -11 412
+ C -1 ; WX 300 ; N twosuperior ; B 33 271 324 676 ;
+ C -1 ; WX 444 ; N eacute ; B 31 -11 459 664 ;
+ C -1 ; WX 500 ; N otilde ; B 27 -11 496 624 ;
++C -1 ; WX 833 ; N Euro ; B -18 0 873 653 ;
+ C -1 ; WX 611 ; N Aacute ; B -51 0 564 876 ;
+ C -1 ; WX 500 ; N ocircumflex ; B 27 -11 468 661 ;
+ C -1 ; WX 444 ; N yacute ; B -24 -206 459 664 ;
+@@ -585,7 +586,7 @@ KPX z o 0
+ KPX z e 0
+ EndKernPairs
+ EndKernData
+-StartComposites 58
++StartComposites 59
+ CC Aacute 2 ; PCC A 0 0 ; PCC acute 139 212 ;
+ CC Acircumflex 2 ; PCC A 0 0 ; PCC circumflex 144 212 ;
+ CC Adieresis 2 ; PCC A 0 0 ; PCC dieresis 139 212 ;
+@@ -636,6 +637,7 @@ CC ocircumflex 2 ; PCC o 0 0 ; PCC circu
+ CC odieresis 2 ; PCC o 0 0 ; PCC dieresis 84 0 ;
+ CC ograve 2 ; PCC o 0 0 ; PCC grave 84 0 ;
+ CC otilde 2 ; PCC o 0 0 ; PCC tilde 69 0 ;
++CC Euro 2 ; PCC C 0 0 ; PCC equal 0 0 ;
+ CC scaron 2 ; PCC s 0 0 ; PCC caron 28 0 ;
+ CC uacute 2 ; PCC u 0 0 ; PCC acute 74 0 ;
+ CC ucircumflex 2 ; PCC u 0 0 ; PCC circumflex 74 0 ;
+@@ -646,4 +648,3 @@ CC ydieresis 2 ; PCC y 0 0 ; PCC dieresi
+ CC zcaron 2 ; PCC z 0 0 ; PCC caron 8 0 ;
+ EndComposites
+ EndFontMetrics
+-
+\ No newline at end of file
+diff -up enscript-1.6.6/afm/tir.afm.newencodings enscript-1.6.6/afm/tir.afm
+--- enscript-1.6.6/afm/tir.afm.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/afm/tir.afm	2019-01-29 12:33:53.508612842 +0100
+@@ -19,7 +19,7 @@ CapHeight 662
+ XHeight 450
+ Ascender 683
+ Descender -217
+-StartCharMetrics 228
++StartCharMetrics 229
+ C 32 ; WX 250 ; N space ; B 0 0 0 0 ;
+ C 33 ; WX 333 ; N exclam ; B 130 -9 238 676 ;
+ C 34 ; WX 408 ; N quotedbl ; B 77 431 331 676 ;
+@@ -181,6 +181,7 @@ C -1 ; WX 444 ; N egrave ; B 25 -10 424
+ C -1 ; WX 300 ; N twosuperior ; B 1 270 296 676 ;
+ C -1 ; WX 444 ; N eacute ; B 25 -10 424 678 ;
+ C -1 ; WX 500 ; N otilde ; B 29 -10 470 638 ;
++C -1 ; WX 889 ; N Euro ; B 12 0 863 662 ;
+ C -1 ; WX 722 ; N Aacute ; B 15 0 706 890 ;
+ C -1 ; WX 500 ; N ocircumflex ; B 29 -10 470 674 ;
+ C -1 ; WX 500 ; N yacute ; B 14 -218 475 678 ;
+@@ -585,7 +586,7 @@ KPX z o 0
+ KPX z e 0
+ EndKernPairs
+ EndKernData
+-StartComposites 58
++StartComposites 59
+ CC Aacute 2 ; PCC A 0 0 ; PCC acute 195 212 ;
+ CC Acircumflex 2 ; PCC A 0 0 ; PCC circumflex 195 212 ;
+ CC Adieresis 2 ; PCC A 0 0 ; PCC dieresis 195 212 ;
+@@ -636,6 +637,7 @@ CC ocircumflex 2 ; PCC o 0 0 ; PCC circu
+ CC odieresis 2 ; PCC o 0 0 ; PCC dieresis 84 0 ;
+ CC ograve 2 ; PCC o 0 0 ; PCC grave 84 0 ;
+ CC otilde 2 ; PCC o 0 0 ; PCC tilde 84 0 ;
++CC Euro 2 ; PCC C 0 0 ; PCC equal 0 0 ;
+ CC scaron 2 ; PCC s 0 0 ; PCC caron 28 0 ;
+ CC uacute 2 ; PCC u 0 0 ; PCC acute 84 0 ;
+ CC ucircumflex 2 ; PCC u 0 0 ; PCC circumflex 84 0 ;
+@@ -646,4 +648,3 @@ CC ydieresis 2 ; PCC y 0 0 ; PCC dieresi
+ CC zcaron 2 ; PCC z 0 0 ; PCC caron 56 0 ;
+ EndComposites
+ EndFontMetrics
+-
+\ No newline at end of file
+diff -up enscript-1.6.6/docs/enscript.man.newencodings enscript-1.6.6/docs/enscript.man
+--- enscript-1.6.6/docs/enscript.man.newencodings	2019-01-29 12:33:53.476613100 +0100
++++ enscript-1.6.6/docs/enscript.man	2019-01-29 12:33:53.511612818 +0100
+@@ -426,6 +426,12 @@ ISO\-8859\-9 (ISO Latin5)
+ .B 885910, latin6
+ ISO\-8859\-10 (ISO Latin6)
+ .TP 8
++.B 885913, latin7
++ISO\-8859\-13 (ISO Latin7)
++.TP 8
++.B 885915, latin9
++ISO\-8859\-15 (ISO Latin9)
++.TP 8
+ .B ascii
+ 7\-bit ascii
+ .TP 8
+diff -up enscript-1.6.6/lib/885913.enc.newencodings enscript-1.6.6/lib/885913.enc
+--- enscript-1.6.6/lib/885913.enc.newencodings	2019-01-29 13:52:56.130878570 +0100
++++ enscript-1.6.6/lib/885913.enc	2019-01-29 13:53:29.557587427 +0100
+@@ -0,0 +1,91 @@
++%
++% 885913 encoding vector.
++%
++% This file is automatically generated from file `885913.txt'.  If you
++% have any corrections to this file, please, edit file `885913.txt' instead.
++%
++
++%
++% This file is part of GNU Enscript.
++%
++% Enscript is free software: you can redistribute it and/or modify
++% it under the terms of the GNU General Public License as published by
++% the Free Software Foundation, either version 3 of the License, or
++% (at your option) any later version.
++%
++% Enscript is distributed in the hope that it will be useful,
++% but WITHOUT ANY WARRANTY; without even the implied warranty of
++% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++% GNU General Public License for more details.
++%
++% You should have received a copy of the GNU General Public License
++% along with Enscript.  If not, see <http://www.gnu.org/licenses/>.
++%
++
++% -- code follows this line --
++/encoding_vector [
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/space        	/exclam       	/quotedbl     	/numbersign   	
++/dollar       	/percent      	/ampersand    	/quoteright   	
++/parenleft    	/parenright   	/asterisk     	/plus         	
++/comma        	/minus        	/period       	/slash        	
++/zero         	/one          	/two          	/three        	
++/four         	/five         	/six          	/seven        	
++/eight        	/nine         	/colon        	/semicolon    	
++/less         	/equal        	/greater      	/question     	
++/at           	/A            	/B            	/C            	
++/D            	/E            	/F            	/G            	
++/H            	/I            	/J            	/K            	
++/L            	/M            	/N            	/O            	
++/P            	/Q            	/R            	/S            	
++/T            	/U            	/V            	/W            	
++/X            	/Y            	/Z            	/bracketleft  	
++/backslash    	/bracketright 	/asciicircum  	/underscore   	
++/quoteleft    	/a            	/b            	/c            	
++/d            	/e            	/f            	/g            	
++/h            	/i            	/j            	/k            	
++/l            	/m            	/n            	/o            	
++/p            	/q            	/r            	/s            	
++/t            	/u            	/v            	/w            	
++/x            	/y            	/z            	/braceleft    	
++/bar          	/braceright   	/asciitilde   	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/space        	/quotedblright	/cent         	/sterling     	
++/currency     	/quotedblbase 	/brokenbar    	/section      	
++/Oslash       	/copyright    	/Rcedilla     	/guillemotleft	
++/logicalnot   	/hyphen       	/registered   	/AE           	
++/degree       	/plusminus    	/twosuperior  	/threesuperior	
++/quotedblleft 	/mu           	/paragraph    	/bullet       	
++/oslash       	/onesuperior  	/rcedilla     	/guillemotright	
++/onequarter   	/onehalf      	/threequarters	/ae           	
++/Aogonek      	/Iogonek      	/Amacron      	/Cacute       	
++/Adieresis    	/Aring        	/Eogonek      	/Emacron      	
++/Ccaron       	/Eacute       	/Zacute       	/Edotaccent   	
++/Gcedilla     	/Kcedilla     	/Imacron      	/Lcedilla     	
++/Scaron       	/Nacute       	/Ncedilla     	/Oacute       	
++/Omacron      	/Otilde       	/Odieresis    	/multiply     	
++/Uogonek      	/Lslash       	/Sacute       	/Umacron      	
++/Udieresis    	/Zdotaccent   	/Zcaron       	/germandbls   	
++/aogonek      	/iogonek      	/amacron      	/cacute       	
++/adieresis    	/aring        	/eogonek      	/emacron      	
++/ccaron       	/eacute       	/zacute       	/edotaccent   	
++/gcedilla     	/kcedilla     	/imacron      	/lcedilla     	
++/scaron       	/nacute       	/ncedilla     	/oacute       	
++/omacron      	/otilde       	/odieresis    	/divide       	
++/uogonek      	/lslash       	/sacute       	/umacron      	
++/udieresis    	/zdotaccent   	/zcaron       	/quoteright   	
++] def
+diff -up enscript-1.6.6/lib/885915.enc.newencodings enscript-1.6.6/lib/885915.enc
+--- enscript-1.6.6/lib/885915.enc.newencodings	2019-01-29 13:53:01.930828054 +0100
++++ enscript-1.6.6/lib/885915.enc	2019-01-29 13:53:42.126477954 +0100
+@@ -0,0 +1,91 @@
++%
++% 885915 encoding vector.
++%
++% This file is automatically generated from file `885915.txt'.  If you
++% have any corrections to this file, please, edit file `885915.txt' instead.
++%
++
++%
++% This file is part of GNU Enscript.
++%
++% Enscript is free software: you can redistribute it and/or modify
++% it under the terms of the GNU General Public License as published by
++% the Free Software Foundation, either version 3 of the License, or
++% (at your option) any later version.
++%
++% Enscript is distributed in the hope that it will be useful,
++% but WITHOUT ANY WARRANTY; without even the implied warranty of
++% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++% GNU General Public License for more details.
++%
++% You should have received a copy of the GNU General Public License
++% along with Enscript.  If not, see <http://www.gnu.org/licenses/>.
++%
++
++% -- code follows this line --
++/encoding_vector [
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/space        	/exclam       	/quotedbl     	/numbersign   	
++/dollar       	/percent      	/ampersand    	/quoteright   	
++/parenleft    	/parenright   	/asterisk     	/plus         	
++/comma        	/minus        	/period       	/slash        	
++/zero         	/one          	/two          	/three        	
++/four         	/five         	/six          	/seven        	
++/eight        	/nine         	/colon        	/semicolon    	
++/less         	/equal        	/greater      	/question     	
++/at           	/A            	/B            	/C            	
++/D            	/E            	/F            	/G            	
++/H            	/I            	/J            	/K            	
++/L            	/M            	/N            	/O            	
++/P            	/Q            	/R            	/S            	
++/T            	/U            	/V            	/W            	
++/X            	/Y            	/Z            	/bracketleft  	
++/backslash    	/bracketright 	/asciicircum  	/underscore   	
++/quoteleft    	/a            	/b            	/c            	
++/d            	/e            	/f            	/g            	
++/h            	/i            	/j            	/k            	
++/l            	/m            	/n            	/o            	
++/p            	/q            	/r            	/s            	
++/t            	/u            	/v            	/w            	
++/x            	/y            	/z            	/braceleft    	
++/bar          	/braceright   	/asciitilde   	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/.notdef      	/.notdef      	/.notdef      	/.notdef      	
++/space        	/exclamdown   	/cent         	/sterling     	
++/Euro         	/yen          	/Scaron       	/section      	
++/scaron       	/copyright    	/ordfeminine  	/guillemotleft	
++/logicalnot   	/hyphen       	/registered   	/macron       	
++/degree       	/plusminus    	/twosuperior  	/threesuperior	
++/Zcaron       	/mu           	/paragraph    	/bullet       	
++/zcaron       	/onesuperior  	/ordmasculine 	/guillemotright	
++/OE           	/oe           	/Ydieresis    	/questiondown 	
++/Agrave       	/Aacute       	/Acircumflex  	/Atilde       	
++/Adieresis    	/Aring        	/AE           	/Ccedilla     	
++/Egrave       	/Eacute       	/Ecircumflex  	/Edieresis    	
++/Igrave       	/Iacute       	/Icircumflex  	/Idieresis    	
++/Eth          	/Ntilde       	/Ograve       	/Oacute       	
++/Ocircumflex  	/Otilde       	/Odieresis    	/multiply     	
++/Oslash       	/Ugrave       	/Uacute       	/Ucircumflex  	
++/Udieresis    	/Yacute       	/Thorn        	/germandbls   	
++/agrave       	/aacute       	/acircumflex  	/atilde       	
++/adieresis    	/aring        	/ae           	/ccedilla     	
++/egrave       	/eacute       	/ecircumflex  	/edieresis    	
++/igrave       	/iacute       	/icircumflex  	/idieresis    	
++/eth          	/ntilde       	/ograve       	/oacute       	
++/ocircumflex  	/otilde       	/odieresis    	/divide       	
++/oslash       	/ugrave       	/uacute       	/ucircumflex  	
++/udieresis    	/yacute       	/thorn        	/ydieresis    	
++] def
+diff -up enscript-1.6.6/lib/make-encoding.pl.newencodings enscript-1.6.6/lib/make-encoding.pl
+--- enscript-1.6.6/lib/make-encoding.pl.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/lib/make-encoding.pl	2019-01-29 12:33:53.513612802 +0100
+@@ -1,4 +1,4 @@
+-#!/usr/local/bin/perl
++#!/usr/bin/perl
+ #
+ # Create encoding vectors from the `*.txt' encoding files.
+ # Copyright (c) 1995-1998 Markku Rossi
+diff -up enscript-1.6.6/lib/Makefile.am.newencodings enscript-1.6.6/lib/Makefile.am
+--- enscript-1.6.6/lib/Makefile.am.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/lib/Makefile.am	2019-01-29 12:33:53.512612810 +0100
+@@ -26,7 +26,7 @@ pkgdata_DATA = ascii.enc asciifise.enc a
+ koi8.enc 88591.enc 88592.enc 88593.enc 88594.enc 88595.enc 88597.enc	\
+ 88599.enc 885910.enc mac.enc ps.enc pslatin1.enc vms.enc a2ps.hdr	\
+ edd.hdr emacs.hdr enscript.hdr enscript-color.hdr frame.hdr mp.hdr	\
+-simple.hdr squeeze.hdr enscript.pro
++simple.hdr squeeze.hdr enscript.pro 885913.enc 885915.enc
+ 
+ sysconf_DATA = enscript.cfg
+ CLEANFILES = $(sysconf_DATA)
+diff -up enscript-1.6.6/lib/Makefile-encodings.newencodings enscript-1.6.6/lib/Makefile-encodings
+--- enscript-1.6.6/lib/Makefile-encodings.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/lib/Makefile-encodings	2019-01-29 12:33:53.512612810 +0100
+@@ -24,7 +24,7 @@
+ 
+ ENCODINGS = ascii.enc asciifise.enc asciidkno.enc ibmpc.enc mac.enc \
+ vms.enc hp8.enc koi8.enc 88591.enc 88592.enc 88593.enc 88594.enc \
+-88595.enc 88597.enc 88599.enc 885910.enc
++88595.enc 88597.enc 88599.enc 885910.enc 885913.enc 885915.enc
+ 
+ all: $(ENCODINGS)
+ 
+@@ -64,6 +64,12 @@ ibmpc.enc: ../ibmpc.txt
+ 885910.enc: ../885910.txt
+ 	./make-encoding.pl ../885910.txt >885910.enc
+ 
++885913.enc: ../885913.txt
++	./make-encoding.pl ../885913.txt >885913.enc
++
++885915.enc: ../885915.txt
++	./make-encoding.pl ../885915.txt >885915.enc
++
+ mac.enc: ../mac.txt
+ 	./make-encoding.pl ../mac.txt >mac.enc
+ 
+diff -up enscript-1.6.6/src/gsint.h.newencodings enscript-1.6.6/src/gsint.h
+--- enscript-1.6.6/src/gsint.h.newencodings	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/src/gsint.h	2019-01-29 12:33:53.513612802 +0100
+@@ -108,6 +108,7 @@ extern double atan2 ___P ((double, doubl
+ 
+ #if HAVE_LC_MESSAGES
+ #include <locale.h>
++#include <langinfo.h>
+ #endif
+ 
+ #ifndef HAVE_GETCWD
+@@ -176,6 +177,8 @@ typedef enum
+   ENC_ISO_8859_7,
+   ENC_ISO_8859_9,
+   ENC_ISO_8859_10,
++  ENC_ISO_8859_13,
++  ENC_ISO_8859_15,
+   ENC_ASCII,
+   ENC_ASCII_FISE,
+   ENC_ASCII_DKNO,
+diff -up enscript-1.6.6/src/main.c.newencodings enscript-1.6.6/src/main.c
+--- enscript-1.6.6/src/main.c.newencodings	2019-01-29 12:33:53.478613084 +0100
++++ enscript-1.6.6/src/main.c	2019-01-29 12:33:53.513612802 +0100
+@@ -795,15 +795,17 @@ double bggray = 1.0;
+ 
+ EncodingRegistry encodings[] =
+ {
+-  {{"88591", "latin1", NULL},		ENC_ISO_8859_1,		'\n', 8},
+-  {{"88592", "latin2", NULL},		ENC_ISO_8859_2,		'\n', 8},
+-  {{"88593", "latin3", NULL},		ENC_ISO_8859_3,		'\n', 8},
+-  {{"88594", "latin4", NULL},		ENC_ISO_8859_4,		'\n', 8},
+-  {{"88595", "cyrillic", NULL},		ENC_ISO_8859_5,		'\n', 8},
+-  {{"88597", "greek", NULL},		ENC_ISO_8859_7,		'\n', 8},
+-  {{"88599", "latin5", NULL},		ENC_ISO_8859_9,		'\n', 8},
+-  {{"885910", "latin6", NULL},		ENC_ISO_8859_10,	'\n', 8},
+-  {{"ascii", NULL, NULL},		ENC_ASCII, 		'\n', 8},
++  {{"88591", "latin1", "ISO-8859-1"},	ENC_ISO_8859_1,		'\n', 8},
++  {{"88592", "latin2", "ISO-8859-2"},	ENC_ISO_8859_2,		'\n', 8},
++  {{"88593", "latin3", "ISO-8859-3"},	ENC_ISO_8859_3,		'\n', 8},
++  {{"88594", "latin4", "ISO-8859-4"},	ENC_ISO_8859_4,		'\n', 8},
++  {{"88595", "cyrillic", "ISO-8859-5"},	ENC_ISO_8859_5,		'\n', 8},
++  {{"88597", "greek", "ISO-8859-7"},	ENC_ISO_8859_7,		'\n', 8},
++  {{"88599", "latin5", "ISO-8859-9"},	ENC_ISO_8859_9,		'\n', 8},
++  {{"885910", "latin6", "ISO-8859-10"},	ENC_ISO_8859_10,	'\n', 8},
++  {{"885913", "latin7", "ISO-8859-13"},	ENC_ISO_8859_13,	'\n', 8},
++  {{"885915", "latin9", "ISO-8859-15"},	ENC_ISO_8859_15,	'\n', 8},
++  {{"ascii", NULL, "ANSI_X3.4-1968"},	ENC_ASCII, 		'\n', 8},
+   {{"asciifise", "asciifi", "asciise"},	ENC_ASCII_FISE,		'\n', 8},
+   {{"asciidkno", "asciidk", "asciino"},	ENC_ASCII_DKNO,		'\n', 8},
+   {{"ibmpc", "pc", "dos"},		ENC_IBMPC, 		'\n', 8},
+diff -up enscript-1.6.6/src/util.c.newencodings enscript-1.6.6/src/util.c
+--- enscript-1.6.6/src/util.c.newencodings	2019-01-29 12:33:53.466613181 +0100
++++ enscript-1.6.6/src/util.c	2019-01-29 12:33:53.514612794 +0100
+@@ -157,6 +157,14 @@ read_config (char *path, char *file)
+ 	{
+ 	  token2 = GET_TOKEN (NULL);
+ 	  CHECK_TOKEN ();
++	  if (!strcasecmp("LC_CTYPE", token2))
++	    {
++	      char * codeset = nl_langinfo(_NL_CTYPE_CODESET_NAME);
++	      if (codeset && !strncasecmp(codeset, "iso", 3))
++		token2 = codeset;
++	      else
++		token2 = "885915";
++	    }
+ 	  xfree (encoding_name);
+ 	  encoding_name = xstrdup (token2);
+ 	}
+@@ -951,6 +959,16 @@ read_font_info (void)
+ 					enc_flags);
+ 	      break;
+ 
++	    case ENC_ISO_8859_13:
++	      (void) afm_font_encoding (font, AFM_ENCODING_ISO_8859_13,
++					enc_flags);
++	      break;
++
++	    case ENC_ISO_8859_15:
++	      (void) afm_font_encoding (font, AFM_ENCODING_ISO_8859_15,
++					enc_flags);
++	      break;
++
+ 	    case ENC_ASCII:
+ 	      (void) afm_font_encoding (font, AFM_ENCODING_ASCII, enc_flags);
+ 	      break;

--- a/enscript/0002-fixes-getopt-compile-with-gcc-15-under-cygwin.patch
+++ b/enscript/0002-fixes-getopt-compile-with-gcc-15-under-cygwin.patch
@@ -1,0 +1,61 @@
+From 71f71d75eb9eaa4821de3b3b174bb0f51030857d Mon Sep 17 00:00:00 2001
+From: Yonggang Luo <luoyonggang@gmail.com>
+Date: Sun, 18 Jan 2026 04:57:51 +0800
+Subject: [PATCH] fixes getopt compile with gcc 15 under cygwin
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+getopt.c:367:21: error: too many arguments to function ‘getenv’; expected 0, have 1
+  367 |   posixly_correct = getenv ("POSIXLY_CORRECT");
+
+getopt.h:108:12: error: prototype declaration
+  108 | extern int getopt ();
+---
+ compat/getopt.c | 3 +--
+ compat/getopt.h | 4 ----
+ 2 files changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/compat/getopt.c b/compat/getopt.c
+index 752f28a..927eac7 100644
+--- a/compat/getopt.c
++++ b/compat/getopt.c
+@@ -43,6 +43,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include <stdlib.h>
+ 
+ /* Comment out all this code if we are using the GNU C Library, and are not
+    actually compiling the library itself.  This code is part of the GNU C
+@@ -210,8 +211,6 @@ static char *posixly_correct;
+ /* Avoid depending on library functions or files
+    whose names are inconsistent.  */
+ 
+-char *getenv ();
+-
+ static char *
+ my_index (str, chr)
+      const char *str;
+diff --git a/compat/getopt.h b/compat/getopt.h
+index 7a21b63..95f5fe4 100644
+--- a/compat/getopt.h
++++ b/compat/getopt.h
+@@ -99,14 +99,10 @@ struct option
+ #define optional_argument	2
+ 
+ #if defined (__STDC__) && __STDC__
+-#ifdef __GNU_LIBRARY__
+ /* Many other libraries have conflicting prototypes for getopt, with
+    differences in the consts, in stdlib.h.  To avoid compilation
+    errors, only prototype getopt for the GNU C library.  */
+ extern int getopt (int argc, char *const *argv, const char *shortopts);
+-#else /* not __GNU_LIBRARY__ */
+-extern int getopt ();
+-#endif /* __GNU_LIBRARY__ */
+ extern int getopt_long (int argc, char *const *argv, const char *shortopts,
+ 		        const struct option *longopts, int *longind);
+ extern int getopt_long_only (int argc, char *const *argv,
+-- 
+2.52.0.windows.1
+

--- a/enscript/PKGBUILD
+++ b/enscript/PKGBUILD
@@ -16,26 +16,76 @@ license=('spdx:GPL-3.0-or-later')
 depends=('perl' 'libintl' 'libiconv')
 makedepends=('autotools' 'gcc' 'gettext-devel' 'libiconv-devel')
 optdepends=('cygutils: Send the output to a physical printer instead of stdout.')
+
+_patches=(
+  # patches from https://src.fedoraproject.org/rpms/enscript/blob/rawhide/f/enscript.spec
+  # Use regexp 'Patch\d+: ' to replace prefixes
+
+  # RH #61294
+  enscript-1.6.1-locale.patch
+
+  # RH #224548
+  enscript-wrap_header.patch
+
+  enscript-1.6.4-rh457720.patch
+  enscript-rh477382.patch
+  # enscript-build.patch cygwin want this
+  enscript-manfixes.patch
+  enscript-bufpos-crash.patch
+  # 1664367 - adding support for 2 other encodings, enscript cannot print f.e. euro symbol
+  # without it
+  # rhbz: https://bugzilla.redhat.com/show_bug.cgi?id=1664367
+  # upstream patch: http://lists.gnu.org/archive/html/bug-enscript/2018-04/msg00008.html
+  0001-enscript-newencodings.patch
+  # enscript bundles some gnulib source files, so some issues or CVEs in gnulib can be
+  # present in enscript
+  # gnulib CVE: https://bugzilla.redhat.com/show_bug.cgi?id=1635896
+  enscript-CVE-vasnprintf.patch
+  # C23 takes empty brackets in declaration as no arguments, have to define args and their types
+  # https://savannah.gnu.org/bugs/index.php?66845
+  enscript-c23.patch
+
+  # Patch tests for .exe extension, from Cygwin
+  enscript-EXEEXT.patch
+
+  0002-fixes-getopt-compile-with-gcc-15-under-cygwin.patch
+)
+
 source=(
         "https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.gz"
         "300ecf85a8fe166a39f9dd818945c7b8a970db39.patch"::"https://git.savannah.gnu.org/cgit/enscript.git/patch/?id=300ecf85a8fe166a39f9dd818945c7b8a970db39"
-        "enscript-EXEEXT.patch")
+        ${_patches[@]}
+        )
 sha256sums=('6d56bada6934d055b34b6c90399aa85975e66457ac5bf513427ae7fc77f5c0bb'
-            '53705eb99a11fbc4277140534331813fff526e5380f5d5a2046484ae92900186'
-            'adba69a58e184c63fe3ac6dc7487967ce019af4bfb0313325a8a8765eee09b1a')
+            '4b00a24c82bd5b806da8c33ba0e89cf6eca16fc7c65858d9e8c5a8053cc2ba71'
+            'f55b8e7d3bbbc7d55c23292e59ccd62ab5a7812a8faefda1221dd1bca0ed82d3'
+            'b33163b8e27be3388058ab15b8aa4e77dd4ef828ed5346f4fd9d6d60b0b2ee1a'
+            '8b42e9a8bd0f8249de9edad25becebea9228739d448ffd66a7ef924e96ef4914'
+            '6ebfa84c3fdb2d48f449139159eac2db3659c9b00e3d1334dd9525afcac0d70e'
+            '0409f5e2a1d93304f5a16af3aa97d7dc22cee83189ca74ca4396d25babb8f8e6'
+            '45d331ddff5da1da995163a5b5f85b577cf64814b2acb7bfddf6a01a5c125c7c'
+            'aa54b033e9e2f3a749e140ae538cc33e4421414edacfeb9a136045af6713e932'
+            'c503b8a065d7232c64ca61d0197b7e28978a30fe65e471afc35bde9fe0aa228d'
+            '644350cf0216526837d4b50d58276604a5dae8d820192ffd5aa430d58a36caa9'
+            '81a8ee79b4ae8972aea0c6c1a20dc6c2482521b7b807bbffb4d6267c11a80838'
+            'c4eca5b96cefa704f9aa435bfd7dc3bf555bcb56580648d0c62a70dcba5e0f07')
 #public key 38734D7787901452 has been revoked
 #validpgpkeys=('0862E74AAD81B2F26170064438734D7787901452')
 
 # To avoid a mess with lpr, the config file will be patched to send to stdout by default.
 prepare() {
   cd $pkgname-$pkgver
+
+  for patch_filename in "${_patches[@]}"; do
+    echo "Applying patch: '${patch_filename}'"
+    patch --binary -Nbp1 -i "${srcdir}/${patch_filename}"
+  done
+
   sed -i '52s/DefaultOutputMethod: printer/DefaultOutputMethod: stdout/' lib/enscript.cfg.in
 
   # Also, tiny additional modification to fix issue with compilation warning fixed in the upstream git, but not stable tarball yet.
   patch -Nbp1 -i "${srcdir}/300ecf85a8fe166a39f9dd818945c7b8a970db39.patch"
 
-  # Patch tests for .exe extension, from Cygwin
-  patch -Nbp2 -i "${srcdir}/enscript-EXEEXT.patch"
 }
 
 build() {

--- a/enscript/enscript-1.6.1-locale.patch
+++ b/enscript/enscript-1.6.1-locale.patch
@@ -1,0 +1,26 @@
+--- enscript-1.6.1/src/main.c.locale	Mon Mar 18 11:23:14 2002
++++ enscript-1.6.1/src/main.c	Mon Mar 18 11:24:08 2002
+@@ -912,9 +912,8 @@
+    * We want to change only messages (gs do not like decimals in 0,1
+    * format ;)
+    */
+-#if HAVE_LC_MESSAGES
+-  setlocale (LC_MESSAGES, "");
+-#endif
++  setlocale (LC_ALL, "");
++  setlocale (LC_NUMERIC, "C");
+ #endif
+ #if ENABLE_NLS
+   bindtextdomain (PACKAGE, LOCALEDIR);
+--- enscript-1.6.1/src/psgen.c.locale	Mon Mar 18 11:23:14 2002
++++ enscript-1.6.1/src/psgen.c	Mon Mar 18 11:23:14 2002
+@@ -1103,7 +1103,8 @@
+   /* Get escape name. */
+   for (i = 0; i < sizeof (escname) - 1 && (ch = is_getc (is)) != EOF; i++)
+     {
+-      if (!isalnum (ch))
++      if (!((ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'Z') ||
++	    (ch >= 'a' && ch <= 'z')))
+ 	{
+ 	  is_ungetc (ch, is);
+ 	  break;

--- a/enscript/enscript-1.6.4-rh457720.patch
+++ b/enscript/enscript-1.6.4-rh457720.patch
@@ -1,0 +1,12 @@
+diff -up enscript-1.6.4/src/mkafmmap.c.rh457720 enscript-1.6.4/src/mkafmmap.c
+--- enscript-1.6.4/src/mkafmmap.c.rh457720	2008-08-08 11:33:47.000000000 +0200
++++ enscript-1.6.4/src/mkafmmap.c	2008-08-08 11:33:58.000000000 +0200
+@@ -139,7 +139,7 @@ main (int argc, char *argv[])
+       int option_index = 0;
+       int c;
+ 
+-      c = getopt_long (argc, argv, "p:h", long_options, &option_index);
++      c = getopt_long (argc, argv, "p:hV", long_options, &option_index);
+       if (c == -1)
+ 	break;
+ 

--- a/enscript/enscript-CVE-vasnprintf.patch
+++ b/enscript/enscript-CVE-vasnprintf.patch
@@ -1,0 +1,15 @@
+diff --git a/intl/vasnprintf.c b/intl/vasnprintf.c
+index 4a8e7f0..65ade71 100644
+--- a/intl/vasnprintf.c
++++ b/intl/vasnprintf.c
+@@ -758,7 +758,9 @@ convert_to_decimal (mpn_t a, size_t extra_zeroes)
+   size_t a_len = a.nlimbs;
+   /* 0.03345 is slightly larger than log(2)/(9*log(10)).  */
+   size_t c_len = 9 * ((size_t)(a_len * (GMP_LIMB_BITS * 0.03345f)) + 1);
+-  char *c_ptr = (char *) malloc (xsum (c_len, extra_zeroes));
++  /* We need extra_zeroes bytes for zeroes, followed by c_len bytes for the
++     digits of a, followed by 1 byte for the terminating NUL.  */
++  char *c_ptr = (char *) malloc (xsum (xsum (extra_zeroes, c_len), 1));
+   if (c_ptr != NULL)
+     {
+       char *d_ptr = c_ptr;

--- a/enscript/enscript-EXEEXT.patch
+++ b/enscript/enscript-EXEEXT.patch
@@ -1,5 +1,5 @@
---- origsrc/enscript-1.6.4/src/tests/defs	2003-03-05 08:26:33.000000000 +0100
-+++ src/enscript-1.6.4/src/tests/defs	2013-04-28 19:59:44.237652400 +0200
+--- a/src/tests/defs	2003-03-05 08:26:33.000000000 +0100
++++ b/src/tests/defs	2013-04-28 19:59:44.237652400 +0200
 @@ -10,7 +10,7 @@ export ENSCRIPT_LIBRARY
  output=testout.ps
  

--- a/enscript/enscript-bufpos-crash.patch
+++ b/enscript/enscript-bufpos-crash.patch
@@ -1,0 +1,12 @@
+diff -up enscript-1.6.5.2/src/psgen.c.bufpos-crash enscript-1.6.5.2/src/psgen.c
+--- enscript-1.6.5.2/src/psgen.c.bufpos-crash	2013-05-13 16:18:05.119393660 +0100
++++ enscript-1.6.5.2/src/psgen.c	2013-05-13 16:19:17.634739778 +0100
+@@ -1928,7 +1928,7 @@ get_next_token (InputStream *is, double
+ 			  bufpos--;
+ 			}
+ 		      /* Check the octal notations "\\%03o". */
+-		      else if (bufpos - 2 > w
++		      else if (bufpos > 2 && bufpos - 2 > w
+ 			       && ISOCTAL (buffer[bufpos])
+ 			       && ISOCTAL (buffer[bufpos - 1])
+ 			       && ISOCTAL (buffer[bufpos - 2])

--- a/enscript/enscript-build.patch
+++ b/enscript/enscript-build.patch
@@ -1,0 +1,11 @@
+diff -up enscript-1.6.6/configure.ac.build enscript-1.6.6/configure.ac
+--- enscript-1.6.6/configure.ac.build	2012-09-25 21:22:49.000000000 +0200
++++ enscript-1.6.6/configure.ac	2012-09-26 15:46:10.988041135 +0200
+@@ -11,7 +11,6 @@ AC_PROG_INSTALL
+ AC_PROG_CC
+ 
+ AC_USE_SYSTEM_EXTENSIONS
+-AM_C_PROTOTYPES
+ 
+ AC_C_CONST
+ AC_FUNC_ALLOCA

--- a/enscript/enscript-c23.patch
+++ b/enscript/enscript-c23.patch
@@ -1,0 +1,13 @@
+diff --git a/compat/regex.c b/compat/regex.c
+index c6907f3..87f2840 100644
+--- a/compat/regex.c
++++ b/compat/regex.c
+@@ -336,7 +336,7 @@ typedef char boolean;
+ #define false 0
+ #define true 1
+ 
+-static int re_match_2_internal ();
++static int re_match_2_internal (struct re_pattern_buffer*, const char*, int, const char*, int, int, struct re_registers*, int);
+ 
+ /* These are the command codes that appear in compiled regular
+    expressions.  Some opcodes are followed by argument bytes.  A

--- a/enscript/enscript-manfixes.patch
+++ b/enscript/enscript-manfixes.patch
@@ -1,0 +1,36 @@
+diff -up enscript-1.6.6/docs/enscript.man.manfixes enscript-1.6.6/docs/enscript.man
+--- enscript-1.6.6/docs/enscript.man.manfixes	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/docs/enscript.man	2013-04-04 13:26:50.257945126 +0200
+@@ -394,6 +394,9 @@ generate RTF (Rich Text Format)
+ generate ANSI terminal control codes
+ .RE
+ .TP 8
++.B \-W, \-\-option=\f2app,option\f3
++Pass option \f2option\f3 to helper application \f2app\f3
++.TP 8
+ .B \-X \f2name\f3, \-\-encoding=\f2name\f3
+ Use the input encoding \f2name\f1.  Currently \f3enscript\f1 supports
+ the following encodings:
+@@ -471,6 +474,10 @@ cookies from the beginning of the file.
+ .B \-\-color\f1[\f3=\f2bool\f1]\f3
+ Use colors in the highlighting outputs.
+ .TP 8
++.B \-\-continuous\-page\-numbers
++Count page numbers across input files. Don't restart numbering at
++beginning of each file.
++.TP 8
+ .B \-\-download\-font=\f2fontname\f3
+ Include the font description file (\f2.pfa\f1 or \f2.pfb\f1 file) of
+ the font \f2fontname\f1 to the generated output.
+diff -up enscript-1.6.6/src/main.c.manfixes enscript-1.6.6/src/main.c
+--- enscript-1.6.6/src/main.c.manfixes	2013-04-04 13:21:31.926629557 +0200
++++ enscript-1.6.6/src/main.c	2013-04-04 13:21:31.953629499 +0200
+@@ -2580,7 +2580,7 @@ Mandatory arguments to long options are
+   -v, --verbose              tell what we are doing\n\
+   -V, --version              print version number\n\
+   -w, --language=LANG        set output language to LANG\n\
+-  -W, --options=APP,OPTION   pass option OPTION to helper application APP\n\
++  -W, --option=APP,OPTION   pass option OPTION to helper application APP\n\
+   -X, --encoding=NAME        use input encoding NAME\n\
+   -z, --no-formfeed          do not interpret form feed characters\n\
+   -Z, --pass-through         pass through PostScript and PCL files\n\

--- a/enscript/enscript-rh477382.patch
+++ b/enscript/enscript-rh477382.patch
@@ -1,0 +1,40 @@
+diff -up enscript-1.6.6/afm/Makefile.am.rh477382 enscript-1.6.6/afm/Makefile.am
+--- enscript-1.6.6/afm/Makefile.am.rh477382	2012-09-20 00:17:34.000000000 +0200
++++ enscript-1.6.6/afm/Makefile.am	2012-09-26 13:42:09.223974485 +0200
+@@ -29,9 +29,12 @@ hvnbo.afm hvno.afm hvo.afm ncb.afm ncbi.
+ pobi.afm poi.afm por.afm sy.afm tib.afm tibi.afm tii.afm tir.afm	\
+ zcmi.afm zd.afm
+ 
+-public_fonts = matrix.afm matrix.pfa
++public_fonts = matrix.afm matrix.eps
+ 
+ afmdir = $(pkgdatadir)/afm
+ dist_afm_DATA = font.map $(default_afm) $(public_fonts) MustRead.html
+ 
+ EXTRA_DIST = ChangeLog.old
++
++matrix.eps: matrix.pfa
++	cp matrix.pfa matrix.eps
+diff -up enscript-1.6.6/src/util.c.rh477382 enscript-1.6.6/src/util.c
+--- enscript-1.6.6/src/util.c.rh477382	2011-10-30 17:48:42.000000000 +0100
++++ enscript-1.6.6/src/util.c	2012-09-26 13:40:53.336866463 +0200
+@@ -1084,9 +1084,16 @@ download_font (char *name)
+       buffer_append (&fname, ".pfb");
+       if (stat (buffer_ptr (&fname), &stat_st) != 0)
+ 	{
+-	  /* Couldn't find font description file, nothing to download. */
+-	  buffer_uninit (&fname);
+-	  return;
++	  /* .eps */
++	  buffer_clear (&fname);
++	  buffer_append (&fname, prefix);
++	  buffer_append (&fname, ".eps");
++	  if (stat (buffer_ptr (&fname), &stat_st) != 0)
++	    {
++	      /* Couldn't find font description file, nothing to download. */
++	      buffer_uninit (&fname);
++	      return;
++	    }
+ 	}
+     }
+ 

--- a/enscript/enscript-wrap_header.patch
+++ b/enscript/enscript-wrap_header.patch
@@ -1,0 +1,50 @@
+diff -up enscript-1.6.5.1/lib/simple.hdr.wrap_header enscript-1.6.5.1/lib/simple.hdr
+--- enscript-1.6.5.1/lib/simple.hdr.wrap_header	2009-01-24 21:59:34.000000000 +0100
++++ enscript-1.6.5.1/lib/simple.hdr	2010-05-21 13:04:28.070346832 +0200
+@@ -3,6 +3,10 @@
+ % Copyright (c) 1995 Markku Rossi.
+ % Author: Markku Rossi <mtr@iki.fi>
+ %
++% Modified: Chris Josefy, USA, MAY 2006
++%  + Added line wrapping to header to work more like AIX enscript
++%  + This assumes that one does not change the header font size from the default
++%  + This also assumes that the line only wraps once
+ 
+ %
+ % This file is part of GNU Enscript.
+@@ -24,6 +28,7 @@
+ % -- code follows this line --
+ %Format: fmodstr	$D{%a %b %d %H:%M:%S %Y}
+ %Format: pagenumstr	$V$%
++%HeaderHeight: 44
+ 
+ /do_header {	% print default simple header
+   gsave
+@@ -39,10 +44,23 @@
+       d_header_w user_header_right_str stringwidth pop sub 5 sub
+       0 moveto user_header_right_str show
+     } {
+-      5 0 moveto fname show
+-      45 0 rmoveto fmodstr show
+-      45 0 rmoveto pagenumstr show
+-    } ifelse
++      fname length fmodstr length add pagenumstr length add 95 6 idiv add d_header_w 6 idiv le{
++        5 0 moveto fname show
++        45 0 rmoveto fmodstr show
++        45 0 rmoveto pagenumstr show
++      } {
++        5 0 moveto fmodstr show
++        45 0 rmoveto pagenumstr show
++        fname length d_header_w 6 idiv idiv 1 add 10 mul 5 exch moveto
++        1 1 fname length d_header_w 6 idiv idiv
++        {
++          dup fname exch 1 sub d_header_w 6 idiv mul d_header_w 6 idiv getinterval show
++          5 exch 10 mul fname length d_header_w 6 idiv idiv 1 add 10 mul exch sub moveto
++        } for
++        5 10 moveto
++        fname fname length d_header_w 6 idiv idiv d_header_w 6 idiv mul dup fname length exch sub getinterval show
++      }ifelse
++    }ifelse
+ 
+   grestore
+ } def


### PR DESCRIPTION
Oh, this is the case why patch should be binary files

https://github.com/msys2/MSYS2-packages/pull/6317