### PR TITLE
Fix mingw-w64-cross-crt ISO vswprintf exact-fit check.

### DIFF
--- a/mingw-w64-cross-crt/0001-crt-Fix-ISO-vswprintf-exact-fit-off-by-one-error-che.patch
+++ b/mingw-w64-cross-crt/0001-crt-Fix-ISO-vswprintf-exact-fit-off-by-one-error-che.patch
@@ -1,0 +1,65 @@
+From 29fe00be14f74a749aab86d3d0704d4580ed8374 Mon Sep 17 00:00:00 2001
+From: Yonggang Luo <luoyonggang@gmail.com>
+Date: Wed, 24 Jun 2026 02:06:57 +0800
+Subject: [PATCH] crt: Fix ISO vswprintf exact-fit off-by-one error check.
+
+- In __mingw_vswprintf, compare retval against n-1 with > not >= after the
+  buffer size decrement; ISO C95+ should fail only when n or more data wide
+  chars are needed.
+- Extend t_swprintf_tmpl.h with an exact-fit swprintf(buf, 10, ...) case and
+  a truncated n=9 failure case to catch regressions.
+---
+ mingw-w64-crt/stdio/mingw_vsnprintf.c     |  7 +++----
+ mingw-w64-crt/testcases/t_swprintf_tmpl.h | 18 ++++++++++++++++++
+ 2 files changed, 21 insertions(+), 4 deletions(-)
+
+diff --git a/mingw-w64-crt/stdio/mingw_vsnprintf.c b/mingw-w64-crt/stdio/mingw_vsnprintf.c
+index b9c357862..dd2d81ea8 100644
+--- a/mingw-w64-crt/stdio/mingw_vsnprintf.c
++++ b/mingw-w64-crt/stdio/mingw_vsnprintf.c
+@@ -57,11 +57,10 @@ int __cdecl __vsnprintf(APICHAR *buf, size_t length, const APICHAR *fmt, va_list
+   buf[retval < (int) length ? retval : (int)length] = '\0';
+ 
+ #if defined(__BUILD_WIDEAPI) && defined(__BUILD_WIDEAPI_ISO)
+-  /* For wide api ISO C95+ vswprintf() when requested length
+-   * is equal or larger than buffer length, returns negative
+-   * value as required by ISO C95+.
++  /* ISO C95+ fails when n or more data wide chars are needed.  length was
++   * already decremented once for the terminator, so use > not >= here.
+    */
+-  if( retval >= (int) length )
++  if( retval > (int) length )
+     retval = -1;
+ #endif
+ 
+diff --git a/mingw-w64-crt/testcases/t_swprintf_tmpl.h b/mingw-w64-crt/testcases/t_swprintf_tmpl.h
+index a12cba9a2..5fe332645 100644
+--- a/mingw-w64-crt/testcases/t_swprintf_tmpl.h
++++ b/mingw-w64-crt/testcases/t_swprintf_tmpl.h
+@@ -19,5 +19,23 @@ int main() {
+     fprintf(stderr, "\n");
+     return 1;
+   }
++
++  /* ISO C95+: output of 9 wide chars plus terminator must succeed when n=10.
++   * Regression for __mingw_vswprintf exact-fit check (retval == n-1). */
++  {
++    wchar_t exact[16] = L"XXXXXXXXXXXXXXXX";
++    ret = swprintf(exact, 10, L".%8x", 0xd8c7bc89U);
++    if (ret != 9 || wcscmp(exact, L".d8c7bc89") != 0) {
++      fprintf(stderr, "exact-fit n=10: ret expected=9 got=%d\n", ret);
++      fprintf(stderr, "exact-fit buffer: %ls\n", exact);
++      return 1;
++    }
++    ret = swprintf(exact, 9, L".%8x", 0xd8c7bc89U);
++    if (ret >= 0) {
++      fprintf(stderr, "exact-fit n=9: ret expected=<0 got=%d\n", ret);
++      return 1;
++    }
++  }
++
+   return 0;
+ }
+-- 
+2.54.0
+

--- a/mingw-w64-cross-crt/PKGBUILD
+++ b/mingw-w64-cross-crt/PKGBUILD
@@ -7,7 +7,7 @@ pkgbase="${_mingw_suff}-${_realname}"
 _targetpkgs=("${_mingw_suff}-ucrt64-${_realname}" "${_mingw_suff}-mingw32-${_realname}" "${_mingw_suff}-mingw64-${_realname}")
 pkgname=("${_mingw_suff}-${_realname}" "${_targetpkgs[@]}")
 pkgver=14.0.0.r1.gbd663f0e1
-pkgrel=1
+pkgrel=2
 pkgdesc='MinGW-w64 CRT for cross-compiler'
 arch=('i686' 'x86_64')
 url='https://www.mingw-w64.org'
@@ -17,9 +17,15 @@ groups=("${_mingw_suff}-toolchain" "${_mingw_suff}")
 makedepends=("git" "${_mingw_suff}-gcc" "${_mingw_suff}-binutils" "${_mingw_suff}-headers" 'autotools')
 options=('!strip' 'staticlibs' '!emptydirs' '!buildflags')
 _commit='bd663f0e159e0f50f12ad2e91ce083d0e1a869ad'
-source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit")
 
-sha256sums=('1371beb9bba3a0315391c0b02256eeb3929f7c57a14b9277debf1902eb329520')
+_patches=(
+  0001-crt-Fix-ISO-vswprintf-exact-fit-off-by-one-error-che.patch
+)
+
+source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit"
+        ${_patches[@]})
+sha256sums=('1371beb9bba3a0315391c0b02256eeb3929f7c57a14b9277debf1902eb329520'
+            '87f03a4b206c4c76c04b96d913b6c1b0a594835f365806fe3296c21d3d648357')
 msys2_references=(
   'archlinux: mingw-w64-crt'
   'cpe: cpe:/a:mingw-w64:mingw-w64'
@@ -29,6 +35,15 @@ pkgver() {
   cd "${srcdir}/mingw-w64"
 
   git describe --long ${_commit} | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
+}
+
+prepare() {
+  cd "${srcdir}/mingw-w64"
+
+  for patch in "${_patches[@]}"; do
+    msg2 "Patching with ${patch}"
+    patch -Nbp1 -i "${srcdir}/${patch}"
+  done
 }
 
 _build() {

--- a/msys2-launcher/PKGBUILD
+++ b/msys2-launcher/PKGBUILD
@@ -3,7 +3,7 @@
 _realname="msys2-launcher"
 pkgname=("${_realname}")
 pkgver=1.5
-pkgrel=3
+pkgrel=4
 pkgdesc="Helper for launching MSYS2 shells"
 arch=('x86_64' 'i686')
 license=('spdx:MIT')


### PR DESCRIPTION
- Patch mingw_vsnprintf.c so __mingw_vswprintf returns -1 only when n or more data wide chars are needed, not when output exactly fills n-1.
- Change the post-decrement error test from >= to >; fixes swprintf(buf, 10, ...) returning -1 for a 9-char result used by msys2-launcher AppID hash.
- Bump mingw-w64-cross-crt pkgrel to 3 and apply the patch in prepare().
- Use _patches array in PKGBUILD; keep patch file beside PKGBUILD.