### PR TITLE
gitattributes: mark patch files as -text, not binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,9 @@
 # Windows batch files need to have CRLF line endings on checkout
 *.cmd text eol=crlf
 
+# Packaging patches: store byte-for-byte; skip * text eol=lf (not binary)
+*.patch -text
+
 # Denote all files that are truly binary and should not be modified
 *.bz2 binary
 *.gz binary


### PR DESCRIPTION
- Use `*.patch -text` instead of `*.patch binary` so Git stores patch files byte-for-byte and does not apply the repo-wide `* text eol=lf` normalization on commit or checkout.
- Unlike `binary` (which sets `-text -diff`), `-text` keeps normal textual diffs in `git diff` and pull requests while still opting out of EOL handling.
- Patch files often carry intentional or mixed line endings in hunks and context lines; rewriting EOLs can change patch applicability or checksums when applied with `patch -p1` in PKGBUILD `prepare()`.
- Place the rule with the other EOL attributes (after `*.cmd`) and document it there rather than under the binary file list.
- `-text` is the usual Git attribute for "commit as-is, show as text" and fits packaging patches better than treating them as opaque binary blobs.


better alternative to https://github.com/msys2/MSYS2-packages/pull/6317

Rationale: https://github.com/msys2/MSYS2-packages/pull/6394#issuecomment-4788697008

