### PR TITLE
xmlto: drop perl makedeps

### DIFF
--- a/xmlto/PKGBUILD
+++ b/xmlto/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=xmlto
 pkgver=0.0.29
-pkgrel=1
+pkgrel=2
 pkgdesc="Convert xml to many other formats"
 arch=('i686' 'x86_64')
 url="https://pagure.io/xmlto/"
@@ -10,7 +10,7 @@ msys2_references=(
   "anitya: 13307"
 )
 license=('spdx:GPL-2.0-or-later')
-depends=('libxslt' 'perl-YAML-Syck' 'perl-Test-Pod')
+depends=('libxslt')
 makedepends=('docbook-xsl' 'autotools' 'gcc')
 source=("https://pagure.io/xmlto/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz")
 sha256sums=('40504db68718385a4eaa9154a28f59e51e59d006d1aa14f5bc9d6fded1d6017a')


### PR DESCRIPTION
It's not using perl from what I see.
Arch dropped it long ago:
https://gitlab.archlinux.org/archlinux/packaging/packages/xmlto/-/commit/e0664ea70bd0a114c8e90fc29449575805731e06