### PR TITLE
bash-completion: Update to 2.18.0

### DIFF
--- a/bash-completion/PKGBUILD
+++ b/bash-completion/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=bash-completion
-pkgver=2.17.0
-pkgrel=2
+pkgver=2.18.0
+pkgrel=1
 pkgdesc="Programmable completion for the bash shell"
 arch=('any')
 url="https://github.com/scop/bash-completion"
@@ -12,7 +12,7 @@ depends=('bash')
 makedepends=('autotools')
 options=('!emptydirs' '!makeflags')
 source=(https://github.com/scop/${pkgname}/releases/download/${pkgver}/${pkgname}-${pkgver}.tar.xz)
-sha256sums=('dd9d825e496435fb3beba3ae7bea9f77e821e894667d07431d1d4c8c570b9e58')
+sha256sums=('88bcf85124f77f74f2f2f8bcd16ac4382d807a827ede742a64940c7116aea33f')
 prepare() {
   cd ${pkgname}-${pkgver}
 
@@ -28,8 +28,4 @@ build() {
 package() {
   cd ${pkgname}-${pkgver}
   make DESTDIR="${pkgdir}" install
-
-  rm "${pkgdir}"/usr/share/bash-completion/completions/makepkg
-  # Provided by patchutils
-  rm "${pkgdir}"/usr/share/bash-completion/completions/interdiff
 }


### PR DESCRIPTION
included completions are now in a different dir and no longer conflict, so no need to delete some