### PR TITLE
vim: update to 9.2.9782

### DIFF
--- a/vim/PKGBUILD
+++ b/vim/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=vim
 _topver=9.2
-_patchlevel=0725
+_patchlevel=0782
 _versiondir="${pkgname}${_topver//./}"
 pkgver=${_topver}.${_patchlevel}
 pkgrel=1
@@ -32,7 +32,7 @@ source=(${pkgname}-${pkgver}.tar.gz::https://github.com/vim/vim/archive/v${pkgve
         'pretend-cygwin-msys.patch'
         'accept-crlf.patch'
         'vim-completion')
-sha256sums=('1a0908e96ecf04fda967113a0647a62c795d7e232c85412f46a1abba47d1a76b'
+sha256sums=('148ad1c29555e0cf6430570730d8b9fc97151a814866e6f549e5e73e4ad0a612'
             'edd18e0756406ee7b659e4552e444c50c3a0c1e9fb4fce2ddd770c933ea6c7f5'
             'bca6e030d50c0d2468ab5c78aa0b359eb18a88a197de8406c593458ffedde922'
             '44d7738a8f801195898eeef766ff77506c717dd5d19145ade3c1c2349d4bc4fd'


### PR DESCRIPTION
Contains security fixes for <https://github.com/vim/vim/security/advisories/GHSA-mf92-v4xw-j45x> / CVE-2026-59858 and <https://github.com/vim/vim/security/advisories/GHSA-fh26-8f79-wj97> /  CVE-2026-59856 and also fixes several memory leaks ([9.2.0773](https://github.com/vim/vim/commit/9dc4e0cbddb91009927bab762eb629a137c74632) up to [9.2.0779](https://github.com/vim/vim/commit/eeeed2b294da499e63e331f40302ffe9dbf96baa)).