### PR TITLE
llvm: backport fix for rustc miscompilations

### DIFF
--- a/llvm/0009-LLVM-cond-in-select-of-load-fold.patch
+++ b/llvm/0009-LLVM-cond-in-select-of-load-fold.patch
@@ -1,0 +1,33 @@
+--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
++++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+@@ -30506,10 +30506,12 @@ bool DAGCombiner::SimplifySelectOps(SDNode *TheSelect, SDValue LHS,
+            SDNode::hasPredecessorHelper(RLD, Visited, Worklist)))
+         return false;
+ 
+-      Addr = DAG.getSelect(SDLoc(TheSelect),
+-                           LLD->getBasePtr().getValueType(),
+-                           TheSelect->getOperand(0), LLD->getBasePtr(),
+-                           RLD->getBasePtr());
++      // If the condition is poison, originally this would result in a poison
++      // result. After the transform, this would result in a load of poison,
++      // which is UB. Freeze the condition to prevent this.
++      Addr = DAG.getSelect(SDLoc(TheSelect), LLD->getBasePtr().getValueType(),
++                           DAG.getFreeze(TheSelect->getOperand(0)),
++                           LLD->getBasePtr(), RLD->getBasePtr());
+     } else {  // Otherwise SELECT_CC
+       // We cannot do this optimization if any pair of {RLD, LLD} is a
+       // predecessor to {RLD, LLD, CondLHS, CondRHS}. As we've already compared
+@@ -30528,10 +30530,10 @@ bool DAGCombiner::SimplifySelectOps(SDNode *TheSelect, SDValue LHS,
+            SDNode::hasPredecessorHelper(RLD, Visited, Worklist)))
+         return false;
+ 
++      SDValue FrozenOp0 = DAG.getFreeze(TheSelect->getOperand(0));
++      SDValue FrozenOp1 = DAG.getFreeze(TheSelect->getOperand(1));
+       Addr = DAG.getNode(ISD::SELECT_CC, SDLoc(TheSelect),
+-                         LLD->getBasePtr().getValueType(),
+-                         TheSelect->getOperand(0),
+-                         TheSelect->getOperand(1),
++                         LLD->getBasePtr().getValueType(), FrozenOp0, FrozenOp1,
+                          LLD->getBasePtr(), RLD->getBasePtr(),
+                          TheSelect->getOperand(4));
+     }

--- a/llvm/PKGBUILD
+++ b/llvm/PKGBUILD
@@ -13,7 +13,7 @@ _version=21.1.8
 _rc=""
 _tag=llvmorg-${_version}${_rc}
 pkgver=${_version}${_rc/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM"
 arch=('i686' 'x86_64')
 url="https://llvm.org/"
@@ -50,6 +50,7 @@ source=("${_url}/llvm-${pkgver}.src.tar.xz"{,.sig}
         "0006-LLVM-Support-Fix-tests-on-Cygwin-151417.patch"
         "0007-LLVM-lit-add-system-cygwin-feature-152780.patch"
         "0008-LLVM-Coverage-Unittest-Fix-dangling-reference-in-uni.patch"
+        "0009-LLVM-cond-in-select-of-load-fold.patch"
         "0101-Clang-Cygwin-Enable-few-conditions-that-are-shared-w.patch"
         "0102-hack-cygwin-allow-multiple-definition-in-c-index-tes.patch"
         "0103-Cygwin-Internal-class-in-explicitly-instantiation-de.patch"
@@ -83,6 +84,7 @@ sha256sums=('d9022ddadb40a15015f6b27e6549a7144704ded8828ba036ffe4b8165707de21'
             'dcf2d91ed1ec5e9b885c8de47fe7dc10465491a2b2e686c16a5819da14efbb9c'
             '18066ca1e97147650e139399db91066453b8a3f00ea0c7187b73f5eedbb56927'
             '5580ef79c1cbe3efd0cc4fca078f29879be8764c62b1792fc7f74350ff862a67'
+            'e615af23122d1abdca01c4e8303cf4a635110d5cd7eeb9efd931442b6ae4a28f'
             'c978145529c8f8f0f13192f7d705c7e5359c2c67cc01e0012679847cbbce9e12'
             'b217f87de73cb6255997ef76630e3bc6e9a99398bd713e79d6c6da500620f60b'
             '9b6b248f63e04f810b4d1d919f0b2eb584b08888f0dad11d41e56769e0a01d10'
@@ -95,7 +97,7 @@ validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D'  # Hans Wennborg, Googl
               '474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard
               'D574BD5D1D0E98895E3BF90044F2485E45D59042'  # Tobias Hieta
               'FFB3368980F3E6BB5737145A316C56D064CACBA5'  # Douglas Yung, Sony
-) 
+)
 noextract=(llvm-${pkgver}.src.tar.xz
            clang-${pkgver}.src.tar.xz)
 
@@ -146,7 +148,8 @@ prepare() {
     0005-LLVM-adjust-lit.cfg.py-for-Cygwin-151416.patch \
     0006-LLVM-Support-Fix-tests-on-Cygwin-151417.patch \
     0007-LLVM-lit-add-system-cygwin-feature-152780.patch \
-    0008-LLVM-Coverage-Unittest-Fix-dangling-reference-in-uni.patch
+    0008-LLVM-Coverage-Unittest-Fix-dangling-reference-in-uni.patch \
+    0009-LLVM-cond-in-select-of-load-fold.patch
 
   # Patch clang
   cd "${srcdir}"/clang

--- a/llvm/README-patches.md
+++ b/llvm/README-patches.md
@@ -18,6 +18,7 @@ Legend:
 - `"0006-LLVM-Support-Fix-tests-on-Cygwin-151417.patch"` :arrow_up_small: https://github.com/llvm/llvm-project/commit/46f6e62eb9ea01e43ec45961e68c22f9c00b0a27
 - `"0007-LLVM-lit-add-system-cygwin-feature-152780.patch"` :arrow_up_small: https://github.com/llvm/llvm-project/commit/37bcd937766d0bb151d4ee54d72d9cc289fee97b
 - `"0008-LLVM-Coverage-Unittest-Fix-dangling-reference-in-uni.patch"` :arrow_down_small: https://github.com/llvm/llvm-project/commit/ca09801bd03579f28edac60077a164fab0474eb4
+- `"0009-LLVM-cond-in-select-of-load-fold.patch"` :arrow_down_small: https://github.com/llvm/llvm-project/commit/f2dfbf06f7db1a3cace4beb9f65d5a7f6a8b6235
 - `"0101-Clang-Cygwin-Enable-few-conditions-that-are-shared-w.patch"` :arrow_up_small: https://github.com/llvm/llvm-project/commit/a3228b6bf98c3efce3722700cf71f8b093e7870c
 - `"0102-hack-cygwin-allow-multiple-definition-in-c-index-tes.patch"` :grey_exclamation:
 - `"0103-Cygwin-Internal-class-in-explicitly-instantiation-de.patch"` :grey_exclamation:


### PR DESCRIPTION
same as in MINGW repo, so we surely don't need to push rust 1.97.1 here (and avoid the `try again` commits)