### PR TITLE
trash: New package

### DIFF
--- a/trash/PKGBUILD
+++ b/trash/PKGBUILD
@@ -1,0 +1,25 @@
+# Maintainer: LIU Hao <lh_mouse@126.com>
+
+_realname=trash
+pkgname=${_realname}
+pkgver=1.1
+pkgrel=1
+pkgdesc="Moves files and directories into the Recycle Bin of the current user"
+arch=('i686' 'x86_64')
+license=('spdx:BSD-2-Clause')
+url='https://github.com/lhmouse/msys2-trash'
+msys2_repository_url='https://github.com/lhmouse/msys2-trash'
+makedepends=('git' 'gcc' 'msys2-w32api-headers' 'msys2-w32api-runtime')
+source=("git+https://github.com/lhmouse/msys2-trash.git#tag=v${pkgver}")
+sha256sums=('bcac3dd94d67fa1780e55972c0783df992d67eeb66174764873bcef6e7ef0aa2')
+
+build() {
+  cd "${srcdir}/msys2-trash"
+  ${CC:-gcc} ${CPPFLAGS} ${CFLAGS} trash.c ${LDFLAGS} -o trash.exe
+}
+
+package() {
+  cd "${srcdir}/msys2-trash"
+  install -Dm755 trash.exe "${pkgdir}/usr/bin/trash.exe"
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
This provides the command `trash` which moves its arguments to the Recycle Bin of the current user.

The idea is from the same command on Ubuntu: https://manpages.ubuntu.com/manpages/bionic/man1/trash.1.html
(It works without a desktop environment too.)

Source code is only one C file: https://github.com/lhmouse/msys2-trash/blob/v1.1/trash.c

```text
Usage: trash [OPTIONS]... [--] PATHS...

Moves PATHS into the Recycle Bin of the current user.

Options:
  -d, --directory       (ignored)
  -f, --force           ignore nonexistent paths
  -h, --help            show help message then exit
  -i, --interactive     prompt before removing every path
  -r, -R, --recursive   (ignored)
  -v, --verbose         print status
  -V, --version         show version information then exit
```
