### PR TITLE
base: Remove dependency on pacman-contrib

### DIFF
--- a/base/PKGBUILD
+++ b/base/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
 
 pkgname=base
-pkgver=2022.06
+pkgver=2026.08
 pkgrel=1
 pkgdesc='Minimal package set to define a basic MSYS2 installation'
 url='https://www.msys2.org'
@@ -31,7 +31,6 @@ depends=(
   'msys2-runtime'
   'nano'
   'pacman'
-  'pacman-contrib'
   'pacman-mirrors'
   'rebase'
   'sed'


### PR DESCRIPTION
pacman-contrib is needed for basic installation.
It pulls perl dependency, which could make MinGW-packages use implicitly MSYS perl instead of mingw-w64-perl.