### PR TITLE
base-devel: Remove dependency on texinfo and gettext

### DIFF
--- a/base-devel/PKGBUILD
+++ b/base-devel/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
 
 pkgname=base-devel
-pkgver=2024.11
+pkgver=2026.08
 pkgrel=1
 pkgdesc='Minimal package set for building packages with makepkg'
 url='https://www.msys2.org'
@@ -17,10 +17,7 @@ depends=(
   'file'
   'flex'
   'gawk'
-  'gettext'
   'grep'
-  'texinfo'
-  'texinfo-tex'
   'make'
   'pacman'
   'patch'


### PR DESCRIPTION
First to prefer using native packages
with MINGW-packages.
Second, because texinfo pulls MSYS perl package which
could be used instead of mingw-w64-perl which is
prefered for MinGW environments.