### PR TITLE
base-devel: remove flex, bison

### DIFF
--- a/base-devel/PKGBUILD
+++ b/base-devel/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=base-devel
 pkgver=2026.08
-pkgrel=3
+pkgrel=4
 pkgdesc='Minimal package set for building packages with makepkg'
 url='https://www.msys2.org'
 arch=('any')
@@ -10,10 +10,8 @@ license=('spdx:BSD-3-Clause')
 depends=(
   'base'
   'binutils'
-  'bison'
   'diffutils'
   'dos2unix'
-  'flex'
   'make'
   'patch'
 )


### PR DESCRIPTION
flex/bison are only required by a small set of tools

this also removes m4 as a transitive dep

there will likely be some fallout from flex/bison during rebuilds