### PR TITLE
perl: update to v5.42.3

### DIFF
--- a/perl/PKGBUILD
+++ b/perl/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=perl
 pkgname=('perl' 'perl-doc' 'perl-devel')
-pkgver=5.42.2
+pkgver=5.42.3
 pkgrel=1
 pkgdesc="A highly capable, feature-rich programming language"
 arch=(i686 x86_64)
@@ -30,7 +30,7 @@ source=(https://www.cpan.org/src/5.0/perl-${pkgver}.tar.xz
         0009-Skip-locale_threads.t-on-Cygwin-incomplete-nl_langin.patch
         0010-perlbug.t-set-PERL_BUILD_PACKAGING-to-avoid-XS-versi.patch)
 options=('makeflags' '!purge' 'emptydirs')
-sha256sums=('0a585eeb9e363c0f80482ddb3571625250c2c86aeb408853e8ea50805cfb14bb'
+sha256sums=('c9387e1473a1866935cb047ece7c2e0a80767a3acdecb79d4a375f8a95970ddc'
             '91bf8a45a3f04f51fe0eca146a71e278d41dbde19ba60dabc1e41c4639477c07'
             '478a52dc440d5ca324f4c95238b39cc8c90d5d7d8d5601fa085ffef79fea04f4'
             '11ce66bcf4803b0bf27179a32ce53f41bcdfa967c4c0d54ac103dbc4951d18a3'


### PR DESCRIPTION
Even though there's a v5.44.0 already, let's wait a while to upgrade to that release train.

See https://metacpan.org/release/SHAY/perl-5.42.3/view/pod/perl.pod for full details (including 3 CVEs).

Note: To keep the churn low, this commit does _not_ re-stabilize the patches commit OIDs (unlike df319ef38 (perl: regenerate patches with stable OIDs, 2026-04-03)).