### PR TITLE
rsync: remove perl from depends & add python to optdepends

### DIFF
--- a/rsync/PKGBUILD
+++ b/rsync/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=rsync
 pkgver=3.4.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A file transfer program to keep remote files in sync"
 arch=('i686' 'x86_64')
 url="https://rsync.samba.org"
@@ -17,7 +17,8 @@ msys2_references=(
 )
 groups=('net-utils')
 license=('spdx:GPL-3.0-or-later')
-depends=('perl' 'libiconv' 'liblz4' 'libopenssl' 'libxxhash' 'libzstd' 'popt')
+depends=('libiconv' 'liblz4' 'libopenssl' 'libxxhash' 'libzstd' 'popt')
+optdepends=('python: for rrsync')
 makedepends=('libiconv-devel' 'liblz4-devel' 'libxxhash-devel' 'libzstd-devel' 'openssl-devel' 'popt-devel' 'autotools' 'gcc')
 conflicts=('rsync2')
 replaces=('rsync2')
@@ -35,9 +36,9 @@ build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
 
   ./configure \
-      --build=${CHOST} \
-      --prefix=/usr
-  
+    --build=${CHOST} \
+    --prefix=/usr
+
   make reconfigure
   make man all
 }


### PR DESCRIPTION
This follows Arch: https://gitlab.archlinux.org/archlinux/packaging/packages/rsync/-/blob/main/PKGBUILD?ref_type=heads