### PR TITLE
vim: adjust depends

### DIFF
--- a/vim/PKGBUILD
+++ b/vim/PKGBUILD
@@ -6,7 +6,7 @@ _topver=9.2
 _patchlevel=0858
 _versiondir="${pkgname}${_topver//./}"
 pkgver=${_topver}.${_patchlevel}
-pkgrel=1
+pkgrel=2
 pkgdesc='Vi Improved, a highly configurable, improved version of the vi text editor'
 arch=('i686' 'x86_64')
 license=('spdx:Vim')
@@ -20,7 +20,13 @@ msys2_references=(
   "cpe: cpe:/a:vim_development_group:vim"
   "gentoo: app-editors/vim"
 )
-depends=('ncurses' 'libiconv' 'libintl' 'libxcrypt' 'perl')
+depends=('ncurses' 'libiconv' 'libintl' 'libxcrypt')
+optdepends=(
+  'python: Python language support'
+  'ruby: Ruby language support'
+  'lua: Lua language support'
+  'perl: Perl language support'
+)
 groups=('editors')
 makedepends=('gawk' 'perl-devel' 'python-devel' 'ruby' 'ncurses-devel' 'autotools' 'gcc'
              'libiconv-devel' 'gettext-devel' 'libxcrypt-devel') # To satisfy python3/dyn feature #3052


### PR DESCRIPTION
* remove perl from depends
* add python, ruby, lua, perl to optdepends

This follows https://gitlab.archlinux.org/archlinux/packaging/packages/vim/-/blob/main/PKGBUILD?ref_type=heads, except that tcl is not added to optdepends as we configure with --disable-tclinterp