### PR TITLE
pacman-contrib: move perl to optdepends

### DIFF
--- a/libpsl/019.1-implement-private-libs.patch
+++ b/libpsl/019.1-implement-private-libs.patch
@@ -1,8 +1,9 @@
 --- libpsl-0.19.1/libpsl.pc.in.orig	2018-02-12 11:00:02.234548800 +0300
-+++ libpsl-0.19.1/libpsl.pc.in	2018-02-12 11:04:03.706374100 +0300
-@@ -8,4 +8,5 @@
++++ libpsl-0.19.1/libpsl.pc.in	2026-08-04 00:00:00.000000000 +0000
+@@ -8,4 +8,6 @@
  Version: @PACKAGE_VERSION@
  URL: @PACKAGE_URL@
  Libs: -L${libdir} -lpsl
-+Libs.private: @LIBICU_LIBS@ @LIBIDN2_LIBS@ @LIBIDN_LIBS@
++Requires.private: libidn2
++Libs.private: -lunistring
  Cflags: -I${includedir}

--- a/libpsl/PKGBUILD
+++ b/libpsl/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=libpsl
 pkgname=("${pkgbase}" "${pkgbase}-devel")
 pkgver=0.21.5
-pkgrel=2
+pkgrel=3
 pkgdesc='Public Suffix List library'
 url='https://github.com/rockdaboot/libpsl'
 msys2_repository_url='https://github.com/rockdaboot/libpsl'
@@ -17,7 +17,7 @@ source=(https://github.com/rockdaboot/libpsl/releases/download/${pkgver}/${pkgna
 sha512sums=('c14d575cecc0f1693894dd79565b6b9220084ddfa43b908a1cefe16d147cdd5ec47796eb0c2135e2f829a951abaf39d8a371ab5c1352f57b36e610e25adf91f5'
             '42cf2d5ff3bd48fbe00d1bf5bc4e7acb0554b9fae65b941c27abf8bd8a21d2c678b78b1e356c7596fc20d17e226dc4014e36b95eb785e9beb41e43d074ef5483'
             '36f4ae0bee8d25a55fb38b64525fa855698830310f5b7e5b3c5c96fa6799622225eab67ccfdb0e20d2092f1398563231c02aecd4bc8c042796cb471ca905fd10'
-            '93290b524b7ea0b4aa5abd50a1cdcad4eeb8d135d7c9d6da02a4751065a7a93fd3c12a5b0be399baf00584d5830f7fb59f4414d56cfd139ec493a799ffbee1d6')
+            '0c57dc46932b9e3e50ae6c4b741d598b8329cde248c35ad1c231eccb14d908a84399e042fa620f9cb8b6a8be01bbdf33708a1669766ee50dcb428e462a61853e')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {

--- a/pacman-contrib/PKGBUILD
+++ b/pacman-contrib/PKGBUILD
@@ -4,15 +4,17 @@
 
 pkgname=pacman-contrib
 pkgver=1.10.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Contributed scripts and tools for pacman systems (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://gitlab.archlinux.org/pacman/pacman-contrib"
 license=('spdx:GPL-2.0-or-later')
-depends=('perl'
-         'pacman'
+depends=('pacman'
          'bash')
-optdepends=('vim')
+optdepends=(
+  'perl: for pacsearch'
+  'vim: default diff program for pacdiff'
+)
 makedepends=('asciidoc'
              'libarchive-devel'
              'libcurl-devel'


### PR DESCRIPTION
It is only used by the pacsearch command, which isn't that useful, and this is the only thing pulling in perl in "base", so move it to optdepends

Arch also has it in optdepends for example.