### PR TITLE
msys2-runtime: restore zipman

### DIFF
--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -13,62 +13,67 @@ msys2_references=(
   'cygwin: cygwin'
   "cpe: cpe:/a:cygwin:cygwin"
 )
-makedepends=('cocom'
-             'git'
-             'perl'
-             'gcc'
-             'mingw-w64-cross-crt'
-             'mingw-w64-cross-gcc'
-             'mingw-w64-cross-zlib'
-             'zlib-devel'
-             'libzstd-devel'
-             'gettext-devel'
-             'libiconv-devel'
-             'autotools'
-             'xmlto'
-             'docbook-xsl')
+makedepends=(
+  'autotools'
+  'cocom'
+  'docbook-xsl'
+  'gcc'
+  'gettext-devel'
+  'git'
+  'libzstd-devel'
+  'libiconv-devel'
+  'mingw-w64-cross-crt'
+  'mingw-w64-cross-gcc'
+  'mingw-w64-cross-zlib'
+  'perl'
+  'xmlto'
+  'zlib-devel'
+)
+_patches=(
+  0001-Fix-msys-library-name-in-import-libraries.patch
+  0002-Rename-dll-from-cygwin-to-msys.patch
+  0003-Convert-Unix-paths-in-args-env-to-Windows-form-for-n.patch
+  0004-Add-functionality-for-changing-OS-name-via-MSYSTEM-e.patch
+  0005-Move-root-to-usr.-Change-sorting-mount-points.-By-de.patch
+  0006-Instead-of-creating-Cygwin-symlinks-use-deep-copy-by.patch
+  0007-Automatically-rewrite-TERM-msys-to-TERM-cygwin.patch
+  0008-Do-not-convert-environment-for-strace.patch
+  0009-strace.cc-Don-t-set-MSYS-noglob.patch
+  0010-Add-debugging-for-strace-make_command_line.patch
+  0011-strace-quiet-be-really-quiet.patch
+  0012-path_conv-special-case-root-directory-to-have-traili.patch
+  0013-When-converting-to-a-Unix-path-avoid-double-trailing.patch
+  0014-dcrt0.cc-Untangle-allow_glob-from-winshell.patch
+  0015-dcrt0.cc-globify-Don-t-quote-literal-strings-differe.patch
+  0016-Add-debugging-for-build_argv.patch
+  0017-environ.cc-New-facility-environment-variable-MSYS2_E.patch
+  0018-Introduce-the-enable_pcon-value-for-MSYS.patch
+  0019-popen-call-usr-bin-sh-instead-of-bin-sh.patch
+  0020-Expose-full-command-lines-to-other-Win32-processes-b.patch
+  0021-Add-a-helper-to-obtain-a-function-s-address-in-kerne.patch
+  0022-Emulate-GenerateConsoleCtrlEvent-upon-Ctrl-C.patch
+  0023-kill-kill-Win32-processes-more-gently.patch
+  0024-Cygwin-make-option-for-native-inner-link-handling.patch
+  0025-docs-skip-building-texinfo-and-PDF-files.patch
+  0026-install-libs-depend-on-the-toollibs.patch
+  0027-POSIX-ify-the-SHELL-variable.patch
+  0028-Handle-ORIGINAL_PATH-just-like-PATH.patch
+  0029-uname-allow-setting-the-system-name-to-CYGWIN.patch
+  0030-Pass-environment-variables-with-empty-values.patch
+  0031-Optionally-disallow-empty-environment-values-again.patch
+  0032-build_env-respect-the-MSYS-environment-variable.patch
+  0033-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch
+  0034-Avoid-sharing-cygheaps-across-Cygwin-versions.patch
+  0035-uname-report-msys2-runtime-commit-hash-too.patch
+  0036-Cygwin-Adjust-CWD-magic-to-accommodate-for-the-lates.patch
+  0037-Cygwin-Fix-segfault-when-XSAVE-area-sizes-are-unalig.patch
+  0038-cygcheck-remove-an-unused-variable-causing-a-build-e.patch
+  0039-dumper-allow-compiling-with-binutils-2.47.patch
+  0040-Cygwin-open-Unlock-fdtab-before-open_with_arch.patch
+)
 source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-${pkgver}
         msys2-runtime.commit
-        0001-Fix-msys-library-name-in-import-libraries.patch
-        0002-Rename-dll-from-cygwin-to-msys.patch
-        0003-Convert-Unix-paths-in-args-env-to-Windows-form-for-n.patch
-        0004-Add-functionality-for-changing-OS-name-via-MSYSTEM-e.patch
-        0005-Move-root-to-usr.-Change-sorting-mount-points.-By-de.patch
-        0006-Instead-of-creating-Cygwin-symlinks-use-deep-copy-by.patch
-        0007-Automatically-rewrite-TERM-msys-to-TERM-cygwin.patch
-        0008-Do-not-convert-environment-for-strace.patch
-        0009-strace.cc-Don-t-set-MSYS-noglob.patch
-        0010-Add-debugging-for-strace-make_command_line.patch
-        0011-strace-quiet-be-really-quiet.patch
-        0012-path_conv-special-case-root-directory-to-have-traili.patch
-        0013-When-converting-to-a-Unix-path-avoid-double-trailing.patch
-        0014-dcrt0.cc-Untangle-allow_glob-from-winshell.patch
-        0015-dcrt0.cc-globify-Don-t-quote-literal-strings-differe.patch
-        0016-Add-debugging-for-build_argv.patch
-        0017-environ.cc-New-facility-environment-variable-MSYS2_E.patch
-        0018-Introduce-the-enable_pcon-value-for-MSYS.patch
-        0019-popen-call-usr-bin-sh-instead-of-bin-sh.patch
-        0020-Expose-full-command-lines-to-other-Win32-processes-b.patch
-        0021-Add-a-helper-to-obtain-a-function-s-address-in-kerne.patch
-        0022-Emulate-GenerateConsoleCtrlEvent-upon-Ctrl-C.patch
-        0023-kill-kill-Win32-processes-more-gently.patch
-        0024-Cygwin-make-option-for-native-inner-link-handling.patch
-        0025-docs-skip-building-texinfo-and-PDF-files.patch
-        0026-install-libs-depend-on-the-toollibs.patch
-        0027-POSIX-ify-the-SHELL-variable.patch
-        0028-Handle-ORIGINAL_PATH-just-like-PATH.patch
-        0029-uname-allow-setting-the-system-name-to-CYGWIN.patch
-        0030-Pass-environment-variables-with-empty-values.patch
-        0031-Optionally-disallow-empty-environment-values-again.patch
-        0032-build_env-respect-the-MSYS-environment-variable.patch
-        0033-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch
-        0034-Avoid-sharing-cygheaps-across-Cygwin-versions.patch
-        0035-uname-report-msys2-runtime-commit-hash-too.patch
-        0036-Cygwin-Adjust-CWD-magic-to-accommodate-for-the-lates.patch
-        0037-Cygwin-Fix-segfault-when-XSAVE-area-sizes-are-unalig.patch
-        0038-cygcheck-remove-an-unused-variable-causing-a-build-e.patch
-        0039-dumper-allow-compiling-with-binutils-2.47.patch
-        0040-Cygwin-open-Unlock-fdtab-before-open_with_arch.patch)
+        ${_patches[@]})
 sha256sums=('6d03f5393cb76a8a28db3eab5ea855fab39ffc7d928d6fc7596af13b70867dc1'
             '0ce1a14b369106854439af093b56888cd014630d7401f95813e46f9d75b04e9c'
             '7c83791a32dbc139159802b7349fe50f69610863feea99bddcbed7d8d449b34f'
@@ -144,55 +149,14 @@ prepare() {
   if test true != "$(git config core.symlinks)"
   then
     git config core.symlinks true &&
-    /usr/bin/git reset --hard
+    git reset --hard
   fi
-  del_file_exists winsup/cygwin/msys2_path_conv.cc \
-    winsup/cygwin/msys2_path_conv.h
+  del_file_exists winsup/cygwin/msys2_path_conv.{cc,h}
 
- apply_git_am_with_msg 0001-Fix-msys-library-name-in-import-libraries.patch \
-  0002-Rename-dll-from-cygwin-to-msys.patch \
-  0003-Convert-Unix-paths-in-args-env-to-Windows-form-for-n.patch \
-  0004-Add-functionality-for-changing-OS-name-via-MSYSTEM-e.patch \
-  0005-Move-root-to-usr.-Change-sorting-mount-points.-By-de.patch \
-  0006-Instead-of-creating-Cygwin-symlinks-use-deep-copy-by.patch \
-  0007-Automatically-rewrite-TERM-msys-to-TERM-cygwin.patch \
-  0008-Do-not-convert-environment-for-strace.patch \
-  0009-strace.cc-Don-t-set-MSYS-noglob.patch \
-  0010-Add-debugging-for-strace-make_command_line.patch \
-  0011-strace-quiet-be-really-quiet.patch \
-  0012-path_conv-special-case-root-directory-to-have-traili.patch \
-  0013-When-converting-to-a-Unix-path-avoid-double-trailing.patch \
-  0014-dcrt0.cc-Untangle-allow_glob-from-winshell.patch \
-  0015-dcrt0.cc-globify-Don-t-quote-literal-strings-differe.patch \
-  0016-Add-debugging-for-build_argv.patch \
-  0017-environ.cc-New-facility-environment-variable-MSYS2_E.patch \
-  0018-Introduce-the-enable_pcon-value-for-MSYS.patch \
-  0019-popen-call-usr-bin-sh-instead-of-bin-sh.patch \
-  0020-Expose-full-command-lines-to-other-Win32-processes-b.patch \
-  0021-Add-a-helper-to-obtain-a-function-s-address-in-kerne.patch \
-  0022-Emulate-GenerateConsoleCtrlEvent-upon-Ctrl-C.patch \
-  0023-kill-kill-Win32-processes-more-gently.patch \
-  0024-Cygwin-make-option-for-native-inner-link-handling.patch \
-  0025-docs-skip-building-texinfo-and-PDF-files.patch \
-  0026-install-libs-depend-on-the-toollibs.patch \
-  0027-POSIX-ify-the-SHELL-variable.patch \
-  0028-Handle-ORIGINAL_PATH-just-like-PATH.patch \
-  0029-uname-allow-setting-the-system-name-to-CYGWIN.patch \
-  0030-Pass-environment-variables-with-empty-values.patch \
-  0031-Optionally-disallow-empty-environment-values-again.patch \
-  0032-build_env-respect-the-MSYS-environment-variable.patch \
-  0033-Revert-Cygwin-Enable-dynamicbase-on-the-Cygwin-DLL-b.patch \
-  0034-Avoid-sharing-cygheaps-across-Cygwin-versions.patch \
-  0035-uname-report-msys2-runtime-commit-hash-too.patch \
-  0036-Cygwin-Adjust-CWD-magic-to-accommodate-for-the-lates.patch \
-  0037-Cygwin-Fix-segfault-when-XSAVE-area-sizes-are-unalig.patch \
-  0038-cygcheck-remove-an-unused-variable-causing-a-build-e.patch \
-  0039-dumper-allow-compiling-with-binutils-2.47.patch \
-  0040-Cygwin-open-Unlock-fdtab-before-open_with_arch.patch
+  apply_git_am_with_msg ${_patches[@]}
 }
 
 build() {
-  [[ -d "${srcdir}"/build-${CHOST} ]] && rm -rf "${srcdir}"/build-${CHOST}
   mkdir -p "${srcdir}"/build-${CHOST} && cd "${srcdir}"/build-${CHOST}
 
   # Gives more verbose compile output when debugging.

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.6.10
-pkgrel=2
+pkgrel=3
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -27,8 +27,6 @@ makedepends=('cocom'
              'autotools'
              'xmlto'
              'docbook-xsl')
-# re zipman: https://github.com/msys2/MSYS2-packages/pull/2687#issuecomment-965714874
-options=('!zipman')
 source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-${pkgver}
         msys2-runtime.commit
         0001-Fix-msys-library-name-in-import-libraries.patch

--- a/msys2-runtime/update-patches.sh
+++ b/msys2-runtime/update-patches.sh
@@ -59,11 +59,8 @@ git --git-dir msys2-runtime rev-parse --verify $msys2_branch >msys2-runtime.comm
 git add $patches msys2-runtime.commit ||
 die "Could not stage new patch set"
 
-in_sources="$(echo "$patches" | sed "{s/^/        /;:1;N;s/\\n/\\\\n        /;b1}")"
-in_prepare="$(echo "$patches" | tr '\n' '\\' | sed -e 's/\\$//' -e 's/\\/ &&&n  /g')"
-sed -i -e "/^        0.*\.patch$/{:1;N;/[^)]$/b1;s|.*|$in_sources)|}" \
-	-e "/^ *apply_git_am_with_msg /{:2;N;/[^}]$/b2;s|.*| apply_git_am_with_msg $in_prepare\\n\\}|}" \
-	PKGBUILD ||
+in_patches="$(echo "$patches" | sed "{s/^/  /;:1;N;s/\\n/\\\\n  /;b1}")"
+sed -i -e "/^_patches=(/{:1;N;/[^)]$/b1;s|.*|_patches=(\\n$in_patches\\n)|}" PKGBUILD ||
 die "Could not update the patch set in PKGBUILD"
 
 if git rev-parse --verify HEAD >/dev/null &&


### PR DESCRIPTION
Almost 5 years have passed, and it should be safe to reenable zipman now.

Also did a cleanup to PKGBUILD, and updated `update-patches.sh` as well.