### PR TITLE
mingw-w64-cross-mingwarm64: fix AArch64 auto-imports

### DIFF
--- a/mingw-w64-cross-mingwarm64-binutils/0011-readline-tcap.h-Update-definitions-for-C23.patch
+++ b/mingw-w64-cross-mingwarm64-binutils/0011-readline-tcap.h-Update-definitions-for-C23.patch
@@ -1,0 +1,50 @@
+From 5c87b330e910f8be1443c881fd16a70e685f1f2f Mon Sep 17 00:00:00 2001
+From: Chris Packham <judge.packham@gmail.com>
+Date: Wed, 30 Apr 2025 16:49:44 +1200
+Subject: [PATCH] readline/tcap.h: Update definitions for C23
+
+C23 changes how function definitions like int `int tputs ()` are
+interpreted. In older standards this meant that the function arguments
+are unknown. In C23 this is interpreted as `int tputs (void)` so now
+when we compile with GCC15 (which defaults to -std=gnu23) we get an
+error such as
+
+  readline/display.c:2839:17: error: too many arguments to function 'tputs'; expected 0, have 3
+
+Add the function arguments for tgetent(), tgetflag(), tgetnum(),
+tgetstr(), tputs() and tgoto().
+
+Signed-off-by: Chris Packham <judge.packham@gmail.com>
+Approved-By: Tom Tromey <tom@tromey.com>
+---
+ readline/readline/tcap.h | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/readline/readline/tcap.h b/readline/readline/tcap.h
+index 859e6eed5aa..9e2ed124e49 100644
+--- a/readline/readline/tcap.h
++++ b/readline/readline/tcap.h
+@@ -46,14 +46,14 @@ extern char *UP, *BC;
+ 
+ extern short ospeed;
+ 
+-extern int tgetent ();
+-extern int tgetflag ();
+-extern int tgetnum ();
+-extern char *tgetstr ();
++extern int tgetent (char *bp, const char *name);
++extern int tgetflag (char *id);
++extern int tgetnum (char *id);
++extern char *tgetstr (char *id, char **area);
+ 
+-extern int tputs ();
++extern int tputs (const char *str, int affcnt, int (*putc)(int));
+ 
+-extern char *tgoto ();
++extern char *tgoto (const char *cap, int col, int row);
+ 
+ #endif /* HAVE_TERMCAP_H */
+ 
+-- 
+2.55.0.windows.3.16.gcf5497b14c5a
+

--- a/mingw-w64-cross-mingwarm64-binutils/PKGBUILD
+++ b/mingw-w64-cross-mingwarm64-binutils/PKGBUILD
@@ -19,7 +19,7 @@ license=('spdx:GPL-3.0-or-later')
 groups=("${_mingw_suff}-toolchain" "${_mingw_suff}")
 depends=("libiconv" "zlib" "libzstd" "libintl")
 checkdepends=('dejagnu' 'bc')
-makedepends=("libiconv-devel" "zlib-devel" 'autotools' 'gcc' 'libzstd-devel' 'gettext-devel' 'git' 'gmp-devel' 'mpfr-devel')
+makedepends=("libiconv-devel" "zlib-devel" 'autotools' 'gcc' 'libzstd-devel' 'gettext-devel' 'git' 'gmp-devel' 'mpfr-devel' 'texinfo')
 options=('staticlibs' '!distcc' '!ccache' '!buildflags')
 _commit="3b69e905b1b94561a48744d5eae52377219173f1"
 source=("${_realname}"::"git+https://github.com/Windows-on-ARM-Experiments/binutils-woarm64.git#commit=${_commit}"

--- a/mingw-w64-cross-mingwarm64-binutils/PKGBUILD
+++ b/mingw-w64-cross-mingwarm64-binutils/PKGBUILD
@@ -6,7 +6,7 @@ _mingw_suff=mingw-w64-cross
 _targetpkgs=("${_mingw_suff}-mingwarm64-${_realname}")
 pkgname=("${_targetpkgs[@]}")
 pkgver=2.44dev
-pkgrel=1
+pkgrel=2
 pkgdesc="A set of programs to assemble and manipulate binary and object files"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/binutils/"
@@ -24,10 +24,12 @@ options=('staticlibs' '!distcc' '!ccache' '!buildflags')
 _commit="3b69e905b1b94561a48744d5eae52377219173f1"
 source=("${_realname}"::"git+https://github.com/Windows-on-ARM-Experiments/binutils-woarm64.git#commit=${_commit}"
         0002-check-for-unusual-file-harder.patch
-        0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch)
+        0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
+        https://github.com/Windows-on-ARM-Experiments/binutils-woarm64/commit/44335833f8f734f978211b082b15aed14efcf958.patch)
 sha256sums=('963e4e4e0eba8918fc300b9119915020ccac0cfc19bda6397ccab0eefe699ccc'
             '2c99345fc575c3a060d6677537f636c6c4154fac0fde508070f3b6296c1060d4'
-            '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18')
+            '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18'
+            '65bd98f3fd953a80d6dbaa5ed1564494f9fb60b3c175ba143a9f27e1687a9695')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
 
@@ -44,7 +46,8 @@ prepare() {
 
   apply_patch_with_msg \
     0002-check-for-unusual-file-harder.patch \
-    0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
+    0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch \
+    44335833f8f734f978211b082b15aed14efcf958.patch
 }
 
 _build() {

--- a/mingw-w64-cross-mingwarm64-binutils/PKGBUILD
+++ b/mingw-w64-cross-mingwarm64-binutils/PKGBUILD
@@ -25,10 +25,12 @@ _commit="3b69e905b1b94561a48744d5eae52377219173f1"
 source=("${_realname}"::"git+https://github.com/Windows-on-ARM-Experiments/binutils-woarm64.git#commit=${_commit}"
         0002-check-for-unusual-file-harder.patch
         0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
+        0011-readline-tcap.h-Update-definitions-for-C23.patch
         https://github.com/Windows-on-ARM-Experiments/binutils-woarm64/commit/44335833f8f734f978211b082b15aed14efcf958.patch)
 sha256sums=('963e4e4e0eba8918fc300b9119915020ccac0cfc19bda6397ccab0eefe699ccc'
             '2c99345fc575c3a060d6677537f636c6c4154fac0fde508070f3b6296c1060d4'
             '4e8ac055df61b1b5d6ae29dc87e1154737c2e87c7b244b44866702cabf1a5d18'
+            '50750b4def37d6d81e8bf0c41681b1f77a66aef52a26d8603240196d5e47b03d'
             '65bd98f3fd953a80d6dbaa5ed1564494f9fb60b3c175ba143a9f27e1687a9695')
 validpgpkeys=('EAF1C276A747E9ED86210CBAC3126D3B4AE55E93'
               '3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F')
@@ -47,6 +49,7 @@ prepare() {
   apply_patch_with_msg \
     0002-check-for-unusual-file-harder.patch \
     0010-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch \
+    0011-readline-tcap.h-Update-definitions-for-C23.patch \
     44335833f8f734f978211b082b15aed14efcf958.patch
 }
 

--- a/mingw-w64-cross-mingwarm64-crt/PKGBUILD
+++ b/mingw-w64-cross-mingwarm64-crt/PKGBUILD
@@ -14,13 +14,14 @@ url='https://www.mingw-w64.org'
 msys2_repository_url='https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-crt'
 license=('spdx:ZPL-2.1 AND LGPL-2.1-or-later')
 groups=("${_mingw_suff}-toolchain" "${_mingw_suff}")
-makedepends=("git" "${_mingw_suff}-mingwarm64-gcc" "${_mingw_suff}-mingwarm64-binutils" "${_mingw_suff}-mingwarm64-headers" 'autotools')
+makedepends=("${_mingw_suff}-mingwarm64-gcc" "${_mingw_suff}-mingwarm64-binutils" "${_mingw_suff}-mingwarm64-headers" 'autotools')
 options=('!strip' 'staticlibs' '!emptydirs' '!buildflags')
 _commit='9d8da7d28c75dd70bcd7b6b5f9b360ebfe13194a'
-source=("mingw-w64"::"git+https://github.com/Windows-on-ARM-Experiments/mingw-woarm64.git#commit=$_commit"
+_srcdir="mingw-woarm64-${_commit}"
+source=("${_srcdir}.tar.gz"::"https://github.com/Windows-on-ARM-Experiments/mingw-woarm64/archive/${_commit}.tar.gz"
         https://github.com/Windows-on-ARM-Experiments/mingw-woarm64/commit/92e63a665c6f217a41401feb69b4662928d370ba.patch)
 
-sha256sums=('1900fb686ee98ef7b55297d7e5298b01b1c1be2d4ca61f2c0fb39bb1dc1a7858'
+sha256sums=('99832156e644429073fc72fdff7e60ce78f816bf9132bac34f8af6bbaebab184'
             'f14c6c365f5519d64e03c41166b229ff1d0c5d404e4833ef3581d85aa4f478da')
 msys2_references=(
   'archlinux: mingw-w64-crt'
@@ -28,7 +29,7 @@ msys2_references=(
 )
 
 prepare() {
-  cd ${srcdir}/mingw-w64
+  cd ${srcdir}/${_srcdir}
 
   patch -p1 -i "${srcdir}/92e63a665c6f217a41401feb69b4662928d370ba.patch"
 }
@@ -53,7 +54,7 @@ _build() {
   fi
 
   unset CC
-  ${srcdir}/mingw-w64/mingw-w64-crt/configure \
+  ${srcdir}/${_srcdir}/mingw-w64-crt/configure \
   --build=${CHOST} \
   --prefix=/opt/${_target} \
   --host=${_target} \

--- a/mingw-w64-cross-mingwarm64-crt/PKGBUILD
+++ b/mingw-w64-cross-mingwarm64-crt/PKGBUILD
@@ -7,7 +7,7 @@ pkgbase="${_mingw_suff}-mingwarm64-${_realname}"
 _targetpkgs=("${_mingw_suff}-mingwarm64-${_realname}")
 pkgname=("${_targetpkgs[@]}")
 pkgver=13.0.0dev
-pkgrel=1
+pkgrel=2
 pkgdesc='MinGW-w64 CRT for cross-compiler'
 arch=('i686' 'x86_64')
 url='https://www.mingw-w64.org'
@@ -17,13 +17,21 @@ groups=("${_mingw_suff}-toolchain" "${_mingw_suff}")
 makedepends=("git" "${_mingw_suff}-mingwarm64-gcc" "${_mingw_suff}-mingwarm64-binutils" "${_mingw_suff}-mingwarm64-headers" 'autotools')
 options=('!strip' 'staticlibs' '!emptydirs' '!buildflags')
 _commit='9d8da7d28c75dd70bcd7b6b5f9b360ebfe13194a'
-source=("mingw-w64"::"git+https://github.com/Windows-on-ARM-Experiments/mingw-woarm64.git#commit=$_commit")
+source=("mingw-w64"::"git+https://github.com/Windows-on-ARM-Experiments/mingw-woarm64.git#commit=$_commit"
+        https://github.com/Windows-on-ARM-Experiments/mingw-woarm64/commit/92e63a665c6f217a41401feb69b4662928d370ba.patch)
 
-sha256sums=('1900fb686ee98ef7b55297d7e5298b01b1c1be2d4ca61f2c0fb39bb1dc1a7858')
+sha256sums=('1900fb686ee98ef7b55297d7e5298b01b1c1be2d4ca61f2c0fb39bb1dc1a7858'
+            'f14c6c365f5519d64e03c41166b229ff1d0c5d404e4833ef3581d85aa4f478da')
 msys2_references=(
   'archlinux: mingw-w64-crt'
   'cpe: cpe:/a:mingw-w64:mingw-w64'
 )
+
+prepare() {
+  cd ${srcdir}/mingw-w64
+
+  patch -p1 -i "${srcdir}/92e63a665c6f217a41401feb69b4662928d370ba.patch"
+}
 
 _build() {
   _target=$1


### PR DESCRIPTION
The current AArch64 cross toolchain emits the auto-import warnings tracked in https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/issues/191 and cannot dynamically link `libstdc++`, as tracked in https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/issues/258. The [binutils fix](https://github.com/Windows-on-ARM-Experiments/binutils-woarm64/commit/44335833f8f734f978211b082b15aed14efcf958)
and [CRT fix](https://github.com/Windows-on-ARM-Experiments/mingw-woarm64/commit/92e63a665c6f217a41401feb69b4662928d370ba) are both required and were validated together in [this run](https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/17958048642).

This deliberately retains the current source snapshots. The broader binutils update in https://github.com/msys2/MSYS2-packages/pull/5539 was reverted because it crashed `msys2-tests`; in that discussion, @lazka [suggested applying patches atop the current source](https://github.com/msys2/MSYS2-packages/pull/5539#issuecomment-3127732199). Both patches apply cleanly to the pinned snapshots.

Since the source was force-pushed and the desired commit is no longer reachable, we switch to downloading the tarball of that commit instead.
