### PR TITLE
ed: update to 1.22.6

### DIFF
--- a/ed/PKGBUILD
+++ b/ed/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=ed
-pkgver=1.22.4
+pkgver=1.22.6
 pkgrel=1
 pkgdesc="A POSIX-compliant line-oriented text editor"
 arch=('i686' 'x86_64')
@@ -11,9 +11,10 @@ depends=('sh')
 makedepends=('autotools' 'gcc')
 options=('!emptydirs')
 source=("https://ftp.gnu.org/gnu/ed/$pkgname-$pkgver.tar.lz"{,.sig})
-sha256sums=('987a1ebbbad3fcf63a1ffa9e29b3fa7de065150d16319d0a49dd8b57f81d3e9c'
+sha256sums=('3f33b22135219c39c3c695f7b7171c2567d3e2a17c798c0a90607320cbb268f2'
             'SKIP')
-validpgpkeys=('1D41C14B272A2219A739FA4F8FE99503132D7742') # Antonio Diaz Diaz <antonio@gnu.org>
+validpgpkeys=('1D41C14B272A2219A739FA4F8FE99503132D7742'
+              '1E5AEE0B18C0DEB45D64AA0325B62C9821501AA0') # Antonio Diaz Diaz <antonio@gnu.org>
 
 build() {
   cd "$pkgname-$pkgver"


### PR DESCRIPTION
New key and package checksum are published at
<https://lists.gnu.org/archive/html/bug-ed/2026-08/msg00003.html>.