### PR TITLE
emacs: Update to 31.1

### DIFF
--- a/emacs/001-no-rebase.patch
+++ b/emacs/001-no-rebase.patch
@@ -1,12 +1,12 @@
---- emacs-29.3/src/Makefile.in.orig	2024-01-06 13:56:31.000000000 +0100
-+++ emacs-29.3/src/Makefile.in	2024-06-11 07:41:07.067826400 +0200
-@@ -613,9 +613,6 @@
+--- emacs-31.1/src/Makefile.in.orig	2026-08-24 17:17:52.787999000 +0200
++++ emacs-31.1/src/Makefile.in	2026-08-24 17:20:18.274448500 +0200
+@@ -630,9 +630,6 @@
  emacs$(EXEEXT): temacs$(EXEEXT) \
-                 lisp.mk $(etc)/DOC $(lisp) \
+                 $(abs_top_builddir)/src/lisp.mk $(etc)/DOC $(lisp) \
                  $(lispsource)/international/charprop.el ${charsets}
 -ifeq ($(SYSTEM_TYPE),cygwin)
 -	find ${top_builddir} -name '*.eln' | rebase -v -O -T -
 -endif
- ifeq ($(DUMPING),unexec)
- 	LC_ALL=C $(RUN_TEMACS) -batch $(BUILD_DETAILS) -l loadup --temacs=dump
-   ifneq ($(PAXCTL_dumped),)
+ 	rm -f $@ && cp -f temacs$(EXEEXT) $@
+ 
+ ## On Haiku, also produce a binary named Emacs with the appropriate

--- a/emacs/PKGBUILD
+++ b/emacs/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Ricky <rickleaf.wu@gmail.com>
 
 pkgname=emacs
-pkgver=30.2
+pkgver=31.1
 pkgrel=1
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (msys2)"
 url="https://www.gnu.org/software/${pkgname}/"
@@ -17,11 +17,12 @@ makedepends=('gawk' 'libiconv-devel' 'libxml2-devel' 'libiconv-devel' 'ncurses-d
 options=('strip')
 source=("https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz"{,.sig}
         '001-no-rebase.patch')
-sha256sums=('b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9'
+sha256sums=('1da5790d9580c81932b5bf700633114468da7b3412d69faa767daebf974f4586'
             'SKIP'
-            '4a82e7f1c51ab4084dcd2625bba2c04b4a99524532e02b641ee91d2748ffddc3')
+            '8e69312a75d4ac7e4c63c6bee8f385ef0756d9f945c685317b8750746bdd635b')
 validpgpkeys=('17E90D521672C04631B1183EE78DAE0F3115E06B' # Eli Zaretskii (eliz) <eliz@gnu.org>
-              'CEA1DE21AB108493CC9C65742E82323B8F4353EE')
+              'CEA1DE21AB108493CC9C65742E82323B8F4353EE'
+              '8DC2487E51ABDD90B5C4753F0F56D0553B6D411B')
 
 prepare() {
   cd "${pkgname}-${pkgver}"
@@ -58,10 +59,6 @@ build() {
 package() {
   cd "${srcdir}"/${pkgname}-${pkgver}
   make DESTDIR="${pkgdir}" install
-  mv "${pkgdir}/usr/bin/ctags.exe" \
-    "${pkgdir}/usr/bin/ctags-emacs.exe"
-  mv "${pkgdir}/usr/share/man/man1/ctags.1" \
-     "${pkgdir}/usr/share/man/man1/ctags-emacs.1"
   rm -f "${pkgdir}/usr/share/info/info.info.gz"
 
   local dir="${pkgdir}/usr/share/${pkgname}"


### PR DESCRIPTION
* 001-no-rebase.patch: refresh
* ctags is gone
* key was announced at https://lists.gnu.org/archive/html/emacs-devel/2026-08/msg00760.html