### PR TITLE
nasm: Update to 3.02

### DIFF
--- a/nasm/PKGBUILD
+++ b/nasm/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=nasm
-pkgver=2.16.03
+pkgver=3.02
 pkgrel=1
 pkgdesc="An 80x86 assembler designed for portability and modularity"
 arch=('i686' 'x86_64')
@@ -14,7 +14,7 @@ msys2_references=(
 license=('spdx:BSD-2-Clause')
 makedepends=('perl-Font-TTF' 'perl-Sort-Versions' 'autotools' 'gcc')
 source=("https://www.nasm.us/pub/nasm/releasebuilds/${pkgver}/${pkgname}-${pkgver}.tar.xz")
-sha256sums=('1412a1c760bbd05db026b6c0d1657affd6631cd0a63cddb6f73cc6d4aa616148')
+sha256sums=('87336eba53b4acfe917424ab5d500d2b0054d9f5148d35c2273ccf2cfb712f0d')
 
 build() {
   cd ${pkgname}-${pkgver}

--- a/nasm/PKGBUILD
+++ b/nasm/PKGBUILD
@@ -12,7 +12,7 @@ msys2_references=(
   'cpe: cpe:/a:nasm:netwide_assembler'
 )
 license=('spdx:BSD-2-Clause')
-makedepends=('perl-Font-TTF' 'perl-Sort-Versions' 'autotools' 'gcc')
+makedepends=('autotools' 'gcc')
 source=("https://www.nasm.us/pub/nasm/releasebuilds/${pkgver}/${pkgname}-${pkgver}.tar.xz")
 sha256sums=('87336eba53b4acfe917424ab5d500d2b0054d9f5148d35c2273ccf2cfb712f0d')
 

--- a/nasm/PKGBUILD
+++ b/nasm/PKGBUILD
@@ -3,11 +3,11 @@
 pkgname=nasm
 pkgver=3.02
 pkgrel=1
-pkgdesc="An 80x86 assembler designed for portability and modularity"
+pkgdesc='An 80x86 assembler designed for portability and modularity'
 arch=('i686' 'x86_64')
-url="https://www.nasm.us/"
-msys2_repository_url="https://github.com/netwide-assembler/nasm"
-msys2_changelog_url="https://nasm.us/doc/nasmdocc.html"
+url='https://www.nasm.us/'
+msys2_repository_url='https://github.com/netwide-assembler/nasm'
+msys2_changelog_url='https://nasm.us/doc/nasmdocc.html'
 msys2_references=(
   'anitya: 2048'
   'archlinux: nasm'
@@ -15,19 +15,26 @@ msys2_references=(
   'gentoo: dev-lang/nasm'
 )
 license=('spdx:BSD-2-Clause')
-makedepends=('autotools' 'gcc')
+makedepends=(
+  'autotools'
+  'gcc'
+)
 source=("https://www.nasm.us/pub/nasm/releasebuilds/${pkgver}/${pkgname}-${pkgver}.tar.xz")
 sha256sums=('87336eba53b4acfe917424ab5d500d2b0054d9f5148d35c2273ccf2cfb712f0d')
 
 build() {
-  cd ${pkgname}-${pkgver}
-  ./configure --prefix=/usr
+  cd "${srcdir}/${pkgname}-${pkgver}"
+
+  ./configure \
+    --prefix=/usr
+
   make all -j1
 }
 
 package() {
-  cd ${pkgname}-${pkgver}
+  cd "${srcdir}/${pkgname}-${pkgver}"
 
   make DESTDIR="${pkgdir}" install
-  install -D -m644 LICENSE "${pkgdir}"/usr/share/licenses/nasm/LICENSE
+
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/nasm/PKGBUILD
+++ b/nasm/PKGBUILD
@@ -28,7 +28,7 @@ build() {
   ./configure \
     --prefix=/usr
 
-  make all -j1
+  make all
 }
 
 package() {

--- a/nasm/PKGBUILD
+++ b/nasm/PKGBUILD
@@ -9,7 +9,10 @@ url="https://www.nasm.us/"
 msys2_repository_url="https://github.com/netwide-assembler/nasm"
 msys2_changelog_url="https://nasm.us/doc/nasmdocc.html"
 msys2_references=(
+  'anitya: 2048'
+  'archlinux: nasm'
   'cpe: cpe:/a:nasm:netwide_assembler'
+  'gentoo: dev-lang/nasm'
 )
 license=('spdx:BSD-2-Clause')
 makedepends=('autotools' 'gcc')

--- a/nasm/PKGBUILD
+++ b/nasm/PKGBUILD
@@ -23,7 +23,7 @@ source=("https://www.nasm.us/pub/nasm/releasebuilds/${pkgver}/${pkgname}-${pkgve
 sha256sums=('87336eba53b4acfe917424ab5d500d2b0054d9f5148d35c2273ccf2cfb712f0d')
 
 build() {
-  cd "${srcdir}/${pkgname}-${pkgver}"
+  cd "${pkgname}-${pkgver}"
 
   ./configure \
     --prefix=/usr
@@ -32,7 +32,7 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/${pkgname}-${pkgver}"
+  cd "${pkgname}-${pkgver}"
 
   make DESTDIR="${pkgdir}" install
 


### PR DESCRIPTION
I think Perl libraries are not needed because make doesn't build docs, neither man pages.

[make all](https://github.com/netwide-assembler/nasm/blob/nasm-3.02/Makefile.in#L232) in source

Related:

```text
configure: WARNING: No asciidoc package found, cannot build man pages
configure: WARNING: No xmlto package found, cannot build man pages
``` 