### PR TITLE
ncdu: Update to fork (1.23.0)

### DIFF
--- a/ncdu/PKGBUILD
+++ b/ncdu/PKGBUILD
@@ -14,9 +14,8 @@ msys2_references=(
 license=('spdx:MIT')
 depends=('ncurses')
 makedepends=('ncurses-devel' 'autotools' 'gcc')
-source=("${pkgname}-${pkgver}.tar.gz::https://github.com/BratishkaErik/${pkgname}/archive/v${pkgver}.tar.gz")
-sha256sums=('086063ac09b293d2510f08af0e9e4eb52d2856f77295989e2fe4e18135c5cb18')
-validpgpkeys=('74460D32B80810EBA9AFA2E962394C698C2739FA') # Yoran Heling <info@yorhel.nl>
+source=("https://github.com/BratishkaErik/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}-src.tar.gz")
+sha256sums=('2eccb4ce6c4e08d9539155789ff7341fdbde67bd746e9f523d5d3095cd872804')
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"

--- a/ncdu/PKGBUILD
+++ b/ncdu/PKGBUILD
@@ -3,29 +3,39 @@
 pkgname=ncdu
 pkgver=1.23.0
 pkgrel=1
-pkgdesc="Disk usage analyzer with an ncurses interface."
+pkgdesc='Disk usage analyzer with an ncurses interface.'
 arch=('i686' 'x86_64')
-url="https://github.com/BratishkaErik/ncdu"
-msys2_repository_url="https://github.com/BratishkaErik/ncdu"
-msys2_changelog_url="https://github.com/BratishkaErik/ncdu/releases"
+url='https://github.com/BratishkaErik/ncdu'
+msys2_repository_url='https://github.com/BratishkaErik/ncdu'
+msys2_changelog_url='https://github.com/BratishkaErik/ncdu/releases'
 msys2_references=(
   'anitya: 6045'
 )
 license=('spdx:MIT')
 depends=('ncurses')
-makedepends=('ncurses-devel' 'autotools' 'gcc')
+makedepends=(
+  'autotools'
+  'gcc'
+  'ncurses-devel'
+)
 source=("https://github.com/BratishkaErik/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}-src.tar.gz")
 sha256sums=('2eccb4ce6c4e08d9539155789ff7341fdbde67bd746e9f523d5d3095cd872804')
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
+
   autoreconf -fi
-  ./configure --prefix=/usr
+
+  ./configure \
+    --prefix=/usr
+
   make
 }
 
 package() {
   cd "${srcdir}/${pkgname}-${pkgver}"
+
   make DESTDIR="${pkgdir}" install
+
   install -Dm644 COPYING "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/ncdu/PKGBUILD
+++ b/ncdu/PKGBUILD
@@ -1,21 +1,26 @@
 # Maintainer: Biswapriyo Nath <nathbappai@gmail.com>
 
 pkgname=ncdu
-pkgver=1.22
+pkgver=1.23.0
 pkgrel=1
 pkgdesc="Disk usage analyzer with an ncurses interface."
 arch=('i686' 'x86_64')
-url="https://dev.yorhel.nl/ncdu"
+url="https://github.com/BratishkaErik/ncdu"
+msys2_repository_url="https://github.com/BratishkaErik/ncdu"
+msys2_changelog_url="https://github.com/BratishkaErik/ncdu/releases"
+msys2_references=(
+  'anitya: 6045'
+)
 license=('spdx:MIT')
 depends=('ncurses')
 makedepends=('ncurses-devel' 'autotools' 'gcc')
-source=("https://dev.yorhel.nl/download/${pkgname}-${pkgver}.tar.gz"{,.asc})
-sha256sums=('0ad6c096dc04d5120581104760c01b8f4e97d4191d6c9ef79654fa3c691a176b'
-            'SKIP')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/BratishkaErik/${pkgname}/archive/v${pkgver}.tar.gz")
+sha256sums=('086063ac09b293d2510f08af0e9e4eb52d2856f77295989e2fe4e18135c5cb18')
 validpgpkeys=('74460D32B80810EBA9AFA2E962394C698C2739FA') # Yoran Heling <info@yorhel.nl>
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
+  autoreconf -fi
   ./configure --prefix=/usr
   make
 }

--- a/ncdu/PKGBUILD
+++ b/ncdu/PKGBUILD
@@ -22,7 +22,7 @@ source=("https://github.com/BratishkaErik/${pkgname}/releases/download/v${pkgver
 sha256sums=('2eccb4ce6c4e08d9539155789ff7341fdbde67bd746e9f523d5d3095cd872804')
 
 build() {
-  cd "${srcdir}/${pkgname}-${pkgver}"
+  cd "${pkgname}-${pkgver}"
 
   autoreconf -fi
 
@@ -33,7 +33,7 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/${pkgname}-${pkgver}"
+  cd "${pkgname}-${pkgver}"
 
   make DESTDIR="${pkgdir}" install
 


### PR DESCRIPTION
Hi, because of unfortunate event described [here](https://vndb.org/t24787) the work of Yorhel is continued under [this fork](https://github.com/BratishkaErik/ncdu).

There wasn't any big change for the original C version, but it should be better to update the sources to active fork (at least active for Zig rewrite and maintained for C).
It uses GitHub Attestations (that uses sigstore) instead of PGP, so it is impossible to add a new key.