### PR TITLE
fmt: Update to 12.2.0

### DIFF
--- a/fmt/PKGBUILD
+++ b/fmt/PKGBUILD
@@ -2,12 +2,20 @@
 # Contributor: Christoph Reiter <reiter.christoph@gmail.com>
 
 pkgname=fmt
-pkgver=12.1.0
+pkgver=12.2.0
 pkgrel=1
 pkgdesc='Open-source formatting library for C++'
 arch=(x86_64 i686)
-url=https://fmt.dev
-msys2_repository_url="https://github.com/fmtlib/fmt"
+url='https://fmt.dev'
+msys2_repository_url='https://github.com/fmtlib/fmt'
+msys2_documentation_url='https://fmt.dev'
+msys2_changelog_url='https://github.com/fmtlib/fmt/blob/main/ChangeLog.md'
+msys2_references=(
+  'anitya: 11526'
+  'archlinux: fmt'
+  'cpe: cpe:/a:fmt:fmt'
+  'gentoo: dev-libs/libfmt'
+)
 license=(spdx:MIT)
 depends=(gcc-libs)
 makedepends=(
@@ -16,7 +24,7 @@ makedepends=(
   gcc
 )
 source=("https://github.com/fmtlib/fmt/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz")
-sha256sums=('ea7de4299689e12b6dddd392f9896f08fb0777ac7168897a244a6d6085043fea')
+sha256sums=('8b852bb5aa6e7d8564f9e81394055395dd1d1936d38dfd3a17792a02bebd7af0')
 
 build() {
   cmake -S "${pkgname}-${pkgver}" -B build \


### PR DESCRIPTION
Update along with metadata since fmt has a conflict with another `fmt` library in anitya