### PR TITLE
bisoncpp: Update to 6.09.02

### DIFF
--- a/bisoncpp/PKGBUILD
+++ b/bisoncpp/PKGBUILD
@@ -2,33 +2,28 @@
 
 pkgbase=bisoncpp
 pkgname=bisonc++
-pkgver=6.04.04
-pkgrel=3
+pkgver=6.09.02
+pkgrel=1
 pkgdesc='C++ parser generator'
 arch=('i686' 'x86_64')
 url='https://fbb-git.gitlab.io/bisoncpp/'
+msys2_repository_url='https://gitlab.com/fbb-git/bisoncpp'
+msys2_changelog_url='https://gitlab.com/fbb-git/bisoncpp/-/blob/master/bisonc++/changelog'
+msys2_references=(
+  'aur: bisonc++'
+)
 license=('spdx:GPL-3.0-or-later')
 depends=('libbobcat')
-makedepends=('icmake'
-             'gcc'
-             'libbobcat-devel'
-             'yodl'
-            )
-source=("https://gitlab.com/fbb-git/bisoncpp/-/archive/${pkgver}/bisoncpp-${pkgver}.tar.gz"
-        'manual_license.patch'
-        )
+makedepends=('icmake' 'gcc' 'libbobcat-devel' 'yodl')
+source=("https://gitlab.com/fbb-git/bisoncpp/-/archive/${pkgver}/bisoncpp-${pkgver}.tar.gz")
 # need to untar gz-file manually, since makepkg's untar program seems
 # not to be able to handle symlinks in the gz-file
 noextract=("bisoncpp-${pkgver}.tar.gz")
-sha256sums=('55df315fb925933ddd0ec4537e67275a62e454768badd4cf0baa1c84ec6237ab'
-            '6f41ebf87253fe458bd4ed5df297e2c69f10bdb73b929297a233df5bd0cd993e')
+sha256sums=('3f111818d7c08b3cb6008506c0f16b73ae806257e3f7f793f42e1ecb7e0183d2')
 
 prepare() {
   # unzip manually
   tar -xf "bisoncpp-${pkgver}.tar.gz"
-
-  cd "${srcdir}/${pkgbase}-${pkgver}/bisonc++"
-  patch -p1 -i "$srcdir/manual_license.patch"
 }
 
 build() {

--- a/bisoncpp/manual_license.patch
+++ b/bisoncpp/manual_license.patch
@@ -1,9 +1,0 @@
---- a/documentation/manual/conditions/gpl.yo	2012-02-08 19:53:51.000000000 +0000
-+++ b/documentation/manual/conditions/gpl.yo	2014-10-23 00:51:58.123510386 +0100
-@@ -4,5 +4,5 @@
- 
- The GPL is shown below:
- 
--verbinclude(/usr/share/common-licenses/GPL)
-+https://www.gnu.org/licenses/gpl-3.0.en.html
- 


### PR DESCRIPTION
Patch not needed since this change:

```diff
-verbinclude(/usr/share/common-licenses/GPL)
+verbinclude(../../../LICENSE)
```