### PR TITLE
uv: update to 0.12.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 *.rar
 *.sig
 *.asc
-*.crate
 *.log
 *.log.[0-9]*
 */src/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.rar
 *.sig
 *.asc
+*.crate
 *.log
 *.log.[0-9]*
 */src/

--- a/uv/PKGBUILD
+++ b/uv/PKGBUILD
@@ -3,12 +3,20 @@
 _realname=uv
 pkgbase=${_realname}
 pkgname=("python-${_realname}-build")
-pkgver=0.12.5
+pkgver=0.12.9
 pkgrel=1
 pkgdesc='An extremely fast Python package installer and resolver, written in Rust (python build backend)'
 arch=('x86_64')
-url="https://github.com/astral-sh/uv"
+url='https://github.com/astral-sh/uv'
 msys2_repository_url='https://github.com/astral-sh/uv'
+msys2_documentation_url='https://docs.astral.sh/uv/'
+msys2_changelog_url='https://github.com/astral-sh/uv/blob/main/CHANGELOG.md'
+msys2_references=(
+  'anitya: 372636'
+  'archlinux: uv'
+  'cpe: cpe:/a:astral:uv'
+  'gentoo: dev-python/uv'
+)
 license=('spdx:Apache-2.0 OR MIT')
 makedepends=('rust'
              'python-maturin'
@@ -19,12 +27,12 @@ makedepends=('rust'
              'git')
 options=('!strip')
 source=("git+${url}.git#tag=${pkgver}"
-        "cap-primitives-4.0.2.crate::https://static.crates.io/crates/cap-primitives/4.0.2/download"
+        "cap-primitives-4.0.3.crate::https://static.crates.io/crates/cap-primitives/4.0.3/download"
         "zstd-sys.tar.gz::https://static.crates.io/crates/zstd-sys/2.0.16+zstd.1.5.7/download"
         "cap-primitives-cygwin.patch"
         "link-zstd-dynamically.patch")
-sha256sums=('29f5740dcbb6d932cdbbed3a3946ac79d921772a0c62a8c8da04ecc0ec90b8d5'
-            'cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0'
+sha256sums=('e835d10b4cee20d898af736bbf4b8219bdd8aaa27c41b758c28877c5d9365968'
+            '8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18'
             '91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748'
             'aa6f471a296583fd3676d57513cb94d152d9472ffe1fe81806b98c59381b8a83'
             '48f4900ceb02d3aaf9a1020f33d56629156e96759f456c0e7ca18bfcf910767b')
@@ -32,12 +40,12 @@ sha256sums=('29f5740dcbb6d932cdbbed3a3946ac79d921772a0c62a8c8da04ecc0ec90b8d5'
 prepare() {
   cd "${_realname}"
 
-  patch -d "../cap-primitives-4.0.2" -p1 -i "../cap-primitives-cygwin.patch"
+  patch -d "../cap-primitives-4.0.3" -p1 -i "../cap-primitives-cygwin.patch"
   patch -d "../zstd-sys-2.0.16+zstd.1.5.7" -i "../link-zstd-dynamically.patch"
   cat >> Cargo.toml <<END
 
 [patch.crates-io]
-cap-primitives.path = "../cap-primitives-4.0.2"
+cap-primitives.path = "../cap-primitives-4.0.3"
 zstd-sys.path = "../zstd-sys-2.0.16+zstd.1.5.7"
 END
 

--- a/uv/PKGBUILD
+++ b/uv/PKGBUILD
@@ -27,7 +27,7 @@ makedepends=('rust'
              'git')
 options=('!strip')
 source=("git+${url}.git#tag=${pkgver}"
-        "cap-primitives-4.0.3.crate::https://static.crates.io/crates/cap-primitives/4.0.3/download"
+        "cap-primitives-4.0.3.tar.gz::https://static.crates.io/crates/cap-primitives/4.0.3/download"
         "zstd-sys.tar.gz::https://static.crates.io/crates/zstd-sys/2.0.16+zstd.1.5.7/download"
         "cap-primitives-cygwin.patch"
         "link-zstd-dynamically.patch")


### PR DESCRIPTION
Funnily enough there exists CPE for uv, so it's not a false alarm :D

I've added `*.crate` binary blobs to gitignore.