### PR TITLE
swig: update to 4.5.1

### DIFF
--- a/swig/PKGBUILD
+++ b/swig/PKGBUILD
@@ -18,7 +18,7 @@ msys2_references=(
 license=('spdx:GPL-3.0-or-later AND LicenseRef-SWIG-Universities')
 depends=('zlib' 'libpcre2_8')
 makedepends=('zlib-devel' 'pcre2-devel' 'autotools' 'gcc')
-source=("https://github.com/swig/swig/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz"
+source=("https://github.com/swig/swig/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz"
         '0001-no-stdcall.patch')
 sha256sums=('7fec50b27deddab5455a9633780b6341eddfb96215a7619e93a76eb27178f653'
             '61f4b47694e89f566d50702def201bafba2ac84c2b35b3f0a00a5ccb834acf62')

--- a/swig/PKGBUILD
+++ b/swig/PKGBUILD
@@ -35,9 +35,10 @@ build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
 
   export MSYSTEM=CYGWIN
+
   ./configure \
-    --build="${CHOST}" \
-    --prefix=/usr
+    --prefix=/usr \
+    --build="${CHOST}"
 
   make
 }

--- a/swig/PKGBUILD
+++ b/swig/PKGBUILD
@@ -16,10 +16,20 @@ msys2_references=(
   'gentoo: dev-lang/swig'
 )
 license=('spdx:GPL-3.0-or-later AND LicenseRef-SWIG-Universities')
-depends=('zlib' 'libpcre2_8')
-makedepends=('zlib-devel' 'pcre2-devel' 'autotools' 'gcc')
-source=("https://github.com/swig/swig/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz"
-        '0001-no-stdcall.patch')
+depends=(
+  'libpcre2_8'
+  'zlib'
+)
+makedepends=(
+  'autotools'
+  'gcc'
+  'pcre2-devel'
+  'zlib-devel'
+)
+source=(
+  "https://github.com/swig/swig/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz"
+  '0001-no-stdcall.patch'
+)
 sha256sums=('dd219a0c8947afe63b818892304390427c2ee7f6edfa1a37853d4efd891982be'
             '61f4b47694e89f566d50702def201bafba2ac84c2b35b3f0a00a5ccb834acf62')
 

--- a/swig/PKGBUILD
+++ b/swig/PKGBUILD
@@ -1,45 +1,52 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=swig
-pkgver=4.5.0
+pkgver=4.5.1
 pkgrel=1
-pkgdesc="Generate scripting interfaces to C/C++ code"
+pkgdesc='Generate scripting interfaces to C/C++ code'
 arch=('i686' 'x86_64')
-url="https://www.swig.org/"
+url='https://www.swig.org'
 msys2_repository_url='https://github.com/swig/swig'
+msys2_documentation_url='https://www.swig.org/doc.html'
+msys2_changelog_url='https://www.swig.org/news.html'
 msys2_references=(
-  "anitya: 4919"
-  "archlinux: swig"
-  "cygwin: swig"
-  "gentoo: dev-lang/swig"
+  'anitya: 4919'
+  'archlinux: swig'
+  'cygwin: swig'
+  'gentoo: dev-lang/swig'
 )
 license=('spdx:GPL-3.0-or-later AND LicenseRef-SWIG-Universities')
 depends=('zlib' 'libpcre2_8')
 makedepends=('zlib-devel' 'pcre2-devel' 'autotools' 'gcc')
-source=(https://downloads.sourceforge.net/${pkgname}/${pkgname}-${pkgver}.tar.gz
-        0001-no-stdcall.patch)
-sha256sums=('22ae0e887f8cca8031a325c67d005207653200b40e71edb3f88780e28e47d0ff'
+source=("https://github.com/swig/swig/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz"
+        '0001-no-stdcall.patch')
+sha256sums=('7fec50b27deddab5455a9633780b6341eddfb96215a7619e93a76eb27178f653'
             '61f4b47694e89f566d50702def201bafba2ac84c2b35b3f0a00a5ccb834acf62')
 
 prepare() {
-  cd ${pkgname}-${pkgver}
+  cd "${srcdir}/${pkgname}-${pkgver}"
 
-  patch -p1 -i ${srcdir}/0001-no-stdcall.patch
+  patch -p1 -i "${srcdir}/0001-no-stdcall.patch"
 
   ./autogen.sh
 }
 
 build() {
-  cd ${pkgname}-${pkgver}
+  cd "${srcdir}/${pkgname}-${pkgver}"
 
   export MSYSTEM=CYGWIN
-  ./configure -build=${CHOST} --prefix=/usr
+  ./configure \
+    --build="${CHOST}" \
+    --prefix=/usr
+
   make
 }
 
 package() {
-  cd ${pkgname}-${pkgver}
+  cd "${srcdir}/${pkgname}-${pkgver}"
+
   make DESTDIR="${pkgdir}" install
-  install -D -m644 LICENSE "${pkgdir}"/usr/share/licenses/${pkgname}/LICENSE
-  install -D -m644 LICENSE-UNIVERSITIES "${pkgdir}"/usr/share/licenses/${pkgname}/LICENSE-UNIVERSITIES
+
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 LICENSE-UNIVERSITIES "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE-UNIVERSITIES"
 }

--- a/swig/PKGBUILD
+++ b/swig/PKGBUILD
@@ -20,7 +20,7 @@ depends=('zlib' 'libpcre2_8')
 makedepends=('zlib-devel' 'pcre2-devel' 'autotools' 'gcc')
 source=("https://github.com/swig/swig/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz"
         '0001-no-stdcall.patch')
-sha256sums=('7fec50b27deddab5455a9633780b6341eddfb96215a7619e93a76eb27178f653'
+sha256sums=('dd219a0c8947afe63b818892304390427c2ee7f6edfa1a37853d4efd891982be'
             '61f4b47694e89f566d50702def201bafba2ac84c2b35b3f0a00a5ccb834acf62')
 
 prepare() {

--- a/swig/PKGBUILD
+++ b/swig/PKGBUILD
@@ -34,15 +34,15 @@ sha256sums=('dd219a0c8947afe63b818892304390427c2ee7f6edfa1a37853d4efd891982be'
             '61f4b47694e89f566d50702def201bafba2ac84c2b35b3f0a00a5ccb834acf62')
 
 prepare() {
-  cd "${srcdir}/${pkgname}-${pkgver}"
+  cd "${pkgname}-${pkgver}"
 
-  patch -p1 -i "${srcdir}/0001-no-stdcall.patch"
+  patch -Np1 -i "${srcdir}/0001-no-stdcall.patch"
 
   ./autogen.sh
 }
 
 build() {
-  cd "${srcdir}/${pkgname}-${pkgver}"
+  cd "${pkgname}-${pkgver}"
 
   export MSYSTEM=CYGWIN
 
@@ -54,7 +54,7 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/${pkgname}-${pkgver}"
+  cd "${pkgname}-${pkgver}"
 
   make DESTDIR="${pkgdir}" install
 


### PR DESCRIPTION
There is a regression fix in 4.5.1, no clue if it applies to anything here. Plus some shell changes.

I updated the source from Sourceforge to GitHub as they mention on [their website](https://www.swig.org/bugs.html) that all development moved to GitHub and it is kept for compatibility.