### PR TITLE
libxml2: update to 2.15.4

### DIFF
--- a/libxml2/PKGBUILD
+++ b/libxml2/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
-pkgbase=libxml2
+pkgbase='libxml2'
 pkgname=('libxml2' 'libxml2-devel')
 pkgver=2.15.4
 pkgrel=1
@@ -17,7 +17,7 @@ msys2_references=(
   'gentoo: dev-libs/libxml2'
 )
 license=('spdx:MIT')
-makedepends=('gcc' 'libreadline-devel' 'zlib-devel' 'autotools' 'libxslt' 'docbook-xsl' 'doxygen' 'libiconv-devel')
+makedepends=('gcc' 'libreadline-devel' 'zlib-devel' 'meson' 'ninja' 'libxslt' 'docbook-xsl' 'doxygen' 'libiconv-devel')
 source=("https://download.gnome.org/sources/libxml2/${pkgver%.*}/${pkgbase}-${pkgver}.tar.xz"
         'https://www.w3.org/XML/Test/xmlts20130923.tar.gz')
 sha256sums=('98087fd181d9070724f3fbc65c7377db03038eb92bd882374daff44940138821'
@@ -28,41 +28,35 @@ prepare() {
 
   rm -rf "${pkgbase}-${pkgver}/xmlconf"
   mv xmlconf -t "${pkgbase}-${pkgver}"
-
-  cd "${pkgbase}-${pkgver}"
-  autoreconf -vfi
 }
 
 build() {
   cd "${srcdir}/${pkgbase}-${pkgver}"
 
-  export lt_cv_deplibs_check_method='pass_all'
-  export MSYSTEM=CYGWIN
+  local _meson_options=(
+    --prefix=/usr
+    --sysconfdir=/etc
+    --localstatedir=/var
+    --buildtype=plain
+    -Ddefault_library=both
+    -Dhistory=enabled
+    -Diconv=enabled
+    -Dlegacy=enabled
+    -Dhttp=enabled
+    -Ddocs=enabled
+    -Dicu=disabled
+    -Dpython=disabled
+  )
 
-  ./configure \
-    --prefix=/usr \
-    --sysconfdir=/etc \
-    --localstatedir=/var \
-    --build="${CHOST}" \
-    --host="${CHOST}" \
-    --target="${CHOST}" \
-    --with-history \
-    --with-iconv \
-    --with-legacy \
-    --with-http \
-    --with-docs \
-    --without-icu \
-    --without-python \
-    --enable-shared \
-    --enable-static
+  meson setup build "${_meson_options[@]}"
+  meson compile -C build
 
-  make
-  make DESTDIR="${srcdir}/dest" install
+  meson install -C build --destdir "${srcdir}/dest"
 }
 
 check() {
   cd "${srcdir}/${pkgbase}-${pkgver}"
-  make check
+  meson test -C build --print-errorlogs
 }
 
 package_libxml2() {
@@ -72,7 +66,9 @@ package_libxml2() {
 
   mkdir -p "${pkgdir}/usr"
   cp -rf "${srcdir}/dest/usr/bin" "${pkgdir}/usr/"
-  rm -f "${pkgdir}/usr/bin/"*-config
+
+  # Meson might drop legacy -config scripts eventually
+  rm -f "${pkgdir}/usr/bin/"*-config 2>/dev/null || true
 
   mkdir -p "${pkgdir}/usr/share"
   cp -rf "${srcdir}/dest/usr/share/man" "${pkgdir}/usr/share/"
@@ -88,7 +84,8 @@ package_libxml2-devel() {
 
   mkdir -p "${pkgdir}/usr/"{bin,share}
 
-  cp -f "${srcdir}/dest/usr/bin/"*-config "${pkgdir}/usr/bin/"
+  # same as in package_libxml2()
+  cp -f "${srcdir}/dest/usr/bin/"*-config "${pkgdir}/usr/bin/" 2>/dev/null || true
   cp -rf "${srcdir}/dest/usr/include" "${pkgdir}/usr/"
   cp -rf "${srcdir}/dest/usr/lib" "${pkgdir}/usr/"
   cp -rf "${srcdir}/dest/usr/share/doc" "${pkgdir}/usr/share/"

--- a/libxml2/PKGBUILD
+++ b/libxml2/PKGBUILD
@@ -17,9 +17,22 @@ msys2_references=(
   'gentoo: dev-libs/libxml2'
 )
 license=('spdx:MIT')
-makedepends=('gcc' 'libreadline-devel' 'zlib-devel' 'meson' 'ninja' 'libxslt' 'docbook-xsl' 'doxygen' 'libiconv-devel')
-source=("https://download.gnome.org/sources/libxml2/${pkgver%.*}/${pkgbase}-${pkgver}.tar.xz"
-        'https://www.w3.org/XML/Test/xmlts20130923.tar.gz')
+makedepends=(
+  'docbook-xsl'
+  'doxygen'
+  'gcc'
+  'git'
+  'libiconv-devel'
+  'libreadline-devel'
+  'libxslt'
+  'meson'
+  'ninja'
+  'zlib-devel'
+)
+source=(
+  "https://download.gnome.org/sources/libxml2/${pkgver%.*}/${pkgbase}-${pkgver}.tar.xz"
+  'https://www.w3.org/XML/Test/xmlts20130923.tar.gz'
+)
 sha256sums=('98087fd181d9070724f3fbc65c7377db03038eb92bd882374daff44940138821'
             '9b61db9f5dbffa545f4b8d78422167083a8568c59bd1129f94138f936cf6fc1f')
 

--- a/libxml2/PKGBUILD
+++ b/libxml2/PKGBUILD
@@ -2,64 +2,50 @@
 
 pkgbase=libxml2
 pkgname=('libxml2' 'libxml2-devel')
-pkgver=2.15.3
+pkgver=2.15.4
 pkgrel=1
-pkgdesc="XML parsing library, version 2"
-arch=(i686 x86_64)
+pkgdesc='XML parsing library, version 2'
+arch=('i686' 'x86_64')
+url='https://gitlab.gnome.org/GNOME/libxml2'
+msys2_repository_url='https://gitlab.gnome.org/GNOME/libxml2'
+msys2_documentation_url='https://gitlab.gnome.org/GNOME/libxml2/-/wikis'
+msys2_changelog_url='https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/NEWS'
+msys2_references=(
+  'anitya: 1783'
+  'archlinux: libxml2'
+  'cpe: cpe:/a:xmlsoft:libxml2'
+  'gentoo: dev-libs/libxml2'
+)
 license=('spdx:MIT')
 makedepends=('gcc' 'libreadline-devel' 'zlib-devel' 'autotools' 'libxslt' 'docbook-xsl' 'doxygen' 'libiconv-devel')
-url="https://gitlab.gnome.org/GNOME/libxml2/-/wikis/"
-msys2_repository_url="https://gitlab.gnome.org/GNOME/libxml2"
-msys2_references=(
-  "cpe: cpe:/a:xmlsoft:libxml2"
-)
 source=("https://download.gnome.org/sources/libxml2/${pkgver%.*}/${pkgbase}-${pkgver}.tar.xz"
-        https://www.w3.org/XML/Test/xmlts20130923.tar.gz)
-sha256sums=('78262a6e7ac170d6528ebfe2efccdf220191a5af6a6cd61ea4a9a9a5042c7a07'
+        'https://www.w3.org/XML/Test/xmlts20130923.tar.gz')
+sha256sums=('98087fd181d9070724f3fbc65c7377db03038eb92bd882374daff44940138821'
             '9b61db9f5dbffa545f4b8d78422167083a8568c59bd1129f94138f936cf6fc1f')
 
-# Helper macros to help make tasks easier #
-apply_patch_with_msg() {
-  for _patch in "$@"
-  do
-    msg2 "Applying $_patch"
-    patch -Nbp1 -i "${srcdir}/$_patch"
-  done
-}
-
-del_file_exists() {
-  for _fname in "$@"
-  do
-    if [ -f $_fname ] || [ -d $_fname ]; then
-      rm -rf $_fname
-    fi
-  done
-}
-# =========================================== #
-
-
 prepare() {
-  cd ${srcdir}
-  del_file_exists ${pkgbase}-${pkgver}/xmlconf
-  mv xmlconf -t ${pkgbase}-${pkgver}
+  cd "${srcdir}"
 
-  cd ${pkgbase}-${pkgver}
+  rm -rf "${pkgbase}-${pkgver}/xmlconf"
+  mv xmlconf -t "${pkgbase}-${pkgver}"
 
+  cd "${pkgbase}-${pkgver}"
   autoreconf -vfi
 }
 
 build() {
-  export lt_cv_deplibs_check_method='pass_all'
+  cd "${srcdir}/${pkgbase}-${pkgver}"
 
-  cd ${pkgbase}-${pkgver}
+  export lt_cv_deplibs_check_method='pass_all'
   export MSYSTEM=CYGWIN
+
   ./configure \
     --prefix=/usr \
     --sysconfdir=/etc \
     --localstatedir=/var \
-    --build=${CHOST} \
-    --host=${CHOST} \
-    --target=${CHOST} \
+    --build="${CHOST}" \
+    --host="${CHOST}" \
+    --target="${CHOST}" \
     --with-history \
     --with-iconv \
     --with-legacy \
@@ -69,38 +55,41 @@ build() {
     --without-python \
     --enable-shared \
     --enable-static
-  make
-  make DESTDIR=${srcdir}/dest install
 
+  make
+  make DESTDIR="${srcdir}/dest" install
 }
 
 check() {
-  cd ${pkgbase}-${pkgver}
+  cd "${srcdir}/${pkgbase}-${pkgver}"
   make check
 }
 
 package_libxml2() {
   depends=('coreutils' 'libreadline' 'zlib')
   groups=('libraries')
-  install=libxml2.install
+  install='libxml2.install'
 
-  mkdir -p ${pkgdir}/usr
-  cp -rf ${srcdir}/dest/usr/bin ${pkgdir}/usr/
-  rm -f ${pkgdir}/usr/bin/*-config
-  mkdir -p ${pkgdir}/usr/share
-  cp -rf ${srcdir}/dest/usr/share/man ${pkgdir}/usr/share/
-  install -Dm644 ${srcdir}/${pkgbase}-${pkgver}/Copyright "${pkgdir}/usr/share/licenses/${pkgbase}/Copyright"
+  mkdir -p "${pkgdir}/usr"
+  cp -rf "${srcdir}/dest/usr/bin" "${pkgdir}/usr/"
+  rm -f "${pkgdir}/usr/bin/"*-config
+
+  mkdir -p "${pkgdir}/usr/share"
+  cp -rf "${srcdir}/dest/usr/share/man" "${pkgdir}/usr/share/"
+
+  install -Dm644 "${srcdir}/${pkgbase}-${pkgver}/Copyright" "${pkgdir}/usr/share/licenses/${pkgbase}/Copyright"
 }
 
 package_libxml2-devel() {
-  pkgdesc="Libxml2 headers and libraries"
+  pkgdesc='Libxml2 headers and libraries'
   groups=('development')
   options=('staticlibs')
   depends=("libxml2=${pkgver}" 'libreadline-devel' 'zlib-devel' 'libiconv-devel')
 
-  mkdir -p ${pkgdir}/usr/{bin,share}
-  cp -f ${srcdir}/dest/usr/bin/*-config ${pkgdir}/usr/bin/
-  cp -rf ${srcdir}/dest/usr/include ${pkgdir}/usr/
-  cp -rf ${srcdir}/dest/usr/lib ${pkgdir}/usr/
-  cp -rf ${srcdir}/dest/usr/share/doc ${pkgdir}/usr/share/
+  mkdir -p "${pkgdir}/usr/"{bin,share}
+
+  cp -f "${srcdir}/dest/usr/bin/"*-config "${pkgdir}/usr/bin/"
+  cp -rf "${srcdir}/dest/usr/include" "${pkgdir}/usr/"
+  cp -rf "${srcdir}/dest/usr/lib" "${pkgdir}/usr/"
+  cp -rf "${srcdir}/dest/usr/share/doc" "${pkgdir}/usr/share/"
 }

--- a/libxml2/PKGBUILD
+++ b/libxml2/PKGBUILD
@@ -44,7 +44,7 @@ prepare() {
 }
 
 build() {
-  cd "${srcdir}/${pkgbase}-${pkgver}"
+  cd "${pkgbase}-${pkgver}"
 
   local _meson_options=(
     --prefix=/usr
@@ -68,7 +68,8 @@ build() {
 }
 
 check() {
-  cd "${srcdir}/${pkgbase}-${pkgver}"
+  cd "${pkgbase}-${pkgver}"
+
   meson test -C build --print-errorlogs
 }
 


### PR DESCRIPTION
Along with update I migrated build system to Meson. It's weird that libxml2 supports autotools, cmake, and meson at the same time. Anyway it's a lot faster