### PR TITLE
python-charset-normalizer: update to 3.5.1

### DIFF
--- a/python-charset-normalizer/PKGBUILD
+++ b/python-charset-normalizer/PKGBUILD
@@ -1,7 +1,7 @@
 # Contributor: Dirk Stolle
 
-_realname=charset-normalizer
-pkgname=python-${_realname}
+_realname='charset-normalizer'
+pkgname="python-${_realname}"
 pkgver=3.5.1
 pkgrel=1
 pkgdesc='A library that helps you read text from an unknown charset encoding'
@@ -28,13 +28,13 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3')
 
 build() {
-  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
+  cd "${srcdir}/${_realname/-/_}-${pkgver}"
 
   python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
-  cd "python-build-${MSYSTEM}"
+  cd "${srcdir}/${_realname/-/_}-${pkgver}"
 
   # Test in virtual env., because tests need installed package.
   python -m venv --system-site-packages test-env
@@ -43,9 +43,9 @@ check() {
 }
 
 package() {
-  cd "python-build-${MSYSTEM}"
+  cd "${srcdir}/${_realname/-/_}-${pkgver}"
 
-  python -m installer --prefix=${MSYSTEM_PREFIX} --destdir="${pkgdir}" dist/*.whl
+  python -m installer --destdir="${pkgdir}" dist/*.whl
 
-  install -Dm644 LICENSE "${pkgdir}${MSYSTEM_PREFIX}/share/licenses/python-${_realname}/LICENSE"
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/python-charset-normalizer/PKGBUILD
+++ b/python-charset-normalizer/PKGBUILD
@@ -45,7 +45,7 @@ check() {
 package() {
   cd "${srcdir}/${_realname/-/_}-${pkgver}"
 
-  python -m installer --destdir="${pkgdir}" dist/*.whl
+  python -m installer --prefix=/usr --destdir="${pkgdir}" dist/*.whl
 
   install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/python-charset-normalizer/PKGBUILD
+++ b/python-charset-normalizer/PKGBUILD
@@ -2,15 +2,16 @@
 
 _realname=charset-normalizer
 pkgname=python-${_realname}
-pkgver=3.4.9
+pkgver=3.5.1
 pkgrel=1
 pkgdesc='A library that helps you read text from an unknown charset encoding'
 arch=('any')
 url='https://charset-normalizer.readthedocs.io/'
-msys2_repository_url='https://github.com/Ousret/charset_normalizer'
-msys2_repository_ulr='https://github.com/jawah/charset_normalizer'
+msys2_repository_url='https://github.com/jawah/charset_normalizer'
+msys2_documentation_url='https://charset-normalizer.readthedocs.io/'
 msys2_changelog_url='https://github.com/jawah/charset_normalizer/blob/master/CHANGELOG.md'
 msys2_references=(
+  'anitya: 55366'
   'archlinux: python-charset-normalizer'
   'gentoo: dev-python/charset-normalizer'
   'purl: pkg:pypi/charset-normalizer'
@@ -24,7 +25,7 @@ makedepends=(
 )
 checkdepends=('python-pytest')
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b')
+sha256sums=('6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3')
 
 build() {
   cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"

--- a/python-charset-normalizer/PKGBUILD
+++ b/python-charset-normalizer/PKGBUILD
@@ -28,13 +28,13 @@ source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realna
 sha256sums=('6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3')
 
 build() {
-  cd "${srcdir}/${_realname/-/_}-${pkgver}"
+  cp -r "${_realname/-/_}-${pkgver}" "python-build-${MSYSTEM}" && cd "python-build-${MSYSTEM}"
 
   python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
-  cd "${srcdir}/${_realname/-/_}-${pkgver}"
+  cd "python-build-${MSYSTEM}"
 
   # Test in virtual env., because tests need installed package.
   python -m venv --system-site-packages test-env
@@ -43,7 +43,7 @@ check() {
 }
 
 package() {
-  cd "${srcdir}/${_realname/-/_}-${pkgver}"
+  cd "python-build-${MSYSTEM}"
 
   python -m installer --prefix=/usr --destdir="${pkgdir}" dist/*.whl
 


### PR DESCRIPTION
Removed not needed mingw logic with a marginal optimization as a bonus