### PR TITLE
[new package] python-vcs-versioning 2.1.2

### DIFF
--- a/python-vcs-versioning/PKGBUILD
+++ b/python-vcs-versioning/PKGBUILD
@@ -1,0 +1,57 @@
+_realname='vcs-versioning'
+pkgname="python-${_realname}"
+pkgver=2.1.2
+pkgrel=1
+pkgdesc='Core VCS versioning functionality extracted as a standalone library that can be used independently of setuptools.'
+arch=('any')
+url='https://setuptools-scm.readthedocs.io'
+msys2_repository_url='https://github.com/pypa/setuptools-scm'
+msys2_documentation_url='https://setuptools-scm.readthedocs.io'
+msys2_changelog_url='https://setuptools-scm.readthedocs.io/latest/changelog'
+msys2_references=(
+  'anitya: 389421'
+  'archlinux: python-vcs-versioning'
+  'gentoo: dev-python/vcs-versioning'
+  'purl: pkg:pypi/vcs-versioning'
+)
+license=('spdx:MIT')
+depends=(
+  'python'
+  'python-packaging'
+)
+makedepends=(
+  'python-build'
+  'python-installer'
+  'python-setuptools'
+)
+checkdepends=(
+  'git'
+  'python-pytest'
+  # useful for check but not available in msys repo
+  # 'python-pytest-cov'
+  # 'python-pytest-xdist'
+)
+options=('!strip')
+source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+sha256sums=('7282122aee5de69d520a9dbe56ebac705a0be7e2cc9b1b97dde4333c45fe782c')
+
+build() {
+  cd "${srcdir}/${_realname/-/_}-${pkgver}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  cd "${srcdir}/${_realname/-/_}-${pkgver}"
+
+  # 2.1.2: 11 failed, 514 passed, 57 skipped, 84 warnings
+  PYTHONPATH="$(pwd)/src" pytest || warning "Tests failed"
+}
+
+package() {
+  cd "${srcdir}/${_realname/-/_}-${pkgver}"
+
+  python -m installer --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE.txt "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.txt"
+}

--- a/python-vcs-versioning/PKGBUILD
+++ b/python-vcs-versioning/PKGBUILD
@@ -1,4 +1,5 @@
 _realname='vcs-versioning'
+_pyname="${_realname/-/_}"
 pkgname="python-${_realname}"
 pkgver=2.1.2
 pkgrel=1
@@ -32,24 +33,24 @@ checkdepends=(
   # 'python-pytest-xdist'
 )
 options=('!strip')
-source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
+source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
 sha256sums=('7282122aee5de69d520a9dbe56ebac705a0be7e2cc9b1b97dde4333c45fe782c')
 
 build() {
-  cd "${srcdir}/${_realname/-/_}-${pkgver}"
+  cd "${_pyname}-${pkgver}"
 
   python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
-  cd "${srcdir}/${_realname/-/_}-${pkgver}"
+  cd "${_pyname}-${pkgver}"
 
   # 2.1.2: 11 failed, 514 passed, 57 skipped, 84 warnings
   PYTHONPATH="$(pwd)/src" pytest || warning "Tests failed"
 }
 
 package() {
-  cd "${srcdir}/${_realname/-/_}-${pkgver}"
+  cd "${_pyname}-${pkgver}"
 
   python -m installer --destdir="${pkgdir}" dist/*.whl
 


### PR DESCRIPTION
This package is needed for the latest `python-setuptools-scm`.