### PR TITLE
[new package] perl-params-someutil 1.09

### DIFF
--- a/perl-Params-SomeUtil/001-xs-version.patch
+++ b/perl-Params-SomeUtil/001-xs-version.patch
@@ -1,0 +1,11 @@
+--- Makefile.PL.orig	2026-09-07 00:05:39.655735100 +0000
++++ Makefile.PL	2026-09-07 00:32:20.504667900 +0000
+@@ -14,7 +14,7 @@
+ unless ( defined $make_xs ) {
+ 	$make_xs = can_xs();
+ }
+-if ( $^O eq 'cygwin' and $make_xs == 1 and not /^-xs/ ) {
++if ( 0 ) {
+ 	# Cygwin goes bonkers breaking `` if using Params::SomeUtil XS version
+ 	# for no apparent reason.
+ 	$make_xs = 0;

--- a/perl-Params-SomeUtil/PKGBUILD
+++ b/perl-Params-SomeUtil/PKGBUILD
@@ -14,8 +14,18 @@ msys2_references=(
 license=('spdx:Artistic-1.0-Perl OR GPL-1.0-or-later')
 groups=('perl-modules')
 depends=('perl')
-source=("https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/${_realname}-${pkgver}.tar.gz")
-sha256sums=('dd4b2286137560fc905c5e2db0bcae19fef20614ac4238dbcb2a4e78f82eb560')
+source=(
+  "https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/${_realname}-${pkgver}.tar.gz"
+  '001-xs-version.patch'
+)
+sha256sums=('dd4b2286137560fc905c5e2db0bcae19fef20614ac4238dbcb2a4e78f82eb560'
+            'e427f4fda43c4223a1c7783646532b2ed804c4e0b05ef3f3ba556dfcecdc23d7')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+
+  patch -Np0 -i "${srcdir}/001-xs-version.patch"
+}
 
 build() {
   cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}" && cd "build-${MSYSTEM}"

--- a/perl-Params-SomeUtil/PKGBUILD
+++ b/perl-Params-SomeUtil/PKGBUILD
@@ -1,0 +1,38 @@
+_realname='Params-SomeUtil'
+pkgname="perl-${_realname}"
+pkgver=1.09
+pkgrel=1
+pkgdesc='Simple, compact and correct param-checking functions'
+arch=('any')
+url='https://metacpan.org/release/Params-SomeUtil'
+msys2_repository_url='https://github.com/uperl/Params-SomeUtil'
+msys2_changelog_url='https://metacpan.org/dist/Params-SomeUtil/changes'
+msys2_references=(
+  'archlinux: perl-params-someutil'
+  'purl: pkg:cpan/PLICEASE/Params-SomeUtil'
+)
+license=('spdx:Artistic-1.0-Perl OR GPL-1.0-or-later')
+groups=('perl-modules')
+depends=('perl')
+source=("https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/Params-SomeUtil-${pkgver}.tar.gz")
+sha256sums=('dd4b2286137560fc905c5e2db0bcae19fef20614ac4238dbcb2a4e78f82eb560')
+
+build() {
+  cd "${_realname}-${pkgver}"
+
+  PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
+  make
+}
+
+check() {
+  cd "${_realname}-${pkgver}"
+
+  # tests: 939 successful, 0 failed
+  make test
+}
+
+package() {
+  cd "${_realname}-${pkgver}"
+
+  make install DESTDIR="${pkgdir}"
+}

--- a/perl-Params-SomeUtil/PKGBUILD
+++ b/perl-Params-SomeUtil/PKGBUILD
@@ -14,7 +14,7 @@ msys2_references=(
 license=('spdx:Artistic-1.0-Perl OR GPL-1.0-or-later')
 groups=('perl-modules')
 depends=('perl')
-source=("https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/Params-SomeUtil-${pkgver}.tar.gz")
+source=("https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/${_realname}-${pkgver}.tar.gz")
 sha256sums=('dd4b2286137560fc905c5e2db0bcae19fef20614ac4238dbcb2a4e78f82eb560')
 
 build() {

--- a/perl-Params-SomeUtil/PKGBUILD
+++ b/perl-Params-SomeUtil/PKGBUILD
@@ -18,21 +18,21 @@ source=("https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/Params-SomeUtil-${pk
 sha256sums=('dd4b2286137560fc905c5e2db0bcae19fef20614ac4238dbcb2a4e78f82eb560')
 
 build() {
-  cd "${_realname}-${pkgver}"
+  cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
 
   PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
   make
 }
 
 check() {
-  cd "${_realname}-${pkgver}"
+  cd "build-${MSYSTEM}"
 
   # tests: 939 successful, 0 failed
   make test
 }
 
 package() {
-  cd "${_realname}-${pkgver}"
+  cd "build-${MSYSTEM}"
 
   make install DESTDIR="${pkgdir}"
 }


### PR DESCRIPTION
This package is needed for the latest `perl-DataOptList` and `perl-Sub-Exporter`. This is a hard fork of `perl-Params-Util` with some long awaited (but not published) fixes.

After update, the original `perl-Params-Util` package is no longer used by any other package.

Some differences:
I've used `any` architecture because I saw that in `LWP-MediaTypes` and many other Perl packages. I guess all of them can be moved to `any` but I could be wrong. Any opinion?

This PKGBUILD is closer to the MINGW (and Arch) one.

I wasn't sure whether I should use the out of source build method (`build-${MSYSTEM}`) @striezel explained to me.
Mostly because the original package wasn't built like that. Although MINGW does that.

Anyway, I followed "best practise" so it should be okay.

