### PR TITLE
perl-data-optlist: update to 0.115

### DIFF
--- a/perl-Data-OptList/PKGBUILD
+++ b/perl-Data-OptList/PKGBUILD
@@ -1,12 +1,12 @@
 # Maintainer: Alexey Pavlov <Alexpux@gmail.com>
 
-_realname=Data-OptList
-pkgname=perl-${_realname}
+_realname='Data-OptList'
+pkgname="perl-${_realname}"
 pkgver=0.115
 pkgrel=1
-pkgdesc="Parse and validate simple name/value option pairs"
+pkgdesc='Parse and validate simple name/value option pairs'
 arch=('any')
-url="https://metacpan.org/dist/Data-OptList"
+url='https://metacpan.org/dist/Data-OptList'
 msys2_repository_url='https://github.com/rjbs/Data-OptList'
 msys2_changelog_url='https://metacpan.org/dist/Data-OptList/changes'
 msys2_references=(
@@ -16,18 +16,21 @@ msys2_references=(
   'purl: pkg:cpan/RJBS/Data-OptList'
 )
 license=('spdx:Artistic-1.0-Perl OR GPL-1.0-or-later')
-depends=('perl-Params-SomeUtil' 'perl-Scalar-List-Utils' 'perl-Sub-Install')
-makedepends=('perl-ExtUtils-MakeMaker')
+depends=(
+  'perl-Params-SomeUtil'
+  'perl-Scalar-List-Utils'
+  'perl-Sub-Install'
+)
+makedepends=(
+  'perl-ExtUtils-MakeMaker'
+)
 options=('!emptydirs')
 source=("https://cpan.metacpan.org/authors/id/R/RJ/RJBS/${_realname}-${pkgver}.tar.gz")
 sha512sums=('7e648b64288fbffcfd79c8c90293d41350e212dc04510da54241b72f0db66a372851fa0b4a751d2cb284eda512db9b9dc11f1649ba80b163a1451b188ce9e3f2')
 
-prepare() {
-  cd ${_realname}-${pkgver}
-}
-
 build() {
-  cd ${_realname}-${pkgver}
+  cd "${_realname}-${pkgver}"
+
   PERL_MM_USE_DEFAULT=1 \
   PERL_AUTOINSTALL=--skipdeps \
   PERL5LIB="" \
@@ -35,11 +38,13 @@ build() {
   PERL_MM_OPT="INSTALLDIRS=vendor" \
   PERL_MB_OPT="--installdirs vendor" \
   perl Makefile.PL
+
   make
 }
 
 check() {
-  cd ${_realname}-${pkgver}
+  cd "${_realname}-${pkgver}"
+
   PERL_MM_USE_DEFAULT=1 \
   PERL5LIB="" \
   make test
@@ -47,6 +52,7 @@ check() {
 }
 
 package() {
-  cd ${_realname}-${pkgver}
+  cd "${_realname}-${pkgver}"
+
   make install DESTDIR="${pkgdir}"
 }

--- a/perl-Data-OptList/PKGBUILD
+++ b/perl-Data-OptList/PKGBUILD
@@ -30,7 +30,7 @@ source=("https://cpan.metacpan.org/authors/id/R/RJ/RJBS/${_realname}-${pkgver}.t
 sha512sums=('7e648b64288fbffcfd79c8c90293d41350e212dc04510da54241b72f0db66a372851fa0b4a751d2cb284eda512db9b9dc11f1649ba80b163a1451b188ce9e3f2')
 
 build() {
-  cd "${_realname}-${pkgver}"
+  cp -r "${_realname}-${pkgver}" "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
 
   PERL_MM_USE_DEFAULT=1 \
   PERL_AUTOINSTALL=--skipdeps \
@@ -44,7 +44,7 @@ build() {
 }
 
 check() {
-  cd "${_realname}-${pkgver}"
+  cd "build-${MSYSTEM}"
 
   PERL_MM_USE_DEFAULT=1 \
   PERL5LIB="" \
@@ -53,7 +53,7 @@ check() {
 }
 
 package() {
-  cd "${_realname}-${pkgver}"
+  cd "build-${MSYSTEM}"
 
   make install DESTDIR="${pkgdir}"
 }

--- a/perl-Data-OptList/PKGBUILD
+++ b/perl-Data-OptList/PKGBUILD
@@ -7,7 +7,12 @@ pkgrel=1
 pkgdesc="Parse and validate simple name/value option pairs"
 arch=('any')
 url="https://metacpan.org/dist/Data-OptList"
+msys2_repository_url='https://github.com/rjbs/Data-OptList'
+msys2_changelog_url='https://metacpan.org/dist/Data-OptList/changes'
 msys2_references=(
+  'anitya: 2769'
+  'archlinux: perl-data-optlist'
+  'gentoo: dev-perl/Data-OptList'
   'purl: pkg:cpan/RJBS/Data-OptList'
 )
 license=('spdx:Artistic-1.0-Perl OR GPL-1.0-or-later')

--- a/perl-Data-OptList/PKGBUILD
+++ b/perl-Data-OptList/PKGBUILD
@@ -16,6 +16,7 @@ msys2_references=(
   'purl: pkg:cpan/RJBS/Data-OptList'
 )
 license=('spdx:Artistic-1.0-Perl OR GPL-1.0-or-later')
+groups=('perl-modules')
 depends=(
   'perl-Params-SomeUtil'
   'perl-Scalar-List-Utils'

--- a/perl-Data-OptList/PKGBUILD
+++ b/perl-Data-OptList/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=Data-OptList
 pkgname=perl-${_realname}
-pkgver=0.114
+pkgver=0.115
 pkgrel=1
 pkgdesc="Parse and validate simple name/value option pairs"
 arch=('any')
@@ -11,11 +11,11 @@ msys2_references=(
   'purl: pkg:cpan/RJBS/Data-OptList'
 )
 license=('spdx:Artistic-1.0-Perl OR GPL-1.0-or-later')
-depends=('perl-Params-Util' 'perl-Scalar-List-Utils' 'perl-Sub-Install')
+depends=('perl-Params-SomeUtil' 'perl-Scalar-List-Utils' 'perl-Sub-Install')
 makedepends=('perl-ExtUtils-MakeMaker')
 options=('!emptydirs')
 source=("https://cpan.metacpan.org/authors/id/R/RJ/RJBS/${_realname}-${pkgver}.tar.gz")
-sha512sums=('72f60ad7d9a6d87ffecfbc0f6f6d48dad2816dd4431d7e82e8ab834e0852da27420fd52fb2a1138254d80bf8b98b94b9fa25b878e1bb155221543a78219ee16a')
+sha512sums=('7e648b64288fbffcfd79c8c90293d41350e212dc04510da54241b72f0db66a372851fa0b4a751d2cb284eda512db9b9dc11f1649ba80b163a1451b188ce9e3f2')
 
 prepare() {
   cd ${_realname}-${pkgver}
@@ -38,6 +38,7 @@ check() {
   PERL_MM_USE_DEFAULT=1 \
   PERL5LIB="" \
   make test
+  # tests: 41 successful, 0 failed
 }
 
 package() {


### PR DESCRIPTION
Blocked by #6619 

This package didn't include `perl` as a dependency. Is it needed / considered a good practice to include? It's changing from package to package.

