### PR TITLE
libpcap: update to 1.10.7

### DIFF
--- a/libpcap/PKGBUILD
+++ b/libpcap/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=libpcap
 pkgname=('libpcap' 'libpcap-devel')
-pkgver=1.10.6
+pkgver=1.10.7
 pkgrel=1
 pkgdesc="A portable C/C++ library for network traffic capture"
 arch=('i686' 'x86_64')
@@ -15,7 +15,7 @@ msys2_references=(
 makedepends=('bison' 'cmake' 'flex' 'gcc' 'ninja' 'openssl-devel')
 source=(https://www.tcpdump.org/release/${pkgname}-${pkgver}.tar.gz
         0003-Disable-man-symlinks.patch)
-sha256sums=('872dd11337fe1ab02ad9d4fee047c9da244d695c6ddf34e2ebb733efd4ed8aa9'
+sha256sums=('0b394ac90dbc0a9838ff97468e05c9c9a3e873dec2514cd58db65d859d296e31'
             'cc3e4218937f5c75448ddcb3b09b1ad90c11ca2a01ade1defe900cba60893e8e')
 
 prepare() {

--- a/libpcap/PKGBUILD
+++ b/libpcap/PKGBUILD
@@ -9,8 +9,12 @@ arch=('i686' 'x86_64')
 license=('spdx:BSD-3-Clause')
 url="https://www.tcpdump.org/"
 msys2_repository_url="https://github.com/the-tcpdump-group/libpcap"
+msys2_changelog_url='https://github.com/the-tcpdump-group/tcpdump/blob/master/CHANGES'
 msys2_references=(
+  'anitya: 1702'
+  'archlinux: libpcap'
   "cpe: cpe:/a:tcpdump:libpcap"
+  'gentoo: net-libs/libpcap'
 )
 makedepends=('bison' 'cmake' 'flex' 'gcc' 'ninja' 'openssl-devel')
 source=(https://www.tcpdump.org/release/${pkgname}-${pkgver}.tar.gz

--- a/libpcap/PKGBUILD
+++ b/libpcap/PKGBUILD
@@ -1,62 +1,73 @@
 # Maintainer: Orgad Shaneh <orgads@gmail.com>
 
-pkgbase=libpcap
+pkgbase='libpcap'
 pkgname=('libpcap' 'libpcap-devel')
 pkgver=1.10.7
 pkgrel=1
-pkgdesc="A portable C/C++ library for network traffic capture"
+pkgdesc='A portable C/C++ library for network traffic capture'
 arch=('i686' 'x86_64')
 license=('spdx:BSD-3-Clause')
-url="https://www.tcpdump.org/"
-msys2_repository_url="https://github.com/the-tcpdump-group/libpcap"
+url='https://www.tcpdump.org/'
+msys2_repository_url='https://github.com/the-tcpdump-group/libpcap'
 msys2_changelog_url='https://github.com/the-tcpdump-group/tcpdump/blob/master/CHANGES'
 msys2_references=(
   'anitya: 1702'
   'archlinux: libpcap'
-  "cpe: cpe:/a:tcpdump:libpcap"
+  'cpe: cpe:/a:tcpdump:libpcap'
   'gentoo: net-libs/libpcap'
 )
-makedepends=('bison' 'cmake' 'flex' 'gcc' 'ninja' 'openssl-devel')
-source=(https://www.tcpdump.org/release/${pkgname}-${pkgver}.tar.gz
-        0003-Disable-man-symlinks.patch)
+makedepends=(
+  'bison'
+  'cmake'
+  'flex'
+  'gcc'
+  'ninja'
+  'openssl-devel'
+)
+source=(
+  "https://www.tcpdump.org/release/${pkgbase}-${pkgver}.tar.gz"
+  '0003-Disable-man-symlinks.patch'
+)
 sha256sums=('0b394ac90dbc0a9838ff97468e05c9c9a3e873dec2514cd58db65d859d296e31'
             'cc3e4218937f5c75448ddcb3b09b1ad90c11ca2a01ade1defe900cba60893e8e')
 
 prepare() {
-  cd ${srcdir}/${pkgbase}-${pkgver}
+  cd "${pkgbase}-${pkgver}"
 
-  patch -p1 -i ${srcdir}/0003-Disable-man-symlinks.patch
+  patch -p1 -i "${srcdir}/0003-Disable-man-symlinks.patch"
 }
 
 build() {
-  mkdir -p build-${pkgbase}-${pkgver}-${CHOST}
-  cd build-${pkgbase}-${pkgver}-${CHOST}
+  mkdir -p "build-${pkgbase}-${pkgver}-${CHOST}"
+  cd "build-${pkgbase}-${pkgver}-${CHOST}"
+
   cmake -GNinja \
     -DCMAKE_INSTALL_PREFIX="/usr" \
     -DPCAP_TYPE=null \
-    ../${pkgbase}-${pkgver}
+    "../${pkgbase}-${pkgver}"
   
   cmake --build .
   DESTDIR="${srcdir}/dest" cmake --install .
 }
 
 package_libpcap() {
-  pkgdesc="A portable C/C++ library for network traffic capture"
+  pkgdesc='A portable C/C++ library for network traffic capture'
   groups=('libraries')
   depends=('gcc-libs')
-  mkdir -p ${pkgdir}/usr/bin
-  cp -f ${srcdir}/dest/usr/bin/*.dll ${pkgdir}/usr/bin/
+
+  mkdir -p "${pkgdir}/usr/bin"
+  cp -f "${srcdir}/dest/usr/bin/"*.dll "${pkgdir}/usr/bin/"
 }
 
 package_libpcap-devel() {
-  pkgdesc="Libpcap headers and libraries"
+  pkgdesc='Libpcap headers and libraries'
   groups=('development')
   depends=("libpcap=${pkgver}")
   options=('staticlibs')
 
-  mkdir -p ${pkgdir}/usr/bin
+  mkdir -p "${pkgdir}/usr/bin"
 
-  cp -f ${srcdir}/dest/usr/bin/pcap-config ${pkgdir}/usr/bin
-  cp -rf ${srcdir}/dest/usr/include ${pkgdir}/usr/
-  cp -rf ${srcdir}/dest/usr/lib ${pkgdir}/usr/
+  cp -f "${srcdir}/dest/usr/bin/pcap-config" "${pkgdir}/usr/bin/"
+  cp -rf "${srcdir}/dest/usr/include" "${pkgdir}/usr/"
+  cp -rf "${srcdir}/dest/usr/lib" "${pkgdir}/usr/"
 }


### PR DESCRIPTION
I changed variable used in `source` from `pkgname` to `pkgbase` because `pkgname` is an array that just accidentally resolves into `libpcap` (the first item) but it is still not explicit.