### PR TITLE
[new package] meson-python 0.21.1

### DIFF
--- a/meson-python/PKGBUILD
+++ b/meson-python/PKGBUILD
@@ -1,7 +1,7 @@
 _realname='meson-python'
 _pyname="${_realname/-/_}"
 pkgname="${_realname}"
-pkgver=0.21.0
+pkgver=0.21.1
 pkgrel=1
 pkgdesc='Meson PEP 517 Python build backend'
 arch=('any')
@@ -35,7 +35,7 @@ checkdepends=(
 options=('!strip')
 source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
 noextract=("${_pyname}-${pkgver}.tar.gz")
-sha256sums=('595c2f40b76692c78274c87b733379d86562583e9ffb975487b9eafada03055b')
+sha256sums=('78b3345dcbc0fed7b939e7e37a9faab35bddaae07bf62e7542c8ad479c395af5')
 
 prepare() {
   # fixes encoding: tests/packages/encoding/???.py

--- a/meson-python/PKGBUILD
+++ b/meson-python/PKGBUILD
@@ -1,0 +1,58 @@
+_realname='meson-python'
+_pyname="${_realname/-/_}"
+pkgname="${_realname}"
+pkgver=0.20.0
+pkgrel=1
+pkgdesc='Meson PEP 517 Python build backend'
+arch=('any')
+url='https://mesonbuild.com/meson-python/'
+msys2_repository_url='https://github.com/mesonbuild/meson-python'
+msys2_changelog_url='https://mesonbuild.com/meson-python/changelog.html'
+msys2_references=(
+  'anitya: 248985'
+  'archlinux: meson-python'
+  "gentoo: dev-python/meson-python"
+  'purl: pkg:pypi/meson-python'
+)
+license=('spdx:MIT')
+depends=(
+  'meson'
+  'python'
+  'python-packaging'
+  'python-pyproject-metadata' # missing
+)
+makedepends=(
+  'python-build'
+  'python-installer'
+)
+checkdepends=(
+  # 'cython'
+  # 'python-pytest'
+  # 'python-pytest-cov' # missing
+  # 'python-pytest-mock' # missing
+  # 'python-wheel' # missing
+)
+options=('!strip')
+source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
+sha256sums=('6d9726ae6cd37e22f210c74b364b30180a68c20442e97ff09f3c566a414af738')
+
+build() {
+  cd "${_pyname}-${pkgver}"
+
+  python -m build --wheel --skip-dependency-check --no-isolation
+}
+
+check() {
+  cd "${_pyname}-${pkgver}"
+
+  # 0.20.0: x failed, x passed, x skipped
+  # PYTHONPATH="${PWD}" python -m pytest || warning "Tests failed"
+}
+
+package() {
+  cd "${_pyname}-${pkgver}"
+
+  python -m installer --prefix=/usr --destdir="${pkgdir}" dist/*.whl
+
+  install -Dm644 LICENSE -t "${pkgdir}/usr/share/licenses/${pkgname}/"
+}

--- a/meson-python/PKGBUILD
+++ b/meson-python/PKGBUILD
@@ -43,20 +43,20 @@ prepare() {
 }
 
 build() {
-  cd "${_pyname}-${pkgver}"
+  cp -r "${_pyname}-${pkgver}" 'python-build' && cd 'python-build'
 
   python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
-  cd "${_pyname}-${pkgver}"
+  cd 'python-build'
 
   # 0.20.0: x failed, x passed, x skipped
   # PYTHONPATH="${PWD}" python -m pytest || warning "Tests failed"
 }
 
 package() {
-  cd "${_pyname}-${pkgver}"
+  cd 'python-build'
 
   python -m installer --prefix=/usr --destdir="${pkgdir}" dist/*.whl
 

--- a/meson-python/PKGBUILD
+++ b/meson-python/PKGBUILD
@@ -19,7 +19,7 @@ depends=(
   'meson'
   'python'
   'python-packaging'
-  'python-pyproject-metadata' # missing
+  'python-pyproject-metadata'
 )
 makedepends=(
   'python-build'
@@ -34,7 +34,13 @@ checkdepends=(
 )
 options=('!strip')
 source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
+noextract=("${_pyname}-${pkgver}.tar.gz")
 sha256sums=('6d9726ae6cd37e22f210c74b364b30180a68c20442e97ff09f3c566a414af738')
+
+prepare() {
+  # fixes encoding: tests/packages/encoding/???.py
+  bsdtar -xf "${_pyname}-${pkgver}.tar.gz" || true
+}
 
 build() {
   cd "${_pyname}-${pkgver}"

--- a/meson-python/PKGBUILD
+++ b/meson-python/PKGBUILD
@@ -43,20 +43,20 @@ prepare() {
 }
 
 build() {
-  cp -r "${_pyname}-${pkgver}" 'python-build' && cd 'python-build'
+  cp -r "${_pyname}-${pkgver}" "build-${MSYSTEM}" && cd "build-${MSYSTEM}"
 
   python -m build --wheel --skip-dependency-check --no-isolation
 }
 
 check() {
-  cd 'python-build'
+  cd "build-${MSYSTEM}"
 
   # 0.20.0: x failed, x passed, x skipped
   # PYTHONPATH="${PWD}" python -m pytest || warning "Tests failed"
 }
 
 package() {
-  cd 'python-build'
+  cd "build-${MSYSTEM}"
 
   python -m installer --prefix=/usr --destdir="${pkgdir}" dist/*.whl
 

--- a/meson-python/PKGBUILD
+++ b/meson-python/PKGBUILD
@@ -1,7 +1,7 @@
 _realname='meson-python'
 _pyname="${_realname/-/_}"
 pkgname="${_realname}"
-pkgver=0.20.0
+pkgver=0.21.0
 pkgrel=1
 pkgdesc='Meson PEP 517 Python build backend'
 arch=('any')
@@ -35,7 +35,7 @@ checkdepends=(
 options=('!strip')
 source=("https://pypi.org/packages/source/${_pyname::1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
 noextract=("${_pyname}-${pkgver}.tar.gz")
-sha256sums=('6d9726ae6cd37e22f210c74b364b30180a68c20442e97ff09f3c566a414af738')
+sha256sums=('595c2f40b76692c78274c87b733379d86562583e9ffb975487b9eafada03055b')
 
 prepare() {
   # fixes encoding: tests/packages/encoding/???.py

--- a/meson-python/PKGBUILD
+++ b/meson-python/PKGBUILD
@@ -11,7 +11,7 @@ msys2_changelog_url='https://mesonbuild.com/meson-python/changelog.html'
 msys2_references=(
   'anitya: 248985'
   'archlinux: meson-python'
-  "gentoo: dev-python/meson-python"
+  'gentoo: dev-python/meson-python'
   'purl: pkg:pypi/meson-python'
 )
 license=('spdx:MIT')


### PR DESCRIPTION
Needed for the latest `pyalpm`.

Blocked by #6627 

Tests require many new packages, so let's omit them for now.

Ready when #6627 is merged.