### PR TITLE
jaq: new package

### DIFF
--- a/jaq/PKGBUILD
+++ b/jaq/PKGBUILD
@@ -1,0 +1,40 @@
+
+
+pkgname=jaq
+pkgver=3.1.1
+pkgrel=1
+pkgdesc="A jq clone"
+arch=('any')
+url="https://github.com/01mf02/jaq"
+msys2_repository_url="${url}"
+msys2_references=(
+  'archlinux: jaq'
+  'purl: pkg:cargo/jaq'
+)
+license=('spdx:MIT')
+makedepends=("rust")
+conflicts=("jq")
+provides=("jq")
+source=("${url}/archive/refs/tags/v${pkgver}.tar.gz"
+        "${url}/releases/download/v${pkgver}/jaq.1")
+sha256sums=('9b8587436be48b5791c8276573321a3d4f404e0dc77ea6503d05725a55edd266'
+            '795bded900db289a0a82cec1f0c66c768f878cbe9b337d892541606bfbb18f18')
+
+prepare() {
+  cd "${pkgname}-${pkgver}"
+  cargo fetch --locked --target "${RUST_CHOST}"
+}
+
+build() {
+  cd "${pkgname}-$pkgver"
+  cargo build --frozen --release
+}
+
+package() {
+  cd "${pkgname}-$pkgver"
+  install -Dm755 "target/release/jaq" "${pkgdir}/usr/bin/jaq"
+  install -Dm644 ../jaq.1 -t "${pkgdir}/usr/share/man/man1"
+  install -Dm644 LICENSE-MIT "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  cd "${pkgdir}/usr/bin"
+  ln jaq jq
+}


### PR DESCRIPTION
Because I want to drop `oniguruma` which is archived and a dependency of `jq`.
`uutils-coreutils` also depends on it (which will be removed at next release).